### PR TITLE
Include transfer learning example for backtesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - De-/serialization of target subclasses via base class
 - Docs building check now part of CI
 - Automatic formatting checks for code examples in documentation
+- Transfer Learning Backtesting example
 
 ### Changed
 - Renamed `bounds_transform_func` target attribute to `transformation`

--- a/examples/Backtesting/transfer_learning.py
+++ b/examples/Backtesting/transfer_learning.py
@@ -1,7 +1,8 @@
 ### Example for a simulation loop using the transfer learning capabilities
 
-# This example shows how to use BayBE's transfer learning capabilities.
-# That is, we demonstrate how to utilize information transfer between tasks.
+# This example shows how to use BayBE's transfer learning capabilities in a backtesting
+# scenario. We also compare the results obtained with transfer learning to results
+# obtained without transfer learning.
 
 # This example assumes some basic familiarity with using BayBE and the lookup
 # functionality functions in discrete search spaces.
@@ -16,47 +17,46 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from botorch.test_functions import SixHumpCamel, ThreeHumpCamel
-from torch import Tensor
 
 from baybe import Campaign
 from baybe.objective import Objective
 from baybe.parameters import NumericalDiscreteParameter, TaskParameter
 from baybe.searchspace import SearchSpace
-from baybe.simulation import simulate_transfer_learning
+from baybe.simulation import simulate_scenarios, simulate_transfer_learning
 from baybe.targets import NumericalTarget
+from baybe.utils import botorch_function_wrapper
 
 #### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 
-N_MC_ITERATIONS = 2
-N_DOE_ITERATIONS = 4
+N_MC_ITERATIONS = 9
+N_DOE_ITERATIONS = 5
 
 #### Defining the tasks
 
 # We use two similar two-dimensional test functions imported from BoTorch.
 # We use them to create a lookup table after creating the search space and the objective.
-three_hump_camel = ThreeHumpCamel()
-six_hump_camel = SixHumpCamel()
+three_hump_camel = botorch_function_wrapper(ThreeHumpCamel())
+six_hump_camel = botorch_function_wrapper(SixHumpCamel())
 
 #### Creating the searchspace and the objective
 
 # The parameter `POINTS_PER_DIM` controls the number of points per dimension.
 # Note that the searchspace will have `POINTS_PER_DIM**2` many points.
 
-BOUNDS = three_hump_camel.bounds
-POINTS_PER_DIM = 20
+POINTS_PER_DIM = 10
 
+# We define two numerical discrete parameters, as well as a ``TaskParameter``.
+# This parameter contains the information about the different tasks that we have in this
+# transfer learning example.
 x1 = NumericalDiscreteParameter(
-    name="x_1", values=list(np.linspace(BOUNDS[0, 0], BOUNDS[1, 0], POINTS_PER_DIM))
+    name="x_1", values=list(np.linspace(-2, 2, POINTS_PER_DIM))
 )
 x2 = NumericalDiscreteParameter(
-    name="x_2", values=list(np.linspace(BOUNDS[0, 1], BOUNDS[1, 1], POINTS_PER_DIM))
+    name="x_2", values=list(np.linspace(-2, 2, POINTS_PER_DIM))
 )
-
-# We now append a ``TaskParameter``. This parameter contains the information about the
-# different tasks that we have in this transfer learning example.
 task_param = TaskParameter(name="Function", values=("ThreeHump", "SixHump"))
 parameters = [x1, x2, task_param]
 
@@ -71,42 +71,32 @@ campaign = Campaign(searchspace=searchspace, objective=objective)
 #### Generating the lookup table
 
 # The lookup table for the parameters and their values need to contain one column per
-# parameter, including one for the TaskParameter. The values in that column describe
-# for which task a measurement was made.
+# parameter, including one for the ``TaskParameter`` and one column for the target value.
+# The table is created by constructing one dataframe per task and concatenating them.
 
-# Generate the grid coordinates using numpy
-x = parameters[0].values
-y = parameters[1].values
+x = x1.values
+y = x2.values
 xx, yy = np.meshgrid(x, y)
 
-lookup = pd.DataFrame({"x_1": xx.flatten(), "x_2": yy.flatten()})
 
-# We randomly decide for each row which function we measure
-lookup["Function"] = np.random.choice(["ThreeHump", "SixHump"], lookup.shape[0])
+lookup_3hc = pd.DataFrame({"x_1": xx.flatten(), "x_2": yy.flatten()})
+lookup_3hc["Target"] = lookup_3hc.apply(three_hump_camel, axis=1)
+lookup_3hc["Function"] = "ThreeHump"
 
+lookup_6hc = pd.DataFrame({"x_1": xx.flatten(), "x_2": yy.flatten()})
+lookup_6hc["Target"] = lookup_6hc.apply(six_hump_camel, axis=1)
+lookup_6hc["Function"] = "SixHump"
 
-# This is a little helper function that is used to apply the function three_hump_camel
-# resp. six_humP-camel if the value of the "Function" column is ``"ThreeHump"`` resp.
-# ``"SixHump"``.
-def _choose_task(x1, x2, function):
-    func_dict = {"ThreeHump": three_hump_camel, "SixHump": six_hump_camel}
-    return float(func_dict[function](Tensor((x1, x2))))
-
-
-# Apply the helper function to the lookup dataframe
-lookup["Target"] = lookup.apply(
-    lambda x: _choose_task(x["x_1"], x["x_2"], x["Function"]), axis=1
-)
+lookup = pd.concat([lookup_3hc, lookup_6hc], ignore_index=True)
 
 # We print the first ten rows to show how the table looks like
 print(lookup.head(10))
-
 
 #### Performing the simulation loop
 
 # We can now use the `simulate_transfer_learning` function to simulate a full experiment.
 
-results = simulate_transfer_learning(
+results_with_tf = simulate_transfer_learning(
     campaign,
     lookup,
     batch_quantity=1,
@@ -114,7 +104,39 @@ results = simulate_transfer_learning(
     n_mc_iterations=N_MC_ITERATIONS,
 )
 
-# The following lines plot the results and save the plot in run_analytical.png
+# To showcase the improvement, we also optimize the same tasks independently and use
+# the `simulate_scenarios` function.
+
+parameters_without_tl = [x1, x2]
+campaign_without_tl_3hc = Campaign(
+    searchspace=SearchSpace.from_product([x1, x2]), objective=objective
+)
+campaign_without_tl_6hc = Campaign(
+    searchspace=SearchSpace.from_product([x1, x2]), objective=objective
+)
+
+scenarios_3hc = {"ThreeHump no TL": campaign_without_tl_3hc}
+scenarios_6hc = {"SixHump no TL": campaign_without_tl_6hc}
+
+results_3hc_no_tl = simulate_scenarios(
+    scenarios_3hc,
+    three_hump_camel,
+    batch_quantity=1,
+    n_doe_iterations=N_DOE_ITERATIONS,
+    n_mc_iterations=N_MC_ITERATIONS,
+)
+
+results_6hc_no_tl = simulate_scenarios(
+    scenarios_6hc,
+    six_hump_camel,
+    batch_quantity=1,
+    n_doe_iterations=N_DOE_ITERATIONS,
+    n_mc_iterations=N_MC_ITERATIONS,
+)
+
+
+# We concatenate all the results and show them in a single plot.
+results = pd.concat([results_with_tf, results_3hc_no_tl, results_6hc_no_tl])
 sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
 plt.gcf().set_size_inches(24, 8)
 plt.savefig("./run_analytical.png")

--- a/examples/Backtesting/transfer_learning.py
+++ b/examples/Backtesting/transfer_learning.py
@@ -130,22 +130,30 @@ results = simulate_transfer_learning(
 # To showcase the improvement, we also optimize the same tasks independently and use
 # the `simulate_scenarios` function.
 
-parameters_without_tl = parameters[:-1]  # We do not need the task parameter here
-
+parameters_no_tl = parameters[:-1]  # We need new task parameters
+scenarios = {}  # Dictionary of all scenarios
+# Iterate over all available test functions to create one campaign for each function
 for function in test_functions:
-    hartmann_function = test_functions[function]  # Get actual function
-    campaign_no_tl = Campaign(
-        searchspace=SearchSpace.from_product(parameters_without_tl), objective=objective
+    hartmann_function = test_functions[function]  # Get current test function
+    task_parameter = TaskParameter(  # Create TaskParameter
+        name="Function",
+        values=("Hartmann", "CHartmann", "CSHartmann"),
+        active_values=[function],
     )
-    scenario = {f"{function}_no_TL": campaign_no_tl}
-    results_no_tl = simulate_scenarios(
-        scenario,
-        hartmann_function,
-        batch_quantity=BATCH_QUANTITY,
-        n_doe_iterations=N_DOE_ITERATIONS,
-        n_mc_iterations=N_MC_ITERATIONS,
+    campaign = Campaign(
+        searchspace=SearchSpace.from_product(parameters_no_tl + [task_parameter]),
+        objective=objective,
     )
-    results = pd.concat([results, results_no_tl])
+    scenarios[f"{function}_no_TL"] = campaign
+
+results_no_tl = simulate_scenarios(
+    scenarios,
+    lookup,
+    batch_quantity=BATCH_QUANTITY,
+    n_doe_iterations=N_DOE_ITERATIONS,
+    n_mc_iterations=N_MC_ITERATIONS,
+)
+results = pd.concat([results, results_no_tl])
 
 
 # We concatenate all the results and show them in a single plot.

--- a/examples/Backtesting/transfer_learning.py
+++ b/examples/Backtesting/transfer_learning.py
@@ -1,0 +1,120 @@
+### Example for a simulation loop using the transfer learning capabilities
+
+# This example shows how to use BayBE's transfer learning capabilities.
+# That is, we demonstrate how to utilize information transfer between tasks.
+
+# This example assumes some basic familiarity with using BayBE and the lookup
+# functionality functions in discrete search spaces.
+# We thus refer to
+# 1. [`campaign`](./../Basics/campaign.md) for a basic example on how to use BayBE and
+# 2. [`full_lookup`](./full_lookup.md) for details on the lookup functionality.
+
+#### Necessary imports for this example
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from botorch.test_functions import SixHumpCamel, ThreeHumpCamel
+from torch import Tensor
+
+from baybe import Campaign
+from baybe.objective import Objective
+from baybe.parameters import NumericalDiscreteParameter, TaskParameter
+from baybe.searchspace import SearchSpace
+from baybe.simulation import simulate_transfer_learning
+from baybe.targets import NumericalTarget
+
+#### Parameters for a full simulation loop
+
+# For the full simulation, we need to define some additional parameters.
+# These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
+
+N_MC_ITERATIONS = 2
+N_DOE_ITERATIONS = 4
+
+#### Defining the tasks
+
+# We use two similar two-dimensional test functions imported from BoTorch.
+# We use them to create a lookup table after creating the search space and the objective.
+three_hump_camel = ThreeHumpCamel()
+six_hump_camel = SixHumpCamel()
+
+#### Creating the searchspace and the objective
+
+# The parameter `POINTS_PER_DIM` controls the number of points per dimension.
+# Note that the searchspace will have `POINTS_PER_DIM**2` many points.
+
+BOUNDS = three_hump_camel.bounds
+POINTS_PER_DIM = 20
+
+x1 = NumericalDiscreteParameter(
+    name="x_1", values=list(np.linspace(BOUNDS[0, 0], BOUNDS[1, 0], POINTS_PER_DIM))
+)
+x2 = NumericalDiscreteParameter(
+    name="x_2", values=list(np.linspace(BOUNDS[0, 1], BOUNDS[1, 1], POINTS_PER_DIM))
+)
+
+# We now append a ``TaskParameter``. This parameter contains the information about the
+# different tasks that we have in this transfer learning example.
+task_param = TaskParameter(name="Function", values=("ThreeHump", "SixHump"))
+parameters = [x1, x2, task_param]
+
+# We now create the searchspace, objective and campaign.
+
+searchspace = SearchSpace.from_product(parameters=parameters)
+objective = Objective(
+    mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
+)
+campaign = Campaign(searchspace=searchspace, objective=objective)
+
+#### Generating the lookup table
+
+# The lookup table for the parameters and their values need to contain one column per
+# parameter, including one for the TaskParameter. The values in that column describe
+# for which task a measurement was made.
+
+# Generate the grid coordinates using numpy
+x = parameters[0].values
+y = parameters[1].values
+xx, yy = np.meshgrid(x, y)
+
+lookup = pd.DataFrame({"x_1": xx.flatten(), "x_2": yy.flatten()})
+
+# We randomly decide for each row which function we measure
+lookup["Function"] = np.random.choice(["ThreeHump", "SixHump"], lookup.shape[0])
+
+
+# This is a little helper function that is used to apply the function three_hump_camel
+# resp. six_humP-camel if the value of the "Function" column is ``"ThreeHump"`` resp.
+# ``"SixHump"``.
+def _choose_task(x1, x2, function):
+    func_dict = {"ThreeHump": three_hump_camel, "SixHump": six_hump_camel}
+    return float(func_dict[function](Tensor((x1, x2))))
+
+
+# Apply the helper function to the lookup dataframe
+lookup["Target"] = lookup.apply(
+    lambda x: _choose_task(x["x_1"], x["x_2"], x["Function"]), axis=1
+)
+
+# We print the first ten rows to show how the table looks like
+print(lookup.head(10))
+
+
+#### Performing the simulation loop
+
+# We can now use the `simulate_transfer_learning` function to simulate a full experiment.
+
+results = simulate_transfer_learning(
+    campaign,
+    lookup,
+    batch_quantity=1,
+    n_doe_iterations=N_DOE_ITERATIONS,
+    n_mc_iterations=N_MC_ITERATIONS,
+)
+
+# The following lines plot the results and save the plot in run_analytical.png
+sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
+plt.gcf().set_size_inches(24, 8)
+plt.savefig("./run_analytical.png")

--- a/examples/Backtesting/transfer_learning.py
+++ b/examples/Backtesting/transfer_learning.py
@@ -139,4 +139,4 @@ results_6hc_no_tl = simulate_scenarios(
 results = pd.concat([results_with_tf, results_3hc_no_tl, results_6hc_no_tl])
 sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
 plt.gcf().set_size_inches(24, 8)
-plt.savefig("./run_analytical.png")
+plt.savefig("./run_transfer_learning.png")

--- a/examples/Backtesting/transfer_learning.py
+++ b/examples/Backtesting/transfer_learning.py
@@ -38,10 +38,13 @@ from baybe.utils import botorch_function_wrapper
 # Also, since the test function we use here is defined for several dimension, we choose
 # a dimension.
 
-DIMENSION = 3
-N_MC_ITERATIONS = 6
-N_DOE_ITERATIONS = 5
-BATCH_QUANTITY = 1
+# Note that these values were chosen to enable a fast execution. We provide "recommended"
+# values for obtaining a fast yet informative example.
+
+DIMENSION = 3  # Recommendation: 3
+N_MC_ITERATIONS = 2  # Recommendation: 6
+N_DOE_ITERATIONS = 2  # Recommendation: 5
+BATCH_QUANTITY = 1  # Recommendation: 1
 
 #### Defining the tasks
 
@@ -65,7 +68,7 @@ test_functions = {
 # The parameter `POINTS_PER_DIM` controls the number of points per dimension.
 # Note that the searchspace will have `POINTS_PER_DIM**DIMENSION` many points.
 # The bounds are defined by the test function.
-POINTS_PER_DIM = 6
+POINTS_PER_DIM = 6  # Recommended: 6
 BOUNDS = Hartmann().bounds
 
 # We define one numerical discrete parameters per dimension, as well as a ``TaskParameter``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 dynamic = ['version']
 dependencies = [
     "attrs>=22.2.0",
-    "botorch>=0.8.1",
+    "botorch>=0.9.3",
     "cattrs>=23.2.0",
     "exceptiongroup",
     "funcy>=1.17",


### PR DESCRIPTION
This PR introduces two basic transfer learning examples.

The first example is a backtesting example that just shows how to initialize and use a `TaskParamter`. In particular, things like `active_values` and more detailed explanations are NOT INTENDED to be part of that example.
Instead, a second example (which is NOT YET included here) will be constructed. This example will guide the user through a more detailed application of the current transfer learning capabilities, including the use of `active_values` and more meaningful lookup tables.
The reason for this is that it is not perfectly clear yet which aspects of the corresponding examples should stay in the examples and which should rather be part of the user guide which is something we will need to discuss.

I intentionally already provided this example independent of the current refactorings regarding the simulation. We might want to finish them first and then include this example or the other way round.