### PR TITLE
Campaign user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Interval.is_finite` replaced with `Interval.is_bounded`
 - Specifying target configs without explicit type information is deprecated
 
+### Changed
+- New version of campaign user guide and basic example
+
 ## [0.7.1] - 2023-12-07
 ### Added
 - Release pipeline now also publishes source distributions

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -157,7 +157,8 @@ campaign.add_measurements(rec)
 new_rec = campaign.recommend(batch_quantity=5)
 ~~~
 
-After adding the measurements the corresponding `DataFrame` thus has the following form:
+After adding the measurements, the corresponding `DataFrame` thus has the following 
+form:
 
 |    | Categorical_1   | Categorical_2   |   Num_disc_1 |   Target_max |
 |---:|:----------------|:----------------|-------------:|-------------:|
@@ -191,15 +192,17 @@ recreated_campaign = Campaign.from_json(campaign_json)
 assert campaign == recreated_campaign
 ~~~
 
+This provides an easy way to persist the current state of your campaign for long 
+term storage and continue the experimentation at a later point in time.
+For more information on serialization, we
+refer to the corresponding [examples](./../../examples/Serialization/Serialization).
+
 ```{admonition} Dataframe serialization
 :class: note
 Note that `DataFrame` objects associated with the `Campaign` object are converted to 
 a binary format during serialization, which has the consequence that their JSON 
 representation is not human-readable.
 ```
-
-For more information on serialization, we
-refer to the corresponding [examples](./../../examples/Serialization/Serialization).
 
 ## Further information
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -122,8 +122,10 @@ This requirement can be disabled upon initialization of a campaign using the
 ## Serialization
 
 Like most of the objects managed by BayBE, `Campaign` objects can be serialized and
-deserialized using the [`to_json`](baybe.utils.serialization.SerialMixin.to_json)
-method. This method converts the `Campaign` to a string in `json` format. As expected,
+deserialized using the [`to_json`](baybe.utils.serialization.SerialMixin.to_json) and
+[`from_json`](baybe.utils.serialization.SerialMixin.from_json) methods.
+These methods convert the `Campaign` to a string in `json` format resp. convert a string
+in`json` format to a `Campaign` object. As expected,
 serializing and de-serializing a campaign yields the exact identical object:
 ~~~python
 campaign_json = campaign.to_json()

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -132,6 +132,8 @@ campaign_json = campaign.to_json()
 recreated_campaign = Campaign.from_json(campaign_json)
 assert campaign == recreated_campaign
 ~~~
+Note that the serialization stores the `DataFrame` objects associated with the
+`Campaign` object in a special encoding that is not human-readable.
 For more information on serialization, using the `to_json` and `from_json` methods, we
 refer to the corresponding [examples](./../../examples/Serialization/Serialization).
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -65,11 +65,11 @@ For more details and a full exemplary config, we refer to the corresponding
 ### Basics
 
 ```{attention}
-Obtaining recommendations resp. adding measurements using the `recommend` resp.
-`add_measurements` functions is the only safe way to inform a `Campaign` object about
-new measurements. These functions update the necessary metadata that is crucial for the
-proper execution of a campaign. It is important to rely on these functions to maintain
-the integrity and reliability of the campaign's execution.
+Requesting recommendations via `recommend` and adding measurements via
+`add_measurements` is the only intended way to interact with a `Campaign` object.
+These methods update the necessary metadata that is crucial for the proper execution of
+a campaign. We recommend to rely on these methods to maintain the integrity and
+reliability of the object.
 ```
 
 To obtain a recommendation for the next batch of experiments, we can query the 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -87,6 +87,8 @@ each other without considering the joint optimization.
 
 Note that this distinction might not be relevant or applicable for all possible
 situation, for example when using recommenders that do not perform joint optimization.
+Currently, the sequential greedy recommender is the only available recommender
+performing joint optimization.
 ```
 
 ### Caching of recommendations

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -9,60 +9,34 @@ serves as the primary interface for interacting with BayBE as a user. This class
 responsible for handling the data, making recommendations, adding measurements and
 most other tasks.
 
-While creating a campaign can be as simple as specifying a search space with experimental
-parameters and an optimization objective, there are numerous additional aspects that can
-be customized and fine-tuned.
-
 ## Creating a campaign
 
-### Minimal definition
+### Using the campaign class
 
 When constructing a campaign, it is necessary to provide two objects:
 A search space (see [class](baybe.searchspace.core.SearchSpace) resp. [user guide](./searchspace))
 and an optimization objective (see [class](baybe.objective.Objective) resp. [user guide](./objective)).
+Optionally, it is possible to provide a different strategy
+(see [class](baybe.strategies.base.Strategy) resp. [user guide](./strategy)) and specify
+other aspects of the campaign (see [here](#AM) for details on
+`numerical_measurements_must_be_within_tolerance`).
 
-The search space describes the possible configuration of parameters that can be tested during the campaign.
 
-```python
-from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
-from baybe.searchspace import SearchSpace
+~~~python
+from baybe import Campaign
 
-cat_param = CategoricalParameter(name="cat_param", values=["a", "b", "c"])
-numdisc_param = NumericalDiscreteParameter(name="numdisc_param", values = tuple(range(1,11)))
+campaign = Campaign(
+    searchspace=my_searchspace,  # Required
+    objective=my_objective,  # Required
+    strategy=my_strategy,  # Optional
+    numerical_measurements_must_be_within_tolerance=my_boolean,  # Optional
+)
+~~~
 
-space = SearchSpace.from_product([cat_param, numdisc_param])
+```{attention}
+Note that we currently also expose other fields via the constructor. This is
+only temporary, and the corresponding fields should be ignored.
 ```
-
-We refer to the [parameters](./parameters) resp. [search spaces](./searchspace) user
-guides for more details.
-
-For the optimization objective, we use a function taking values from 1 to 10 that we aim
-to maximize.
-
-```python
-from baybe.targets import NumericalTarget
-from baybe.objective import Objective
-
-target = NumericalTarget(name="quality", mode="MAX", bounds=(1,10))
-objective = Objective(mode="SINGLE", targets=[target])
-```
-
-Combining the search space and the objective now enables us to create a campaign.
-
-```python
-from baybe.campaign import Campaign
-
-campaign = Campaign(searchspace=space, objective=objective)
-```
-
-### Providing a different strategy
-
-By default, campaigns use the composite
-[`TwoPhaseStrategy`](baybe.strategies.composite.TwoPhaseStrategy).
-Using the optional `strategy` keyword, it is possible to provide a different
-[Strategy](baybe.strategies.base.Strategy).
-For more information on strategies in general, we refer to the corresponding
-[user guide](./strategy).
 
 ### Creating a campaign via a JSON config
 
@@ -70,7 +44,7 @@ It is also possible to specify a `Campaign` via a configuration string and using
 function [`Campaign.from_config`](baybe.campaign.Campaign.from_config).
 The specification of config files as well as what they contain are automatically
 derived from the class structure.
-Furthermore, a config file can be valuated using the function 
+Furthermore, a config file can be validated using 
 [Campaign.validate_config](baybe.campaign.Campaign.validate_config).
 For more details and a full exemplary config, we refer to the corresponding
 [example](./../../examples/Serialization/create_from_config).
@@ -85,68 +59,65 @@ Obtaining recommendations resp. adding measurements using the `recommend` resp.
 new measurements. These functions update the necessary metadata that is crucial for the
 proper execution of a campaign. It is important to rely on these functions to maintain
 the integrity and reliability of the campaign's execution.
-
-Further note that we currently also expose other fields via the constructor. This is
-only temporary, and the corresponding fields should be ignored.
 ```
 
 To obtain a recommendation for the next experiment, we can query the campaign and use
 the [`recommend`](baybe.campaign.Campaign.recommend) function. The function takes only
-one argument, which is the `batch_quantity` keyword. This specifies the desired size of
+the `batch_quantity` keyword, specifying the desired size of
 the batch of experiments to be conducted.
 
-```python
+~~~python
 rec = campaign.recommend(batch_quantity=3)
-```
+~~~
 
 The `recommend` function returns a `DataFrame` with `batch_quantity` many rows, each 
 representing a set of parameters from the search space.
 
-### Influence of the batch size
-
-Regarding the choice of a suitable `batch_size`, it is important to understand the
-difference between performing multiple recommendations with batch size of 1 and a single
-recommendation with a larger batch size.
-* **Batch size larger than 1**: When using a larger batch size, the recommended experiments
+```{important}
+There is a difference between performing multiple recommendations
+with batch size of 1 and a single recommendation with a larger batch size.
+* **Batch size larger than 1**: The recommended experiments
 are chosen to *jointly* optimized the acquisition function.
 This means that the recommendations are made considering the interaction of multiple
 experiments together.
-* **Batch size of 1**: When making several smaller recommendations, each *individual*
-recommendation optimizes the acquisition function at the specific point in time when it
-is requested. In this case, the recommendations are made independently of each other
-without considering the joint optimization.
+* **Batch size of 1**: When making several smaller recommendations instead, each
+*individual* recommendation optimizes the acquisition function at the specific point in 
+time when it is requested. In this case, the recommendations are made independently of
+each other without considering the joint optimization.
+
 Note that this distinction might not be relevant or applicable for all possible
 situation, for example when using recommenders that do not perform joint optimization.
-
+```
 
 ### Caching of recommendations
 
 Whenever recommendations are made, the `Campaign` object caches them. If measurements
 for the recommendations are added, then the cached recommendations are deleted. However,
 if no measurements are added and the `recommend` function is called again, then the
-`Campaign` object simply returns the cached recommendations instead of generating new
+`Campaign` object returns the cached recommendations instead of generating new
 ones. In addition, the cache is also reset if the batch size of the repeated call has
 changed compared to the first one. This is due to the way the batch size influences
 which points are being recommended.
 This caching mechanism helps to optimize performance by avoiding unnecessary
 re-computations when measurements are not provided.
 
+(AM)=
 ## Adding measurements
 
-To add measurements, we expand the  `DataFrame` that was created by the `recommend`
-function by adding a new column for the target. We can then provide the campaign with
-these measurements and receive a new recommendation.
+Measurements are added by expanding the  `DataFrame` that was created by the `recommend`
+function by adding a new column for the target. 
 
-```python
-rec["quality"] = [2,4,9]
+~~~python
+rec["my_target"] = [2,4,9] # 3 values matching the batch_quantity of 3
 campaign.add_measurements(rec)
 new_rec = campaign.recommend(batch_quantity=5)
-```
+~~~
 
 For discrete parameters, measurements are required to fall into a
 predefined tolerance by default.
 This tolerance is defined on the level of the individual parameters.
-This requirement can be disabled upon initialization of a Campaign by using the `numerical_measurements_must_be_within_tolerance` flag.
+This requirement can be disabled upon initialization of a campaign using the
+`numerical_measurements_must_be_within_tolerance` flag.
 
 ## Serialization
 
@@ -154,11 +125,11 @@ Like most of the objects managed by BayBE, `Campaign` objects can be serialized 
 deserialized using the [`to_json`](baybe.utils.serialization.SerialMixin.to_json)
 method. This method converts the `Campaign` to a string in `json` format. As expected,
 serializing and de-serializing a campaign yields the exact identical object:
-```python
+~~~python
 campaign_json = campaign.to_json()
 recreated_campaign = Campaign.from_json(campaign_json)
 assert campaign == recreated_campaign
-```
+~~~
 For more information on serialization, using the `to_json` and `from_json` methods, we
 refer to the corresponding [examples](./../../examples/Serialization/Serialization).
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -93,22 +93,41 @@ with the three parameters `Categorial_1`, `Categorical_2` and `Num_disc_1`:
 | 18 | C               | bad             |            1 |
 |  9 | B               | bad             |            1 |
 
-```{important}
-There is a difference between performing multiple recommendations
-with batch size of 1 and a single recommendation with a larger batch size.
-* **Batch size larger than 1**: The recommended experiments
-are chosen to *jointly* optimized the acquisition function.
-This means that the recommendations are made considering the interaction of multiple
-experiments together.
-* **Batch size of 1**: When making several smaller recommendations instead, each
-*individual* recommendation optimizes the acquisition function at the specific point in
-time when it is requested. In this case, the recommendations are made independently of
-each other without considering the joint optimization.
+```{admonition} Batch optimization
+:class: important
+In general, the parameter configurations in a recommended batch are **jointly**
+optimized and therefore tailored to the specific batch size requested. 
+This means that for two batches of different requested sizes, the smaller batch will not 
+necessarily correspond to a subset of the configurations contained in the larger batch. 
+An intuitive explanation for this phenomenon is that the more experiments one can 
+afford to run, the less need there is to focus on "safe bets" and the more room
+becomes available to test "high-risk/high-gain" configurations, since only one of the
+tested configurations from the batch has to perform well.
 
-Note that this distinction might not be relevant or applicable for all possible
-situation, for example when using recommenders that do not perform joint optimization.
-Currently, the sequential greedy recommender is the only available recommender
-performing joint optimization.
+**The bottom line is:** You should always ask for exactly as many
+recommendations as you are willing to run parallel experiments in your next 
+experimental iteration.
+An approach where only a subset of experiments taken from a larger recommended batch is
+used is strongly discouraged.
+
+**Note:** While the above distinction is true in the general case, it may not be 
+relevant for all configured settings, for instance, when the used recommender 
+is not capable of joint optimization. Currently, the 
+[SequentialGreedyRecommender](baybe.recommenders.bayesian.SequentialGreedyRecommender)
+is the only recommender available that performs joint optimization.
+```
+
+```{admonition} Sequential vs. parallel experimentation
+:class: note
+If you have a fixed experimental budget but the luxury of choosing 
+whether to run your experiments sequentially or in parallel, sequential 
+experimentation will give you the better overall results in expectation.
+This is because in the sequential approach, each subsequent recommendation can 
+leverage the additional data from previous iterations, which allows 
+more accurate predictive models to be built. However, in real-world use cases, the 
+question is typically answered by other factors, such as whether parallel
+experimentation is feasible in the first place, or whether the given time budget 
+even allows for sequential runs.
 ```
 
 ### Caching of recommendations

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -1,9 +1,10 @@
 # Campaigns
 
-[... add some brief general (non-BayBE related!) intro about campaigns here: what are
-they, why do they naturally arise in the context of Bayesian optimization ... similar
-to the general part in other guide sections ...]
-In summary, campaigns are an integral part of Bayesian optimization and, accordingly,
+When it comes to Bayesian optimization, campaigns emerge as an essential component.
+They encompass a group of interconnected experiments that collectively aim to navigate
+the search space and find an optimal solution. They take center stage in orchestrating
+the iterative process of selecting, evaluating, and refining candidate solutions.
+Thus, campaigns are an integral part of Bayesian optimization and, accordingly,
 they also play a central role in BayBE.
 
 The [`Campaign`](baybe.campaign.Campaign) class provides a structured framework for 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -79,10 +79,19 @@ experiments to be conducted.
 
 ~~~python
 rec = campaign.recommend(batch_quantity=3)
+print(rec.to_markdown())
 ~~~
 
 Calling the function returns a `DataFrame` with `batch_quantity` many rows, each
 representing a particular parameter configuration from the campaign's search space.
+Thus, the following might be a `DataFrame` returned by `recommend` in a search space
+with the three parameters `Categorial_1`, `Categorical_2` and `Num_disc_1`:
+
+|    | Categorical_1   | Categorical_2   |   Num_disc_1 |
+|---:|:----------------|:----------------|-------------:|
+| 15 | B               | good            |            1 |
+| 18 | C               | bad             |            1 |
+|  9 | B               | bad             |            1 |
 
 ```{important}
 There is a difference between performing multiple recommendations
@@ -128,6 +137,14 @@ rec["Target_max"] = [2, 4, 9]  # 3 values matching the batch_quantity of 3
 campaign.add_measurements(rec)
 new_rec = campaign.recommend(batch_quantity=5)
 ~~~
+
+After adding the measurements the corresponding `DataFrame` thus has the following form:
+
+|    | Categorical_1   | Categorical_2   |   Num_disc_1 |   Target_max |
+|---:|:----------------|:----------------|-------------:|-------------:|
+| 15 | B               | good            |            1 |            2 |
+| 18 | C               | bad             |            1 |            4 |
+|  9 | B               | bad             |            1 |            9 |
 
 ```{note}
 For discrete parameters, the parameter values associated with the provided measurements

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -165,7 +165,8 @@ After adding the measurements the corresponding `DataFrame` thus has the followi
 | 18 | C               | bad             |            1 |            4 |
 |  9 | B               | bad             |            1 |            9 |
 
-```{note}
+```{admonition} Parameter tolerances
+:class: note
 For discrete parameters, the parameter values associated with the provided measurements
 are required to fall into a predefined tolerance interval by default, which is
 defined on the level of the individual parameters.
@@ -190,7 +191,8 @@ recreated_campaign = Campaign.from_json(campaign_json)
 assert campaign == recreated_campaign
 ~~~
 
-```{note}
+```{admonition} Dataframe serialization
+:class: note
 Note that `DataFrame` objects associated with the `Campaign` object are converted to 
 a binary format during serialization, which has the consequence that their JSON 
 representation is not human-readable.

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -1,6 +1,6 @@
 # Campaigns
 
-Campaigns play a crucial role in Design of Experiments, and consequently also for BayBE.
+Campaigns play a crucial role in Design of Experiments (DOE), and consequently also for BayBE.
 They serve as a structured framework for defining and documenting an experimentation
 process.
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -26,10 +26,10 @@ other aspects of the campaign (see [here](#AM) for details on
 from baybe import Campaign
 
 campaign = Campaign(
-    searchspace=my_searchspace,  # Required
-    objective=my_objective,  # Required
-    strategy=my_strategy,  # Optional
-    numerical_measurements_must_be_within_tolerance=my_boolean,  # Optional
+    searchspace=searchspace,  # Required
+    objective=objective,  # Required
+    strategy=strategy,  # Optional
+    numerical_measurements_must_be_within_tolerance=boolean,  # Optional
 )
 ~~~
 
@@ -108,7 +108,7 @@ Measurements are added by expanding the  `DataFrame` that was created by the `re
 function by adding a new column for the target. 
 
 ~~~python
-rec["my_target"] = [2,4,9] # 3 values matching the batch_quantity of 3
+rec["Target_max"] = [2,4,9] # 3 values matching the batch_quantity of 3
 campaign.add_measurements(rec)
 new_rec = campaign.recommend(batch_quantity=5)
 ~~~

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -91,8 +91,8 @@ situation, for example when using recommenders that do not perform joint optimiz
 
 ### Caching of recommendations
 
-Whenever recommendations are made, the `Campaign` object caches them. If measurements
-for the recommendations are added, then the cached recommendations are deleted. However,
+Whenever recommendations are made, the `Campaign` object caches them. If any new 
+measurements are added, then the cached recommendations are deleted. However,
 if no measurements are added and the `recommend` function is called again, then the
 `Campaign` object returns the cached recommendations instead of generating new
 ones. In addition, the cache is also reset if the batch size of the repeated call has

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -108,7 +108,7 @@ Measurements are added by expanding the  `DataFrame` that was created by the `re
 function by adding a new column for the target. 
 
 ~~~python
-rec["Target_max"] = [2,4,9] # 3 values matching the batch_quantity of 3
+rec["Target_max"] = [2, 4, 9]  # 3 values matching the batch_quantity of 3
 campaign.add_measurements(rec)
 new_rec = campaign.recommend(batch_quantity=5)
 ~~~

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -2,28 +2,20 @@
 
 Campaigns play a crucial role in Design of Experiments, and consequently also for BayBE.
 They serve as a structured framework for defining and documenting an experimentation
-process. The [`Campaign`](baybe.campaign.Campaign) class is used to model campaigns and 
-serves as the primary interface for interacting with BayBE.
+process.
+
+The [`Campaign`](baybe.campaign.Campaign) class is used to model campaigns and 
+serves as the primary interface for interacting with BayBE as a user. This class is
+responsible for handling the data, making recommendations, adding measurements and
+most other tasks.
+
 While creating a campaign can be as simple as specifying a search space with experimental
 parameters and an optimization objective, there are numerous additional aspects that can
 be customized and fine-tuned.
 
-## Our example: Optimizing the brewing of coffee
+## Creating a campaign
 
-Since a researcher is a person turning caffeine into either theory or code, we use the
-example of optimizing the process of brewing coffee in this user guide.
-
-We use the following parameters for optimizing our brewing process:
-* **Grind size:** The grind size influences the extraction of the flavors.
-The available options are ``[coarse, rather_coarse, rather_fine, fine]``.
-* **Water temperature:** The temperature affects the rate at which the coffee compounds
-are extracted. We can vary the temperature in 0.1°C increments within the range of
-90.5°C to 96°C.
-* **Brewing time:** The brewing time can influence the coffee flavor due to potential
-over- or under-extraction. We allow brewing times between 120 and 360 seconds, with the
-ability to stop brewing after each 10-second interval.
-
-## Minimal definition of a campaign
+### Minimal definition
 
 When constructing a campaign, it is necessary to provide two objects:
 A search space (see [class](baybe.searchspace.core.SearchSpace) resp. [user guide](./searchspace))
@@ -35,19 +27,17 @@ The search space describes the possible configuration of parameters that can be 
 from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
 from baybe.searchspace import SearchSpace
 
-grind_size = CategoricalParameter(name="grind_size", values=["coarse", "rather_coarse", "rather_fine", "fine"])
-temp = NumericalDiscreteParameter(name="temp", values = tuple([t/10.0 for t in range (905, 961)]))
-time = NumericalDiscreteParameter(name="time", values = tuple(range(120, 370, 10)))
+cat_param = CategoricalParameter(name="cat_param", values=["a", "b", "c"])
+numdisc_param = NumericalDiscreteParameter(name="numdisc_param", values = tuple(range(1,11)))
 
-space = SearchSpace.from_product([grind_size, temp, time])
+space = SearchSpace.from_product([cat_param, numdisc_param])
 ```
 
 We refer to the [parameters](./parameters) resp. [search spaces](./searchspace) user
 guides for more details.
 
-To assess the quality of our coffee, we use a subjective evaluation method
-involving tasting and assigning a rating on a scale of 1 to 10, where a higher score
-indicates better quality.
+For the optimization objective, we use a function taking values from 1 to 10 that we aim
+to maximize.
 
 ```python
 from baybe.targets import NumericalTarget
@@ -65,14 +55,39 @@ from baybe.campaign import Campaign
 campaign = Campaign(searchspace=space, objective=objective)
 ```
 
-## Getting a recommendation and adding a measurement
+### Providing a different strategy
+
+By default, campaigns use the composite
+[`TwoPhaseStrategy`](baybe.strategies.composite.TwoPhaseStrategy).
+Using the optional `strategy` keyword, it is possible to provide a different
+[Strategy](baybe.strategies.base.Strategy).
+For more information on strategies in general, we refer to the corresponding
+[user guide](./strategy).
+
+### Creating a campaign via a JSON config
+
+It is also possible to specify a `Campaign` via a configuration string and using the
+function [`Campaign.from_config`](baybe.campaign.Campaign.from_config).
+The specification of config files as well as what they contain are automatically
+derived from the class structure.
+Furthermore, a config file can be valuated using the function 
+[Campaign.validate_config](baybe.campaign.Campaign.validate_config).
+For more details and a full exemplary config, we refer to the corresponding
+[example](./../../examples/Serialization/create_from_config).
+
+## Getting recommendations
+
+### Basics
 
 ```{attention}
-Adding recommendations and measurements using the `recommend` and `add_measurements`
-functions is the safe only way to inform a `Campaign` object about new measurements.
-These functions update the necessary metadata that is crucial for the proper
-execution of a campaign. It is important to rely on these functions to maintain the
-integrity and reliability of the campaign's execution.
+Obtaining recommendations resp. adding measurements using the `recommend` resp.
+`add_measurements` functions is the only safe way to inform a `Campaign` object about
+new measurements. These functions update the necessary metadata that is crucial for the
+proper execution of a campaign. It is important to rely on these functions to maintain
+the integrity and reliability of the campaign's execution.
+
+Further note that we currently also expose other fields via the constructor. This is
+only temporary, and the corresponding fields should be ignored.
 ```
 
 To obtain a recommendation for the next experiment, we can query the campaign and use
@@ -86,44 +101,23 @@ rec = campaign.recommend(batch_quantity=3)
 
 The `recommend` function returns a `DataFrame` with `batch_quantity` many rows, each 
 representing a set of parameters from the search space.
-To add measurements, we expand the `DataFrame` by adding a new column for the target.
-We can then provide the campaign with these measurements and receive a new
-recommendation.
 
-```python
-rec["quality"] = [2,4,9]
-campaign.add_measurements(rec)
-new_rec = campaign.recommend(batch_quantity=5)
-```
+### Influence of the batch size
 
-## Further specification of campaigns
-
-Although only a search space and an objective are necessary to create a campaign,
-several other aspects can be changed by the user.
-1. **A strategy:**: By default, campaigns use the composite
-[`TwoPhaseStrategy`](baybe.strategies.composite.TwoPhaseStrategy).
-This can be changed using the `strategy` keyword.
-2. **Numerical tolerance**: By default, numerical measurements are required to fall into
-a predefined tolerance. This requirement can be disabled by using the
-`numerical_measurements_must_be_within_tolerance` flag.
-
-
-## Details on design and functionality
-
-### Batch sizes and their influence on recommendations
-
-The `batch_quantity` keyword allows you to adjust the number of recommendations returned
-by the `recommend` function. However, it is important to understand the difference
-between performing multiple recommendations with batch size of 1 and a single
+Regarding the choice of a suitable `batch_size`, it is important to understand the
+difference between performing multiple recommendations with batch size of 1 and a single
 recommendation with a larger batch size.
-* **Larger batch size**: When using a larger batch size, the recommended experiments are
-chosen to *jointly* optimized the acquisition function.
+* **Batch size larger than 1**: When using a larger batch size, the recommended experiments
+are chosen to *jointly* optimized the acquisition function.
 This means that the recommendations are made considering the interaction of multiple
 experiments together.
-* **Smaller batch size**: When making several smaller recommendations, each *individual*
+* **Batch size of 1**: When making several smaller recommendations, each *individual*
 recommendation optimizes the acquisition function at the specific point in time when it
 is requested. In this case, the recommendations are made independently of each other
 without considering the joint optimization.
+Note that this distinction might not be relevant or applicable for all possible
+situation, for example when using recommenders that do not perform joint optimization.
+
 
 ### Caching of recommendations
 
@@ -131,13 +125,33 @@ Whenever recommendations are made, the `Campaign` object caches them. If measure
 for the recommendations are added, then the cached recommendations are deleted. However,
 if no measurements are added and the `recommend` function is called again, then the
 `Campaign` object simply returns the cached recommendations instead of generating new
-ones. This caching mechanism helps to optimize performance by avoiding unnecessary
+ones. In addition, the cache is also reset if the batch size of the repeated call has
+changed compared to the first one. This is due to the way the batch size influences
+which points are being recommended.
+This caching mechanism helps to optimize performance by avoiding unnecessary
 re-computations when measurements are not provided.
 
-### Serialization
+## Adding measurements
 
-Like most of the objects managed by BayBE, `Campaign` objects in BayBE can be serialized
-and deserialized using the [`to_json`](baybe.utils.serialization.SerialMixin.to_json)
+To add measurements, we expand the  `DataFrame` that was created by the `recommend`
+function by adding a new column for the target. We can then provide the campaign with
+these measurements and receive a new recommendation.
+
+```python
+rec["quality"] = [2,4,9]
+campaign.add_measurements(rec)
+new_rec = campaign.recommend(batch_quantity=5)
+```
+
+For discrete parameters, measurements are required to fall into a
+predefined tolerance by default.
+This tolerance is defined on the level of the individual parameters.
+This requirement can be disabled upon initialization of a Campaign by using the `numerical_measurements_must_be_within_tolerance` flag.
+
+## Serialization
+
+Like most of the objects managed by BayBE, `Campaign` objects can be serialized and
+deserialized using the [`to_json`](baybe.utils.serialization.SerialMixin.to_json)
 method. This method converts the `Campaign` to a string in `json` format. As expected,
 serializing and de-serializing a campaign yields the exact identical object:
 ```python
@@ -148,12 +162,8 @@ assert campaign == recreated_campaign
 For more information on serialization, using the `to_json` and `from_json` methods, we
 refer to the corresponding [examples](./../../examples/Serialization/Serialization).
 
-It is also possible to specify a `Campaign` via a configuration string and the function
-[`Campaign.from_config`](baybe.campaign.Campaign.from_config).
-As fully specifying a configuration takes too much, we refer to the corresponding
-[example](./../../examples/Serialization/create_from_config).
+## Further information
 
-### Further information
-
-For an additional and more condensed example explaining the `Campaign` object, we refer
-to the corresponding [example](./../../examples/Basics/campaign).
+In all of the [examples](./../../examples/examples), a campaign is created. For more
+details on how to create campaigns for a specific use case, we thus propose to have
+a look at the most suitable example.

--- a/examples/Basics/campaign.py
+++ b/examples/Basics/campaign.py
@@ -1,8 +1,8 @@
 ### Basic example for using BayBE
 
 # This example shows how to create a campaign and how to use it.
-# It details how a user can first define parameters of the searchspace and the objective.
-# These can then be used to create a proper campaign that can be used to get recommendations.
+# It is intended to be used as a first point of interaction with campaign after having
+# read the corresponding [user guide](./../../userguide/campaigns).
 
 #### Necessary imports for this example
 
@@ -13,20 +13,10 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Creation of searchspace object
+#### Setup
 
-# This part shows how the user can create a searchspace object.
-# In general, searchspaces can be continuous, discrete or hybrid.
-# This depends on the parameters of the searchspace.
-# In this examples, a basic discrete searchspace is presented.
-# Discrete variables can be numerical, categorical or encoded chemical substances.
-
-# To create a searchspace, we need to define all parameters that can vary between experiments.
-
-# This example presents the optimization of a direct Arylation reaction.
-# For this, we require data for solvents, ligands and bases.
-
-# The available solvents, bases and ligands are described in the following dictionaries via SMILES.
+# This example presents the optimization of a direct Arylation reaction in a discrete
+# space. For this, we require data for solvents, ligands and bases.
 
 dict_solvent = {
     "DMAc": r"CC(N(C)C)=O",
@@ -49,17 +39,14 @@ dict_ligand = {
     "(t-Bu)PhCPhos": r"CN(C)C1=CC=CC(N(C)C)=C1C2=CC=CC=C2P(C(C)(C)C)C3=CC=CC=C3",
 }
 
-# This part shows how to create the parameter objects that are used to create the campaign.
 # We define the chemical substances parameters using the dictionaries defined previously.
 # Here, we use `"MORDRED"` encoding, but others are available.
-
-# We proceed to define numerical discrete parameters: `temperature` and `concentration`.
+# We proceed to define numerical discrete parameters `temperature` and `concentration`
+# and create the search space.
 
 solvent = SubstanceParameter("Solvent", data=dict_solvent, encoding="MORDRED")
 base = SubstanceParameter("Base", data=dict_base, encoding="MORDRED")
 ligand = SubstanceParameter("Ligand", data=dict_ligand, encoding="MORDRED")
-
-# Define numerical discrete parameters: Temperature, Concentration
 
 temperature = NumericalDiscreteParameter(
     "Temperature", values=[90, 105, 120], tolerance=2
@@ -68,28 +55,16 @@ concentration = NumericalDiscreteParameter(
     "Concentration", values=[0.057, 0.1, 0.153], tolerance=0.005
 )
 
-# To simplify the creation of the campaign, we collect all parameters in a single list.
-
 parameters = [solvent, base, ligand, temperature, concentration]
-
-# The searchspace object can now be easily created as follows.
 
 searchspace = SearchSpace.from_product(parameters=parameters)
 
-#### Creation of objective object
-
-# In this part we specify the objective of the optimization process.
-# In this example, we consider a single numerical target.
-# The user indicates the target variable as well as what he is trying to achieve.
-# That is, the user can decide whether to maximize, minimize or match a specific value.
-# In this example, we maximize the yield of a reaction.
-# Hence, we indicate that the target is numerical, named `"yield"` and use the mode `"MAX"`.
+# In this example, we maximize the yield of a reaction and define a corresponding
+# objective.
 
 objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
-
-#### Creation of a campaign
 
 # We now finally create the campaign using the objects configure previously.
 
@@ -98,46 +73,22 @@ campaign = Campaign(
     objective=objective,
 )
 
-# Note that an additional strategy object can be specified while creating the campaign.
-# This object and its parameters are described in the basic example 'strategies'
-# If no strategy is supplied, a default one is used.
-# Details on strategies can be found in [`strategies`](./strategies.md)
+#### Getting a recommendation and adding measurements
 
-#### Getting a recommendation
+# We use the `recommend()` function of the campaign for getting measurements.
 
-# In this part we use the campaign to recommend the next experiments to be conducted.
-# To do so we use the `recommend()` function of the campaign.
+recommendation = campaign.recommend(batch_quantity=2)
 
-# The user can specify the size of the batch of recommendations desired.
-# The value needs to be an integer >= 1.
-
-recommendation = campaign.recommend(batch_quantity=1)
-
-print("\n\nRecommended measurements with batch_quantity = 1: ")
+print("\n\nRecommended measurements with batch_quantity = 2: ")
 print(recommendation)
 
-# `recommendation` is a dataframe with one column per parameter.
-# Each row is a suggested experiment filled with a value to try for each parameter.
-
-# If we set a greater batch quantity, the `recommendation` dataframe contains more rows.
-
-for batch_quantity in [2, 3]:
-    recommendation = campaign.recommend(batch_quantity=batch_quantity)
-    print(f"\n\nRecommended measurements with batch_quantity = {batch_quantity}: ")
-    print(recommendation)
-
-#### Adding a measurement
-
-# In this part we add target values obtained while conducting new measurements.
-# This is done by creating a new column in the `recommendation` dataframe named after the target.
-# In this example, we use the `add_fake_results()` utility function to create some fake results.
+# Adding target values is done by creating a new column in the `recommendation`
+# dataframe named after the target.
+# In this example, we use the `add_fake_results()` utility to create fake results.
+# We then update the campaign by adding the measurements.
 
 add_fake_results(recommendation, campaign)
 print("\n\nRecommended experiments with fake measured values: ")
 print(recommendation)
-
-# The recommendation dataframe now has a new column named `yield` filled with fake values.
-
-# Finally, we update the campaign by adding the measurement.
 
 campaign.add_measurements(recommendation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -543,6 +543,12 @@ def fixture_campaign(parameters, constraints, strategy, objective):
     )
 
 
+@pytest.fixture(name="searchspace")
+def fixture_searchspace(parameters, constraints):
+    """Returns a searchspace."""
+    return SearchSpace.from_product(parameters=parameters, constraints=constraints)
+
+
 @pytest.fixture(name="twophase_strategy")
 def fixture_default_twophase_strategy(recommender, initial_recommender):
     """The default ```TwoPhaseStrategy``` to be used if not specified differently."""


### PR DESCRIPTION
This PR reorganizes the campaign user guide and thus implements #60 .
The user guide is now way more informative, contains more details and better explanation. As there a lot of the code and specifically the explanations in the new user guide and the previous basic examples were duplicate, the corresponding example was trimmed down and condensed.
