### PR TITLE
Change Release Pipeline Check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           python-version: '3.11'
       - name: Install test-package
         run: |
-          pip install --index-url https://test.pypi.org/simple/ baybe==${{  github.ref_name }}
+          pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ baybe==${{  github.ref_name }}
       - name: Download packages built
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           python-version: '3.11'
       - name: Install test-package
         run: |
-          pip install --index-url https://test.pypi.org/simple/ baybe
+          pip install --index-url https://test.pypi.org/simple/ baybe==${{  github.ref_name }}
       - name: Download packages built
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
- now pulls the exact verison form test-PyPI for the check
- adds the original PyPI as fallback for packages not on testPyPI

Note that this would not be accurate if the same tag would have been uploaded to test-PyPI before. But even in that case the correct and most current wheel would be released to PyPI so imo thats fine