### PR TITLE
Refactor exposed campaign attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Several minor issues in documentation
-- Private `Campaign` attributes are now private and no longer exposed via constructor
+- Visibility and constructor exposure of `Campaign` attributes that should be private
 
 ### Removed
 - `botorch_function_wrapper` from `baybe.utils` namespace
 
 ### Deprecations
-- Passing a `numerical_measurements_must_be_within_tolerance` to the `Campaign` 
+- Passing `numerical_measurements_must_be_within_tolerance` to the `Campaign` 
   constructor is no longer supported. Instead, `Campaign.add_measurements` now
   takes an additional parameter to control the behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `botorch_function_wrapper` from `baybe.utils` namespace
 
+### Deprecations
+- Passing a `numerical_measurements_must_be_within_tolerance` to the `Campaign` 
+  constructor is no longer supported. Instead, `Campaign.add_measurements` now
+  takes an additional parameter to control the behavior.
+
 ## [0.7.2] - 2024-01-24
 ### Added
 - Target enums 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Several minor issues in documentation
+- Private `Campaign` attributes are now private and no longer exposed via constructor
 
 ### Removed
 - `botorch_function_wrapper` from `baybe.utils` namespace

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -65,9 +65,6 @@ class Campaign(SerialMixin):
     )
     """The experimental representation of the conducted experiments."""
 
-    numerical_measurements_must_be_within_tolerance: bool = field(default=True)
-    """Flag for forcing numerical measurements to be within tolerance."""
-
     # Metadata
     n_batches_done: int = field(default=0, init=False)
     """The number of already processed batches."""
@@ -140,7 +137,11 @@ class Campaign(SerialMixin):
 
         _validation_converter.structure(config, Campaign)
 
-    def add_measurements(self, data: pd.DataFrame) -> None:
+    def add_measurements(
+        self,
+        data: pd.DataFrame,
+        numerical_measurements_must_be_within_tolerance: bool = True,
+    ) -> None:
         """Add results from a dataframe to the internal database.
 
         Each addition of data is considered a new batch. Added results are checked for
@@ -152,6 +153,8 @@ class Campaign(SerialMixin):
         Args:
             data: The data to be added (with filled values for targets). Preferably
                 created via :func:`baybe.campaign.Campaign.recommend`.
+            numerical_measurements_must_be_within_tolerance: Flag indicating if
+                numerical parameters need to be within their tolerances.
 
         Raises:
             ValueError: If one of the targets has missing values or NaNs in the provided
@@ -190,7 +193,7 @@ class Campaign(SerialMixin):
         # Update meta data
         # TODO: refactor responsibilities
         self.searchspace.discrete.mark_as_measured(
-            data, self.numerical_measurements_must_be_within_tolerance
+            data, numerical_measurements_must_be_within_tolerance
         )
 
         # Read in measurements and add them to the database
@@ -209,7 +212,7 @@ class Campaign(SerialMixin):
             self._cached_recommendation,
             data,
             self.parameters,
-            self.numerical_measurements_must_be_within_tolerance,
+            numerical_measurements_must_be_within_tolerance,
         )
 
     def recommend(self, batch_quantity: int = 5) -> pd.DataFrame:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -93,7 +93,7 @@ class Campaign(SerialMixin):
             )
 
     @property
-    def data(self) -> pd.DataFrame:
+    def measurements(self) -> pd.DataFrame:
         """The experimental data added to the Campaign."""
         return self._measurements_exp
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -86,7 +86,7 @@ class Campaign(SerialMixin):
     def _validate_tolerance_flag(self, _, value) -> None:
         if value is not None:
             raise DeprecationError(
-                f"Passing a 'numerical_measurements_must_be_within_tolerance' flag to "
+                f"Passing 'numerical_measurements_must_be_within_tolerance' to "
                 f"the constructor is deprecated. The flag has become a parameter of "
                 f"{self.__class__.__name__}.{Campaign.add_measurements.__name__}."
             )

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -84,6 +84,7 @@ class Campaign(SerialMixin):
 
     @numerical_measurements_must_be_within_tolerance.validator
     def _validate_tolerance_flag(self, _, value) -> None:
+        """Raise a DeprecationError if the tolerance flag is used."""
         if value is not None:
             raise DeprecationError(
                 f"Passing 'numerical_measurements_must_be_within_tolerance' to "

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -78,6 +78,11 @@ class Campaign(SerialMixin):
     """The cached recommendations."""
 
     @property
+    def data(self) -> pd.DataFrame:
+        """The experimental data added to the Campaign."""
+        return self._measurements_exp
+
+    @property
     def parameters(self) -> List[Parameter]:
         """The parameters of the underlying search space."""
         return self.searchspace.parameters

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -45,4 +45,8 @@ class NumericalUnderflowError(Exception):
 
 
 class OptionalImportError(Exception):
-    """Attempted to import an optional but uninstalled dependency."""
+    """An attempt was made to import an optional but uninstalled dependency."""
+
+
+class DeprecationError(Exception):
+    """Can be used to signal deprecations to the user, interrupting code exception."""

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -49,4 +49,4 @@ class OptionalImportError(Exception):
 
 
 class DeprecationError(Exception):
-    """Can be used to signal deprecations to the user, interrupting code exception."""
+    """Signals the use of a deprecated mechanism to the user, interrupting execution."""

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -25,11 +25,10 @@ describe the underlying optimization problem at hand:
 | What should be optimized in the campaign?  | `Objective` ([class](baybe.objective.Objective) / [user guide](./objective))              |
 | Which experimental factors can be altered? | `SearchSpace` ([class](baybe.searchspace.core.SearchSpace) / [user guide](./searchspace)) |
 
-Apart from this basic configuration, it is possible to provide additional instructions, 
-such as the specific optimization 
+Apart from this basic configuration, it is possible to further define the specific
+optimization 
 `Strategy`&nbsp;([class](baybe.strategies.base.Strategy) 
-/ [user guide](./strategies)) to be used, as well as other aspects of the campaign 
-(see [here](#AM) for details on `numerical_measurements_must_be_within_tolerance`).
+/ [user guide](./strategies)) to be used.
 
 
 ~~~python
@@ -39,7 +38,6 @@ campaign = Campaign(
     searchspace=searchspace,  # Required
     objective=objective,  # Required
     strategy=strategy,  # Optional
-    numerical_measurements_must_be_within_tolerance=boolean,  # Optional
 )
 ~~~
 
@@ -158,8 +156,8 @@ form:
 For discrete parameters, the parameter values associated with the provided measurements
 are required to fall into a predefined tolerance interval by default, which is
 defined on the level of the individual parameters.
-This requirement can be disabled using the 
-`numerical_measurements_must_be_within_tolerance` flag of the campaign.
+This requirement can be disabled using the method's
+`numerical_measurements_must_be_within_tolerance` flag.
 ```
 
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -43,11 +43,6 @@ campaign = Campaign(
 )
 ~~~
 
-```{attention}
-Note that we currently also expose other fields via the constructor. 
-This is only temporary, and the corresponding fields should be ignored.
-```
-
 ### Creation from a JSON config
 Instead of using the default constructor, it is also possible to create a `Campaign` 
 from a JSON configuration string via 
@@ -63,14 +58,6 @@ For more details and a full exemplary config, we refer to the corresponding
 ## Getting recommendations
 
 ### Basics
-
-```{attention}
-Requesting recommendations via `recommend` and adding measurements via
-`add_measurements` is the only intended way to interact with a `Campaign` object.
-These methods update the necessary metadata that is crucial for the proper execution of
-a campaign. We recommend to rely on these methods to maintain the integrity and
-reliability of the object.
-```
 
 To obtain a recommendation for the next batch of experiments, we can query the 
 campaign via the [`recommend`](baybe.campaign.Campaign.recommend) method.

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -114,7 +114,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign._measurements_exp
+measurements = campaign.data
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -114,7 +114,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign.data
+measurements = campaign.measurements
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -114,7 +114,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign.measurements_exp
+measurements = campaign._measurements_exp
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -103,7 +103,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign._measurements_exp
+measurements = campaign.data
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -103,7 +103,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign.data
+measurements = campaign.measurements
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -103,7 +103,7 @@ for k in range(N_ITERATIONS):
     campaign.add_measurements(recommendation)
 
 #### Verify the constraints
-measurements = campaign.measurements_exp
+measurements = campaign._measurements_exp
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -116,7 +116,7 @@ for kIter in range(N_ITERATIONS):
     campaign.add_measurements(rec)
 
     print("\n\nInternal measurement dataframe computational representation Y:\n")
-    print(campaign.measurements_targets_comp)
+    print(campaign._measurements_targets_comp)
 
 
 #### Addendum: Description of `transformation` functions

--- a/tests/test_constraints_continuous.py
+++ b/tests/test_constraints_continuous.py
@@ -16,7 +16,7 @@ from .conftest import run_iterations
 def test_equality1(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -28,7 +28,7 @@ def test_equality1(campaign, n_iterations, batch_quantity):
 def test_equality2(campaign, n_iterations, batch_quantity):
     """Test equality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"], 0.3)
@@ -40,7 +40,7 @@ def test_equality2(campaign, n_iterations, batch_quantity):
 def test_inequality1(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -52,7 +52,7 @@ def test_inequality1(campaign, n_iterations, batch_quantity):
 def test_inequality2(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -69,7 +69,7 @@ def test_inequality2(campaign, n_iterations, batch_quantity):
 def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -86,7 +86,7 @@ def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
 def test_hybridspace_ineq(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign._measurements_exp
+    res = campaign.data
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()

--- a/tests/test_constraints_continuous.py
+++ b/tests/test_constraints_continuous.py
@@ -16,7 +16,7 @@ from .conftest import run_iterations
 def test_equality1(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -28,7 +28,7 @@ def test_equality1(campaign, n_iterations, batch_quantity):
 def test_equality2(campaign, n_iterations, batch_quantity):
     """Test equality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"], 0.3)
@@ -40,7 +40,7 @@ def test_equality2(campaign, n_iterations, batch_quantity):
 def test_inequality1(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -52,7 +52,7 @@ def test_inequality1(campaign, n_iterations, batch_quantity):
 def test_inequality2(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -69,7 +69,7 @@ def test_inequality2(campaign, n_iterations, batch_quantity):
 def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -86,7 +86,7 @@ def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
 def test_hybridspace_ineq(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.data
+    res = campaign.measurements
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()

--- a/tests/test_constraints_continuous.py
+++ b/tests/test_constraints_continuous.py
@@ -16,7 +16,7 @@ from .conftest import run_iterations
 def test_equality1(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -28,7 +28,7 @@ def test_equality1(campaign, n_iterations, batch_quantity):
 def test_equality2(campaign, n_iterations, batch_quantity):
     """Test equality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"], 0.3)
@@ -40,7 +40,7 @@ def test_equality2(campaign, n_iterations, batch_quantity):
 def test_inequality1(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -52,7 +52,7 @@ def test_inequality1(campaign, n_iterations, batch_quantity):
 def test_inequality2(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with unequal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"]).ge(0.299).all()
@@ -69,7 +69,7 @@ def test_inequality2(campaign, n_iterations, batch_quantity):
 def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
     """Test equality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert np.allclose(1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"], 0.3)
@@ -86,7 +86,7 @@ def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
 def test_hybridspace_ineq(campaign, n_iterations, batch_quantity):
     """Test inequality constraint with equal weights."""
     run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
-    res = campaign.measurements_exp
+    res = campaign._measurements_exp
     print(res)
 
     assert (1.0 * res["Conti_finite1"] + 1.0 * res["Conti_finite2"]).ge(0.299).all()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from baybe import BayBE, Campaign
+from baybe.exceptions import DeprecationError
 from baybe.searchspace import SearchSpace
 from baybe.strategies import Strategy
 from baybe.targets import Objective
@@ -90,3 +91,10 @@ def test_deprecated_config():
     """Using the deprecated config format raises a warning."""
     with pytest.warns(UserWarning):
         Campaign.from_config(deprecated_config)
+
+
+@pytest.mark.parametrize("flag", [False, True])
+def test_deprecated_campaign_tolerance_flag(flag):
+    """Constructing a Campaign with the deprecated tolerance flag raises an error."""
+    with pytest.raises(DeprecationError):
+        Campaign(None, None, None, numerical_measurements_must_be_within_tolerance=flag)


### PR DESCRIPTION
This PR optimizes the public attributes of the campaign class and which of those are exposed via the constructor. 
The corresponding admonitions in the user guide (that warned about these attribute) are removed. 
Further, the PR deprecates the `numerical_measurements_must_be_within_tolerance` flag as a class attribute and turns it into a method parameter of `add_measurements`.