### PR TITLE
torch import optimization

### DIFF
--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar, List, Tuple
 
 import pandas as pd
-
 from attr import define, field
 from attr.validators import min_len
 from torch import Tensor, tensor

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar, List, Tuple
 
 import pandas as pd
-import torch
+
 from attr import define, field
 from attr.validators import min_len
 from torch import Tensor
@@ -18,6 +18,7 @@ from baybe.utils import (
     unstructure_base,
 )
 from baybe.utils.serialization import converter
+from baybe.utils.lazy_loader import LazyLoader
 
 
 @define
@@ -158,7 +159,8 @@ class ContinuousConstraint(Constraint, ABC):
             for p in self.parameters
             if p in param_names
         ]
-
+        lazy_loader = LazyLoader("torch")
+        torch = lazy_loader.load()
         return (
             torch.tensor(param_indices),
             torch.tensor(self.coefficients, dtype=DTypeFloatTorch),

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from attr import define, field
 from attr.validators import min_len
-from torch import Tensor
+from torch import Tensor, tensor
 
 from baybe.constraints.conditions import Condition
 from baybe.parameters import NumericalContinuousParameter
@@ -18,7 +18,6 @@ from baybe.utils import (
     unstructure_base,
 )
 from baybe.utils.serialization import converter
-from baybe.utils.lazy_loader import LazyLoader
 
 
 @define
@@ -159,11 +158,10 @@ class ContinuousConstraint(Constraint, ABC):
             for p in self.parameters
             if p in param_names
         ]
-        lazy_loader = LazyLoader("torch")
-        torch = lazy_loader.load()
+
         return (
-            torch.tensor(param_indices),
-            torch.tensor(self.coefficients, dtype=DTypeFloatTorch),
+            tensor(param_indices),
+            tensor(self.coefficients, dtype=DTypeFloatTorch),
             self.rhs,
         )
 

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -6,10 +6,11 @@ from abc import ABC, abstractmethod
 from typing import Callable, Dict, Tuple, Type
 
 import pandas as pd
-import torch
+
 from torch import Tensor
 
 from baybe.utils import to_tensor
+from baybe.utils.lazy_loader import LazyLoader
 
 _ScaleFun = Callable[[Tensor], Tensor]
 
@@ -94,12 +95,16 @@ class DefaultScaler(Scaler):
 
     type = "DEFAULT"
     # See base class.
-
+    
     def fit_transform(  # noqa: D102
         self, x: Tensor, y: Tensor
     ) -> Tuple[Tensor, Tensor]:
         # See base class.
 
+        # Load PyTorch using our LazyLoader class
+        lazy_loader = LazyLoader("torch")
+        torch = lazy_loader.load()
+        
         # Get the searchspace boundaries
         searchspace = to_tensor(self.searchspace)
         bounds = torch.vstack(

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from typing import Callable, Dict, Tuple, Type
 
 import pandas as pd
-
 from torch import Tensor
 
 from baybe.utils import to_tensor

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -95,7 +95,7 @@ class DefaultScaler(Scaler):
 
     type = "DEFAULT"
     # See base class.
-    
+
     def fit_transform(  # noqa: D102
         self, x: Tensor, y: Tensor
     ) -> Tuple[Tensor, Tensor]:
@@ -104,7 +104,7 @@ class DefaultScaler(Scaler):
         # Load PyTorch using our LazyLoader class
         lazy_loader = LazyLoader("torch")
         torch = lazy_loader.load()
-        
+
         # Get the searchspace boundaries
         searchspace = to_tensor(self.searchspace)
         bounds = torch.vstack(

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -6,10 +6,9 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-
 from attr import define, field
 from botorch.utils.sampling import get_polytope_samples
-from torch import empty, stack, Tensor
+from torch import Tensor, empty, stack
 
 from baybe.constraints import (
     ContinuousLinearEqualityConstraint,

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -6,9 +6,10 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-import torch
+
 from attr import define, field
 from botorch.utils.sampling import get_polytope_samples
+from torch import empty, stack, Tensor
 
 from baybe.constraints import (
     ContinuousLinearEqualityConstraint,
@@ -96,11 +97,11 @@ class SubspaceContinuous:
         return [p.name for p in self.parameters]
 
     @property
-    def param_bounds_comp(self) -> torch.Tensor:
+    def param_bounds_comp(self) -> Tensor:
         """Return bounds as tensor."""
         if not self.parameters:
-            return torch.empty(2, 0, dtype=DTypeFloatTorch)
-        return torch.stack([p.bounds.to_tensor() for p in self.parameters]).T
+            return empty(2, 0, dtype=DTypeFloatTorch)
+        return stack([p.bounds.to_tensor() for p in self.parameters]).T
 
     def transform(
         self,

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import List, Optional, cast
 
 import pandas as pd
-from torch import Tensor
+from torch import Tensor, hstack
 from attr import define, field
 
 from baybe.constraints import (
@@ -26,7 +26,6 @@ from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.searchspace.validation import validate_parameters
 from baybe.telemetry import TELEM_LABELS, telemetry_record_value
 from baybe.utils import SerialMixin, converter
-from baybe.utils.lazy_loader import LazyLoader
 
 
 class SearchSpaceType(Enum):
@@ -188,10 +187,8 @@ class SearchSpace(SerialMixin):
 
     @property
     def param_bounds_comp(self) -> Tensor:
-        """Return bounds as tensor. `torch` is loaded lazily in this function."""
-        lazy_loader = LazyLoader("torch")
-        torch = lazy_loader.load()
-        return torch.hstack(
+        """Return bounds as tensor."""
+        return hstack(
             [self.discrete.param_bounds_comp, self.continuous.param_bounds_comp]
         )
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import List, Optional, cast
 
 import pandas as pd
-import torch
+from torch import Tensor
 from attr import define, field
 
 from baybe.constraints import (
@@ -26,6 +26,7 @@ from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.searchspace.validation import validate_parameters
 from baybe.telemetry import TELEM_LABELS, telemetry_record_value
 from baybe.utils import SerialMixin, converter
+from baybe.utils.lazy_loader import LazyLoader
 
 
 class SearchSpaceType(Enum):
@@ -186,8 +187,10 @@ class SearchSpace(SerialMixin):
         )
 
     @property
-    def param_bounds_comp(self) -> torch.Tensor:
-        """Return bounds as tensor."""
+    def param_bounds_comp(self) -> Tensor:
+        """Return bounds as tensor. `torch` is loaded lazily in this function."""
+        lazy_loader = LazyLoader("torch")
+        torch = lazy_loader.load()
         return torch.hstack(
             [self.discrete.param_bounds_comp, self.continuous.param_bounds_comp]
         )

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -6,8 +6,8 @@ from enum import Enum
 from typing import List, Optional, cast
 
 import pandas as pd
-from torch import Tensor, hstack
 from attr import define, field
+from torch import Tensor, hstack
 
 from baybe.constraints import (
     ContinuousLinearEqualityConstraint,

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
 import numpy as np
 import pandas as pd
-
 from attr import define, field
 from cattrs import IterableValidationError
-from torch import empty, from_numpy, Tensor
+from torch import Tensor, empty, from_numpy
+
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER
 from baybe.constraints.base import DiscreteConstraint
 from baybe.parameters import (

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
 import numpy as np
 import pandas as pd
-import torch
+
 from attr import define, field
 from cattrs import IterableValidationError
-
+from torch import empty, from_numpy, Tensor
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER
 from baybe.constraints.base import DiscreteConstraint
 from baybe.parameters import (
@@ -251,14 +251,14 @@ class SubspaceDiscrete:
         return len(self.parameters) == 0
 
     @property
-    def param_bounds_comp(self) -> torch.Tensor:
+    def param_bounds_comp(self) -> Tensor:
         """Return bounds as tensor.
 
         Take bounds from the parameter definitions, but discards bounds belonging to
         columns that were filtered out during the creation of the space.
         """
         if not self.parameters:
-            return torch.empty(2, 0)
+            return empty(2, 0)
         bounds = np.hstack(
             [
                 np.vstack([p.comp_df[col].min(), p.comp_df[col].max()])
@@ -267,7 +267,7 @@ class SubspaceDiscrete:
                 if col in self.comp_rep.columns
             ]
         )
-        return torch.from_numpy(bounds)
+        return from_numpy(bounds)
 
     def mark_as_measured(
         self,

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -5,9 +5,8 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Dict, List, Tuple, Type
 
-import torch
 from attr import define, field
-from torch import Tensor
+from torch import Tensor, diag_embed, eye
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.utils import _prepare_inputs, _prepare_targets
@@ -78,10 +77,10 @@ class Surrogate(ABC, SerialMixin):
         # Apply covariance transformation for marginal posterior models
         if not self.joint_posterior:
             # Convert to tensor containing covariance matrices
-            covar = torch.diag_embed(covar)
+            covar = diag_embed(covar)
 
         # Add small diagonal variances for numerical stability
-        covar.add_(torch.eye(covar.shape[-1]) * _MIN_VARIANCE)
+        covar.add_(eye(covar.shape[-1]) * _MIN_VARIANCE)
 
         return mean, covar
 

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -11,7 +11,7 @@ It is planned to solve this issue in the future.
 from typing import Callable, ClassVar, Tuple
 
 from attrs import define, field, validators
-from torch import from_numpy, Tensor
+from torch import Tensor, from_numpy
 
 from baybe.exceptions import ModelParamsNotSupportedError
 from baybe.parameters import (

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -10,9 +10,8 @@ It is planned to solve this issue in the future.
 
 from typing import Callable, ClassVar, Tuple
 
-import torch
 from attrs import define, field, validators
-from torch import Tensor
+from torch import from_numpy, Tensor
 
 from baybe.exceptions import ModelParamsNotSupportedError
 from baybe.parameters import (
@@ -162,8 +161,8 @@ if _ONNX_INSTALLED:
             #   about the mean only and it's not clear how this will be handled in the
             #   future. Once there are more choices available, this should be revisited.
             return (
-                torch.from_numpy(results[0]).to(DTypeFloatTorch),
-                torch.from_numpy(results[1]).pow(2).to(DTypeFloatTorch),
+                from_numpy(results[0]).to(DTypeFloatTorch),
+                from_numpy(results[1]).pow(2).to(DTypeFloatTorch),
             )
 
         def _fit(

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -2,7 +2,6 @@
 
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
-import torch
 from attr import define, field
 from botorch.models import SingleTaskGP
 from botorch.models.transforms import Normalize, Standardize
@@ -12,7 +11,7 @@ from gpytorch.kernels import IndexKernel, MaternKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
 from gpytorch.priors import GammaPrior
-from torch import Tensor
+from torch import tensor, Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -117,8 +116,8 @@ class GaussianProcessSurrogate(Surrogate):
             batch_shape=batch_shape,
             outputscale_prior=outputscale_prior[0],
         )
-        base_covar_module.outputscale = torch.tensor([outputscale_prior[1]])
-        base_covar_module.base_kernel.lengthscale = torch.tensor([lengthscale_prior[1]])
+        base_covar_module.outputscale = tensor([outputscale_prior[1]])
+        base_covar_module.base_kernel.lengthscale = tensor([lengthscale_prior[1]])
 
         # create GP covariance
         if task_idx is None:
@@ -135,7 +134,7 @@ class GaussianProcessSurrogate(Surrogate):
         likelihood = GaussianLikelihood(
             noise_prior=noise_prior[0], batch_shape=batch_shape
         )
-        likelihood.noise = torch.tensor([noise_prior[1]])
+        likelihood.noise = tensor([noise_prior[1]])
 
         # construct and fit the Gaussian process
         self._model = SingleTaskGP(

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -11,7 +11,7 @@ from gpytorch.kernels import IndexKernel, MaternKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
 from gpytorch.priors import GammaPrior
-from torch import tensor, Tensor
+from torch import Tensor, tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, Dict, Optional, Tuple
 
 from attr import define, field
 from sklearn.linear_model import ARDRegression
-from torch import from_numpy, Tensor
+from torch import Tensor, from_numpy
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -9,10 +9,9 @@ available in the future. Thus, please have a look in the source code directly.
 
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
-import torch
 from attr import define, field
 from sklearn.linear_model import ARDRegression
-from torch import Tensor
+from torch import from_numpy, Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -51,8 +50,8 @@ class BayesianLinearSurrogate(Surrogate):
         dists = self._model.predict(candidates.numpy(), return_std=True)
 
         # Split into posterior mean and variance
-        mean = torch.from_numpy(dists[0])
-        var = torch.from_numpy(dists[1]).pow(2)
+        mean = from_numpy(dists[0])
+        var = from_numpy(dists[1]).pow(2)
 
         return mean, var
 

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -3,7 +3,7 @@
 from typing import ClassVar, Optional, Tuple
 
 from attr import define, field
-from torch import ones, Tensor
+from torch import Tensor, ones
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -2,9 +2,8 @@
 
 from typing import ClassVar, Optional, Tuple
 
-import torch
 from attr import define, field
-from torch import Tensor
+from torch import ones, Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -34,8 +33,8 @@ class MeanPredictionSurrogate(Surrogate):
     def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
         # See base class.
         # TODO: use target value bounds for covariance scaling when explicitly provided
-        mean = self.target_value * torch.ones([len(candidates)])
-        var = torch.ones(len(candidates))
+        mean = self.target_value * ones([len(candidates)])
+        var = ones(len(candidates))
         return mean, var
 
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -9,10 +9,9 @@ available in the future. Thus, please have a look in the source code directly.
 
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
-import torch
 from attr import define, field
 from ngboost import NGBRegressor
-from torch import Tensor
+from torch import from_numpy, Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -57,8 +56,8 @@ class NGBoostSurrogate(Surrogate):
         dists = self._model.pred_dist(candidates)
 
         # Split into posterior mean and variance
-        mean = torch.from_numpy(dists.mean())
-        var = torch.from_numpy(dists.var)
+        mean = from_numpy(dists.mean())
+        var = from_numpy(dists.var)
 
         return mean, var
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, Dict, Optional, Tuple
 
 from attr import define, field
 from ngboost import NGBRegressor
-from torch import from_numpy, Tensor
+from torch import Tensor, from_numpy
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -10,10 +10,9 @@ available in the future. Thus, please have a look in the source code directly.
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import numpy as np
-
 from attr import define, field
 from sklearn.ensemble import RandomForestRegressor
-from torch import from_numpy, Tensor
+from torch import Tensor, from_numpy
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -10,10 +10,10 @@ available in the future. Thus, please have a look in the source code directly.
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import numpy as np
-import torch
+
 from attr import define, field
 from sklearn.ensemble import RandomForestRegressor
-from torch import Tensor
+from torch import from_numpy, Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -53,7 +53,7 @@ class RandomForestSurrogate(Surrogate):
         # NOTE: explicit conversion to ndarray is needed due to a pytorch issue:
         # https://github.com/pytorch/pytorch/pull/51731
         # https://github.com/pytorch/pytorch/issues/13918
-        predictions = torch.from_numpy(
+        predictions = from_numpy(
             np.asarray(
                 [
                     self._model.estimators_[tree].predict(candidates)

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, ClassVar, Tuple, Type
 
-from torch import Tensor, float64, diag_embed, std, reshape, stack
+from torch import Tensor, diag_embed, float64, reshape, stack, std
 
 from baybe.scaler import DefaultScaler
 from baybe.searchspace import SearchSpace

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, ClassVar, Tuple, Type
 
-import torch
-from torch import Tensor
+from torch import Tensor, float64
 
 from baybe.scaler import DefaultScaler
 from baybe.searchspace import SearchSpace
@@ -14,8 +13,8 @@ from baybe.searchspace import SearchSpace
 if TYPE_CHECKING:
     from baybe.surrogates.base import Surrogate
 
-# Use float64 (which is recommended at least for BoTorch models)
-_DTYPE = torch.float64
+# Use Pytorch's float64 (which is recommended at least for BoTorch models)
+_DTYPE = float64
 
 _MIN_TARGET_STD = 1e-6
 

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, Iterable, List, TypeVar
 
 import numpy as np
-import torch
+from torch import manual_seed
 
 _T = TypeVar("_T")
 _U = TypeVar("_U")
@@ -56,7 +56,7 @@ def set_random_seed(seed: int):
     Args:
         seed: The chosen global random seed.
     """
-    torch.manual_seed(seed)
+    manual_seed(seed)
     random.seed(seed)
     np.random.seed(seed)
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import torch
-from torch import Tensor
+
+from torch import from_numpy, Tensor
 
 from baybe.targets.enum import TargetMode
 from baybe.utils.numeric import DTypeFloatNumpy, DTypeFloatTorch
@@ -38,7 +38,7 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
     #  care of this) df.values has been changed to df.values.astype(float),
     #  even though this seems like double casting here.
     out = (
-        torch.from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)
+        from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)
         for df in dfs
     )
     if len(dfs) == 1:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-
-from torch import from_numpy, Tensor
+from torch import Tensor, from_numpy
 
 from baybe.targets.enum import TargetMode
 from baybe.utils.numeric import DTypeFloatNumpy, DTypeFloatTorch

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -38,8 +38,7 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
     #  care of this) df.values has been changed to df.values.astype(float),
     #  even though this seems like double casting here.
     out = (
-        from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)
-        for df in dfs
+        from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch) for df in dfs
     )
     if len(dfs) == 1:
         out = next(out)

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -7,9 +7,9 @@ from functools import singledispatchmethod
 from typing import Any, Optional, Tuple, Union
 
 import numpy as np
-from torch import tensor, Tensor
 from attrs import define, field
 from packaging import version
+from torch import Tensor, tensor
 
 from baybe.utils.numeric import DTypeFloatNumpy, DTypeFloatTorch
 

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -7,7 +7,7 @@ from functools import singledispatchmethod
 from typing import Any, Optional, Tuple, Union
 
 import numpy as np
-import torch
+from torch import tensor, Tensor
 from attrs import define, field
 from packaging import version
 
@@ -125,9 +125,9 @@ class Interval:
         """Transform the interval to a :class:`numpy.ndarray`."""
         return np.array([self.lower, self.upper], dtype=DTypeFloatNumpy)
 
-    def to_tensor(self) -> torch.Tensor:
+    def to_tensor(self) -> Tensor:
         """Transform the interval to a :class:`torch.Tensor`."""
-        return torch.tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
+        return tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
 
     def contains(self, number: float) -> bool:
         """Check whether the interval contains a given number.

--- a/baybe/utils/lazy_loader.py
+++ b/baybe/utils/lazy_loader.py
@@ -1,0 +1,13 @@
+""" A utility class for loading heavier modules lazily"""
+
+import importlib
+
+class LazyLoader:
+    def __init__(self, module_name):
+        self.module_name = module_name
+        self.module = None
+
+    def load(self):
+        if self.module is None:
+            self.module = importlib.import_module(self.module_name)
+        return self.module

--- a/baybe/utils/lazy_loader.py
+++ b/baybe/utils/lazy_loader.py
@@ -2,6 +2,7 @@
 
 import importlib
 
+
 class LazyLoader:
     def __init__(self, module_name):
         self.module_name = module_name

--- a/baybe/utils/lazy_loader.py
+++ b/baybe/utils/lazy_loader.py
@@ -1,14 +1,24 @@
-""" A utility class for loading heavier modules lazily"""
+"""A utility for loading heavier modules lazily."""
 
 import importlib
 
+from attr import define, field
 
+
+@define
 class LazyLoader:
-    def __init__(self, module_name):
-        self.module_name = module_name
-        self.module = None
+    """A class responsible for lazy loading module."""
+
+    # Object variable
+    module_name: str = field()
+    """String representation of the module we wish to load."""
+
+    # Object variable
+    module = field(init=False, default=None)
+    """The imported module"""
 
     def load(self):
+        """Load the required module using importlib."""
         if self.module is None:
             self.module = importlib.import_module(self.module_name)
         return self.module

--- a/baybe/utils/numeric.py
+++ b/baybe/utils/numeric.py
@@ -2,12 +2,12 @@
 from typing import List
 
 import numpy as np
-import torch
+from torch import float64
 
 DTypeFloatNumpy = np.float64
 """Floating point data type used for numpy arrays."""
 
-DTypeFloatTorch = torch.float64
+DTypeFloatTorch = float64
 """Floating point data type used for torch tensors."""
 
 DTypeFloatONNX = np.float32

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -11,7 +11,6 @@
 from typing import Optional, Tuple
 
 import numpy as np
-import torch
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.ensemble import (
     GradientBoostingRegressor,
@@ -19,7 +18,7 @@ from sklearn.ensemble import (
     StackingRegressor,
 )
 from sklearn.linear_model import LinearRegression, Ridge
-from torch import Tensor
+from torch import Tensor, tensor
 
 from baybe.campaign import Campaign
 from baybe.objective import Objective
@@ -53,8 +52,8 @@ class MeanVarEstimator(BaseEstimator, RegressorMixin):
 
     def predict(self, data: Tensor) -> Tuple[Tensor, Tensor]:
         """Predict based on ensemble unweighted mean and variance."""
-        mean = torch.tensor(data.mean(axis=1))
-        var = torch.tensor(data.var(axis=1))
+        mean = tensor(data.mean(axis=1))
+        var = tensor(data.var(axis=1))
         return mean, var
 
 

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -110,9 +110,7 @@ class NeuralNetDropoutSurrogate:
         # Convert input from double to float
         candidates = candidates.float()
         # Run mc experiments through the NN with dropout
-        predictions = cat(
-            [self.model(candidates).unsqueeze(dim=0) for _ in range(MC)]
-        )
+        predictions = cat([self.model(candidates).unsqueeze(dim=0) for _ in range(MC)])
 
         # Compute posterior mean and variance
         mean = predictions.mean(dim=0)

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -11,8 +11,8 @@
 from typing import List, Optional, Tuple
 
 import numpy as np
+from torch import Tensor, cat, nn
 from torch.optim import Adam
-from torch import Tensor, nn, cat
 
 from baybe.campaign import Campaign
 from baybe.objective import Objective

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -11,8 +11,8 @@
 from typing import List, Optional, Tuple
 
 import numpy as np
-import torch
-from torch import Tensor, nn
+from torch.optim import Adam
+from torch import Tensor, nn, cat
 
 from baybe.campaign import Campaign
 from baybe.objective import Objective
@@ -44,7 +44,7 @@ HYPERPARAMS = {
     "epochs": 10,
     "lr": 1e-3,
     "criterion": nn.MSELoss,
-    "optimizer": torch.optim.Adam,
+    "optimizer": Adam,
 }
 
 # MC Parameters
@@ -110,7 +110,7 @@ class NeuralNetDropoutSurrogate:
         # Convert input from double to float
         candidates = candidates.float()
         # Run mc experiments through the NN with dropout
-        predictions = torch.cat(
+        predictions = cat(
             [self.model(candidates).unsqueeze(dim=0) for _ in range(MC)]
         )
 

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -9,10 +9,10 @@ when the input and output scales are changed.
 
 import matplotlib.pyplot as plt
 import numpy as np
-from torch import from_numpy, linspace, manual_seed
 from botorch.acquisition import qExpectedImprovement
 from botorch.optim import optimize_acqf_discrete
 from funcy import rpartial
+from torch import from_numpy, linspace, manual_seed
 
 import streamlit as st
 from baybe.acquisition import debotorchize

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -111,9 +111,7 @@ def main():
     )
 
     # create the input grid and corresponding target values
-    test_x = linspace(
-        lower_parameter_limit, upper_parameter_limit, N_PARAMETER_VALUES
-    )
+    test_x = linspace(lower_parameter_limit, upper_parameter_limit, N_PARAMETER_VALUES)
     test_y = from_numpy(fun(test_x.numpy()))
 
     # randomly select the specified number of training data points

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -9,7 +9,7 @@ when the input and output scales are changed.
 
 import matplotlib.pyplot as plt
 import numpy as np
-import torch
+from torch import from_numpy, linspace, manual_seed
 from botorch.acquisition import qExpectedImprovement
 from botorch.optim import optimize_acqf_discrete
 from funcy import rpartial
@@ -99,7 +99,7 @@ def main():
 
     # fix the chosen random seed
     np.random.seed(random_seed)
-    torch.manual_seed(random_seed)
+    manual_seed(random_seed)
 
     # select the test function and the surrogate model class
     fun = rpartial(
@@ -111,10 +111,10 @@ def main():
     )
 
     # create the input grid and corresponding target values
-    test_x = torch.linspace(
+    test_x = linspace(
         lower_parameter_limit, upper_parameter_limit, N_PARAMETER_VALUES
     )
-    test_y = torch.from_numpy(fun(test_x.numpy()))
+    test_y = from_numpy(fun(test_x.numpy()))
 
     # randomly select the specified number of training data points
     train_idx = np.random.choice(


### PR DESCRIPTION
### Initial Import Profiling Results
Here's the result of profiling `import babye` before optimizing torch imports:

![import baybe profile before optimizing](https://github.com/emdgroup/baybe/assets/5112312/7e4b32d5-5c72-4848-a601-28541909edc9)

And this is after optimization:

![after optimizing](https://github.com/emdgroup/baybe/assets/5112312/7d621196-6b32-41a1-a3e6-ba4b60ab0c5c)

It seems `import torch` is not a significant bottleneck, but it's slightly improved.

Here's the summary of what's done regarding `import torch`:

1. Simplest, most effective solution first: just import what's needed explicitly. For the most part, I was able to explicitly import the functions that were used.
2. If not effective or feasible (e.g. too many methods/classes are used), use lazy loading (only in `scaler.py`)

