### PR TITLE
Fix type alias and generic in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `bounds_transform_func` target attribute to `transformation`
 - `Interval.is_bounded` now implements the mathematical definition of boundedness
 - Moved and renamed target transform utility functions
+- Examples have two levels of headings in the table of content
+- Fix orders of examples in table of content
 
 ### Fixed
 - Wrong use of `tolerance` argument in constraints user guide
+- Errors with generics and type aliases in documentation
 
 ### Removed
 - Conda install instructions and version badge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -214,6 +216,7 @@ html_theme_options = {
 if "BAYBE_DOCS_LINKCHECK_IGNORE" in os.environ:
     linkcheck_ignore = ["https://emdgroup.github.io/baybe/"]
 
+autodoc_type_aliases = {"Smiles": "Smiles"}
 
 # Everything in the module has the prefix baybe
 modindex_common_prefix = ["baybe."]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,11 @@ nitpick_ignore_regex = [
     (r"py:.*", "baybe.constraints.conditions.Condition.__init__"),
     (r"py:.*", "baybe.utils.serialization.SerialMixin.__init__"),
     (r"DeprecationWarning:", ""),
+    # Ignore the generics in utils.basic
+    # Might be able to us a regex here, is done explicitly at the moment for full
+    # transparency.
+    (r"py:class", "baybe.utils.basic._T"),
+    (r"py:class", "baybe.utils.basic._U"),
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/templates/custom-attribute-template.rst
+++ b/docs/templates/custom-attribute-template.rst
@@ -1,0 +1,7 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+{% if not fullname in ("Smiles") %}
+.. auto{{ objtype }}:: {{ objname }}
+{% endif %}

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -7,7 +7,8 @@
    .. rubric:: Module Attributes
 
    .. autosummary::
-      :toctree:                                  
+      :toctree: 
+      :template: custom-attribute-template.rst                               
    {% for item in attributes %}
       {{ item }}
    {%- endfor %}


### PR DESCRIPTION
This PR fixes the following minor errors in the documentation.
1. The `Smiles` type alias introduced in `parameters.substance`. This type alias is manually configured in `conf.py`. In order to avoid the documentation to load all of the attributes and functions of `str`, the templates were changed slightly to not include those, resulting in the output shown at the end.
2. The generics in `baybe.utils.basic`. Sphinx behaves weird when using generics (see https://github.com/sphinx-doc/sphinx/issues/10974). Thus, an exception was included in the nitpick_ignore dictionary, eliminating the error.
![image](https://github.com/emdgroup/baybe/assets/84016733/f797d0fa-5cc6-44bd-813a-866990693408)
![image](https://github.com/emdgroup/baybe/assets/84016733/0232bf51-9cbb-4644-b943-d47ed950eedc)
![image](https://github.com/emdgroup/baybe/assets/84016733/b080dd11-305f-44a6-af28-c50e30958235)
