### PR TITLE
Formatting test for user guide code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hypothesis` strategies and tests for targets and intervals
 - De-/serialization of target subclasses via base class
 - Docs building check now part of CI
-- Automatic formatting checks for user guide code examples
+- Automatic formatting checks for code examples in documentation
 
 ### Changed
 - Renamed `bounds_transform_func` target attribute to `transformation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hypothesis` strategies and tests for targets and intervals
 - De-/serialization of target subclasses via base class
 - Docs building check now part of CI
+- Automatic formatting checks for user guide code examples
 
 ### Changed
 - Renamed `bounds_transform_func` target attribute to `transformation`

--- a/README.md
+++ b/README.md
@@ -157,18 +157,22 @@ parameters = [
     CategoricalParameter(
         name="Granularity",
         values=["coarse", "medium", "fine"],
-        encoding="OHE", # one-hot encoding of categories
+        encoding="OHE",  # one-hot encoding of categories
     ),
     NumericalDiscreteParameter(
         name="Pressure[bar]",
         values=[1, 5, 10],
-        tolerance=0.2, # allows experimental inaccuracies up to 0.2 when reading values 
+        tolerance=0.2,  # allows experimental inaccuracies up to 0.2 when reading values
     ),
     SubstanceParameter(
         name="Solvent",
-        data={"Solvent A": "COC", "Solvent B": "CCC", # label-SMILES pairs
-              "Solvent C": "O", "Solvent D": "CS(=O)C"},
-        encoding="MORDRED", # chemical encoding via mordred package
+        data={
+            "Solvent A": "COC",
+            "Solvent B": "CCC",  # label-SMILES pairs
+            "Solvent C": "O",
+            "Solvent D": "CS(=O)C",
+        },
+        encoding="MORDRED",  # chemical encoding via mordred package
     ),
 ]
 ```
@@ -210,8 +214,8 @@ from baybe.strategies import TwoPhaseStrategy
 from baybe.recommenders import SequentialGreedyRecommender, FPSRecommender
 
 strategy = TwoPhaseStrategy(
-    initial_recommender=FPSRecommender(), # farthest point sampling
-    recommender=SequentialGreedyRecommender(), # Bayesian model-based optimization
+    initial_recommender=FPSRecommender(),  # farthest point sampling
+    recommender=SequentialGreedyRecommender(),  # Bayesian model-based optimization
 )
 ```
 

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -48,9 +48,9 @@ The constraint assuring that they always sum up to 1.0 would look like this:
 from baybe.constraints import ContinuousLinearEqualityConstraint
 
 ContinuousLinearEqualityConstraint(
-    parameters = ["x_1", "x_2", "x_3"], # these parameters must exist in the search space
-    coefficients = [1.0, 1.0, 1.0],
-    rhs = 1.0
+    parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
+    coefficients=[1.0, 1.0, 1.0],
+    rhs=1.0,
 )
 ```
 
@@ -82,10 +82,10 @@ The following constraint would achieve this:
 from baybe.constraints import ContinuousLinearInequalityConstraint
 
 ContinuousLinearInequalityConstraint(
-    parameters = ["x_1", "x_2", "x_3"], # these parameters must exist in the search space
-    coefficients = [-1.0, -1.0, -1.0],
-    rhs = -0.8 # coefficients and rhs are negated because we model a `<=` constraint
-),
+    parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
+    coefficients=[-1.0, -1.0, -1.0],
+    rhs=-0.8,  # coefficients and rhs are negated because we model a `<=` constraint
+)
 ```
 
 A more detailed example can be found
@@ -104,9 +104,9 @@ achieved with a [`ThresholdCondition`](baybe.constraints.conditions.ThresholdCon
 ```python
 from baybe.constraints import ThresholdCondition
 
-ThresholdCondition( # will select all values above 150
-    threshold = 150,
-    operator = ">",
+ThresholdCondition(  # will select all values above 150
+    threshold=150,
+    operator=">",
 )
 ```
 
@@ -116,8 +116,8 @@ In case a specific subset of values needs to be selected, it can be done with th
 ```python
 from baybe.constraints import SubSelectionCondition
 
-SubSelectionCondition( # will select two solvents identified by their labels
-    selection = ["Ethanol", "DMF"]
+SubSelectionCondition(  # will select two solvents identified by their labels
+    selection=["Ethanol", "DMF"]
 )
 ```
 
@@ -141,15 +141,19 @@ The following example would exclude entries where "Ethanol" and "DMF" are combin
 temperatures above 150, which might be due to their chemical instability at those
 temperatures:
 ```python
-from baybe.constraints import DiscreteExcludeConstraint, ThresholdCondition, SubSelectionCondition
+from baybe.constraints import (
+    DiscreteExcludeConstraint,
+    ThresholdCondition,
+    SubSelectionCondition,
+)
 
 DiscreteExcludeConstraint(
-    parameters = ["Temperature", "Solvent"], # names of the affected parameters
-    combiner = "AND", # specifies how the conditions are logically combined
-    conditions = [ # requires one condition for each entry in parameters
-        ThresholdCondition(threshold = 150, operator = ">"),
-        SubSelectionCondition(selection = ["Ethanol", "DMF"]),
-    ]
+    parameters=["Temperature", "Solvent"],  # names of the affected parameters
+    combiner="AND",  # specifies how the conditions are logically combined
+    conditions=[  # requires one condition for each entry in parameters
+        ThresholdCondition(threshold=150, operator=">"),
+        SubSelectionCondition(selection=["Ethanol", "DMF"]),
+    ],
 )
 ```
 
@@ -168,11 +172,12 @@ If these parameters were instead discrete, the corresponding constraint would lo
 from baybe.constraints import DiscreteSumConstraint, ThresholdCondition
 
 DiscreteSumConstraint(
-    parameters = ["x_1", "x_2", "x_3"],
-    condition = ThresholdCondition( # set condition that should apply to the sum
-        threshold = 1.0,
-        operator = "=",
-        tolerance = 0.001) # optional; here, everything between 0.999 and 1.001 would also be considered valid
+    parameters=["x_1", "x_2", "x_3"],
+    condition=ThresholdCondition(  # set condition that should apply to the sum
+        threshold=1.0,
+        operator="=",
+        tolerance=0.001,  # optional; here, everything between 0.999 and 1.001 would also be considered valid
+    ),
 )
 ```
 
@@ -190,11 +195,9 @@ We can exclude such occurrences with the
 [`DiscreteNoLabelDuplicatesConstraint`](baybe.constraints.discrete.DiscreteNoLabelDuplicatesConstraint):
 
 ```python
-from baybe.constraints import  DiscreteNoLabelDuplicatesConstraint
+from baybe.constraints import DiscreteNoLabelDuplicatesConstraint
 
-DiscreteNoLabelDuplicatesConstraint(
-    parameters=["Solvent_1", "Solvent_2"]
-)
+DiscreteNoLabelDuplicatesConstraint(parameters=["Solvent_1", "Solvent_2"])
 ```
 
 Without this constraint, combinations like below would be possible:
@@ -221,17 +224,17 @@ from baybe.constraints import DiscreteLinkedParametersConstraint
 
 dict_solvents = {"Water": "O", "THF": "C1CCOC1", "Octanol": "CCCCCCCCO"}
 solvent_encoding1 = SubstanceParameter(
-    name = 'Solvent_RDKIT_enc',
-    data = dict_solvents,
-    encoding = "RDKIT",
+    name="Solvent_RDKIT_enc",
+    data=dict_solvents,
+    encoding="RDKIT",
 )
 solvent_encoding2 = SubstanceParameter(
-    name = 'Solvent_MORDRED_enc',
-    data = dict_solvents,
-    encoding = "MORDRED",
+    name="Solvent_MORDRED_enc",
+    data=dict_solvents,
+    encoding="MORDRED",
 )
 DiscreteLinkedParametersConstraint(
-    parameters = ["Solvent_RDKIT_enc", "Solvent_MORDRED_enc"]
+    parameters=["Solvent_RDKIT_enc", "Solvent_MORDRED_enc"]
 )
 ```
 
@@ -280,12 +283,18 @@ from baybe.constraints import DiscreteDependenciesConstraint, SubSelectionCondit
 DiscreteDependenciesConstraint(
     parameters=["Switch_1", "Switch_2"],  # the two parameters upon which others depend
     conditions=[
-        SubSelectionCondition(selection=["on"]),     # values of Switch_1 that activate the affected parameters
-        SubSelectionCondition(selection=["right"]),  # values of Switch_2 that activate the affected parameters
+        SubSelectionCondition(
+            # values of Switch_1 that activate the affected parameters
+            selection=["on"]
+        ),
+        SubSelectionCondition(
+            # values of Switch_2 that activate the affected parameters
+            selection=["right"]
+        ),
     ],
     affected_parameters=[
-      ["Solvent", "Fraction"],  # parameters affected by Switch_1
-      ["Frame_1", "Frame_2"]    # parameters affected by Switch_2
+        ["Solvent", "Fraction"],  # parameters affected by Switch_1
+        ["Frame_1", "Frame_2"],  # parameters affected by Switch_2
     ],
 )
 ```
@@ -347,7 +356,11 @@ removes permutation-invariant combinations of solvents that have additional
 dependencies as well:
 
 ```python
-from baybe.constraints import DiscretePermutationInvarianceConstraint, DiscreteDependenciesConstraint, ThresholdCondition
+from baybe.constraints import (
+    DiscretePermutationInvarianceConstraint,
+    DiscreteDependenciesConstraint,
+    ThresholdCondition,
+)
 
 DiscretePermutationInvarianceConstraint(
     parameters=["Solvent_1", "Solvent_2", "Solvent_3"],
@@ -377,7 +390,8 @@ import pandas as pd
 import numpy as np
 from baybe.constraints import DiscreteCustomConstraint
 
-def custom_filter(df: pd.DataFrame) -> pd.Series: # this signature is required
+
+def custom_filter(df: pd.DataFrame) -> pd.Series:  # this signature is required
     """
     In this example, we exclude entries where the square root of the
     temperature times the cubed pressure are larger than 5.6.
@@ -386,9 +400,13 @@ def custom_filter(df: pd.DataFrame) -> pd.Series: # this signature is required
 
     return mask_good
 
+
 DiscreteCustomConstraint(
-    parameters = ["Pressure", "Temperature"], # the custom function will have access to these variables
-    validator = custom_filter
+    parameters=[  # the custom function will have access to these variables
+        "Pressure",
+        "Temperature",
+    ],
+    validator=custom_filter,
 )
 ```
 

--- a/docs/userguide/parameters.md
+++ b/docs/userguide/parameters.md
@@ -26,8 +26,8 @@ that lies within the chosen interval.
 from baybe.parameters import NumericalContinuousParameter
 
 NumericalContinuousParameter(
-   name = "Temperature",
-   bounds = (0, 100),
+    name="Temperature",
+    bounds=(0, 100),
 )
 ```
 
@@ -58,8 +58,9 @@ that specified tolerance from any of the possible values.
 from baybe.parameters import NumericalDiscreteParameter
 
 NumericalDiscreteParameter(
-   name = "Temperature",
-   values = (0, 10, 20, 30, 40, 50), # you can also use np.arange or similar to provide values
+    name="Temperature",
+    # you can also use np.arange or similar to provide values
+    values=(0, 10, 20, 30, 40, 50),
 )
 ```
 
@@ -80,9 +81,9 @@ be reasonable.
 from baybe.parameters import CategoricalParameter
 
 CategoricalParameter(
-   name = "Intensity",
-   values = ("low", "medium" ,"high"),
-   encoding = "INT", # optional, uses integer encoding as described above
+    name="Intensity",
+    values=("low", "medium", "high"),
+    encoding="INT",  # optional, uses integer encoding as described above
 )
 ```
 
@@ -119,8 +120,8 @@ SubstanceParameter(
         "1-Octanol": "CCCCCCCCO",
         "Toluene": "CC1=CC=CC=C1",
     },
-    encoding = "MORDRED", # optional
-    decorrelate = 0.7, # optional
+    encoding="MORDRED",  # optional
+    decorrelate=0.7,  # optional
 )
 ```
 
@@ -164,17 +165,18 @@ polymers:
 import pandas as pd
 from baybe.parameters import CustomDiscreteParameter
 
-descriptors = pd.DataFrame({
+descriptors = pd.DataFrame(
+    {
         "Glass_Transition_TempC": [20, -71, -39],
         "Weight_kDalton": [120, 32, 241],
-    }, 
-   index = ["Polymer A", "Polymer B", "Polymer C"] # put labels in the index
+    },
+    index=["Polymer A", "Polymer B", "Polymer C"],  # put labels in the index
 )
 
 CustomDiscreteParameter(
-    name = "Polymer",
-    data = descriptors,
-    decorrelate = True, # optional, uses default correlation threshold
+    name="Polymer",
+    data=descriptors,
+    decorrelate=True,  # optional, uses default correlation threshold
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ telemetry = [
 ]
 
 test = [
+    "baybe[lint]", # The tests also include linting the code in the docs
     "hypothesis[pandas]>=6.88.4",
     "pytest>=7.2.0",
     "pytest-cov>=4.1.0",

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -17,8 +17,11 @@ def test_readme():
 
 @pytest.mark.parametrize("file", Path("docs/userguide/").rglob("*.md"))
 def test_userguide(file: Path):
-    """The blocks in the user guide become a valid python script when concatenated."""
-    userguide_code = "\n".join(extract_code_blocks(file))
+    """The blocks in the user guide become a valid python script when concatenated.
+
+    Blocks surrounded with "triple-tilde" are ignored.
+    """
+    userguide_code = "\n".join(extract_code_blocks(file, include_tilde=False))
     exec(userguide_code)
 
 

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -8,16 +8,13 @@ import pytest
 
 from .utils import extract_code_blocks
 
-
-def test_readme():
-    """The blocks in the README become a valid python script when concatenated."""
-    readme_code = "\n".join(extract_code_blocks("README.md"))
-    exec(readme_code)
+doc_files = ["README.md", *Path("docs/userguide/").rglob("*.md")]
+"""Files whose code blocks are to be checked."""
 
 
-@pytest.mark.parametrize("file", Path("docs/userguide/").rglob("*.md"))
-def test_userguide(file: Path):
-    """The blocks in the user guide become a valid python script when concatenated.
+@pytest.mark.parametrize("file", doc_files)
+def test_code_executability(file: Path):
+    """The code blocks in the file become a valid python script when concatenated.
 
     Blocks surrounded with "triple-tilde" are ignored.
     """
@@ -25,9 +22,9 @@ def test_userguide(file: Path):
     exec(userguide_code)
 
 
-@pytest.mark.parametrize("file", Path("docs/userguide/").rglob("*.md"))
-def test_userguide_code_format(file: Path):
-    """The blocks in the user guide are properly formatted.
+@pytest.mark.parametrize("file", doc_files)
+def test_code_format(file: Path):
+    """The code blocks in the file are properly formatted.
 
     If it fails, run `pytest` with the `-s` flag to show the necessary format changes.
     """

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -1,6 +1,8 @@
 """Test the code provided in the docs."""
 
+import subprocess
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -9,12 +11,49 @@ from .utils import extract_code_blocks
 
 def test_readme():
     """The blocks in the README become a valid python script when concatenated."""
-    readme_code = extract_code_blocks("README.md")
+    readme_code = "\n".join(extract_code_blocks("README.md"))
     exec(readme_code)
 
 
 @pytest.mark.parametrize("file", Path("docs/userguide/").rglob("*.md"))
 def test_userguide(file: Path):
     """The blocks in the user guide become a valid python script when concatenated."""
-    userguide_code = extract_code_blocks(file)
+    userguide_code = "\n".join(extract_code_blocks(file))
     exec(userguide_code)
+
+
+@pytest.mark.parametrize("file", Path("docs/userguide/").rglob("*.md"))
+def test_userguide_code_format(file: Path):
+    """The blocks in the user guide are properly formatted.
+
+    If it fails, run `pytest` with the `-s` flag to show the necessary format changes.
+    """
+    code_blocks = extract_code_blocks(file)
+    success = True
+    for block in code_blocks:
+        with NamedTemporaryFile("w+") as f:
+            f.write(block)
+            f.write("\n")  # the code blocks contain no empty line at the end
+            f.flush()
+            result = subprocess.run(
+                ["ruff", "format", "--check", f"{f.name}"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if result.returncode:
+                success = False
+                print("\nOriginal Code")
+                print("-------------")
+                print(block, "\n")
+                print("\nReformatted Code")
+                print("----------------")
+                subprocess.run(
+                    ["ruff", "format", f"{f.name}"],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                f.seek(0)
+                print(f.read(), "\n")
+    assert success

--- a/tests/docs/utils.py
+++ b/tests/docs/utils.py
@@ -5,9 +5,16 @@ from pathlib import Path
 from typing import List, Union
 
 
-def extract_code_blocks(path: Union[str, Path]) -> List[str]:
+def extract_code_blocks(
+    path: Union[str, Path], include_tilde: bool = True
+) -> List[str]:
     """Extract all python code blocks from the specified file."""
     contents = Path(path).read_text()
-    code_blocks = re.findall(r"```python\s+(.*?)\s+```", contents, flags=re.DOTALL)
+    pattern = (
+        r"(?:```|~~~)python\s+(.*?)\s+(?:```|~~~)"
+        if include_tilde
+        else r"```python\s+(.*?)\s+```"
+    )
+    code_blocks = re.findall(pattern, contents, flags=re.DOTALL)
 
     return code_blocks

--- a/tests/docs/utils.py
+++ b/tests/docs/utils.py
@@ -2,13 +2,12 @@
 
 import re
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 
-def extract_code_blocks(path: Union[str, Path]) -> str:
-    """Extract all python code blocks from the specified file into a single string."""
+def extract_code_blocks(path: Union[str, Path]) -> List[str]:
+    """Extract all python code blocks from the specified file."""
     contents = Path(path).read_text()
     code_blocks = re.findall(r"```python\s+(.*?)\s+```", contents, flags=re.DOTALL)
-    concatenated_code = "\n".join(code_blocks)
 
-    return concatenated_code
+    return code_blocks


### PR DESCRIPTION
Adds a test that pipes all user guide code blocks through ruff to check for proper formatting. Run `pytest -s tests/docs/test_docs.py` to see the necessary formatting changes that can be copy-pasted.