### PR TITLE
Post 0.7.0 link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Link handling in documentation
+
 ## [0.7.0] - 2023-12-04
 ### Added
 - GitHub CI pipelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ we recommend the following workflow:
    There are several test environments you can run via `tox`, each corresponding to a
    [developer tool](#developer-tools) in a certain Python version. 
    You can retrieve all available environments via `tox list`.
-   For more information, see our [README about tests](tests/README.md).
+   For more information, see our [README about tests](https://github.com/emdgroup/baybe/blob/main/tests/README.md).
    
    For instance, running all code tests in Python 3.11 can be achieved via:
    ```console
@@ -70,6 +70,7 @@ we recommend the following workflow:
 
 1. Open a pull request via Github's web page.
 
+(developer-tools)=
 ## Developer Tools
 
 In order to maintain a high code quality, we use a variety of code developer tools. 
@@ -98,7 +99,7 @@ tox -e <env>
 ```
 where `<env>` is any of the environment names found via `tox list`.
 
-
+(code-design)=
 ## Code Design
 
 When reading BayBE's code, you will notice certain re-occurring design patterns.
@@ -121,7 +122,7 @@ make sure that the newly written code is well integrated into the existing packa
 module hierarchy.
 In particular, public functionality should be imported into the appropriate high-level
 namespaces for easier user import. For an example, see our
-[parameter namespace](baybe/parameters/__init__.py).
+[parameter namespace](https://github.com/emdgroup/baybe/blob/main/baybe/parameters/__init__.py).
 
 ## Writing Docstrings
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -12,7 +12,7 @@ series of measurements and the iterative sequence of events involved.
 To construct a new campaign, it is necessary to provide two objects.
 1. **A search space:** The parameter space in which the campaign operates. It can be a purely discrete, purely continuous or hybir space.
 We refer to the [`Searchspace`](baybe.searchspace.core.SearchSpace) class resp. the corresponding [user guide](./searchspace) for more details.
-2. **An objective:** The optimization objective. It is possible to either optimize a single target or to combine different targets. We refer to the [`Objective`](baybe.objective.Objective) class resp. the corresponding [user guide](./objectives) for more details.
+2. **An objective:** The optimization objective. It is possible to either optimize a single target or to combine different targets. We refer to the [`Objective`](baybe.objective.Objective) class resp. the corresponding [user guide](./objective) for more details.
 
 The following additional aspects are available to further specify a campaign:
 * **A strategy:**: The strategy that is used during the campaign. As a default, a [`TwoPhaseStrategy`](baybe.strategies.composite.TwoPhaseStrategy) is employed. For more details on strategies, see [here](./strategy).

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -27,6 +27,7 @@ Not all surrogate models are able to treat continuous constraints. In such situa
 the constraints are currently silently ignored.
 ```   
 
+(CLEQ)=
 ### ``ContinuousLinearEqualityConstraint``
 This linear constraint asserts that the following equation is true (up to numerical 
 rounding errors): 
@@ -68,7 +69,7 @@ both sides, i.e. the coefficients and rhs, by -1.
 ```
 
 Let us amend the example from 
-[`ContinuousLinearEqualityConstraint`](#continuouslinearequalityconstraint) and assume 
+[`ContinuousLinearEqualityConstraint`](#CLEQ) and assume 
 that there is always a fourth component to the mixture which serves as a "filler".
 In such a case we might want to ensure that the first three components only make up to 
 80% of the mixture. 
@@ -147,7 +148,7 @@ DiscreteExcludeConstraint(
 
 ### ``DiscreteSumConstraint`` and ``DiscreteProductConstraint``
 These constraints constrain sums or products of numerical parameters. In the example 
-from [``ContinuousLinearEqualityConstraint``](#continuouslinearequalityconstraint) we 
+from [``ContinuousLinearEqualityConstraint``](#CLEQ) we 
 had three continuous parameters ``x_1``, ``x_2`` and ``x_3`` which needed to sum 
 up to 1.0.
 If these parameters were instead discrete, the corresponding constraint would look like:

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ commands =
 [testenv:docs,docs-py{38,39,310,311}]
 description = Build documentation
 extras = docs
+passenv = BAYBE_DOCS_LINKCHECK_IGNORE
 commands = 
     python --version
     python docs/scripts/convert_code_to_documentation.py {posargs}


### PR DESCRIPTION
This PR fixes some links that are broken. These are:
- Links that point to files that are not part of the documentation (baybe/parameters/__init__.py as well as tests/README.md)
- Links that point to headers in the same file (userguide/constraints.md). This was solved by including explicit links as follows:
![image](https://github.com/emdgroup/baybe/assets/84016733/dbfcbec6-8c53-406b-a2f6-a15b705cc02f)
![image](https://github.com/emdgroup/baybe/assets/84016733/f711c812-e174-4e40-b6c5-4c5bcc9982d1)
- Links that were not properly adjusted during a previous rebase (userguide/campaign.md)