### PR TITLE
Fix open issues in doc generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Github CI pipelines
+- Optional --force option for force building the documentation despite errors
+- Enabled passing optional arguments to `tox -e docs` calls
 
 ### Changed
 - Now has concise contribution guidelines

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -4,7 +4,7 @@ import argparse
 import os
 import pathlib
 import shutil
-from subprocess import DEVNULL, STDOUT, CalledProcessError, check_call
+from subprocess import DEVNULL, STDOUT, CalledProcessError, check_call, run
 
 from tqdm import tqdm
 
@@ -248,8 +248,10 @@ except CalledProcessError:
     print(
         """One of the processes raised a critical error. Re-running with more output."""
     )
-    check_call(link_call)
-    check_call(building_call)
+    # We do not want to fail the next two calls, even if an error code is returned.
+    # Hence, we us run instad of check_call
+    run(link_call, check=False)
+    run(building_call + ["--keep-going"], check=False)
 
 # Clean the other files
 for directory in [sdk_dir, autosummary_dir]:

--- a/tox.ini
+++ b/tox.ini
@@ -50,4 +50,4 @@ description = Build documentation and verify, including examples. Results are st
 extras = docs
 commands = 
     python --version
-    python docs/scripts/convert_code_to_documentation.py
+    python docs/scripts/convert_code_to_documentation.py {posargs}


### PR DESCRIPTION
This PR prevents the documentation building from failing when encountering an error.

This is achieved by replacing the `check_call` commands by `run` in case of an error that is raised.