### PR TITLE
Remove BoTorch Workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix orders of examples in table of content
 - `DiscreteCustomConstraint` validator now expects data frame instead of series
 - `ignore_example` flag builds but does not execute examples when building documentation
+- New version of campaign user guide and basic example
+- BoTorch dependency bumped to `>=0.9.0`
 
 ### Fixed
 - Wrong use of `tolerance` argument in constraints user guide
@@ -33,13 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Conda install instructions and version badge
 - Early fail for different Python versions in regular pipeline
+- Workaround for BoTorch hybrid recommender data type
 
 ### Deprecations
 - `Interval.is_finite` replaced with `Interval.is_bounded`
 - Specifying target configs without explicit type information is deprecated
-
-### Changed
-- New version of campaign user guide and basic example
+- Python 3.8 no longer supported
 
 ## [0.7.1] - 2023-12-07
 ### Added

--- a/baybe/recommenders/bayesian.py
+++ b/baybe/recommenders/bayesian.py
@@ -415,12 +415,6 @@ class SequentialGreedyRecommender(BayesianRecommender):
                 f"acquisition functions."
             ) from ex
 
-        # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-        # TODO [14819]: The following code is necessary due to floating point
-        #   inaccuracies introduced by BoTorch (potentially due to some float32
-        #   conversion?). The current workaround is the match the recommendations back
-        #   to the closest candidate points.
-
         # Split discrete and continuous parts
         disc_points = points[:, : len(candidates_comp.columns)]
         cont_points = points[:, len(candidates_comp.columns) :]
@@ -443,7 +437,6 @@ class SequentialGreedyRecommender(BayesianRecommender):
         # Adjust the index of the continuous part and create overall recommendations
         rec_cont_exp.index = rec_disc_exp.index
         rec_exp = pd.concat([rec_disc_exp, rec_cont_exp], axis=1)
-        # <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
         return rec_exp
 

--- a/baybe/recommenders/bayesian.py
+++ b/baybe/recommenders/bayesian.py
@@ -293,7 +293,6 @@ class SequentialGreedyRecommender(BayesianRecommender):
                 on=list(candidates_comp),
             )["index"]
         )
-        assert len(points) == len(idxs)
 
         return idxs
 
@@ -380,7 +379,8 @@ class SequentialGreedyRecommender(BayesianRecommender):
         # format expected by BoTorch
         # TODO: Currently assumes that discrete parameters are first and continuous
         #   second. Once parameter redesign [11611] is completed, we might adjust this.
-        candidates_comp.columns = list(range(len(candidates_comp.columns)))
+        num_comp_columns = len(candidates_comp.columns)
+        candidates_comp.columns = list(range(num_comp_columns))
         fixed_features_list = candidates_comp.to_dict("records")
 
         # Actual call of the BoTorch optimization routine
@@ -395,7 +395,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
                 equality_constraints=[
                     c.to_botorch(
                         searchspace.continuous.parameters,
-                        idx_offset=len(candidates_comp.columns),
+                        idx_offset=num_comp_columns,
                     )
                     for c in searchspace.continuous.constraints_lin_eq
                 ]
@@ -403,7 +403,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
                 inequality_constraints=[
                     c.to_botorch(
                         searchspace.continuous.parameters,
-                        idx_offset=len(candidates_comp.columns),
+                        idx_offset=num_comp_columns,
                     )
                     for c in searchspace.continuous.constraints_lin_ineq
                 ]
@@ -416,8 +416,8 @@ class SequentialGreedyRecommender(BayesianRecommender):
             ) from ex
 
         # Split discrete and continuous parts
-        disc_points = points[:, : len(candidates_comp.columns)]
-        cont_points = points[:, len(candidates_comp.columns) :]
+        disc_points = points[:, :num_comp_columns]
+        cont_points = points[:, num_comp_columns:]
 
         # Get selected candidate indices
         idxs = pd.Index(

--- a/baybe/recommenders/sampling.py
+++ b/baybe/recommenders/sampling.py
@@ -46,7 +46,6 @@ class RandomRecommender(NonPredictiveRecommender):
             replace=len(disc_candidates) < batch_quantity,
         )
 
-        cont_random.reset_index(drop=True)
         cont_random.index = disc_random.index
         return pd.concat([disc_random, cont_random], axis=1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "scikit-learn-extra>=0.3.0",
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
-    "torch>=1.11.0",
+    "torch>=1.13.1",
     "baybe[telemetry]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,13 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python =">=3.8,<3.12"
+requires-python =">=3.9,<3.12"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 dynamic = ['version']
 dependencies = [
     "attrs>=22.2.0",
-    "botorch>=0.8.1",
+    "botorch>=0.9.0",
     "cattrs>=23.2.0",
     "exceptiongroup",
     "funcy>=1.17",


### PR DESCRIPTION
- removes the botorch workaround for hybrid recommender
- bumps botorch version requirement
- fix: Changelog had two `changed` sections
- Python 3.8 can no longer be supported

I could not enable Python 3.12 support as several packages including torch do not support it yet