### PR TITLE
Mypy for intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Conda install instructions and version badge
 
+### Deprecations
+- `Interval.is_finite` replaced with `Interval.is_closed`
+- `Interval.is_bounded` replaced with `Interval.is_closed` / `Interval.is_half_open`
+
 ## [0.7.1] - 2023-12-07
 ### Added
 - Release pipeline now also publishes source distributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Target enums 
-- `mypy` for targets package
+- `mypy` for targets and intervals
 
 ### Changed
 - Renamed `bounds_transform_func` target attribute to `transform_mode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed `bounds_transform_func` target attribute to `transform_mode`
+- `Interval.is_bounded` now implements the mathematical definition of boundedness
 - Moved and renamed target transform utility functions
 
 ### Removed
 - Conda install instructions and version badge
 
 ### Deprecations
-- `Interval.is_finite` replaced with `Interval.is_closed`
-- `Interval.is_bounded` replaced with `Interval.is_closed` / `Interval.is_half_open`
+- `Interval.is_finite` replaced with `Interval.is_bounded`
 
 ## [0.7.1] - 2023-12-07
 ### Added

--- a/baybe/objective.py
+++ b/baybe/objective.py
@@ -74,7 +74,7 @@ class Objective(SerialMixin):
         # Raises a ValueError if there are unbounded targets when using objective mode
         # DESIRABILITY.
         if self.mode == "DESIRABILITY":
-            if any(not target.bounds.is_bounded for target in targets):
+            if any(not target.bounds.is_closed for target in targets):
                 raise ValueError(
                     "In 'DESIRABILITY' mode for multiple targets, each target must "
                     "have bounds defined."

--- a/baybe/objective.py
+++ b/baybe/objective.py
@@ -74,7 +74,7 @@ class Objective(SerialMixin):
         # Raises a ValueError if there are unbounded targets when using objective mode
         # DESIRABILITY.
         if self.mode == "DESIRABILITY":
-            if any(not target.bounds.is_closed for target in targets):
+            if any(not target.bounds.is_bounded for target in targets):
                 raise ValueError(
                     "In 'DESIRABILITY' mode for multiple targets, each target must "
                     "have bounds defined."

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -114,11 +114,11 @@ class NumericalContinuousParameter(Parameter):
         """Validate bounds.
 
         Raises:
-            InfiniteIntervalError: If the provided interval is not closed.
+            InfiniteIntervalError: If the provided interval is not finite.
         """
-        if not value.is_closed:
+        if not value.is_bounded:
             raise InfiniteIntervalError(
-                f"You are trying to initialize a parameter with an infinite interval "
+                f"You are trying to initialize a parameter with an infinite range "
                 f"of {value.to_tuple()}. Infinite intervals for parameters are "
                 f"currently not supported."
             )

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -114,9 +114,9 @@ class NumericalContinuousParameter(Parameter):
         """Validate bounds.
 
         Raises:
-            InfiniteIntervalError: If the provided interval is infinite.
+            InfiniteIntervalError: If the provided interval is not closed.
         """
-        if not value.is_finite:
+        if not value.is_closed:
             raise InfiniteIntervalError(
                 f"You are trying to initialize a parameter with an infinite interval "
                 f"of {value.to_tuple()}. Infinite intervals for parameters are "

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -24,7 +24,7 @@ if version.parse(sys.version.split()[0]) < version.parse("3.9.8"):
             setattr(cls, "__annotations__", cls.__func__.__annotations__)
         return self.dispatcher.register(cls, func=method)
 
-    singledispatchmethod.register = _register
+    singledispatchmethod.register = _register  # type: ignore[method-assign]
 
 
 class InfiniteIntervalError(Exception):

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -1,6 +1,7 @@
 """Utilities for handling intervals."""
 
 import sys
+import warnings
 from collections.abc import Iterable
 from functools import singledispatchmethod
 from typing import Any, Union
@@ -54,19 +55,45 @@ class Interval:
             )
 
     @property
+    def is_closed(self):
+        """Check whether the interval is closed."""
+        return np.isfinite(self.lower) and np.isfinite(self.upper)
+
+    @property
+    def is_half_open(self):
+        """Check whether the interval is half-open."""
+        return np.isfinite(self.lower) ^ np.isfinite(self.upper)
+
+    @property
+    def is_open(self):
+        """Check whether the interval is open."""
+        return (not np.isfinite(self.lower)) and (not np.isfinite(self.upper))
+
+    @property
     def is_finite(self):
         """Check whether the interval is finite."""
+        warnings.warn(
+            "The use of 'Interval.is_finite' is deprecated and will be disabled in "
+            "a future version. Use 'Interval.is_closed' instead.",
+            DeprecationWarning,
+        )
         return np.isfinite(self.lower) and np.isfinite(self.upper)
 
     @property
     def is_bounded(self):
         """Check whether the interval is bounded."""
+        warnings.warn(
+            "The use of 'Interval.is_bounded' is deprecated and will be disabled in "
+            "a future version. Use 'Interval.is_bounded' or 'Interval.is_half_open' "
+            "instead, depending on the situation.",
+            DeprecationWarning,
+        )
         return np.isfinite(self.lower) or np.isfinite(self.upper)
 
     @property
     def center(self):
-        """The center of the interval. Only applicable for finite intervals."""
-        if not self.is_finite:
+        """The center of the interval. Only applicable for closed intervals."""
+        if not self.is_closed:
             raise InfiniteIntervalError(
                 f"The interval {self} is infinite and thus has no center."
             )
@@ -91,7 +118,7 @@ class Interval:
         return Interval(*bounds)
 
     def to_tuple(self):
-        """Transfor the interval to a tuple."""
+        """Transform the interval to a tuple."""
         return self.lower, self.upper
 
     def to_ndarray(self):

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from collections.abc import Iterable
 from functools import singledispatchmethod
-from typing import Any, Tuple, Union
+from typing import Any, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -88,12 +88,10 @@ class Interval:
         return np.isfinite(self.lower) and np.isfinite(self.upper)
 
     @property
-    def center(self) -> float:
-        """The center of the interval. Only applicable for bounded intervals."""
+    def center(self) -> Optional[float]:
+        """The center of the interval, or ``None`` if the interval is unbounded."""
         if not self.is_bounded:
-            raise InfiniteIntervalError(
-                f"The interval {self} is infinite and thus has no center."
-            )
+            return None
         return (self.lower + self.upper) / 2
 
     @singledispatchmethod

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -119,11 +119,11 @@ class Interval:
         return self.lower, self.upper
 
     def to_ndarray(self) -> np.ndarray:
-        """Transform the interval to a ndarray."""
+        """Transform the interval to a :class:`numpy.ndarray`."""
         return np.array([self.lower, self.upper], dtype=DTypeFloatNumpy)
 
     def to_tensor(self) -> torch.Tensor:
-        """Transform the interval to a tensor."""
+        """Transform the interval to a :class:`torch.Tensor`."""
         return torch.tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
 
     def contains(self, number: float) -> bool:

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -58,45 +58,39 @@ class Interval:
             )
 
     @property
-    def is_closed(self) -> bool:
-        """Check whether the interval is closed."""
-        return np.isfinite(self.lower) and np.isfinite(self.upper)
+    def is_bounded(self) -> bool:
+        """Check if the interval is bounded."""
+        return self.is_left_bounded and self.is_right_bounded
 
     @property
-    def is_half_open(self) -> bool:
-        """Check whether the interval is half-open."""
-        return np.isfinite(self.lower) ^ np.isfinite(self.upper)
+    def is_left_bounded(self) -> bool:
+        """Check if the interval is left-bounded."""
+        return np.isfinite(self.lower)
 
     @property
-    def is_open(self) -> bool:
-        """Check whether the interval is open."""
-        return (not np.isfinite(self.lower)) and (not np.isfinite(self.upper))
+    def is_right_bounded(self) -> bool:
+        """Check if the interval is right-bounded."""
+        return np.isfinite(self.upper)
+
+    @property
+    def is_half_bounded(self) -> bool:
+        """Check if the interval is half-bounded."""
+        return self.is_left_bounded ^ self.is_right_bounded
 
     @property
     def is_finite(self) -> bool:
         """Check whether the interval is finite."""
         warnings.warn(
             "The use of 'Interval.is_finite' is deprecated and will be disabled in "
-            "a future version. Use 'Interval.is_closed' instead.",
+            "a future version. Use 'Interval.is_bounded' instead.",
             DeprecationWarning,
         )
         return np.isfinite(self.lower) and np.isfinite(self.upper)
 
     @property
-    def is_bounded(self) -> bool:
-        """Check whether the interval is bounded."""
-        warnings.warn(
-            "The use of 'Interval.is_bounded' is deprecated and will be disabled in "
-            "a future version. Use 'Interval.is_bounded' or 'Interval.is_half_open' "
-            "instead, depending on the situation.",
-            DeprecationWarning,
-        )
-        return np.isfinite(self.lower) or np.isfinite(self.upper)
-
-    @property
     def center(self) -> float:
-        """The center of the interval. Only applicable for closed intervals."""
-        if not self.is_closed:
+        """The center of the interval. Only applicable for bounded intervals."""
+        if not self.is_bounded:
             raise InfiniteIntervalError(
                 f"The interval {self} is infinite and thus has no center."
             )

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,7 +8,14 @@ exclude = (?x)(
           | baybe/searchspace
           | baybe/strategies
           | baybe/surrogates
-          | baybe/utils
+          | baybe/utils/basic.py
+          | baybe/utils/boolean.py
+          | baybe/utils/botorch_wrapper.py
+          | baybe/utils/chemistry.py
+          | baybe/utils/dataframe.py
+          | baybe/utils/numeric.py
+          | baybe/utils/sampling_algorithms.py
+          | baybe/utils/serialization.py
           | baybe/acquisition.py
           | baybe/campaign.py
           | baybe/deprecation.py

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -8,22 +8,23 @@ from baybe import BayBE, Campaign
 from baybe.searchspace import SearchSpace
 from baybe.strategies import Strategy
 from baybe.targets import Objective
+from baybe.utils.interval import Interval
 
 
 def test_deprecated_baybe_class(parameters, objective):
-    """Using the deprecated ```BayBE``` class should raise a warning."""
+    """Using the deprecated ``BayBE`` class should raise a warning."""
     with pytest.warns(DeprecationWarning):
         BayBE(SearchSpace.from_product(parameters), objective)
 
 
 def test_moved_objective(targets):
-    """Importing ```Objective``` from ```baybe.targets``` should raise a warning."""
+    """Importing ``Objective`` from ``baybe.targets`` should raise a warning."""
     with pytest.warns(DeprecationWarning):
         Objective(mode="SINGLE", targets=targets)
 
 
 def test_renamed_surrogate():
-    """Importing from ```baybe.surrogate``` should raise a warning."""
+    """Importing from ``baybe.surrogate`` should raise a warning."""
     with pytest.warns(DeprecationWarning):
         from baybe.surrogate import GaussianProcessSurrogate  # noqa: F401
 
@@ -38,6 +39,18 @@ def test_missing_strategy_type(config):
 
 
 def test_deprecated_strategy_class():
-    """Using the deprecated ```Strategy``` class should raise a warning."""
+    """Using the deprecated ``Strategy`` class should raise a warning."""
     with pytest.warns(DeprecationWarning):
         Strategy()
+
+
+def test_deprecated_interval_is_finite():
+    """Using the deprecated ``Interval.is_finite`` property should raise a warning."""
+    with pytest.warns(DeprecationWarning):
+        Interval(0, 1).is_finite
+
+
+def test_deprecated_interval_is_bounded():
+    """Using the deprecated ``Interval.is_bounded`` property should raise a warning."""
+    with pytest.warns(DeprecationWarning):
+        Interval(0, 1).is_bounded

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -48,9 +48,3 @@ def test_deprecated_interval_is_finite():
     """Using the deprecated ``Interval.is_finite`` property should raise a warning."""
     with pytest.warns(DeprecationWarning):
         Interval(0, 1).is_finite
-
-
-def test_deprecated_interval_is_bounded():
-    """Using the deprecated ``Interval.is_bounded`` property should raise a warning."""
-    with pytest.warns(DeprecationWarning):
-        Interval(0, 1).is_bounded


### PR DESCRIPTION
Enables `mypy` for the `Interval` class, which are used by targets (done in #54) and parameters (done in #28). Along the way, adds missing type hints and cleans up the class properties.

In particular, replaces the somewhat misleading `is_finite` and `is_bounded` methods with the common and easy-to-understand mathematical definitions `is_open`, `is_half_open` and `is_closed`, ensuring backward compatibility via deprecation mechanisms.

@AVHopp , @Scienfitz: Note that the PR builds upon #54, in order to configure the right diff view.