### PR TITLE
Use pydoclint as flake8 plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,12 @@
 # (pre-commit, environment.yml, requirements.txt, pyproject.toml, ...)
 
 repos:
-- repo: https://github.com/jsh9/pydoclint
-  rev: 0.2.1
+- repo: https://github.com/pycqa/flake8
+  rev: 7.0.0
   hooks:
-    - id: pydoclint
-      args: [--config=pydoclint.toml]
+    - id: flake8
+      additional_dependencies: [pydoclint]  
+      args: [--select=DOC, --config=pydoclint.toml]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.6
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Wrong use of `tolerance` argument in constraints user guide
 - Errors with generics and type aliases in documentation
-- Deduplication bug in substance_data hypothesis strategy
+- Deduplication bug in substance_data hypothesis 
+- Use pydoclint as flake8 plugin and not as a stand-alone linter
 
 ### Removed
 - Conda install instructions and version badge

--- a/baybe/parameters/validation.py
+++ b/baybe/parameters/validation.py
@@ -29,7 +29,9 @@ def validate_decorrelation(obj: Any, attribute: Any, value: float) -> None:
         lt(1.0)(obj, attribute, value)
 
 
-def validate_is_finite(obj: Any, _: Any, value: Sequence[float]) -> None:
+def validate_is_finite(  # noqa: DOC101, DOC103
+    obj: Any, _: Any, value: Sequence[float]
+) -> None:
     """Validate that ``value`` contains no infinity/nan.
 
     Raises:

--- a/pydoclint.toml
+++ b/pydoclint.toml
@@ -1,6 +1,10 @@
 # The following are options that are used for pydoclint
-[tool.pydoclint]
-style = "google" # Use google docstring style 
-arg-type-hints-in-docstring = false # We do not have the type hints in the docstrings
-check-return-types = false #  We do not have the return types in the docstrings
-exclude = "validat" # Skip files that are only used for validation
+# Note that we need to use pydoclint as a flake8 plugin as we cannot have the
+# in-line noqa exclusions otherwise
+[flake8]
+# Use google docstring style 
+style=google
+# We do not have the type hints in the docstrings
+arg-type-hints-in-docstring=False 
+# We do not have the return types in the docstrings
+check-return-types=False

--- a/pydoclint.toml
+++ b/pydoclint.toml
@@ -1,5 +1,6 @@
 # The following are options that are used for pydoclint
-
-style = google # Use google docstring style 
-arg-type-hints-in-docstring = False # We do not have the type hints in the docstrings
-check-return-types = False #  We do not have the return types in the docstrings
+[tool.pydoclint]
+style = "google" # Use google docstring style 
+arg-type-hints-in-docstring = false # We do not have the type hints in the docstrings
+check-return-types = false #  We do not have the return types in the docstrings
+exclude = "validat" # Skip files that are only used for validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ examples = [
 ]
 
 lint = [
+    "flake8==7.0.0", # see DEV TOOLS NOTE
     "pre-commit==2.19.0", # see DEV TOOLS NOTE
     "pydoclint==0.2.1", # see DEV TOOLS NOTE
     "ruff==0.1.6", # see DEV TOOLS NOTE


### PR DESCRIPTION
This PR changes the way that pydoclint is used. Previously, it was used as a stand-alone linter. This PR changes this and introduces it as a plugin for flake8.

The reason for this change is that (due to a previous error), pydoclint did not use the provided configuration file. Once this was changed, I realized that pydoclint does **not** allow you to use `noqa` for making in-line exceptions of specific error codes. This is only available when using it as a flake8 plugin (see https://jsh9.github.io/pydoclint/how_to_ignore.html).

For that reason, flake8 was reintroduced. It is configured in a way that it *only* reports the errors related to pydoclint and uses the pre-defined configuration file (see https://jsh9.github.io/pydoclint/ Section 2.2.)

Also, this PR adds one `noqa` that was overlooked previously.