### PR TITLE
Rename batch_quantity to batch_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,14 +113,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Replacing `pylint`, `flake8`, `µfmt` and `usort` with `ruff`
+- Markdown based documentation replaced with HTML based documentation
 
 ### Fixed
 - `encoding` is no longer a class variable
 - Now installed with correct `pandas` dependency flag
 - `comp_df` column names for `CustomDiscreteParameter` are now safe
-
-### Deprecations
-- Markdown based documentation replaced with HTML based documentation
 
 ## [0.6.0] - 2023-11-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passing `numerical_measurements_must_be_within_tolerance` to the `Campaign` 
   constructor is no longer supported. Instead, `Campaign.add_measurements` now
   takes an additional parameter to control the behavior.
+- `batch_quantity` replaced with `batch_size`
 
 ## [0.7.2] - 2024-01-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ In particular, available measurements can be submitted at any time and also seve
 times before querying the next recommendations.
 
 ```python
-df = campaign.recommend(batch_quantity=3)
+df = campaign.recommend(batch_size=3)
 print(df)
 ```
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -234,7 +234,11 @@ class Campaign(SerialMixin):
             numerical_measurements_must_be_within_tolerance,
         )
 
-    def recommend(self, batch_size: int = 5) -> pd.DataFrame:
+    def recommend(
+        self,
+        batch_size: int = 5,
+        batch_quantity: int = None,  # type: ignore[assignment]
+    ) -> pd.DataFrame:
         """Provide the recommendations for the next batch of experiments.
 
         Args:
@@ -246,6 +250,13 @@ class Campaign(SerialMixin):
         Raises:
             ValueError: If ``batch_size`` is smaller than 1.
         """
+        if batch_quantity is not None:
+            raise DeprecationError(
+                f"Passing the keyword 'batch_quantity' to "
+                f"'{self.__class__.__name__}.{self.recommend.__name__}' is deprecated. "
+                f"Use 'batch_size' instead."
+            )
+
         if batch_size < 1:
             raise ValueError(
                 f"You must at least request one recommendation per batch, but provided "

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -243,6 +243,7 @@ class Campaign(SerialMixin):
 
         Args:
             batch_size: Number of requested recommendations.
+            batch_quantity: Deprecated! Use ``batch_size`` instead.
 
         Returns:
             Dataframe containing the recommendations in experimental representation.

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -234,27 +234,27 @@ class Campaign(SerialMixin):
             numerical_measurements_must_be_within_tolerance,
         )
 
-    def recommend(self, batch_quantity: int = 5) -> pd.DataFrame:
+    def recommend(self, batch_size: int = 5) -> pd.DataFrame:
         """Provide the recommendations for the next batch of experiments.
 
         Args:
-            batch_quantity: Number of requested recommendations.
+            batch_size: Number of requested recommendations.
 
         Returns:
             Dataframe containing the recommendations in experimental representation.
 
         Raises:
-            ValueError: If ``batch_quantity`` is smaller than 1.
+            ValueError: If ``batch_size`` is smaller than 1.
         """
-        if batch_quantity < 1:
+        if batch_size < 1:
             raise ValueError(
                 f"You must at least request one recommendation per batch, but provided "
-                f"{batch_quantity=}."
+                f"{batch_size=}."
             )
 
         # If there are cached recommendations and the batch size of those is equal to
         # the previously requested one, we just return those
-        if len(self._cached_recommendation) == batch_quantity:
+        if len(self._cached_recommendation) == batch_size:
             return self._cached_recommendation
 
         # Update recommendation meta data
@@ -265,7 +265,7 @@ class Campaign(SerialMixin):
         # Get the recommended search space entries
         rec = self.strategy.recommend(
             self.searchspace,
-            batch_quantity,
+            batch_size,
             self._measurements_parameters_comp,
             self._measurements_targets_comp,
         )
@@ -275,7 +275,7 @@ class Campaign(SerialMixin):
 
         # Telemetry
         telemetry_record_value(TELEM_LABELS["COUNT_RECOMMEND"], 1)
-        telemetry_record_value(TELEM_LABELS["BATCH_QUANTITY"], batch_quantity)
+        telemetry_record_value(TELEM_LABELS["BATCH_SIZE"], batch_size)
 
         return rec
 

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -32,7 +32,7 @@ def _select_candidates_and_recommend(
     Args:
         searchspace: The search space.
         recommend: The Callable representing the recommendation function.
-        batch_size: The chosen batch quantity.
+        batch_size: The chosen batch size.
         allow_repeated_recommendations: Allow to make recommendations that were already
             recommended earlier.
         allow_recommending_already_measured: Allow to output recommendations that were

--- a/baybe/recommenders/clustering.py
+++ b/baybe/recommenders/clustering.py
@@ -104,7 +104,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         self,
         searchspace: SearchSpace,
         candidates_comp: pd.DataFrame,
-        batch_quantity: int,
+        batch_size: int,
     ) -> pd.Index:
         # See base class.
 
@@ -117,7 +117,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
 
         # Set model parameters and perform fit
         model = self.model_class(
-            **{self.model_cluster_num_parameter_name: batch_quantity},
+            **{self.model_cluster_num_parameter_name: batch_size},
             **self.model_params,
         )
         model.fit(candidates_scaled)

--- a/baybe/recommenders/sampling.py
+++ b/baybe/recommenders/sampling.py
@@ -21,7 +21,7 @@ class RandomRecommender(NonPredictiveRecommender):
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
-        batch_quantity: int,
+        batch_size: int,
         candidates_comp: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
@@ -33,8 +33,8 @@ class RandomRecommender(NonPredictiveRecommender):
                     random recommender to a purely discrete space. Please ensure that
                     this dataframe is not None."""
                 )
-            return candidates_comp.sample(batch_quantity)
-        cont_random = searchspace.continuous.samples_random(n_points=batch_quantity)
+            return candidates_comp.sample(batch_size)
+        cont_random = searchspace.continuous.samples_random(n_points=batch_size)
         if searchspace.type == SearchSpaceType.CONTINUOUS:
             return cont_random
         disc_candidates, _ = searchspace.discrete.get_candidates(True, True)
@@ -42,8 +42,8 @@ class RandomRecommender(NonPredictiveRecommender):
         # TODO decide mechanism if number of possible discrete candidates is smaller
         #  than batch size
         disc_random = disc_candidates.sample(
-            n=batch_quantity,
-            replace=len(disc_candidates) < batch_quantity,
+            n=batch_size,
+            replace=len(disc_candidates) < batch_size,
         )
 
         cont_random.reset_index(drop=True)
@@ -62,7 +62,7 @@ class FPSRecommender(NonPredictiveRecommender):
         self,
         searchspace: SearchSpace,
         candidates_comp: pd.DataFrame,
-        batch_quantity: int,
+        batch_size: int,
     ) -> pd.Index:
         # See base class.
 
@@ -71,5 +71,5 @@ class FPSRecommender(NonPredictiveRecommender):
         scaler = StandardScaler()
         scaler.fit(searchspace.discrete.comp_rep)
         candidates_scaled = np.ascontiguousarray(scaler.transform(candidates_comp))
-        ilocs = farthest_point_sampling(candidates_scaled, batch_quantity)
+        ilocs = farthest_point_sampling(candidates_scaled, batch_size)
         return candidates_comp.index[ilocs]

--- a/baybe/simulation.py
+++ b/baybe/simulation.py
@@ -72,7 +72,7 @@ def simulate_transfer_learning(
     lookup: pd.DataFrame,
     /,
     *,
-    batch_quantity: int = 1,
+    batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     groupby: Optional[List[str]] = None,
     n_mc_iterations: int = 1,
@@ -95,7 +95,7 @@ def simulate_transfer_learning(
     Args:
         campaign: See :func:`baybe.simulation.simulate_experiment`.
         lookup: See :func:`baybe.simulation.simulate_scenarios`.
-        batch_quantity: See :func:`baybe.simulation.simulate_scenarios`.
+        batch_size: See :func:`baybe.simulation.simulate_scenarios`.
         n_doe_iterations: See :func:`baybe.simulation.simulate_scenarios`.
         groupby: See :func:`baybe.simulation.simulate_scenarios`.
         n_mc_iterations: See :func:`baybe.simulation.simulate_scenarios`.
@@ -147,7 +147,7 @@ def simulate_transfer_learning(
     return simulate_scenarios(
         scenarios,
         lookup,
-        batch_quantity=batch_quantity,
+        batch_size=batch_size,
         n_doe_iterations=n_doe_iterations,
         groupby=groupby,
         n_mc_iterations=n_mc_iterations,
@@ -160,7 +160,7 @@ def simulate_scenarios(
     lookup: Optional[Union[pd.DataFrame, Callable]] = None,
     /,
     *,
-    batch_quantity: int = 1,
+    batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     initial_data: Optional[List[pd.DataFrame]] = None,
     groupby: Optional[List[str]] = None,
@@ -178,7 +178,7 @@ def simulate_scenarios(
     Args:
         scenarios: A dictionary mapping scenario identifiers to DOE specifications.
         lookup: See :func:`baybe.simulation.simulate_experiment`.
-        batch_quantity: See :func:`baybe.simulation.simulate_experiment`.
+        batch_size: See :func:`baybe.simulation.simulate_experiment`.
         n_doe_iterations: See :func:`baybe.simulation.simulate_experiment`.
         initial_data: A list of initial data sets for which the scenarios should be
             simulated.
@@ -230,7 +230,7 @@ def simulate_scenarios(
             _simulate_groupby(
                 scenarios[Scenario],
                 lookup,
-                batch_quantity=batch_quantity,
+                batch_size=batch_size,
                 n_doe_iterations=n_doe_iterations,
                 initial_data=data,
                 groupby=groupby,
@@ -275,7 +275,7 @@ def _simulate_groupby(
     lookup: Optional[Union[pd.DataFrame, Callable[..., Tuple[float, ...]]]] = None,
     /,
     *,
-    batch_quantity: int = 1,
+    batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     initial_data: Optional[pd.DataFrame] = None,
     groupby: Optional[List[str]] = None,
@@ -294,7 +294,7 @@ def _simulate_groupby(
     Args:
         campaign: See :func:`baybe.simulation.simulate_experiment`.
         lookup: See :func:`baybe.simulation.simulate_experiment`.
-        batch_quantity: See :func:`baybe.simulation.simulate_experiment`.
+        batch_size: See :func:`baybe.simulation.simulate_experiment`.
         n_doe_iterations: See :func:`baybe.simulation.simulate_experiment`.
         initial_data: See :func:`baybe.simulation.simulate_experiment`.
         groupby: See :func:`baybe.simulation.simulate_scenarios`.
@@ -346,7 +346,7 @@ def _simulate_groupby(
             df_group = simulate_experiment(
                 campaign_group,
                 lookup,
-                batch_quantity=batch_quantity,
+                batch_size=batch_size,
                 n_doe_iterations=n_doe_iterations,
                 initial_data=initial_data,
                 random_seed=random_seed,
@@ -377,7 +377,7 @@ def simulate_experiment(
     lookup: Optional[Union[pd.DataFrame, Callable]] = None,
     /,
     *,
-    batch_quantity: int = 1,
+    batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     initial_data: Optional[pd.DataFrame] = None,
     random_seed: int = _DEFAULT_SEED,
@@ -402,7 +402,7 @@ def simulate_experiment(
             settings. can be chosen. The callable is assumed to return either a float
             or a tuple of floats and to accept an arbitrary number of floats as input.
             Finally,``None`` can be chosen, producing fake results.
-        batch_quantity: The number of recommendations to be queried per iteration.
+        batch_size: The number of recommendations to be queried per iteration.
         n_doe_iterations:  The number of iterations to run the design-of-experiments
             loop. If not specified, the simulation proceeds until there are no more
             testable configurations left.
@@ -502,7 +502,7 @@ def simulate_experiment(
     while k_iteration < limit:
         # Get the next recommendations and corresponding measurements
         try:
-            measured = campaign.recommend(batch_quantity=batch_quantity)
+            measured = campaign.recommend(batch_size=batch_size)
         except NotEnoughPointsLeftError:
             # TODO: This except block requires a more elegant solution
             strategy = campaign.strategy

--- a/baybe/strategies/base.py
+++ b/baybe/strategies/base.py
@@ -28,7 +28,7 @@ class Strategy(SerialMixin, ABC):
     def select_recommender(
         self,
         searchspace: SearchSpace,
-        batch_quantity: int = 1,
+        batch_size: int = 1,
         train_x: Optional[pd.DataFrame] = None,
         train_y: Optional[pd.DataFrame] = None,
     ) -> Recommender:
@@ -36,7 +36,7 @@ class Strategy(SerialMixin, ABC):
 
         Args:
             searchspace: See :func:`baybe.strategies.base.Strategy.recommend`.
-            batch_quantity: See :func:`baybe.strategies.base.Strategy.recommend`.
+            batch_size: See :func:`baybe.strategies.base.Strategy.recommend`.
             train_x: See :func:`baybe.strategies.base.Strategy.recommend`.
             train_y: See :func:`baybe.strategies.base.Strategy.recommend`.
 
@@ -47,7 +47,7 @@ class Strategy(SerialMixin, ABC):
     def recommend(
         self,
         searchspace: SearchSpace,
-        batch_quantity: int = 1,
+        batch_size: int = 1,
         train_x: Optional[pd.DataFrame] = None,
         train_y: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
@@ -55,7 +55,7 @@ class Strategy(SerialMixin, ABC):
 
         Args:
             searchspace: The search space in which the experiments are conducted.
-            batch_quantity: The number of experiments to be conducted in parallel.
+            batch_size: The number of experiments to be conducted in parallel.
             train_x: The features of the conducted experiments.
             train_y: The corresponding response values.
 
@@ -64,13 +64,13 @@ class Strategy(SerialMixin, ABC):
         """
         recommender = self.select_recommender(
             searchspace,
-            batch_quantity,
+            batch_size,
             train_x,
             train_y,
         )
         return recommender.recommend(
             searchspace,
-            batch_quantity,
+            batch_size,
             train_x,
             train_y,
             self.allow_repeated_recommendations,

--- a/baybe/strategies/composite.py
+++ b/baybe/strategies/composite.py
@@ -52,7 +52,7 @@ class TwoPhaseStrategy(Strategy):
     def select_recommender(  # noqa: D102
         self,
         searchspace: SearchSpace,
-        batch_quantity: int = 1,
+        batch_size: int = 1,
         train_x: Optional[pd.DataFrame] = None,
         train_y: Optional[pd.DataFrame] = None,
     ) -> Recommender:
@@ -125,7 +125,7 @@ class SequentialStrategy(Strategy):
     def select_recommender(  # noqa: D102
         self,
         searchspace: SearchSpace,
-        batch_quantity: int = 1,
+        batch_size: int = 1,
         train_x: Optional[pd.DataFrame] = None,
         train_y: Optional[pd.DataFrame] = None,
     ) -> Recommender:
@@ -209,7 +209,7 @@ class StreamingSequentialStrategy(Strategy):
     def select_recommender(  # noqa: D102
         self,
         searchspace: SearchSpace,
-        batch_quantity: int = 1,
+        batch_size: int = 1,
         train_x: Optional[pd.DataFrame] = None,
         train_y: Optional[pd.DataFrame] = None,
     ) -> Recommender:

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -9,7 +9,7 @@ Important:
     host machine names are irreversibly anonymized.
 
 **Monitored quantities are:**
-    * ``batch_quantity`` used when querying recommendations
+    * ``batch_size`` used when querying recommendations
     * Number of parameters in the search space
     * Number of constraints in the search space
     * How often ``recommend`` was called
@@ -114,7 +114,7 @@ DEFAULT_TELEMETRY_HOSTNAME = (
 # Telemetry labels for metrics
 TELEM_LABELS = {
     "RECOMMENDED_MEASUREMENTS_PERCENTAGE": "value_recommended-measurements-percentage",
-    "BATCH_QUANTITY": "value_batch-quantity",
+    "BATCH_SIZE": "value_batch-quantity",
     "COUNT_ADD_RESULTS": "count_add-results",
     "COUNT_RECOMMEND": "count_recommend",
     "NUM_PARAMETERS": "value_num-parameters",

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -114,7 +114,7 @@ DEFAULT_TELEMETRY_HOSTNAME = (
 # Telemetry labels for metrics
 TELEM_LABELS = {
     "RECOMMENDED_MEASUREMENTS_PERCENTAGE": "value_recommended-measurements-percentage",
-    "BATCH_SIZE": "value_batch-quantity",
+    "BATCH_SIZE": "value_batch-size",
     "COUNT_ADD_RESULTS": "count_add-results",
     "COUNT_RECOMMEND": "count_recommend",
     "NUM_PARAMETERS": "value_num-parameters",

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -59,15 +59,15 @@ For more details and a full exemplary config, we refer to the corresponding
 
 To obtain a recommendation for the next batch of experiments, we can query the 
 campaign via the [`recommend`](baybe.campaign.Campaign.recommend) method.
-It expects a parameter `batch_quantity` that specifies the desired number of 
+It expects a parameter `batch_size` that specifies the desired number of 
 experiments to be conducted.
 
 ~~~python
-rec = campaign.recommend(batch_quantity=3)
+rec = campaign.recommend(batch_size=3)
 print(rec.to_markdown())
 ~~~
 
-Calling the function returns a `DataFrame` with `batch_quantity` many rows, each
+Calling the function returns a `DataFrame` with `batch_size` many rows, each
 representing a particular parameter configuration from the campaign's search space.
 Thus, the following might be a `DataFrame` returned by `recommend` in a search space
 with the three parameters `Categorial_1`, `Categorical_2` and `Num_disc_1`:
@@ -137,9 +137,9 @@ this is most easily achieved by augmenting the  `DataFrame` returned from that c
 with the respective target columns.
 
 ~~~python
-rec["Target_max"] = [2, 4, 9]  # 3 values matching the batch_quantity of 3
+rec["Target_max"] = [2, 4, 9]  # 3 values matching the batch_size of 3
 campaign.add_measurements(rec)
-new_rec = campaign.recommend(batch_quantity=5)
+new_rec = campaign.recommend(batch_size=5)
 ~~~
 
 After adding the measurements, the corresponding `DataFrame` thus has the following 

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -119,7 +119,7 @@ scenarios = {
 results = simulate_scenarios(
     scenarios,
     WRAPPED_FUNCTION,
-    batch_quantity=3,
+    batch_size=3,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -108,7 +108,7 @@ scenarios = {
 results = simulate_scenarios(
     scenarios,
     sum_of_squares,
-    batch_quantity=3,
+    batch_size=3,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Backtesting/full_initial_data.py
+++ b/examples/Backtesting/full_initial_data.py
@@ -123,7 +123,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_quantity=3,
+    batch_size=3,
     n_doe_iterations=N_DOE_ITERATIONS,
     initial_data=initial_data,
 )

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -118,7 +118,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_quantity=3,
+    batch_size=3,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -151,7 +151,7 @@ scenarios = {
 results = simulate_scenarios(
     scenarios,
     sum_of_squares,
-    batch_quantity=2,
+    batch_size=2,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Backtesting/impute_mode.py
+++ b/examples/Backtesting/impute_mode.py
@@ -124,7 +124,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_quantity=3,
+    batch_size=3,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
     impute_mode="best",

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -98,7 +98,7 @@ scenarios = {"BayBE": campaign}
 results = simulate_scenarios(
     scenarios,
     sum_of_squares,
-    batch_quantity=2,
+    batch_size=2,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Basics/campaign.py
+++ b/examples/Basics/campaign.py
@@ -77,9 +77,9 @@ campaign = Campaign(
 
 # We use the `recommend()` function of the campaign for getting measurements.
 
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
-print("\n\nRecommended measurements with batch_quantity = 2: ")
+print("\n\nRecommended measurements with batch_size = 2: ")
 print(recommendation)
 
 # Adding target values is done by creating a new column in the `recommendation`

--- a/examples/Basics/strategies.py
+++ b/examples/Basics/strategies.py
@@ -80,8 +80,8 @@ available_acq_functions = [
     "UCB",  # upper confidence bound with beta of 1.0
 ]
 
-# Note that the qvailability of the acquisition functions might depend on the `batch_quantity`:
-#   - If `batch_quantity` is set to 1, all available acquisition functions can be chosen
+# Note that the qvailability of the acquisition functions might depend on the `batch_size`:
+#   - If `batch_size` is set to 1, all available acquisition functions can be chosen
 #   - If a larger value is chosen, only those that allow batching.
 #       That is, 'q'-variants of the acquisition functions must be chosen.
 
@@ -177,7 +177,7 @@ campaign = Campaign(
 
 # This campaign can then be used to get recommendations and add measurements:
 
-recommendation = campaign.recommend(batch_quantity=3)
+recommendation = campaign.recommend(batch_size=3)
 print("\n\nRecommended experiments: ")
 print(recommendation)
 

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -98,11 +98,11 @@ campaign = Campaign(
     objective=objective,
 )
 
-BATCH_QUANTITY = 5
+BATCH_SIZE = 5
 N_ITERATIONS = 2
 
 for k in range(N_ITERATIONS):
-    recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+    recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
     # target value are looked up via the botorch wrapper
     target_values = []

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -87,11 +87,11 @@ campaign = Campaign(
     objective=objective,
 )
 
-BATCH_QUANTITY = 3
+BATCH_SIZE = 3
 N_ITERATIONS = 3
 
 for k in range(N_ITERATIONS):
-    recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+    recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
     # target value are looked up via the botorch wrapper
     target_values = []

--- a/examples/Constraints_Discrete/custom_constraints.py
+++ b/examples/Constraints_Discrete/custom_constraints.py
@@ -146,6 +146,6 @@ for kIter in range(N_ITERATIONS):
         ).sum(),
     )
 
-    rec = campaign.recommend(batch_quantity=5)
+    rec = campaign.recommend(batch_size=5)
     add_fake_results(rec, campaign)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/dependency_constraints.py
+++ b/examples/Constraints_Discrete/dependency_constraints.py
@@ -107,6 +107,6 @@ for kIter in range(N_ITERATIONS):
         ).sum(),
     )
 
-    rec = campaign.recommend(batch_quantity=5)
+    rec = campaign.recommend(batch_size=5)
     add_fake_results(rec, campaign)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/exclusion_constraints.py
+++ b/examples/Constraints_Discrete/exclusion_constraints.py
@@ -140,6 +140,6 @@ for kIter in range(N_ITERATIONS):
         ).sum(),
     )
 
-    rec = campaign.recommend(batch_quantity=5)
+    rec = campaign.recommend(batch_size=5)
     add_fake_results(rec, campaign)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -164,6 +164,6 @@ for kIter in range(N_ITERATIONS):
         .sum(),
     )
 
-    rec = campaign.recommend(batch_quantity=5)
+    rec = campaign.recommend(batch_size=5)
     add_fake_results(rec, campaign)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/prodsum_constraints.py
+++ b/examples/Constraints_Discrete/prodsum_constraints.py
@@ -136,6 +136,6 @@ for kIter in range(N_ITERATIONS):
         .sum(),
     )
 
-    rec = campaign.recommend(batch_quantity=5)
+    rec = campaign.recommend(batch_size=5)
     add_fake_results(rec, campaign)
     campaign.add_measurements(rec)

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -137,7 +137,7 @@ campaign = Campaign(
 )
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -147,7 +147,7 @@ add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
 # Do another round of recommendations
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
 print("Recommendation from campaign:")

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -188,7 +188,7 @@ campaign = Campaign(
 )
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -198,7 +198,7 @@ add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
 # Do another round of recommendations
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
 print("Recommendation from campaign:")

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -107,7 +107,7 @@ campaign = Campaign(
 #### Iterate with recommendations and measurements
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -119,7 +119,7 @@ campaign.add_measurements(recommendation)
 #### Model Outputs
 
 # Do another round of recommendations
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
 print("Recommendation from campaign:")

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -96,7 +96,7 @@ print("The model object in json format:")
 print(surrogate_model.to_json(), end="\n" * 3)
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -111,7 +111,7 @@ campaign.add_measurements(recommendation)
 print("Here you will see some model outputs as we set verbose to True")
 
 # Do another round of recommendations
-recommendation = campaign.recommend(batch_quantity=2)
+recommendation = campaign.recommend(batch_size=2)
 
 
 # Print second round of recommendations

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -107,7 +107,7 @@ N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
     print(f"\n\n##### ITERATION {kIter+1} #####")
 
-    rec = campaign.recommend(batch_quantity=3)
+    rec = campaign.recommend(batch_size=3)
     print("\nRecommended measurements:\n", rec)
 
     add_fake_results(rec, campaign)

--- a/examples/Searchspaces/continuous_space_botorch_function.py
+++ b/examples/Searchspaces/continuous_space_botorch_function.py
@@ -73,8 +73,8 @@ campaign = Campaign(
 
 # Get a recommendation for a fixed batched quantity.
 
-BATCH_QUANTITY = 3
-recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+BATCH_SIZE = 3
+recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.

--- a/examples/Searchspaces/continuous_space_botorch_function.py
+++ b/examples/Searchspaces/continuous_space_botorch_function.py
@@ -71,7 +71,7 @@ campaign = Campaign(
     objective=objective,
 )
 
-# Get a recommendation for a fixed batched quantity.
+# Get a recommendation for a fixed batch size.
 
 BATCH_SIZE = 3
 recommendation = campaign.recommend(batch_size=BATCH_SIZE)

--- a/examples/Searchspaces/continuous_space_custom_function.py
+++ b/examples/Searchspaces/continuous_space_custom_function.py
@@ -64,7 +64,7 @@ campaign = Campaign(
     objective=objective,
 )
 
-# Get a recommendation for a fixed batched quantity.
+# Get a recommendation for a fixed batch size.
 BATCH_SIZE = 3
 recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 

--- a/examples/Searchspaces/continuous_space_custom_function.py
+++ b/examples/Searchspaces/continuous_space_custom_function.py
@@ -65,8 +65,8 @@ campaign = Campaign(
 )
 
 # Get a recommendation for a fixed batched quantity.
-BATCH_QUANTITY = 3
-recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+BATCH_SIZE = 3
+recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.

--- a/examples/Searchspaces/discrete_space.py
+++ b/examples/Searchspaces/discrete_space.py
@@ -91,8 +91,8 @@ campaign = Campaign(
 )
 
 # Get a recommendation for a fixed batched quantity.
-BATCH_QUANTITY = 3
-recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+BATCH_SIZE = 3
+recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.

--- a/examples/Searchspaces/discrete_space.py
+++ b/examples/Searchspaces/discrete_space.py
@@ -90,7 +90,7 @@ campaign = Campaign(
     objective=objective,
 )
 
-# Get a recommendation for a fixed batched quantity.
+# Get a recommendation for a fixed batch size.
 BATCH_SIZE = 3
 recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 

--- a/examples/Searchspaces/hybrid_space.py
+++ b/examples/Searchspaces/hybrid_space.py
@@ -118,7 +118,7 @@ campaign = Campaign(
     strategy=hybrid_strategy,
 )
 
-# Get a recommendation for a fixed batched quantity.
+# Get a recommendation for a fixed batch size.
 BATCH_SIZE = 3
 recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 

--- a/examples/Searchspaces/hybrid_space.py
+++ b/examples/Searchspaces/hybrid_space.py
@@ -119,8 +119,8 @@ campaign = Campaign(
 )
 
 # Get a recommendation for a fixed batched quantity.
-BATCH_QUANTITY = 3
-recommendation = campaign.recommend(batch_quantity=BATCH_QUANTITY)
+BATCH_SIZE = 3
+recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.

--- a/examples/Serialization/basic_serialization.py
+++ b/examples/Serialization/basic_serialization.py
@@ -91,8 +91,8 @@ print("Passed basic assertion check!")
 # To further show how serialization affects working with campaigns, we will now
 # create and compare some recommendations in both campaigns.
 
-recommendation_orig = campaign.recommend(batch_quantity=2)
-recommendation_recreate = campaign_recreate.recommend(batch_quantity=2)
+recommendation_orig = campaign.recommend(batch_size=2)
+recommendation_recreate = campaign_recreate.recommend(batch_size=2)
 
 print("Recommendation from original object:")
 print(recommendation_orig)

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -95,5 +95,5 @@ CONFIG = str(
 campaign = Campaign.from_config(CONFIG)
 
 # We now perform a recommendation as usual and print it.
-recommendation = campaign.recommend(batch_quantity=3)
+recommendation = campaign.recommend(batch_size=3)
 print(recommendation)

--- a/streamlit/initial_strategy.py
+++ b/streamlit/initial_strategy.py
@@ -109,7 +109,7 @@ def main():
     # create the strategy and generate the recommendations
     # TODO: The acquisition function should become optional for model-free methods
     strategy = selection_strategies[strategy_name]()
-    selection = strategy.recommend(searchspace=searchspace, batch_quantity=n_selected)
+    selection = strategy.recommend(searchspace=searchspace, batch_size=n_selected)
 
     # show the result
     fig = plot_point_selection(points.values, selection.index.values, strategy_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,10 +134,10 @@ def fixture_n_iterations(request):
 
 @pytest.fixture(
     params=[pytest.param(1, marks=pytest.mark.slow), 3],
-    name="batch_quantity",
+    name="batch_size",
     ids=["b1", "b3"],
 )
-def fixture_batch_quantity(request):
+def fixture_batch_size(request):
     """Number of recommendations requested per iteration.
 
     Testing 1 as edge case and 3 as a case for >1.
@@ -750,18 +750,18 @@ def fixture_default_onnx_surrogate(onnx_str) -> Union["CustomONNXSurrogate", Non
 # TODO consider turning this into a fixture returning a campaign after running some
 #  fake iterations
 def run_iterations(
-    campaign: Campaign, n_iterations: int, batch_quantity: int, add_noise: bool = True
+    campaign: Campaign, n_iterations: int, batch_size: int, add_noise: bool = True
 ) -> None:
     """Run a campaign for some fake iterations.
 
     Args:
         campaign: The campaign encapsulating the experiments.
         n_iterations: Number of iterations run.
-        batch_quantity: Number of recommended points per iteration.
+        batch_size: Number of recommended points per iteration.
         add_noise: Flag whether measurement noise should be added every 2nd iteration.
     """
     for k in range(n_iterations):
-        rec = campaign.recommend(batch_quantity=batch_quantity)
+        rec = campaign.recommend(batch_size=batch_size)
         # dont use parameter noise for these tests
 
         add_fake_results(rec, campaign)

--- a/tests/test_constraints_continuous.py
+++ b/tests/test_constraints_continuous.py
@@ -12,10 +12,10 @@ from .conftest import run_iterations
 
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_1"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
-def test_equality1(campaign, n_iterations, batch_quantity):
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
+def test_equality1(campaign, n_iterations, batch_size):
     """Test equality constraint with equal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 
@@ -24,10 +24,10 @@ def test_equality1(campaign, n_iterations, batch_quantity):
 
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_2"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
-def test_equality2(campaign, n_iterations, batch_quantity):
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
+def test_equality2(campaign, n_iterations, batch_size):
     """Test equality constraint with unequal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 
@@ -36,10 +36,10 @@ def test_equality2(campaign, n_iterations, batch_quantity):
 
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_3"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
-def test_inequality1(campaign, n_iterations, batch_quantity):
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
+def test_inequality1(campaign, n_iterations, batch_size):
     """Test inequality constraint with equal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 
@@ -48,10 +48,10 @@ def test_inequality1(campaign, n_iterations, batch_quantity):
 
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_4"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
-def test_inequality2(campaign, n_iterations, batch_quantity):
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
+def test_inequality2(campaign, n_iterations, batch_size):
     """Test inequality constraint with unequal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 
@@ -64,11 +64,11 @@ def test_inequality2(campaign, n_iterations, batch_quantity):
     [["Solvent_1", "Conti_finite1", "Conti_finite3", "Conti_finite2"]],
 )
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_1"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
 @pytest.mark.parametrize("n_grid_points", [5], ids=["grid5"])
-def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
+def test_hybridspace_eq(campaign, n_iterations, batch_size):
     """Test equality constraint with equal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 
@@ -81,11 +81,11 @@ def test_hybridspace_eq(campaign, n_iterations, batch_quantity):
     [["Solvent_1", "Conti_finite1", "Conti_finite3", "Conti_finite2"]],
 )
 @pytest.mark.parametrize("constraint_names", [["ContiConstraint_3"]])
-@pytest.mark.parametrize("batch_quantity", [5], ids=["b5"])
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
 @pytest.mark.parametrize("n_grid_points", [5], ids=["grid5"])
-def test_hybridspace_ineq(campaign, n_iterations, batch_quantity):
+def test_hybridspace_ineq(campaign, n_iterations, batch_size):
     """Test inequality constraint with equal weights."""
-    run_iterations(campaign, n_iterations, batch_quantity, add_noise=False)
+    run_iterations(campaign, n_iterations, batch_size, add_noise=False)
     res = campaign.measurements
     print(res)
 

--- a/tests/test_custom_parameter.py
+++ b/tests/test_custom_parameter.py
@@ -11,6 +11,6 @@ from .conftest import run_iterations
 
 
 @pytest.mark.parametrize("parameter_names", [["Custom_1", "Custom_2"]])
-def test_run_iterations(campaign, n_iterations, batch_quantity):
+def test_run_iterations(campaign, n_iterations, batch_size):
     """Test if iterative loop runs with custom parameters."""
-    run_iterations(campaign, n_iterations, batch_quantity)
+    run_iterations(campaign, n_iterations, batch_size)

--- a/tests/test_custom_surrogate.py
+++ b/tests/test_custom_surrogate.py
@@ -45,10 +45,10 @@ if _ONNX_INSTALLED:
     )
     def test_supported_parameter_types(campaign: Campaign, should_raise: bool):
         """Using an ONNX model with unsupported parameters should raise an exception."""
-        run_iterations(campaign, n_iterations=1, batch_quantity=1)
+        run_iterations(campaign, n_iterations=1, batch_size=1)
         context = pytest.raises(TypeError) if should_raise else nullcontext()
         with context:
-            campaign.recommend(batch_quantity=1)
+            campaign.recommend(batch_size=1)
 
 
 def test_validate_architectures():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -98,3 +98,9 @@ def test_deprecated_campaign_tolerance_flag(flag):
     """Constructing a Campaign with the deprecated tolerance flag raises an error."""
     with pytest.raises(DeprecationError):
         Campaign(None, None, None, numerical_measurements_must_be_within_tolerance=flag)
+
+
+def test_deprecated_batch_quantity_keyword(campaign):
+    """Using the deprecated batch_quantity keyword raises an error."""
+    with pytest.raises(DeprecationError):
+        campaign.recommend(batch_quantity=5)  # noqa: E999

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -19,7 +19,7 @@ def test_bad_parameter_input_value(campaign, good_reference_values, bad_val, req
     if request.node.callspec.id in param_xfails:
         pytest.xfail()
 
-    rec = campaign.recommend(batch_quantity=3)
+    rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
         campaign,
@@ -42,7 +42,7 @@ def test_bad_target_input_value(campaign, good_reference_values, bad_val, reques
     if request.node.callspec.id in target_xfails:
         pytest.xfail()
 
-    rec = campaign.recommend(batch_quantity=3)
+    rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
         campaign,

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -100,39 +100,39 @@ test_targets = [
 #   MarginalRecommender (or similar) is re-added, the acqf-tests can be reactivated.
 # @pytest.mark.slow
 # @pytest.mark.parametrize("acquisition_function_cls", valid_acquisition_functions)
-# def test_iter_acquisition_function(campaign, n_iterations, batch_quantity):
-#     run_iterations(campaign, n_iterations, batch_quantity)
+# def test_iter_acquisition_function(campaign, n_iterations, batch_size):
+#     run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("surrogate_model", valid_surrogate_models)
-def test_iter_surrogate_model(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_surrogate_model(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("initial_recommender", valid_initial_recommenders)
-def test_iter_initial_recommender(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_initial_recommender(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("target_names", test_targets)
-def test_iter_targets(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_targets(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("recommender", valid_discrete_recommenders)
-def test_iter_recommender_discrete(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_recommender_discrete(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("recommender", valid_continuous_recommenders)
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
-def test_iter_recommender_continuous(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_recommender_continuous(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow
@@ -141,10 +141,10 @@ def test_iter_recommender_continuous(campaign, n_iterations, batch_quantity):
     "parameter_names",
     [["Categorical_1", "SomeSetting", "Num_disc_1", "Conti_finite1", "Conti_finite2"]],
 )
-def test_iter_recommender_hybrid(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_iter_recommender_hybrid(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.parametrize("strategy", valid_strategies, indirect=True)
-def test_strategies(campaign, n_iterations, batch_quantity):
-    run_iterations(campaign, n_iterations, batch_quantity)
+def test_strategies(campaign, n_iterations, batch_size):
+    run_iterations(campaign, n_iterations, batch_size)

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -15,6 +15,6 @@ from .conftest import _CHEM_INSTALLED, run_iterations
     [["Categorical_1", f"Substance_1_{enc}"] for enc in SubstanceEncoding],
     ids=[enc.name for enc in SubstanceEncoding],
 )
-def test_run_iterations(campaign, batch_quantity, n_iterations):
+def test_run_iterations(campaign, batch_size, n_iterations):
     """Test running some iterations with fake results and a substance parameter."""
-    run_iterations(campaign, n_iterations, batch_quantity)
+    run_iterations(campaign, n_iterations, batch_size)


### PR DESCRIPTION
This PR renames all `batch_quantity` method parameters to `batch_size`, which is more on point and easier to understand. Also, it adds a deprecation mechanism for `batch_quantity`.