### PR TITLE
Change docs publishing trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Documentation
 
 on:
-  push:
-    branches: main
-  workflow_dispatch:
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
This change intends to trigger the publication of docs to only-on-release
Currently its published on each update to main

it means the docs (starting from the next release) will only be online for the latest published release (also known as `stable`)
the publication on merge-into-main (also known as `latest`) can be reenabled once we figured out multi-version docs