### PR TITLE
Make parameter and objective classes slotted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Parameter classes are now slotted due to `cached_property` attrs support
+
 ## [0.10.0] - 2024-08-02
 ### Breaking Changes
 - Providing an explicit `batch_size` is now mandatory when asking for recommendations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Parameter classes are now slotted due to `cached_property` attrs support
+- Parameter and objective classes are now slotted due to `cached_property` attrs support
 
 ## [0.10.0] - 2024-08-02
 ### Breaking Changes

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -14,11 +14,8 @@ from baybe.serialization.core import (
 from baybe.serialization.mixin import SerialMixin
 from baybe.targets.base import Target
 
-# TODO: Reactive slots in all classes once cached_property is supported:
-#   https://github.com/python-attrs/attrs/issues/164
 
-
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class Objective(ABC, SerialMixin):
     """Abstract base class for all objectives."""
 

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -61,7 +61,7 @@ def scalarize(
     return func(values, weights=weights)
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class DesirabilityObjective(Objective):
     """An objective scalarizing multiple targets using desirability values."""
 

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -8,7 +8,7 @@ from baybe.objectives.base import Objective
 from baybe.targets.base import Target
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class SingleTargetObjective(Objective):
     """An objective focusing on a single target."""
 

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -24,11 +24,8 @@ if TYPE_CHECKING:
     from baybe.searchspace.core import SearchSpace
     from baybe.searchspace.discrete import SubspaceDiscrete
 
-# TODO: Reactive slots in all classes once cached_property is supported:
-#   https://github.com/python-attrs/attrs/issues/164
 
-
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class Parameter(ABC, SerialMixin):
     """Abstract base class for all parameters.
 
@@ -79,11 +76,9 @@ class Parameter(ABC, SerialMixin):
         return SearchSpace.from_parameter(self)
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class DiscreteParameter(Parameter, ABC):
     """Abstract class for discrete parameters."""
-
-    # TODO [15280]: needs to be refactored
 
     # class variables
     encoding: ParameterEncoding | None = field(init=False, default=None)
@@ -143,7 +138,7 @@ class DiscreteParameter(Parameter, ABC):
         return param_dict
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class ContinuousParameter(Parameter):
     """Abstract class for continuous parameters."""
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -14,7 +14,7 @@ from baybe.parameters.validation import validate_unique_values
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class CategoricalParameter(DiscreteParameter):
     """Parameter class for categorical parameters."""
 
@@ -60,7 +60,7 @@ class CategoricalParameter(DiscreteParameter):
         return comp_df
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class TaskParameter(CategoricalParameter):
     """Parameter class for task parameters."""
 

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -16,7 +16,7 @@ from baybe.utils.dataframe import df_uncorrelated_features
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class CustomDiscreteParameter(DiscreteParameter):
     """Custom parameters.
 

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -16,7 +16,7 @@ from baybe.utils.interval import InfiniteIntervalError, Interval, convert_bounds
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class NumericalDiscreteParameter(DiscreteParameter):
     """Parameter class for discrete numerical parameters (a.k.a. setpoints)."""
 
@@ -97,7 +97,7 @@ class NumericalDiscreteParameter(DiscreteParameter):
         return any(differences_acceptable)
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class NumericalContinuousParameter(ContinuousParameter):
     """Parameter class for continuous numerical parameters."""
 

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -23,7 +23,7 @@ Smiles = str
 """Type alias for SMILES strings."""
 
 
-@define(frozen=True, slots=False)
+@define(frozen=True)
 class SubstanceParameter(DiscreteParameter):
     """Generic substances that are treated with cheminformatics descriptors.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = [
 ]
 dynamic = ['version']
 dependencies = [
-    "attrs>=22.2.0",
+    "attrs>=24.1.0",
     "botorch>=0.9.3,<1",
     "cattrs>=23.2.0",
     "exceptiongroup",


### PR DESCRIPTION
Now that `attrs==24.1.0` supports `cached_property` with slotted classes, we can finally enable slots for our parameter and objective classes.