### PR TITLE
Move authors from pyproject to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,13 @@ With the newly arrived data, BayBE can produce a refined design for the next ite
 This loop would typically continue until a desired target value has been achieved in
 the experiment.
 
+## Authors
+
+- Martin Fitzner (Merck KGaA, Darmstadt, Germany), [Contact](mailto:martin.fitzner@merckgroup.com), [Github](https://github.com/Scienfitz)
+- Adrian Šošić (Merck Life Science KGaA, Darmstadt, Germany), [Contact](mailto:adrian.sosic@merckgroup.com), [Github](https://github.com/AdrianSosic)
+- Alexander Hopp (Merck KGaA, Darmstadt, Germany) [Contact](mailto:alexander.hopp@merckgroup.com), [Github](https://github.com/AVHopp)
+- Alex Lee (EMD Electronics, Tempe, Arizona, USA) [Contact](mailto:alex.lee@emdgroup.com), [Github](https://github.com/galaxee87)
+
 
 ## Known Issues
 A list of know issues can be found [here](docs/known_issues.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [project]
 name = "baybe"
 description = "Bayesian Back End for Design of Experiments"
+authors = [
+    {name = "Merck KGaA, Darmstadt, Germany"},
+]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python =">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,6 @@
 [project]
 name = "baybe"
 description = "Bayesian Back End for Design of Experiments"
-authors = [
-    { name = "Martin Fitzner (Merck KGaA, Darmstadt, Germany)", email = "martin.fitzner@merckgroup.com" },
-    { name = "Adrian Šošić (Merck Life Science KGaA, Darmstadt, Germany)", email = "adrian.sosic@merckgroup.com" },
-    { name = "Alexander Hopp (Merck KGaA, Darmstadt, Germany)", email = "alexander.hopp@merckgroup.com" },
-    { name = "Alex Lee (EMD Electronics, Tempe, Arizona, USA)", email = "alex.lee@emdgroup.com" },
-]
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python =">=3.8,<3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baybe"
-description = "Bayesian Back End for Design of Experiments"
+description = "A Bayesian Back End for Design of Experiments"
 authors = [
     {name = "Merck KGaA, Darmstadt, Germany"},
 ]


### PR DESCRIPTION
As discussed, this PR removes the authors from the pyproject.toml and includes a corresponding section in the README.