### PR TITLE
Move doc building utilities to separate file

### DIFF
--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -4,9 +4,9 @@ import argparse
 import os
 import pathlib
 import shutil
-from subprocess import DEVNULL, STDOUT, check_call, run
+from subprocess import check_call, run
 
-from tqdm import tqdm
+from utils import adjust_banner, create_example_documentation
 
 from baybe.telemetry import VARNAME_TELEMETRY_ENABLED
 
@@ -66,190 +66,6 @@ sdk_dir = pathlib.Path("docs/sdk")
 autosummary_dir = pathlib.Path("docs/_autosummary")
 destination_dir = pathlib.Path(DESTINATION_DIR)
 
-
-def create_example_documentation(example_dest_dir: str):
-    """Create the documentation version of the examples files.
-
-    Note that this deletes the destination directory if it already exists.
-
-    Args:
-        example_dest_dir: The destination directory.
-    """
-    # Folder where the .md files created are stored
-    examples_directory = pathlib.Path(example_dest_dir)
-
-    # if the destination directory already exists it is deleted
-    if examples_directory.is_dir():
-        shutil.rmtree(examples_directory)
-
-    # Copy the examples folder in the destination directory
-    shutil.copytree("examples", examples_directory)
-
-    # For the toctree of the top level example folder, we need to keep track of all
-    # folders. We thus write the header here and populate it during the execution of the
-    # examples
-    ex_file = """# Examples\n\n```{toctree}\n:maxdepth: 2\n\n"""
-
-    # List all directories in the examples folder
-    ex_directories = [d for d in examples_directory.iterdir() if d.is_dir()]
-
-    # This list contains the order of the examples as we want to have them in the end.
-    # The examples that should be the first ones are already included here and skipped
-    # later on. ALl other are just included.
-    ex_order = [
-        "Basics<Basics/Basics>\n",
-        "Searchspaces<Searchspaces/Searchspaces>\n",
-        "Constraints Discrete<Constraints_Discrete/Constraints_Discrete>\n",
-        "Constraints Continuous<Constraints_Continuous/Constraints_Continuous>\n",
-        "Multi Target<Multi_Target/Multi_Target>\n",
-        "Serialization<Serialization/Serialization>\n",
-        "Custom Surrogates<Custom_Surrogates/Custom_Surrogates>\n",
-    ]
-
-    # Iterate over the directories.
-    for sub_directory in (pbar := tqdm(ex_directories)):
-        # Get the name of the current folder
-        # Format it by replacing underscores and capitalizing the words
-        folder_name = sub_directory.stem
-        formatted = " ".join(word.capitalize() for word in folder_name.split("_"))
-
-        # Create the link to the folder to the top level toctree.
-        ex_file_entry = formatted + f"<{folder_name}/{folder_name}>\n"
-        # Add it to the list of examples if it is not already contained
-        if ex_file_entry not in ex_order:
-            ex_order.append(ex_file_entry)
-
-        # We need to create a file for the inclusion of the folder
-        subdir_toctree = f"# {folder_name}\n\n" + "```{toctree}\n:maxdepth: 2\n\n"
-
-        # Set description of progressbar
-        pbar.set_description("Overall progress")
-
-        # list all .py files in the subdirectory that need to be converted
-        py_files = list(sub_directory.glob("**/*.py"))
-
-        # Iterate through the individual example files
-        for file in (inner_pbar := tqdm(py_files, leave=False)):
-            # Include the name of the file to the toctree
-            # Format it by replacing underscores and capitalizing the words
-            file_name = file.stem
-            formatted = " ".join(word.capitalize() for word in file_name.split("_"))
-            # Remove duplicate "constraints" for the files in the constraints folder.
-            if "Constraints" in folder_name and "Constraints" in formatted:
-                formatted = formatted.replace("Constraints", "")
-
-            # Also format the Prodsum name to Product/Sum
-            if "Prodsum" in formatted:
-                formatted = formatted.replace("Prodsum", "Product/Sum")
-            subdir_toctree += formatted + f"<{file_name}>\n"
-
-            # Set description for progress bar
-            inner_pbar.set_description(f"Progressing {folder_name}")
-
-            # Create the Markdown file:
-
-            # 1. Convert the file to jupyter notebook
-            check_call(
-                ["jupytext", "--to", "notebook", file], stdout=DEVNULL, stderr=STDOUT
-            )
-
-            notebook_path = file.with_suffix(".ipynb")
-
-            # 2. Execute the notebook and convert to markdown.
-            # This is only done if we decide not to ignore the examples.
-            # The creation of the files themselves and converting them to markdown still
-            # happens since we need the files to check for link integrity.
-            convert_execute = [
-                "jupyter",
-                "nbconvert",
-                "--to",
-                "notebook",
-                "--inplace",
-                notebook_path,
-            ]
-            if not IGNORE_EXAMPLES:
-                convert_execute.append("--execute")
-
-            to_markdown = ["jupytext", "--to", "markdown", notebook_path]
-
-            check_call(convert_execute, stdout=DEVNULL, stderr=STDOUT)
-            check_call(
-                to_markdown,
-                stdout=DEVNULL,
-                stderr=STDOUT,
-            )
-
-            # CLEANUP
-            # Remove all lines that try to include a png file
-            markdown_path = file.with_suffix(".md")
-            with open(markdown_path, "r", encoding="UTF-8") as markdown_file:
-                lines = markdown_file.readlines()
-
-            lines = [line for line in lines if "![png]" not in line]
-
-            # Rewrite the file
-            with open(markdown_path, "w", encoding="UTF-8") as markdown_file:
-                markdown_file.writelines(lines)
-
-        # Write last line of toctree file for this directory and write the file
-        subdir_toctree += "```"
-        with open(
-            sub_directory / f"{sub_directory.name}.md", "w", encoding="UTF-8"
-        ) as f:
-            f.write(subdir_toctree)
-
-    # Append the ordered list of examples to the file for the top level folder
-    ex_file += "".join(ex_order)
-    # Write last line of top level toctree file and write the file
-    ex_file += "```"
-    with open(
-        examples_directory / f"{examples_directory.name}.md", "w", encoding="UTF-8"
-    ) as f:
-        f.write(ex_file)
-
-    # Remove remaining files and subdirectories from the destination directory
-    # Remove any not markdown files
-    for file in examples_directory.glob("**/*"):
-        if file.is_file() and file.suffix != ".md":
-            file.unlink(file)
-
-    # Remove any remaining empty subdirectories
-    for subdirectory in examples_directory.glob("*/*"):
-        if subdirectory.is_dir() and not any(subdirectory.iterdir()):
-            subdirectory.rmdir()
-
-
-def adjust_banner(file_path: str, light_banner: str, dark_banner: str) -> None:
-    """Adjust the banner to have different versions for light and dark furo style.
-
-    Args:
-        file_path: The (relative) path to the file that needs to be adjusted. Typically
-            the index and README_link file.
-        light_banner: The name of the light mode banner.
-        dark_banner: The name of the dark mode banner.
-    """
-    with open(file_path, "r") as file:
-        lines = file.readlines()
-
-    line_index = None
-    for i, line in enumerate(lines):
-        if "banner" in line:
-            line_index = i
-            break
-
-    if line_index is not None:
-        line = lines[line_index]
-        light_line = line.replace("reference external", "reference external only-light")
-        lines[line_index] = light_line
-        # lines.insert(line_index + 1, light_line)
-        dark_line = light_line.replace("only-light", "only-dark")
-        dark_line = dark_line.replace(light_banner, dark_banner)
-        lines[line_index + 1] = dark_line
-
-        with open(file_path, "w") as file:
-            file.writelines(lines)
-
-
 # Collect all of the directories and delete them if they still exist.
 directories = [sdk_dir, autosummary_dir, build_dir, destination_dir]
 
@@ -282,7 +98,9 @@ building_call = [
 
 # Process examples if required.
 # Note that ignoring of examples now happens by simply not executing them.
-create_example_documentation(example_dest_dir="docs/examples")
+create_example_documentation(
+    example_dest_dir="docs/examples", ignore_examples=IGNORE_EXAMPLES
+)
 
 
 if FORCE:

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -1,0 +1,192 @@
+"""This file contains some utility function for building the documentation."""
+
+import pathlib
+import shutil
+from subprocess import DEVNULL, STDOUT, check_call
+
+from tqdm import tqdm
+
+
+def adjust_banner(file_path: str, light_banner: str, dark_banner: str) -> None:
+    """Adjust the banner to have different versions for light and dark furo style.
+
+    Args:
+        file_path: The (relative) path to the file that needs to be adjusted. Typically
+            the index and README_link file.
+        light_banner: The name of the light mode banner.
+        dark_banner: The name of the dark mode banner.
+    """
+    with open(file_path, "r") as file:
+        lines = file.readlines()
+
+    line_index = None
+    for i, line in enumerate(lines):
+        if "banner" in line:
+            line_index = i
+            break
+
+    if line_index is not None:
+        line = lines[line_index]
+        light_line = line.replace("reference external", "reference external only-light")
+        lines[line_index] = light_line
+        # lines.insert(line_index + 1, light_line)
+        dark_line = light_line.replace("only-light", "only-dark")
+        dark_line = dark_line.replace(light_banner, dark_banner)
+        lines[line_index + 1] = dark_line
+
+        with open(file_path, "w") as file:
+            file.writelines(lines)
+
+
+def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
+    """Create the documentation version of the examples files.
+
+    Note that this deletes the destination directory if it already exists.
+
+    Args:
+        example_dest_dir: The destination directory.
+        ignore_examples: A flag denoting whether or not to ignore the examples. If set,
+            then the examples are constructed, but not executed.
+    """
+    # Folder where the .md files created are stored
+    examples_directory = pathlib.Path(example_dest_dir)
+
+    # if the destination directory already exists it is deleted
+    if examples_directory.is_dir():
+        shutil.rmtree(examples_directory)
+
+    # Copy the examples folder in the destination directory
+    shutil.copytree("examples", examples_directory)
+
+    # For the toctree of the top level example folder, we need to keep track of all
+    # folders. We thus write the header here and populate it during the execution of the
+    # examples
+    ex_file = """# Examples\n\n```{toctree}\n:maxdepth: 2\n\n"""
+
+    # List all directories in the examples folder
+    ex_directories = [d for d in examples_directory.iterdir() if d.is_dir()]
+
+    # This list contains the order of the examples as we want to have them in the end.
+    # The examples that should be the first ones are already included here and skipped
+    # later on. ALl other are just included.
+    ex_order = [
+        "Basics<Basics/Basics>\n",
+        "Searchspaces<Searchspaces/Searchspaces>\n",
+        "Constraints Discrete<Constraints_Discrete/Constraints_Discrete>\n",
+        "Constraints Continuous<Constraints_Continuous/Constraints_Continuous>\n",
+        "Multi Target<Multi_Target/Multi_Target>\n",
+        "Serialization<Serialization/Serialization>\n",
+        "Custom Surrogates<Custom_Surrogates/Custom_Surrogates>\n",
+    ]
+
+    # Iterate over the directories.
+    for sub_directory in (pbar := tqdm(ex_directories)):
+        # Get the name of the current folder
+        # Format it by replacing underscores and capitalizing the words
+        folder_name = sub_directory.stem
+        formatted = " ".join(word.capitalize() for word in folder_name.split("_"))
+
+        # Create the link to the folder to the top level toctree.
+        ex_file_entry = formatted + f"<{folder_name}/{folder_name}>\n"
+        # Add it to the list of examples if it is not already contained
+        if ex_file_entry not in ex_order:
+            ex_order.append(ex_file_entry)
+
+        # We need to create a file for the inclusion of the folder
+        subdir_toctree = f"# {folder_name}\n\n" + "```{toctree}\n:maxdepth: 2\n\n"
+
+        # Set description of progressbar
+        pbar.set_description("Overall progress")
+
+        # list all .py files in the subdirectory that need to be converted
+        py_files = list(sub_directory.glob("**/*.py"))
+
+        # Iterate through the individual example files
+        for file in (inner_pbar := tqdm(py_files, leave=False)):
+            # Include the name of the file to the toctree
+            # Format it by replacing underscores and capitalizing the words
+            file_name = file.stem
+            formatted = " ".join(word.capitalize() for word in file_name.split("_"))
+            # Remove duplicate "constraints" for the files in the constraints folder.
+            if "Constraints" in folder_name and "Constraints" in formatted:
+                formatted = formatted.replace("Constraints", "")
+
+            # Also format the Prodsum name to Product/Sum
+            if "Prodsum" in formatted:
+                formatted = formatted.replace("Prodsum", "Product/Sum")
+            subdir_toctree += formatted + f"<{file_name}>\n"
+
+            # Set description for progress bar
+            inner_pbar.set_description(f"Progressing {folder_name}")
+
+            # Create the Markdown file:
+
+            # 1. Convert the file to jupyter notebook
+            check_call(
+                ["jupytext", "--to", "notebook", file], stdout=DEVNULL, stderr=STDOUT
+            )
+
+            notebook_path = file.with_suffix(".ipynb")
+
+            # 2. Execute the notebook and convert to markdown.
+            # This is only done if we decide not to ignore the examples.
+            # The creation of the files themselves and converting them to markdown still
+            # happens since we need the files to check for link integrity.
+            convert_execute = [
+                "jupyter",
+                "nbconvert",
+                "--to",
+                "notebook",
+                "--inplace",
+                notebook_path,
+            ]
+            if not ignore_examples:
+                convert_execute.append("--execute")
+
+            to_markdown = ["jupytext", "--to", "markdown", notebook_path]
+
+            check_call(convert_execute, stdout=DEVNULL, stderr=STDOUT)
+            check_call(
+                to_markdown,
+                stdout=DEVNULL,
+                stderr=STDOUT,
+            )
+
+            # CLEANUP
+            # Remove all lines that try to include a png file
+            markdown_path = file.with_suffix(".md")
+            with open(markdown_path, "r", encoding="UTF-8") as markdown_file:
+                lines = markdown_file.readlines()
+
+            lines = [line for line in lines if "![png]" not in line]
+
+            # Rewrite the file
+            with open(markdown_path, "w", encoding="UTF-8") as markdown_file:
+                markdown_file.writelines(lines)
+
+        # Write last line of toctree file for this directory and write the file
+        subdir_toctree += "```"
+        with open(
+            sub_directory / f"{sub_directory.name}.md", "w", encoding="UTF-8"
+        ) as f:
+            f.write(subdir_toctree)
+
+    # Append the ordered list of examples to the file for the top level folder
+    ex_file += "".join(ex_order)
+    # Write last line of top level toctree file and write the file
+    ex_file += "```"
+    with open(
+        examples_directory / f"{examples_directory.name}.md", "w", encoding="UTF-8"
+    ) as f:
+        f.write(ex_file)
+
+    # Remove remaining files and subdirectories from the destination directory
+    # Remove any not markdown files
+    for file in examples_directory.glob("**/*"):
+        if file.is_file() and file.suffix != ".md":
+            file.unlink(file)
+
+    # Remove any remaining empty subdirectories
+    for subdirectory in examples_directory.glob("*/*"):
+        if subdirectory.is_dir() and not any(subdirectory.iterdir()):
+            subdirectory.rmdir()


### PR DESCRIPTION
This PR creates a new file under docs/scripts that contains utilities for building the documentation.

The reasons for this change are mainly
1. We might need some more utilities for properly including figures in light/dark mode in the examples
2. The conversion file contained functions that are used in the conversion, but technically not part of the conversion itself (like `adjust_banners`).

The only content-wise change is that the `convert_examples` function (which now lives in `utils`) has another argument in its signature for ignoring the examples. Previously, this was not necessary as the global flag was used. Other than that, no changes were made.