### PR TITLE
Explicit top-level files for example folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Optional `chem` dependencies are lazily imported
+- Explicit top-level files for example folders
+- Remove additional headings in table of contents of examples
 
 ### Fixed
 - Several minor issues in documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Copy button for code blocks in documentation
 - `mypy` for campaign, constraints and telemetry
+- Top-level example summaries
 
 ### Changed
 - Optional `chem` dependencies are lazily imported
-- Explicit top-level files for example folders
-- Remove additional headings in table of contents of examples
 
 ### Fixed
 - Several minor issues in documentation
+
+### Removed
+- Detailed headings in table of contents of examples
 
 ## [0.7.2] - 2024-01-24
 ### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,10 @@ nitpick_ignore_regex = [
     (r"py:class", "baybe.utils.basic._U"),
 ]
 
+
+# Ignore the warnings that are given by autosectionlabel
+suppress_warnings = ["autosectionlabel.*"]
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,7 @@ except Exception as e:
 # autodoc_typehints
 extensions = [
     "sphinx.ext.napoleon",  # Necessary for numpy/google docstrings to work
+    "sphinx.ext.autosectionlabel",  # Automatically create anchors for page sections
     "sphinx.ext.autodoc",  # Crucial for autodocumentation
     "sphinx.ext.autosummary",  # Autosummary
     "sphinx.ext.intersphinx",  # Links to other documentations like numpy, python,...
@@ -87,6 +88,7 @@ extensions = [
     "sphinx_copybutton",  # Copy button for code blocks
 ]
 myst_enable_extensions = ["dollarmath"]  # Enables Latex-like math in markdown files
+autosectionlabel_prefix_document = True  # Make sure autosectionlabels are unique
 
 
 # Tell sphinx where to find the templates

--- a/docs/misc/license_link.md
+++ b/docs/misc/license_link.md
@@ -1,5 +1,4 @@
 # License
 ```{literalinclude} ../../LICENSE
 :language: text
-:relative-docs: docs/
 ```

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -119,8 +119,13 @@ def create_example_documentation(example_dest_dir: str):
         if ex_file_entry not in ex_order:
             ex_order.append(ex_file_entry)
 
-        # We need to create a file for the inclusion of the folder
-        subdir_toctree = f"# {folder_name}\n\n" + "```{toctree}\n:maxdepth: 1\n\n"
+        # We need to create a file for the inclusion of the folder.
+        # We thus get the content of the corresponding header file.
+        header_folder_name = sub_directory / f"{folder_name}_Header.md"
+        with open(header_folder_name, "r") as file:
+            header = "\n".join(file.readlines())
+
+        subdir_toctree = header + "\n```{toctree}\n:maxdepth: 1\n\n"
 
         # Set description of progressbar
         pbar.set_description("Overall progress")
@@ -210,8 +215,9 @@ def create_example_documentation(example_dest_dir: str):
     # Remove remaining files and subdirectories from the destination directory
     # Remove any not markdown files
     for file in examples_directory.glob("**/*"):
-        if file.is_file() and file.suffix != ".md":
-            file.unlink(file)
+        if file.is_file():
+            if file.suffix != ".md" or "Header" in file.name:
+                file.unlink(file)
 
     # Remove any remaining empty subdirectories
     for subdirectory in examples_directory.glob("*/*"):

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -120,7 +120,7 @@ def create_example_documentation(example_dest_dir: str):
             ex_order.append(ex_file_entry)
 
         # We need to create a file for the inclusion of the folder
-        subdir_toctree = f"# {folder_name}\n\n" + "```{toctree}\n:maxdepth: 2\n\n"
+        subdir_toctree = f"# {folder_name}\n\n" + "```{toctree}\n:maxdepth: 1\n\n"
 
         # Set description of progressbar
         pbar.set_description("Overall progress")

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -123,7 +123,7 @@ def create_example_documentation(example_dest_dir: str):
         # We thus get the content of the corresponding header file.
         header_folder_name = sub_directory / f"{folder_name}_Header.md"
         with open(header_folder_name, "r") as file:
-            header = "\n".join(file.readlines())
+            header = "".join(file.readlines())
 
         subdir_toctree = header + "\n```{toctree}\n:maxdepth: 1\n\n"
 

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -122,8 +122,7 @@ def create_example_documentation(example_dest_dir: str):
         # We need to create a file for the inclusion of the folder.
         # We thus get the content of the corresponding header file.
         header_folder_name = sub_directory / f"{folder_name}_Header.md"
-        with open(header_folder_name, "r") as file:
-            header = "".join(file.readlines())
+        header = header_folder_name.read_text()
 
         subdir_toctree = header + "\n```{toctree}\n:maxdepth: 1\n\n"
 

--- a/examples/Backtesting/Backtesting_Header.md
+++ b/examples/Backtesting/Backtesting_Header.md
@@ -1,0 +1,5 @@
+# Backtesting
+
+These examples demonstrate the backtesting capabilities of BayBE.
+By "backtesting", we refer to the process of setting up a campaign, getting recommendations
+and adding measurements in an iterative fashion by using an existing lookup in the form of historical data or analytical functions.

--- a/examples/Backtesting/Backtesting_Header.md
+++ b/examples/Backtesting/Backtesting_Header.md
@@ -1,5 +1,4 @@
 # Backtesting
 
-These examples demonstrate the backtesting capabilities of BayBE.
-By "backtesting", we refer to the process of setting up a campaign, getting recommendations
-and adding measurements in an iterative fashion by using an existing lookup in the form of historical data or analytical functions.
+These examples demonstrate BayBE's
+{doc}`Backtesting </userguide/simulation>` capabilities.

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a BoTorch test function
+## Example for full simulation loop using a BoTorch test function
 
 # This example shows a simulation loop for a single target with a BoTorch test function as lookup.
 # That is, we perform several Monte Carlo runs with several iterations.
@@ -11,7 +11,7 @@
 # 2. [`discrete_space`](./../Searchspaces/discrete_space.md) for details on using a
 # BoTorch test function.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,7 +28,7 @@ from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
@@ -36,7 +36,7 @@ from baybe.utils import botorch_function_wrapper
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 2
 
-#### Defining the test function
+### Defining the test function
 
 # See [`discrete_space`](./../Searchspaces/discrete_space.md) for details.
 
@@ -57,7 +57,7 @@ else:
 BOUNDS = TestFunction.bounds
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # The parameter `POINTS_PER_DIM` controls the number of points per dimension.
 # Note that the searchspace will have `POINTS_PER_DIM**DIMENSION` many points.
@@ -83,7 +83,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # To simplify adjusting the example for other strategies, we construct some strategy objects.
 # For details on strategy objects, we refer to [`strategies`](./../Basics/strategies.md).
@@ -106,7 +106,7 @@ random_campaign = Campaign(
     objective=objective,
 )
 
-#### Performing the simulation loop
+### Performing the simulation loop
 
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a custom analytical test function
+## Example for full simulation loop using a custom analytical test function
 
 # This example shows a simulation loop for a single target with a custom test function as lookup.
 # That is, we perform several Monte Carlo runs with several iterations.
@@ -11,7 +11,7 @@
 # - [`campaign`](./../Basics/campaign.md) for a basic example on how to use BayBE and
 # - [here](./../Searchspaces/continuous_space_custom_function.md) for how to use a custom function.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,7 +26,7 @@ from baybe.simulation import simulate_scenarios
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
@@ -34,7 +34,7 @@ from baybe.targets import NumericalTarget
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 2
 
-#### Defining the test function
+### Defining the test function
 
 # See [here](./../Searchspaces/continuous_space_custom_function.md) for details.
 
@@ -50,7 +50,7 @@ def sum_of_squares(*x: float) -> float:
 DIMENSION = 4
 BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # As we expect it to be the most common use case, we construct a purely discrete space here.
 # Details on how to adjust this for other spaces can be found in the searchspace examples.
@@ -73,7 +73,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # To simplify adjusting the example for other strategies, we construct some strategy objects.
 # For details on strategy objects, we refer to [`strategies`](./../Basics/strategies.md).
@@ -96,7 +96,7 @@ random_campaign = Campaign(
     objective=objective,
 )
 
-#### Performing the simulation loop
+### Performing the simulation loop
 
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.

--- a/examples/Backtesting/full_initial_data.py
+++ b/examples/Backtesting/full_initial_data.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a table-based lookup mechanism with initial data
+## Example for full simulation loop using a table-based lookup mechanism with initial data
 
 # This example shows a simulation for a direct arylation where all combinations have been measured.
 # It also demonstrates how to use initial data by using a lookup mechanism.
@@ -8,7 +8,7 @@
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 # We refer to [`full_lookup`](./full_lookup.md) for details on the lookup mechanism.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -23,14 +23,14 @@ from baybe.simulation import simulate_scenarios
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define an additional parameter.
 # Since this example uses initial data, we only need to define the number of iterations per run.
 # The number of runs is determined by the number of initial data points provided.
 N_DOE_ITERATIONS = 5
 
-#### Lookup functionality and data creation
+### Lookup functionality and data creation
 
 # See [`full_lookup`](./full_lookup.md) for details.
 
@@ -42,7 +42,7 @@ except FileNotFoundError:
     except FileNotFoundError as e:
         print(e)
 
-#### Inclusion of initial data
+### Inclusion of initial data
 
 # To include initial data, we sample some rows from the lookup table.
 # Note that the initial_data needs to be a list of `pd.DataFrame` objects.
@@ -80,7 +80,7 @@ dict_ligand = {
     "Me2PPh": r"CP(C)C1=CC=CC=C1",
 }
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Here, we create the parameter objects, the searchspace and the objective.
 
@@ -101,7 +101,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # In this example, we create two campaigns.
 # One uses the default recommender and the other one makes random recommendations.
@@ -112,7 +112,7 @@ campaign_rand = Campaign(
     objective=objective,
 )
 
-#### Performing the simulation loop
+### Performing the simulation loop
 
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # This function is where we provide the `initial_data` dataframe.

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a table-based lookup mechanism
+## Example for full simulation loop using a table-based lookup mechanism
 
 # This example shows a simulation for a direct arylation where all combinations have been measured.
 # This allows us to access information about previously conducted experiments from .xlsx-files.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -21,7 +21,7 @@ from baybe.simulation import simulate_scenarios
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
@@ -29,7 +29,7 @@ from baybe.targets import NumericalTarget
 N_DOE_ITERATIONS = 5
 N_MC_ITERATIONS = 3
 
-#### Lookup functionality and data creation
+### Lookup functionality and data creation
 
 # We read the information about the conducted experiments from a .xlsx-file.
 # This data set was obtained from [Shields, B.J., Stevens et al. Nature 590, 89–96 (2021)](https://doi.org/10.1038/s41586-021-03213-y) and contains measurements of a reaction yield,
@@ -77,7 +77,7 @@ dict_ligand = {
     "Me2PPh": r"CP(C)C1=CC=CC=C1",
 }
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Here, we create the parameter objects, the searchspace and the objective.
 
@@ -98,7 +98,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # In this example, we create two campaigns.
 # One uses the default recommender and the other one makes random recommendations.

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a custom analytical test function in a hybrid space
+## Example for full simulation loop using a custom analytical test function in a hybrid space
 
 # This example shows a simulation loop for a single target with a custom test function as lookup.
 # Most importantly, it demonstrates the creation of a custom hybrid searchspace.
@@ -7,7 +7,7 @@
 # We refer to [`campaign`](./../Basics/campaign.md) for a more  basic example resp.
 # to [`custom_analytical`](./custom_analytical.md) for details on the lookup mechanism.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,14 +26,14 @@ from baybe.simulation import simulate_scenarios
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 2
 
-#### Defining the test function.
+### Defining the test function.
 
 
 # See [`here`](./custom_analytical.md) for details on the custom analytical test function.
@@ -52,7 +52,7 @@ def sum_of_squares(*x: float) -> float:
 DIMENSION = 4
 BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
-#### Constructing the hybrid searchspace
+### Constructing the hybrid searchspace
 
 # Our goal is to construct a hybrid searchspace containing discrete and continuous parameters.
 # We thus need to specify which indices should be discrete and which should be continuous.
@@ -101,7 +101,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # This example compares three different available hybrid recommenders:
 # The `SequentialGreedyRecommender`, the `NaiveHybridRecommedner` and the `RandomRecommender`.

--- a/examples/Backtesting/impute_mode.py
+++ b/examples/Backtesting/impute_mode.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using a table-based lookup mechanism with incomplete data
+## Example for full simulation loop using a table-based lookup mechanism with incomplete data
 
 # This example shows a simulation for a direct arylation where not all combinations were measured.
 # This allows us to access information about previously conducted experiments from .xlsx-files.
@@ -7,7 +7,7 @@
 # We refer to [`campaign`](./../Basics/campaign.md) for a more  basic example resp.
 # to [`full_lookup`](./full_lookup.md) for details on the lookup mechanism.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -22,14 +22,14 @@ from baybe.simulation import simulate_scenarios
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 5
 
-#### Lookup functionality and data creation
+### Lookup functionality and data creation
 
 # See [`full_lookup`](./full_lookup.md) for details.
 try:
@@ -71,7 +71,7 @@ dict_ligand = {
     "Me2PPh": r"CP(C)C1=CC=CC=C1",
 }
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Here, we create the parameter objects, the searchspace and the objective.
 
@@ -92,7 +92,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
 
-#### Constructing campaigns for the simulation loop
+### Constructing campaigns for the simulation loop
 
 # In this example, we create two campaigns.
 # One uses the default recommender and the other one makes random recommendations.

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -1,4 +1,4 @@
-### Example for full simulation loop using the multi target mode for custom analytic functions
+## Example for full simulation loop using the multi target mode for custom analytic functions
 
 # This example shows how to use a multi target objective for a custom analytic function.
 # It uses a desirability value to handle several targets.
@@ -9,7 +9,7 @@
 # - [`custom_analytical`](./custom_analytical.md) for custom test functions, and
 # - [`desirability`](./../Multi_Target/desirability.md) for multiple targets.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 from typing import Tuple
 
@@ -22,7 +22,7 @@ from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
 
-#### Parameters for a full simulation loop
+### Parameters for a full simulation loop
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
@@ -30,7 +30,7 @@ from baybe.targets import NumericalTarget
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 4
 
-#### Defining the test function
+### Defining the test function
 
 
 # See [`custom_analytical`](./custom_analytical.md) for details
@@ -45,7 +45,7 @@ def sum_of_squares(*x: float) -> Tuple[float, float]:
 DIMENSION = 4
 BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
-#### Creating the searchspace
+### Creating the searchspace
 
 # In this example, we construct a purely discrete space with 10 points per dimension.
 parameters = [
@@ -60,7 +60,7 @@ parameters = [
 searchspace = SearchSpace.from_product(parameters=parameters)
 
 
-#### Creating multiple target object
+### Creating multiple target object
 
 # The multi target mode is handled when creating the objective object.
 # Thus we first need to define the different targets.
@@ -74,7 +74,7 @@ Target_2 = NumericalTarget(
 )
 
 
-#### Creating the objective object
+### Creating the objective object
 
 # We collect the two targets in a list and use this list to construct the objective.
 
@@ -88,7 +88,7 @@ objective = Objective(
 )
 
 
-#### Constructing a campaign and performing the simulation loop
+### Constructing a campaign and performing the simulation loop
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 

--- a/examples/Basics/Basics_Header.md
+++ b/examples/Basics/Basics_Header.md
@@ -1,5 +1,5 @@
 # Basics
 
-These examples show the most basic aspects of BayBE.
-The Campaign example shows how to set up a `Campaign` object.
-The Strategies example shows how different strategies can be used.
+These examples demonstrate the most basic aspects of BayBE: How to set up a
+{doc}`Campaign </userguide/campaigns>` and how to configure an optimization
+{doc}`Strategy </userguide/strategies>`.

--- a/examples/Basics/Basics_Header.md
+++ b/examples/Basics/Basics_Header.md
@@ -1,0 +1,5 @@
+# Basics
+
+These examples show the most basic aspects of BayBE.
+The Campaign example shows how to set up a `Campaign` object.
+The Strategies example shows how different strategies can be used.

--- a/examples/Basics/campaign.py
+++ b/examples/Basics/campaign.py
@@ -1,10 +1,10 @@
-### Basic example for using BayBE
+## Basic example for using BayBE
 
 # This example shows how to create a campaign and how to use it.
 # It is intended to be used as a first point of interaction with campaign after having
 # read the corresponding [user guide](./../../userguide/campaigns).
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 from baybe import Campaign
 from baybe.objective import Objective
@@ -13,7 +13,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Setup
+### Setup
 
 # This example presents the optimization of a direct Arylation reaction in a discrete
 # space. For this, we require data for solvents, ligands and bases.
@@ -73,7 +73,7 @@ campaign = Campaign(
     objective=objective,
 )
 
-#### Getting a recommendation and adding measurements
+### Getting a recommendation and adding measurements
 
 # We use the `recommend()` function of the campaign for getting measurements.
 

--- a/examples/Basics/strategies.py
+++ b/examples/Basics/strategies.py
@@ -1,4 +1,4 @@
-### Example for using different strategies
+## Example for using different strategies
 
 # This example shows how to create and use strategy objects.
 # Such an object specifies the strategy adopted to make recommendations.
@@ -14,7 +14,7 @@
 # This examples assumes some basic familiarity with using BayBE.
 # We refer to [`campaign`](./campaign.md) for a more general and basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 from baybe import Campaign
 from baybe.objective import Objective
@@ -31,7 +31,7 @@ from baybe.surrogates import (
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Available initial strategies
+### Available initial strategies
 
 # For the first recommendation, the user can specify which strategy to use.
 # The following initial recommenders are available.
@@ -47,7 +47,7 @@ initial_recommenders = [
 # Per default the initial recommender chosen is a random recommender.
 INITIAL_RECOMMENDER = RandomRecommender()
 
-#### Available surrogate models
+### Available surrogate models
 
 # This model uses available data to model the objective function as well as the uncertainty.
 # The surrogate model is then used by the acquisition function to make recommendations.
@@ -65,7 +65,7 @@ available_surrogate_models = [
 SURROGATE_MODEL = GaussianProcessSurrogate()
 
 
-#### Acquisition function
+### Acquisition function
 
 # This function looks for points where measurements of the target value could improve the model.
 # The following acquisition functions are generally available.
@@ -89,7 +89,7 @@ available_acq_functions = [
 
 ACQ_FUNCTION = "qEI"
 
-#### Other parameters
+### Other parameters
 
 # Two other boolean hyperparameters can be specified when creating a strategy object.
 # The first one allows the recommendation of points that were already recommended previously.
@@ -99,7 +99,7 @@ ACQ_FUNCTION = "qEI"
 ALLOW_REPEATED_RECOMMENDATIONS = True
 ALLOW_RECOMMENDING_ALREADY_MEASURED = True
 
-#### Creating the strategy object
+### Creating the strategy object
 
 # To create the strategy object, each parameter described above can be specified as follows.
 # Note that they all have default values.
@@ -120,7 +120,7 @@ print(strategy)
 # Their meaning and how to use and define it are explained in the hybrid backtesting example.
 # We thus refer to [`hybrid`](./../Backtesting/hybrid.md) for details on these.
 
-#### Example Searchspace and objective parameters
+### Example Searchspace and objective parameters
 
 # We use the same data used in the [`campaign`](./campaign.md) example.
 
@@ -165,7 +165,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
 
-#### Creating the campaign
+### Creating the campaign
 
 # The strategy object can now be used together with the searchspace and the objective as follows.
 

--- a/examples/Constraints_Continuous/Constraints_Continuous_Header.md
+++ b/examples/Constraints_Continuous/Constraints_Continuous_Header.md
@@ -1,0 +1,4 @@
+# Constraints Continuous
+
+These examples demonstrate how continuous constraints can be used in continuous and
+hybrid search spaces.

--- a/examples/Constraints_Continuous/Constraints_Continuous_Header.md
+++ b/examples/Constraints_Continuous/Constraints_Continuous_Header.md
@@ -1,4 +1,5 @@
 # Constraints Continuous
 
-These examples demonstrate how continuous constraints can be used in continuous and
-hybrid search spaces.
+These examples demonstrate how
+{ref}`Continuous Parameter Constraints <userguide/constraints:continuous constraints>`
+can be applied to continuous and hybrid search spaces.

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -1,4 +1,4 @@
-### Example for constraints in a hybrid searchspace
+## Example for constraints in a hybrid searchspace
 
 # Example for optimizing a synthetic test functions in a hybrid space with one
 # constraint in the discrete subspace and one constraint in the continuous subspace.
@@ -11,7 +11,7 @@
 # details on this aspect.
 
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 from botorch.test_functions import Rastrigin
@@ -28,7 +28,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Defining the test function
+### Defining the test function
 
 # See [`discrete_space`](./../Searchspaces/discrete_space.md) for details.
 
@@ -49,7 +49,7 @@ else:
 BOUNDS = TestFunction.bounds
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Since the searchspace is continuous, we construct `NumericalContinuousParameter`.
 # We use the data of the test function to deduce bounds and number of parameters.
@@ -91,7 +91,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Construct the campaign and run some iterations
+### Construct the campaign and run some iterations
 
 campaign = Campaign(
     searchspace=searchspace,
@@ -113,7 +113,7 @@ for k in range(N_ITERATIONS):
 
     campaign.add_measurements(recommendation)
 
-#### Verify the constraints
+### Verify the constraints
 measurements = campaign.measurements_exp
 TOLERANCE = 0.01
 

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -1,4 +1,4 @@
-### Example for linear constraints in a continuous searchspace
+## Example for linear constraints in a continuous searchspace
 
 # Example for optimizing a synthetic test functions in a continuous space with linear
 # constraints.
@@ -11,7 +11,7 @@
 # details on this aspect.
 
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 from botorch.test_functions import Rastrigin
@@ -27,7 +27,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Defining the test function
+### Defining the test function
 
 # See [`discrete_space`](./../Searchspaces/discrete_space.md) for details.
 
@@ -43,7 +43,7 @@ else:
 BOUNDS = TestFunction.bounds
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Since the searchspace is continuous test, we construct `NumericalContinuousParameter`s
 # We use that data of the test function to deduce bounds and number of parameters.
@@ -80,7 +80,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Construct the campaign and run some iterations
+### Construct the campaign and run some iterations
 
 campaign = Campaign(
     searchspace=searchspace,
@@ -102,7 +102,7 @@ for k in range(N_ITERATIONS):
 
     campaign.add_measurements(recommendation)
 
-#### Verify the constraints
+### Verify the constraints
 measurements = campaign.measurements_exp
 TOLERANCE = 0.01
 

--- a/examples/Constraints_Discrete/Constraints_Discrete_Header.md
+++ b/examples/Constraints_Discrete/Constraints_Discrete_Header.md
@@ -1,4 +1,5 @@
 # Constraints Discrete
 
-These examples demonstrate how to use the different available constraints that can be
-used to restrict discrete search spaces.
+These examples demonstrate how
+{ref}`Discrete Parameter Constraints <userguide/constraints:discrete constraints>`
+can be applied to discrete search spaces.

--- a/examples/Constraints_Discrete/Constraints_Discrete_Header.md
+++ b/examples/Constraints_Discrete/Constraints_Discrete_Header.md
@@ -1,0 +1,4 @@
+# Constraints Discrete
+
+These examples demonstrate how to use the different available constraints that can be
+used to restrict discrete search spaces.

--- a/examples/Constraints_Discrete/custom_constraints.py
+++ b/examples/Constraints_Discrete/custom_constraints.py
@@ -1,4 +1,4 @@
-### Example for using custom constraints in discrete searchspaces
+## Example for using custom constraints in discrete searchspaces
 
 # This examples shows how a custom constraint can be created for a discrete searchspace.
 # That is, it shows how the user can define a constraint restricting the searchspace.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 import pandas as pd
@@ -23,7 +23,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup
+### Experiment setup
 
 # We begin by setting up some parameters for our experiments.
 dict_solvent = {
@@ -49,7 +49,7 @@ concentration = NumericalDiscreteParameter(
 
 parameters = [solvent, speed, temperature, concentration]
 
-#### Creating the constraint
+### Creating the constraint
 
 # The constraints are handled when creating the searchspace object.
 # We thus need to define our constraint first as follows.
@@ -88,7 +88,7 @@ constraint = DiscreteCustomConstraint(
     parameters=["Concentration", "Solvent", "Temperature"], validator=custom_function
 )
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 searchspace = SearchSpace.from_product(parameters=parameters, constraints=[constraint])
 
@@ -96,19 +96,19 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="yield", mode="MAX")]
 )
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
-#### Manual verification of the constraint
+### Manual verification of the constraint
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
-    print(f"\n\n##### ITERATION {kIter+1} #####")
+    print(f"\n\n#### ITERATION {kIter+1} ####")
 
-    print("### ASSERTS ###")
+    print("## ASSERTS ##")
     print(
         "Number of entries with water, temp > 120 and concentration > 5:      ",
         (

--- a/examples/Constraints_Discrete/dependency_constraints.py
+++ b/examples/Constraints_Discrete/dependency_constraints.py
@@ -1,4 +1,4 @@
-### Example for using dependency constraints in discrete searchspaces
+## Example for using dependency constraints in discrete searchspaces
 
 # This example shows how a dependency constraint can be created for a discrete searchspace.
 # For instance, some parameters might only be relevant when another parameter has a certain value.
@@ -7,7 +7,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 
@@ -23,7 +23,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup
+### Experiment setup
 
 dict_solvent = {
     "water": "O",
@@ -40,7 +40,7 @@ frame2 = CategoricalParameter(name="FrameB", values=["A", "B"])
 
 parameters = [solvent, switch1, switch2, fraction1, frame1, frame2]
 
-#### Creating the constraints
+### Creating the constraints
 
 # The constraints are handled when creating the searchspace object.
 # It is thus necessary to define it before the searchspace creation.
@@ -54,7 +54,7 @@ constraint = DiscreteDependenciesConstraint(
     affected_parameters=[["Solv", "Frac1"], ["FrameA", "FrameB"]],
 )
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 searchspace = SearchSpace.from_product(parameters=parameters, constraints=[constraint])
 
@@ -62,19 +62,19 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target_1", mode="MAX")]
 )
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
-#### Manual verification of the constraints
+### Manual verification of the constraints
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 N_ITERATIONS = 5
 for kIter in range(N_ITERATIONS):
-    print(f"\n##### ITERATION {kIter+1} #####")
+    print(f"\n#### ITERATION {kIter+1} ####")
 
-    print("### ASSERTS ###")
+    print("## ASSERTS ##")
     print(
         f"Number entries with both switches on "
         f"(expected {7*len(dict_solvent)*2*2}): ",

--- a/examples/Constraints_Discrete/exclusion_constraints.py
+++ b/examples/Constraints_Discrete/exclusion_constraints.py
@@ -1,4 +1,4 @@
-### Example for using exclusion constraints in discrete searchspaces
+## Example for using exclusion constraints in discrete searchspaces
 
 # This examples shows how an exclusion constraint can be created for a discrete searchspace.
 # This can be used if some parameter values are incompatible with values of another parameter.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 
@@ -26,7 +26,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup
+### Experiment setup
 
 # We begin by setting up some parameters for our experiments.
 dict_solvent = {
@@ -54,7 +54,7 @@ pressure = NumericalDiscreteParameter(
 
 parameters = [solvent, speed, temperature, pressure]
 
-#### Creating the constraint
+### Creating the constraint
 
 # This constraint simulates a situation where solvents `C2` and `C4` are not
 # compatible with temperatures larger than 151 and should thus be excluded.
@@ -90,7 +90,7 @@ constraint_3 = DiscreteExcludeConstraint(
     ],
 )
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # We now create the searchspace using the previously defined constraints.
 searchspace = SearchSpace.from_product(
@@ -101,19 +101,19 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target_1", mode="MAX")]
 )
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
 
-#### Manual verification of the constraints
+### Manual verification of the constraints
 
 # The following loop performs some iterations and manually verifies the given constraints.
 N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
-    print(f"\n\n##### ITERATION {kIter+1} #####")
+    print(f"\n\n#### ITERATION {kIter+1} ####")
 
-    print("### ASSERTS ###")
+    print("## ASSERTS ##")
     print(
         "Number of entries with either Solvents C2 or C4 and a temperature above 151: ",
         (

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -1,4 +1,4 @@
-### Example for using a mixture use case in a discrete searchspace
+## Example for using a mixture use case in a discrete searchspace
 
 # Example for imposing sum constraints for discrete parameters.
 # The constraints simulate a situation where we want to mix up to three solvents.
@@ -8,7 +8,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import math
 
@@ -28,7 +28,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup
+### Experiment setup
 
 # This parameter denotes the tolerance with regard to the calculation of the sum.
 SUM_TOLERANCE = 1.0
@@ -55,7 +55,7 @@ fraction3 = NumericalDiscreteParameter(
 
 parameters = [solvent1, solvent2, solvent3, fraction1, fraction2, fraction3]
 
-#### Creating the constraint
+### Creating the constraint
 
 # Since the constraints are required for the creation of the searchspace, we create
 # them next.
@@ -90,7 +90,7 @@ no_duplicates_constraint = DiscreteNoLabelDuplicatesConstraint(
 
 constraints = [perm_inv_constraint, sum_constraint, no_duplicates_constraint]
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 searchspace = SearchSpace.from_product(parameters=parameters, constraints=constraints)
 
@@ -98,20 +98,20 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target_1", mode="MAX")]
 )
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
-#### Manual verification of the constraint
+### Manual verification of the constraint
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 
 N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
-    print(f"\n##### ITERATION {kIter+1} #####")
+    print(f"\n#### ITERATION {kIter+1} ####")
 
-    print("### ASSERTS ###")
+    print("## ASSERTS ##")
     print(
         "No. of searchspace entries where fractions do not sum to 100.0:      ",
         campaign.searchspace.discrete.exp_rep[["Frac1", "Frac2", "Frac3"]]

--- a/examples/Constraints_Discrete/prodsum_constraints.py
+++ b/examples/Constraints_Discrete/prodsum_constraints.py
@@ -1,11 +1,11 @@
-### Example for using exclusion constraints incorporating sums and products
+## Example for using exclusion constraints incorporating sums and products
 
 # This examples demonstrates an exclusion constraint using products and sums.
 
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 
@@ -25,7 +25,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup
+### Experiment setup
 
 dict_solvent = {
     "water": "O",
@@ -66,7 +66,7 @@ parameters = [
     num_parameter_6,
 ]
 
-#### Creating the constraints
+### Creating the constraints
 
 # Constraints are used when creating the searchspace object.
 # Thus, they need to be defined prior to the searchspace creation.
@@ -86,7 +86,7 @@ prod_constraint = DiscreteProductConstraint(
 
 constraints = [sum_constraint_1, sum_constraint_2, prod_constraint]
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 searchspace = SearchSpace.from_product(parameters=parameters, constraints=constraints)
 
@@ -94,20 +94,20 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target_1", mode="MAX")]
 )
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
-#### Manual verification of the constraints
+### Manual verification of the constraints
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 
 N_ITERATIONS = 5
 for kIter in range(N_ITERATIONS):
-    print(f"\n\n##### ITERATION {kIter+1} #####")
+    print(f"\n\n#### ITERATION {kIter+1} ####")
 
-    print("### ASSERTS ###")
+    print("## ASSERTS ##")
     print(
         "Number of entries with 1,2-sum above 150:      ",
         (

--- a/examples/Custom_Surrogates/Custom_Surrogates_Header.md
+++ b/examples/Custom_Surrogates/Custom_Surrogates_Header.md
@@ -1,0 +1,3 @@
+# Custom Surrogates
+
+These examples show how to use custom pretrained models and architectures.

--- a/examples/Custom_Surrogates/Custom_Surrogates_Header.md
+++ b/examples/Custom_Surrogates/Custom_Surrogates_Header.md
@@ -1,3 +1,3 @@
 # Custom Surrogates
 
-These examples show how to use custom pretrained models and architectures.
+These examples demonstrate how to use custom {doc}`Surrogate </userguide/surrogates>` architectures and pre-trained [ONNX](https://onnx.ai) models.

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -1,4 +1,4 @@
-### Example for surrogate model with a custom architecture using `sklearn`
+## Example for surrogate model with a custom architecture using `sklearn`
 
 # This example shows how to define a `sklearn` model architecture and use it as a surrogate.
 # Please note that the model is not designed to be useful but to demonstrate the workflow.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 from typing import Optional, Tuple
 
@@ -35,7 +35,7 @@ from baybe.surrogates import register_custom_architecture
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Surrogate Definition with BayBE Registration
+### Surrogate Definition with BayBE Registration
 
 # The final estimator class must follow the sklearn estimator interface.
 # More details [here](https://scikit-learn.org/stable/developers/develop.html).
@@ -91,7 +91,7 @@ class StackingRegressorSurrogate:
         self.model.fit(train_x, train_y.ravel())
 
 
-#### Experiment Setup
+### Experiment Setup
 
 parameters = [
     CategoricalParameter(
@@ -121,7 +121,7 @@ parameters = [
 ]
 
 
-#### Run DOE iterations with custom surrogate
+### Run DOE iterations with custom surrogate
 # Create campaign
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
@@ -156,7 +156,7 @@ print(recommendation)
 print()
 
 
-#### Serialization
+### Serialization
 
 # Serialization of custom models is not supported
 try:

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -1,4 +1,4 @@
-### Example for surrogate model with a custom architecture using `pytorch`
+## Example for surrogate model with a custom architecture using `pytorch`
 
 # This example shows how to define a `pytorch` model architecture and use it as a surrogate.
 # Please note that the model is not designed to be useful but to demonstrate the workflow.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 from typing import List, Optional, Tuple
 
@@ -28,7 +28,7 @@ from baybe.surrogates import register_custom_architecture
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Architecture definition
+### Architecture definition
 
 # Note that the following is an example `PyTorch` Neural Network.
 # Details of the setup is not the focus of BayBE but can be found in `Pytorch` guides.
@@ -89,7 +89,7 @@ class NeuralNetDropout(nn.Module):
         return self.model(data)
 
 
-#### Surrogate Definition with BayBE Registration
+### Surrogate Definition with BayBE Registration
 
 # The class must include `_fit` and `_posterior` functions with the correct signatures
 
@@ -142,7 +142,7 @@ class NeuralNetDropoutSurrogate:
             opt.step()
 
 
-#### Experiment Setup
+### Experiment Setup
 
 parameters = [
     CategoricalParameter(
@@ -172,7 +172,7 @@ parameters = [
 ]
 
 
-#### Run DOE iterations with custom surrogate
+### Run DOE iterations with custom surrogate
 # Create campaign
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
@@ -207,7 +207,7 @@ print(recommendation)
 print()
 
 
-#### Serialization
+### Serialization
 
 # Serialization of custom models is not supported
 try:

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -1,4 +1,4 @@
-### Example for surrogate model with a custom pretrained model
+## Example for surrogate model with a custom pretrained model
 
 # This example shows how to pre-train a model and use it as a surrogate.
 # Please note that the model is not designed to be useful but to demonstrate the workflow.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 import numpy as np
 import torch
@@ -25,7 +25,7 @@ from baybe.surrogates import CustomONNXSurrogate
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results, to_tensor
 
-#### Experiment Setup
+### Experiment Setup
 
 parameters = [
     NumericalDiscreteParameter(
@@ -40,7 +40,7 @@ parameters = [
 ]
 
 
-#### "Pre-training" stage
+### "Pre-training" stage
 
 # Note that this example trains with several helpers built-in to BayBE.
 # This can be done independently (and elsewhere).
@@ -63,7 +63,7 @@ model = BayesianRidge()
 model.fit(train_x, train_y)
 
 
-#### Convert model to onnx
+### Convert model to onnx
 
 # Need the option to return standard deviation
 options = {type(model): {"return_std": True}}
@@ -84,14 +84,14 @@ onnx_str = convert_sklearn(
 ).SerializeToString()  # serialize to string to save in file
 
 
-#### Create a surrogate model with a pretrained model
+### Create a surrogate model with a pretrained model
 
 surrogate_model = CustomONNXSurrogate(
     onnx_str=onnx_str,
     onnx_input_name=ONNX_INPUT_NAME,  # specify input name
 )
 
-#### Create campaign
+### Create campaign
 
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
@@ -104,7 +104,7 @@ campaign = Campaign(
     ),
 )
 
-#### Iterate with recommendations and measurements
+### Iterate with recommendations and measurements
 
 # Let's do a first round of recommendation
 recommendation = campaign.recommend(batch_quantity=2)
@@ -116,7 +116,7 @@ print(recommendation)
 add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
-#### Model Outputs
+### Model Outputs
 
 # Do another round of recommendations
 recommendation = campaign.recommend(batch_quantity=2)
@@ -126,7 +126,7 @@ print("Recommendation from campaign:")
 print(recommendation)
 
 
-#### Using configuration instead
+### Using configuration instead
 
 # Note that this can be placed inside an overall baybe config
 # Refer to [`create_from_config`](./../Serialization/create_from_config.md) for an example
@@ -137,7 +137,7 @@ CONFIG = {
     "onnx_input_name": ONNX_INPUT_NAME,
 }
 
-#### Model creation from dict (or json if string)
+### Model creation from dict (or json if string)
 model_from_python = CustomONNXSurrogate(
     onnx_str=onnx_str, onnx_input_name=ONNX_INPUT_NAME
 )

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -1,4 +1,4 @@
-### Example for custom parameter passing in surrogate models
+## Example for custom parameter passing in surrogate models
 
 # This example shows how to define surrogate models with custom model parameters.
 # It also shows the validations that are done and how to specify these parameters through
@@ -7,7 +7,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 import numpy as np
 
@@ -25,7 +25,7 @@ from baybe.surrogates import NGBoostSurrogate
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment Setup
+### Experiment Setup
 
 parameters = [
     CategoricalParameter(
@@ -54,13 +54,13 @@ parameters = [
     ),
 ]
 
-#### Create a surrogate model with custom model parameters
+### Create a surrogate model with custom model parameters
 
 # Please note that model_params is an optional argument:
 # The defaults will be used if none specified
 surrogate_model = NGBoostSurrogate(model_params={"n_estimators": 50, "verbose": True})
 
-#### Validation of model parameters
+### Validation of model parameters
 
 try:
     invalid_surrogate_model = NGBoostSurrogate(model_params={"NOT_A_PARAM": None})
@@ -68,7 +68,7 @@ except ValueError as e:
     print("The validator will give an error here:")
     print(e)
 
-#### Links for documentation
+### Links for documentation
 
 # Note that `GaussianProcessSurrogate` will support custom parameters in the future
 
@@ -76,7 +76,7 @@ except ValueError as e:
 # [`NGBoostModel`](https://stanfordmlgroup.github.io/ngboost/1-useage.html)
 # [`BayesianLinearModel`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.ARDRegression.html)
 
-#### Creating the campaign
+### Creating the campaign
 
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
@@ -89,7 +89,7 @@ campaign = Campaign(
     ),
 )
 
-#### Iterate with recommendations and measurements
+### Iterate with recommendations and measurements
 
 # We can print the surrogate model object
 print("The model object in json format:")
@@ -105,7 +105,7 @@ print(recommendation)
 add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
-#### Model Outputs
+### Model Outputs
 
 # Note that this model is only triggered when there is data.
 print("Here you will see some model outputs as we set verbose to True")
@@ -118,7 +118,7 @@ recommendation = campaign.recommend(batch_quantity=2)
 print("Recommendation from campaign:")
 print(recommendation)
 
-#### Using configuration instead
+### Using configuration instead
 
 # Note that this can be placed inside an overall campaign config
 # Refer to [`create_from_config`](./../Serialization/create_from_config.md) for an example
@@ -138,7 +138,7 @@ CONFIG = str(
 """
 )
 
-#### Model creation from json
+### Model creation from json
 recreate_model = NGBoostSurrogate.from_json(CONFIG)
 
 # This configuration creates the same model

--- a/examples/Multi_Target/Multi_Target_Header.md
+++ b/examples/Multi_Target/Multi_Target_Header.md
@@ -1,3 +1,4 @@
 # Multi Target
 
-These examples show the multi target capabilities supported by BayBE.
+These examples demonstrate BayBE's
+{ref}`Multi-Target Capabilities <userguide/objective:desirability>`.

--- a/examples/Multi_Target/Multi_Target_Header.md
+++ b/examples/Multi_Target/Multi_Target_Header.md
@@ -1,0 +1,3 @@
+# Multi Target
+
+These examples show the multi target capabilities supported by BayBE.

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -1,4 +1,4 @@
-### Example for using the multi target mode for the objective
+## Example for using the multi target mode for the objective
 
 # Example for using the multi target mode for the objective.
 # It uses a desirability value to handle several targets.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 from baybe import Campaign
 from baybe.objective import Objective
@@ -15,7 +15,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import add_fake_results
 
-#### Experiment setup and creating the searchspace
+### Experiment setup and creating the searchspace
 
 Categorical_1 = CategoricalParameter("Cat_1", values=["22", "33"], encoding="OHE")
 Categorical_2 = CategoricalParameter(
@@ -35,7 +35,7 @@ parameters = [Categorical_1, Categorical_2, Num_disc_1, Num_disc_2]
 searchspace = SearchSpace.from_product(parameters=parameters)
 
 
-#### Defining the targets
+### Defining the targets
 
 # The multi target mode is handled when creating the objective object.
 # Thus we first need to define the different targets.
@@ -67,7 +67,7 @@ Target_3 = NumericalTarget(
 # the range around this target that is considered viable.
 
 
-#### Creating the objective
+### Creating the objective
 
 # Now to work with these three targets the objective object must be properly created.
 # The mode is set to `DESIRABILITY` and the targets are described in a list.
@@ -92,12 +92,12 @@ objective = Objective(
 
 print(objective)
 
-#### Creating and printing the campaign
+### Creating and printing the campaign
 
 campaign = Campaign(searchspace=searchspace, objective=objective)
 print(campaign)
 
-#### Performing some iterations
+### Performing some iterations
 
 # The following loop performs some recommendations and adds fake results.
 # It also prints what happens to internal data.
@@ -105,7 +105,7 @@ print(campaign)
 N_ITERATIONS = 3
 
 for kIter in range(N_ITERATIONS):
-    print(f"\n\n##### ITERATION {kIter+1} #####")
+    print(f"\n\n#### ITERATION {kIter+1} ####")
 
     rec = campaign.recommend(batch_quantity=3)
     print("\nRecommended measurements:\n", rec)
@@ -119,7 +119,7 @@ for kIter in range(N_ITERATIONS):
     print(campaign.measurements_targets_comp)
 
 
-#### Addendum: Description of `transformation` functions
+### Addendum: Description of `transformation` functions
 
 # This function is used to transform target values to the interval `[0,1]` for `MAX`/`MIN` mode.
 # An ascending or decreasing `LINEAR` function is used per default.

--- a/examples/Searchspaces/Searchspaces_Header.md
+++ b/examples/Searchspaces/Searchspaces_Header.md
@@ -1,0 +1,3 @@
+# Searchspaces
+
+These examples demonstrate how to set up and use the different kind of search spaces supported by BayBE.

--- a/examples/Searchspaces/Searchspaces_Header.md
+++ b/examples/Searchspaces/Searchspaces_Header.md
@@ -1,3 +1,4 @@
 # Searchspaces
 
-These examples demonstrate how to set up and use the different kind of search spaces supported by BayBE.
+These examples demonstrate various ways to configure
+{doc}`Search Spaces </userguide/searchspace>`.

--- a/examples/Searchspaces/continuous_space_botorch_function.py
+++ b/examples/Searchspaces/continuous_space_botorch_function.py
@@ -1,4 +1,4 @@
-### Example for using a synthetic BoTorch test function in a continuous searchspace
+## Example for using a synthetic BoTorch test function in a continuous searchspace
 
 # Example for using the synthetic test functions in a continuous spaces.
 # All test functions that are available in BoTorch are also available here and wrapped
@@ -10,7 +10,7 @@
 # We thus refer to [`discrete_space`](./discrete_space.md) for details on this aspect.
 
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 from botorch.test_functions import Rastrigin
 
@@ -21,7 +21,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Defining the test function
+### Defining the test function
 
 # See [`discrete_space`](./../Searchspaces/discrete_space.md) for details.
 
@@ -47,7 +47,7 @@ else:
 BOUNDS = TestFunction.bounds
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # Since the searchspace is continuous test, we construct `NumericalContinuousParameter`s
 # We use that data of the test function to deduce bounds and number of parameters.
@@ -64,7 +64,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing the campaign and performing a recommendation
+### Constructing the campaign and performing a recommendation
 
 campaign = Campaign(
     searchspace=searchspace,

--- a/examples/Searchspaces/continuous_space_custom_function.py
+++ b/examples/Searchspaces/continuous_space_custom_function.py
@@ -1,11 +1,11 @@
-### Example for using a custom BoTorch test function in a continuous searchspace
+## Example for using a custom BoTorch test function in a continuous searchspace
 
 # This example shows how an arbitrary python function can be used as lookup.
 
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 from baybe import Campaign
 from baybe.objective import Objective
@@ -13,7 +13,7 @@ from baybe.parameters import NumericalContinuousParameter
 from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 
-#### Defining the custom test function
+### Defining the custom test function
 
 # The function should accept an arbitrary or fixed amount of floats as input.
 # It needs to return either a single float or a tuple of floats.
@@ -41,7 +41,7 @@ TEST_FUNCTION = sum_of_squares
 DIMENSION = 4
 BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 parameters = [
     NumericalContinuousParameter(
@@ -57,7 +57,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing the campaign and performing a recommendation
+### Constructing the campaign and performing a recommendation
 
 campaign = Campaign(
     searchspace=searchspace,

--- a/examples/Searchspaces/discrete_space.py
+++ b/examples/Searchspaces/discrete_space.py
@@ -1,11 +1,11 @@
-### Example for using a synthetic BoTorch test function in a discrete searchspace
+## Example for using a synthetic BoTorch test function in a discrete searchspace
 
 # Example for using the synthetic test functions in discrete spaces.
 
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 from botorch.test_functions import Rastrigin
@@ -17,7 +17,7 @@ from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Defining the test function
+### Defining the test function
 
 # BoTorch offers a variety of different test functions, all of which can be used.
 # Note that some test functions are only defined for specific dimensions.
@@ -58,7 +58,7 @@ BOUNDS = TestFunction.bounds
 
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Creating the searchspace and the objective
+### Creating the searchspace and the objective
 
 # In this example, we construct a purely discrete space.
 # The parameter `POINTS_PER_DIM` controls the number of points per dimension.
@@ -83,7 +83,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing the campaign and performing a recommendation
+### Constructing the campaign and performing a recommendation
 
 campaign = Campaign(
     searchspace=searchspace,

--- a/examples/Searchspaces/hybrid_space.py
+++ b/examples/Searchspaces/hybrid_space.py
@@ -1,4 +1,4 @@
-### Example for using synthetic test functions in hybrid spaces
+## Example for using synthetic test functions in hybrid spaces
 
 # This examples shows how to optimize a custom test function in a hybrid searchspace.
 # It focuses on the searchspace-related aspects and not on the custom test function.
@@ -7,7 +7,7 @@
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 # For details on using synthetic test functions, we refer to other examples in this directory.
 
-#### Necessary imports for this example
+### Necessary imports for this example
 
 import numpy as np
 from botorch.test_functions import Rastrigin
@@ -21,7 +21,7 @@ from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 from baybe.utils import botorch_function_wrapper
 
-#### Defining the test function and the hybrid dimensions
+### Defining the test function and the hybrid dimensions
 
 # See [`discrete_space`](./discrete_space.md) for details on the test function.
 
@@ -70,7 +70,7 @@ if set(CONT_INDICES + DISC_INDICES) != set(range(DIMENSION)):
 BOUNDS = TestFunction.bounds
 WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
-#### Constructing the hybrid searchspace
+### Constructing the hybrid searchspace
 
 # The following parameter decides how many points each discrete dimension should have.
 POINTS_PER_DIM = 3
@@ -99,7 +99,7 @@ objective = Objective(
     mode="SINGLE", targets=[NumericalTarget(name="Target", mode="MIN")]
 )
 
-#### Constructing hybrid recommenders
+### Constructing hybrid recommenders
 
 # Here, we explicitly create a strategy object to use the `NaiveHybridRecommender`.
 # The keywords `disc_recommender` and `cont_recommender` can be used to select different

--- a/examples/Serialization/Serialization_Header.md
+++ b/examples/Serialization/Serialization_Header.md
@@ -1,3 +1,3 @@
 # Serialization
 
-These examples demonstrate how to use (de-)serialization.
+These examples demonstrate BayBE's de-/serialization capabilities.

--- a/examples/Serialization/Serialization_Header.md
+++ b/examples/Serialization/Serialization_Header.md
@@ -1,0 +1,3 @@
+# Serialization
+
+These examples demonstrate how to use (de-)serialization.

--- a/examples/Serialization/basic_serialization.py
+++ b/examples/Serialization/basic_serialization.py
@@ -1,4 +1,4 @@
-### Example for the serialization of a campaign
+## Example for the serialization of a campaign
 
 # This example shows how to serialize and also de-serialize a campaign.
 # It demonstrates and shows that the "original" and "new" objects behave the same.
@@ -6,7 +6,7 @@
 # This example assumes some basic familiarity with using BayBE.
 # We thus refer to [`campaign`](./../Basics/campaign.md) for a basic example.
 
-#### Necessary imports
+### Necessary imports
 
 import numpy as np
 
@@ -22,7 +22,7 @@ from baybe.searchspace import SearchSpace
 from baybe.strategies import TwoPhaseStrategy
 from baybe.targets import NumericalTarget
 
-#### Experiment setup
+### Experiment setup
 
 parameters = [
     CategoricalParameter(
@@ -51,7 +51,7 @@ parameters = [
     ),
 ]
 
-#### Creating the campaign
+### Creating the campaign
 
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
@@ -64,7 +64,7 @@ campaign = Campaign(
     ),
 )
 
-#### Serialization and de-serialization
+### Serialization and de-serialization
 
 # We begin by printing the original campaign
 print("Original object")
@@ -86,7 +86,7 @@ print(campaign_recreate, end="\n" * 3)
 assert campaign == campaign_recreate
 print("Passed basic assertion check!")
 
-#### Comparing recommendations in both objects
+### Comparing recommendations in both objects
 
 # To further show how serialization affects working with campaigns, we will now
 # create and compare some recommendations in both campaigns.

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -1,4 +1,4 @@
-### Example for creating campaigns from configs
+## Example for creating campaigns from configs
 
 # This example shows how to load a configuration file and use it to create a campaign.
 # In such a configuration file, the objects used to create a campaign are represented by
@@ -7,11 +7,11 @@
 # Note that the json format is required for the config file.
 # You can create such a config by providing a  dictionary with `"type":"name of the class"`.
 
-#### Necessary imports
+### Necessary imports
 
 from baybe import Campaign
 
-#### The configuration dictionary as a string
+### The configuration dictionary as a string
 
 # Note that the following explicit call `str()` is not strictly necessary.
 # It is included since our method of converting this example to a markdown file does not
@@ -88,7 +88,7 @@ CONFIG = str(
 """
 )
 
-#### Creating a campaign from the configuration file
+### Creating a campaign from the configuration file
 
 # Although we know in this case that the config represents a valid configuration for a
 # campaign. If the config is invalid an exception will be thrown.

--- a/examples/Serialization/validate_config.py
+++ b/examples/Serialization/validate_config.py
@@ -1,16 +1,16 @@
-### Example for validation of a config file
+## Example for validation of a config file
 
 # This example shows how to load and validate a user defined configuration file.
 # We use the two configuration dictionaries.
 # The first one represents a valid configuration, the second does not.
 
-#### Necessary imports
+### Necessary imports
 
 from cattrs import ClassValidationError
 
 from baybe import Campaign
 
-#### Defining config dictionaries
+### Defining config dictionaries
 
 # Note that the following explicit call `str()` is not strictly necessary.
 # It is included since our method of converting this example to a markdown file does not
@@ -157,7 +157,7 @@ INVALID_CONFIG = str(
 """
 )
 
-#### Verification of the two dictionaries
+### Verification of the two dictionaries
 
 # The first validation should work
 Campaign.validate_config(CONFIG)


### PR DESCRIPTION
This introduces explicit markdown files for the example folders. These were previously generated automatically.

Having manual files allows us to include information into these top-level files. Currently, each files contains one or two sentences what the examples in the corresponding folders are about. Note that this information is currently not complete and probably not how it should be, but since we are planning a general example overhaul anyway, I would propose to not over-engineer these now and just go with something in the line of what is proposed here.
Note that this approach now forces us to manually include new examples in these markdown files, as they will not show up in the documentation otherwise. However, this approach gives us way more flexibility since we can now e.g. have more information on the top level, rename the individual entries in the corresponding tables of content and so on.