### PR TITLE
Fix example output in documentation

### DIFF
--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -147,7 +147,7 @@ def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
             if not ignore_examples:
                 convert_execute.append("--execute")
 
-            to_markdown = ["jupytext", "--to", "markdown", notebook_path]
+            to_markdown = ["jupyter", "nbconvert", "--to", "markdown", notebook_path]
 
             check_call(convert_execute, stdout=DEVNULL, stderr=STDOUT)
             check_call(

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -125,6 +125,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_analytical.png
+
 sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
 plt.gcf().set_size_inches(24, 8)
 plt.savefig("./run_analytical.png")

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -4,7 +4,6 @@
 # That is, we perform several Monte Carlo runs with several iterations.
 # In addition, we also store and display the results.
 
-
 # This example assumes some basic familiarity with using BayBE and how to use BoTorch test
 # functions in discrete searchspaces.
 # For further details, we thus refer to
@@ -101,6 +100,7 @@ random_campaign = Campaign(
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.
 # For this, it is necessary to define a dictionary mapping scenario names to campaigns.
+
 scenarios = {
     "Sequential greedy EI": seq_greedy_EI_campaign,
     "Random": random_campaign,
@@ -114,6 +114,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_analytical.png
+
 sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
 plt.gcf().set_size_inches(24, 8)
 plt.savefig("./run_analytical.png")

--- a/examples/Backtesting/full_initial_data.py
+++ b/examples/Backtesting/full_initial_data.py
@@ -28,6 +28,7 @@ from baybe.targets import NumericalTarget
 # For the full simulation, we need to define an additional parameter.
 # Since this example uses initial data, we only need to define the number of iterations per run.
 # The number of runs is determined by the number of initial data points provided.
+
 N_DOE_ITERATIONS = 5
 
 ### Lookup functionality and data creation
@@ -47,10 +48,12 @@ except FileNotFoundError:
 # To include initial data, we sample some rows from the lookup table.
 # Note that the initial_data needs to be a list of `pd.DataFrame` objects.
 # One experiment will be performed per provided initial data set.
+
 initial_data = [lookup.sample(n=5), lookup.sample(n=5), lookup.sample(n=5)]
 
 # As usual, we set up some experiment.
 # Note that we now need to ensure that the names fit the names in the provided .xlsx file!
+
 dict_solvent = {
     "DMAc": r"CC(N(C)C)=O",
     "Butyornitrile": r"CCCC#N",
@@ -105,6 +108,7 @@ objective = Objective(
 
 # In this example, we create two campaigns.
 # One uses the default recommender and the other one makes random recommendations.
+
 campaign = Campaign(searchspace=searchspace, objective=objective)
 campaign_rand = Campaign(
     searchspace=searchspace,
@@ -118,6 +122,7 @@ campaign_rand = Campaign(
 # This function is where we provide the `initial_data` dataframe.
 # Note that this function enables to run multiple scenarios by a single function call.
 # For this, it is necessary to define a dictionary mapping scenario names to campaigns.
+
 scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 
 results = simulate_scenarios(
@@ -129,6 +134,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_full_initial_data.png
+
 max_yield = lookup["yield"].max()
 sns.lineplot(
     data=results, x="Num_Experiments", y="yield_CumBest", hue="Scenario", marker="x"

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -48,6 +48,7 @@ except FileNotFoundError:
 
 # As usual, we set up some experiment.
 # Note that we now need to ensure that the names fit the names in the provided .xlsx file!
+
 dict_solvent = {
     "DMAc": r"CC(N(C)C)=O",
     "Butyornitrile": r"CCCC#N",
@@ -113,6 +114,7 @@ campaign_rand = Campaign(
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.
 # For this, it is necessary to define a dictionary mapping scenario names to campaigns.
+
 scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 
 results = simulate_scenarios(
@@ -124,6 +126,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_full_lookup.png
+
 max_yield = lookup["yield"].max()
 sns.lineplot(
     data=results, x="Num_Experiments", y="yield_CumBest", hue="Scenario", marker="x"

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -30,6 +30,7 @@ from baybe.targets import NumericalTarget
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
+
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 2
 
@@ -37,6 +38,8 @@ N_DOE_ITERATIONS = 2
 
 
 # See [`here`](./custom_analytical.md) for details on the custom analytical test function.
+
+
 def sum_of_squares(*x: float) -> float:
     """Calculate the sum of squares."""
     res = 0
@@ -49,6 +52,7 @@ def sum_of_squares(*x: float) -> float:
 # This is necessary to know for the creation of the parameters.
 # Similarly, it is necessary to state the bounds of the parameters.
 # These should be provided as a list of two-dimensional tuples.
+
 DIMENSION = 4
 BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
@@ -56,10 +60,12 @@ BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 
 # Our goal is to construct a hybrid searchspace containing discrete and continuous parameters.
 # We thus need to specify which indices should be discrete and which should be continuous.
+
 CONT_INDICES = [0, 1]
 DISC_INDICES = [2, 3]
 
 # This code verifies whether the provided indices agree with `DIMENSION`.
+
 if set(CONT_INDICES + DISC_INDICES) != set(range(DIMENSION)):
     raise ValueError(
         "Either the intersection between CONT_IND and DISC_IND is not empty or your "
@@ -70,10 +76,12 @@ if set(CONT_INDICES + DISC_INDICES) != set(range(DIMENSION)):
 # Note that this example uses the `SequentialGreedyRecommender` (among others).
 # This recommender performs a brute-force optimization over the discrete subspace.
 # We thus heavily advise to keep the number of discrete parameters and points rather small here.
+
 POINTS_PER_DIM = 6
 
 
 # Construct the continuous parameters as NumericContinuous parameters.
+
 cont_parameters = [
     NumericalContinuousParameter(
         name=f"x_{k+1}",
@@ -83,6 +91,7 @@ cont_parameters = [
 ]
 
 # Construct the discrete parameters as `NumericalDiscreteParameters`.
+
 disc_parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k+1}",
@@ -93,6 +102,7 @@ disc_parameters = [
 ]
 
 # Concatenate the continuous and discrete parameters.
+
 parameters = cont_parameters + disc_parameters
 
 # Construct searchspace and objective.
@@ -143,6 +153,7 @@ random_campaign = Campaign(
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.
 # For this, it is necessary to define a dictionary mapping scenario names to campaigns.
+
 scenarios = {
     "Sequential greedy": seq_greedy_campaign,
     "Naive hybrid": naive_hybrid_campaign,
@@ -157,6 +168,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_analytical.png
+
 sns.lineplot(data=results, x="Num_Experiments", y="Target_CumBest", hue="Scenario")
 plt.gcf().set_size_inches(24, 8)
 plt.savefig("./run_hybrid.png")

--- a/examples/Backtesting/impute_mode.py
+++ b/examples/Backtesting/impute_mode.py
@@ -26,12 +26,14 @@ from baybe.targets import NumericalTarget
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
+
 N_MC_ITERATIONS = 2
 N_DOE_ITERATIONS = 5
 
 ### Lookup functionality and data creation
 
 # See [`full_lookup`](./full_lookup.md) for details.
+
 try:
     lookup = pd.read_excel("./lookup_withmissing.xlsx")
 except FileNotFoundError:
@@ -42,6 +44,7 @@ except FileNotFoundError:
 
 # As usual, we set up some experiment.
 # Note that we now need to ensure that the names fit the names in the provided .xlsx file!
+
 dict_solvent = {
     "DMAc": r"CC(N(C)C)=O",
     "Butyornitrile": r"CCCC#N",
@@ -107,6 +110,7 @@ campaign_rand = Campaign(
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
 # Note that this function enables to run multiple scenarios by a single function call.
 # For this, it is necessary to define a dictionary mapping scenario names to campaigns.
+
 scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 
 # The lookup table does not contain data for all possible combination of parameters.
@@ -131,6 +135,7 @@ results = simulate_scenarios(
 )
 
 # The following lines plot the results and save the plot in run_impute_mode.png
+
 max_yield = lookup["yield"].max()
 sns.lineplot(
     data=results, x="Num_Experiments", y="yield_CumBest", hue="Scenario", marker="x"

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -33,7 +33,9 @@ N_DOE_ITERATIONS = 4
 ### Defining the test function
 
 
-# See [`custom_analytical`](./custom_analytical.md) for details
+# See [`custom_analytical`](./custom_analytical.md) for details.
+
+
 def sum_of_squares(*x: float) -> Tuple[float, float]:
     """Calculate the sum of squares."""
     res = 0
@@ -48,6 +50,7 @@ BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 ### Creating the searchspace
 
 # In this example, we construct a purely discrete space with 10 points per dimension.
+
 parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k+1}",
@@ -66,6 +69,7 @@ searchspace = SearchSpace.from_product(parameters=parameters)
 # Thus we first need to define the different targets.
 # We use two targets here.
 # The first target is maximized and the second target is minimized during the optimization process.
+
 Target_1 = NumericalTarget(
     name="Target_1", mode="MAX", bounds=(0, 100), transformation="LINEAR"
 )
@@ -93,6 +97,7 @@ objective = Objective(
 campaign = Campaign(searchspace=searchspace, objective=objective)
 
 # We can now use the `simulate_scenarios` function to simulate a full experiment.
+
 scenarios = {"BayBE": campaign}
 
 results = simulate_scenarios(

--- a/examples/Basics/strategies.py
+++ b/examples/Basics/strategies.py
@@ -53,7 +53,8 @@ INITIAL_RECOMMENDER = RandomRecommender()
 # The surrogate model is then used by the acquisition function to make recommendations.
 
 # The following are some available basic surrogates
-# Use `baybe.surrogates.get_available_surrogates()` for a complete list
+# Use `baybe.surrogates.get_available_surrogates()` for a complete list.
+
 available_surrogate_models = [
     GaussianProcessSurrogate(),
     RandomForestSurrogate(),
@@ -62,6 +63,7 @@ available_surrogate_models = [
 ]
 
 # Per default a Gaussian Process is used
+
 SURROGATE_MODEL = GaussianProcessSurrogate()
 
 
@@ -94,8 +96,8 @@ ACQ_FUNCTION = "qEI"
 # Two other boolean hyperparameters can be specified when creating a strategy object.
 # The first one allows the recommendation of points that were already recommended previously.
 # The second one allows the recommendation of points that have already been measured.
-
 # Per default, they are set to `True`.
+
 ALLOW_REPEATED_RECOMMENDATIONS = True
 ALLOW_RECOMMENDING_ALREADY_MEASURED = True
 

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -38,6 +38,7 @@ TestFunctionClass = Rastrigin
 # Specify a numerical stride for discrete parameters.
 # If you make it too small, it will make calculations expensive.
 # If you make it too large, constraints might not be satisfied anywhere.
+
 STRIDE = 1.0
 
 if not hasattr(TestFunctionClass, "dim"):
@@ -53,6 +54,7 @@ WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
 # Since the searchspace is continuous, we construct `NumericalContinuousParameter`.
 # We use the data of the test function to deduce bounds and number of parameters.
+
 parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k + 1}",
@@ -74,6 +76,7 @@ parameters = [
 # We model the following constraints:
 # `1.0*x_1 + 1.0*x_2 = 1.0`
 # `1.0*x_3 - 1.0*x_4 = 2.0`
+
 constraints = [
     DiscreteSumConstraint(
         parameters=["x_1", "x_2"],
@@ -118,6 +121,7 @@ measurements = campaign.measurements
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`
+
 print(
     "1.0*x_1 + 1.0*x_2 = 1.0 satisfied in all recommendations? ",
     np.allclose(
@@ -126,6 +130,7 @@ print(
 )
 
 # `1.0*x_3 - 1.0*x_4 = 2.0`
+
 print(
     "1.0*x_3 - 1.0*x_4 = 2.0 satisfied in all recommendations? ",
     np.allclose(

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -10,7 +10,6 @@
 # We thus refer to [`discrete_space`](./../Searchspaces/discrete_space.md) for
 # details on this aspect.
 
-
 ### Necessary imports for this example
 
 import numpy as np
@@ -47,6 +46,7 @@ WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
 # Since the searchspace is continuous test, we construct `NumericalContinuousParameter`s
 # We use that data of the test function to deduce bounds and number of parameters.
+
 parameters = [
     NumericalContinuousParameter(
         name=f"x_{k+1}",
@@ -60,6 +60,7 @@ parameters = [
 # `1.0*x_3 - 1.0*x_4 = 2.0`
 # `1.0*x_1 + 1.0*x_3 >= 1.0`
 # `2.0*x_2 + 3.0*x_4 <= 1.0` which is equivalent to `-2.0*x_2 - 3.0*x_4 >= -1.0`
+
 constraints = [
     ContinuousLinearEqualityConstraint(
         parameters=["x_1", "x_2"], coefficients=[1.0, 1.0], rhs=1.0
@@ -102,11 +103,13 @@ for k in range(N_ITERATIONS):
 
     campaign.add_measurements(recommendation)
 
-#### Verify the constraints
+### Verify the constraints
+
 measurements = campaign.measurements
 TOLERANCE = 0.01
 
 # `1.0*x_1 + 1.0*x_2 = 1.0`
+
 print(
     "1.0*x_1 + 1.0*x_2 = 1.0 satisfied in all recommendations? ",
     np.allclose(
@@ -115,6 +118,7 @@ print(
 )
 
 # `1.0*x_3 - 1.0*x_4 = 2.0`
+
 print(
     "1.0*x_3 - 1.0*x_4 = 2.0 satisfied in all recommendations? ",
     np.allclose(
@@ -123,12 +127,14 @@ print(
 )
 
 # `1.0*x_1 + 1.0*x_3 >= 1.0`
+
 print(
     "1.0*x_1 + 1.0*x_3 >= 1.0 satisfied in all recommendations? ",
     (1.0 * measurements["x_1"] + 1.0 * measurements["x_3"]).ge(1.0 - TOLERANCE).all(),
 )
 
 # `2.0*x_2 + 3.0*x_4 <= 1.0`
+
 print(
     "2.0*x_2 + 3.0*x_4 <= 1.0 satisfied in all recommendations? ",
     (2.0 * measurements["x_2"] + 3.0 * measurements["x_4"]).le(1.0 + TOLERANCE).all(),

--- a/examples/Constraints_Discrete/custom_constraints.py
+++ b/examples/Constraints_Discrete/custom_constraints.py
@@ -84,6 +84,7 @@ def custom_function(df: pd.DataFrame) -> pd.Series:
 
 
 # We now initialize the `CustomConstraint` with all parameters this function should have access to.
+
 constraint = DiscreteCustomConstraint(
     parameters=["Concentration", "Solvent", "Temperature"], validator=custom_function
 )
@@ -104,6 +105,7 @@ print(campaign)
 ### Manual verification of the constraint
 
 # The following loop performs some recommendations and manually verifies the given constraints.
+
 N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
     print(f"\n\n#### ITERATION {kIter+1} ####")

--- a/examples/Constraints_Discrete/dependency_constraints.py
+++ b/examples/Constraints_Discrete/dependency_constraints.py
@@ -45,6 +45,7 @@ parameters = [solvent, switch1, switch2, fraction1, frame1, frame2]
 # The constraints are handled when creating the searchspace object.
 # It is thus necessary to define it before the searchspace creation.
 # Note that multiple dependencies have to be included in a single constraint object.
+
 constraint = DiscreteDependenciesConstraint(
     parameters=["Switch1", "Switch2"],
     conditions=[
@@ -70,6 +71,7 @@ print(campaign)
 ### Manual verification of the constraints
 
 # The following loop performs some recommendations and manually verifies the given constraints.
+
 N_ITERATIONS = 5
 for kIter in range(N_ITERATIONS):
     print(f"\n#### ITERATION {kIter+1} ####")

--- a/examples/Constraints_Discrete/exclusion_constraints.py
+++ b/examples/Constraints_Discrete/exclusion_constraints.py
@@ -29,6 +29,7 @@ from baybe.utils import add_fake_results
 ### Experiment setup
 
 # We begin by setting up some parameters for our experiments.
+
 dict_solvent = {
     "water": "O",
     "C1": "C",
@@ -70,6 +71,7 @@ constraint_1 = DiscreteExcludeConstraint(
 
 # This constraint simulates a situation where solvents `C5` and `C6` are not
 # compatible with pressures larger than 5 and should thus be excluded.
+
 constraint_2 = DiscreteExcludeConstraint(
     parameters=["Pressure", "Solv"],
     combiner="AND",
@@ -81,6 +83,7 @@ constraint_2 = DiscreteExcludeConstraint(
 
 # This constraint simulates a situation where pressures below 3 should never be
 # combined with temperatures above 120.
+
 constraint_3 = DiscreteExcludeConstraint(
     parameters=["Pressure", "Temp"],
     combiner="AND",
@@ -93,6 +96,7 @@ constraint_3 = DiscreteExcludeConstraint(
 ### Creating the searchspace and the objective
 
 # We now create the searchspace using the previously defined constraints.
+
 searchspace = SearchSpace.from_product(
     parameters=parameters, constraints=[constraint_1, constraint_2, constraint_3]
 )
@@ -109,6 +113,7 @@ print(campaign)
 ### Manual verification of the constraints
 
 # The following loop performs some iterations and manually verifies the given constraints.
+
 N_ITERATIONS = 3
 for kIter in range(N_ITERATIONS):
     print(f"\n\n#### ITERATION {kIter+1} ####")

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -31,6 +31,7 @@ from baybe.utils import add_fake_results
 ### Experiment setup
 
 # This parameter denotes the tolerance with regard to the calculation of the sum.
+
 SUM_TOLERANCE = 1.0
 
 dict_solvents = {
@@ -42,7 +43,9 @@ dict_solvents = {
 solvent1 = SubstanceParameter(name="Solv1", data=dict_solvents, encoding="MORDRED")
 solvent2 = SubstanceParameter(name="Solv2", data=dict_solvents, encoding="MORDRED")
 solvent3 = SubstanceParameter(name="Solv3", data=dict_solvents, encoding="MORDRED")
+
 # Parameters for representing the fraction.
+
 fraction1 = NumericalDiscreteParameter(
     name="Frac1", values=list(np.linspace(0, 100, 12)), tolerance=0.2
 )
@@ -63,6 +66,7 @@ parameters = [solvent1, solvent2, solvent3, fraction1, fraction2, fraction3]
 # The reason is that constraints are normally applied in a specific order.
 # However, the fractions should be invariant under permutations.
 # We thus require an explicit constraint for this.
+
 perm_inv_constraint = DiscretePermutationInvarianceConstraint(
     parameters=["Solv1", "Solv2", "Solv3"],
     dependencies=DiscreteDependenciesConstraint(
@@ -77,6 +81,7 @@ perm_inv_constraint = DiscretePermutationInvarianceConstraint(
 )
 
 # This is now the actual sum constraint
+
 sum_constraint = DiscreteSumConstraint(
     parameters=["Frac1", "Frac2", "Frac3"],
     condition=ThresholdCondition(threshold=100, operator="=", tolerance=SUM_TOLERANCE),
@@ -84,6 +89,7 @@ sum_constraint = DiscreteSumConstraint(
 
 # The permutation invariance might create duplicate labels.
 # We thus include a constraint to remove them.
+
 no_duplicates_constraint = DiscreteNoLabelDuplicatesConstraint(
     parameters=["Solv1", "Solv2", "Solv3"]
 )

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -42,8 +42,9 @@ from baybe.utils import add_fake_results
 
 # The choice of using tensors in fit/predict is purely for BayBE, not a requirement.
 
-
 # Final estimator
+
+
 class MeanVarEstimator(BaseEstimator, RegressorMixin):
     """Stack final estimator for mean and variance."""
 
@@ -59,7 +60,10 @@ class MeanVarEstimator(BaseEstimator, RegressorMixin):
 
 
 # Registration
+
 # The class must include `_fit` and `_posterior` functions with the correct signatures.
+
+
 @register_custom_architecture(
     joint_posterior_attr=False, constant_target_catching=False, batchify_posterior=True
 )
@@ -123,6 +127,7 @@ parameters = [
 
 ### Run DOE iterations with custom surrogate
 # Create campaign
+
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=Objective(
@@ -143,6 +148,7 @@ print("Recommendation from campaign:")
 print(recommendation)
 
 # Add some fake results
+
 add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
@@ -150,6 +156,7 @@ campaign.add_measurements(recommendation)
 recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
+
 print("Recommendation from campaign:")
 print(recommendation)
 
@@ -159,6 +166,7 @@ print()
 ### Serialization
 
 # Serialization of custom models is not supported
+
 try:
     campaign.to_json()
 except RuntimeError as e:

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -34,12 +34,14 @@ from baybe.utils import add_fake_results
 # Details of the setup is not the focus of BayBE but can be found in `Pytorch` guides.
 
 # Model Configuration
+
 INPUT_DIM = 10
 OUTPUT_DIM = 1
 DROPOUT = 0.5
 NUM_NEURONS = [128, 32, 8]
 
 # Model training hyperparameters
+
 HYPERPARAMS = {
     "epochs": 10,
     "lr": 1e-3,
@@ -48,10 +50,13 @@ HYPERPARAMS = {
 }
 
 # MC Parameters
+
 MC = 100
 
 
 # Helper functions
+
+
 def _create_linear_block(in_features: int, out_features: int) -> list:
     """Create a linear block with dropout and relu activation."""
     return [nn.Linear(in_features, out_features), nn.Dropout(p=DROPOUT), nn.ReLU()]
@@ -67,6 +72,8 @@ def _create_hidden_layers(num_neurons: List[int]) -> list:
 
 
 # Model Architecture
+
+
 class NeuralNetDropout(nn.Module):
     """Pytorch implementation of Neural Network with Dropout."""
 
@@ -95,6 +102,8 @@ class NeuralNetDropout(nn.Module):
 
 
 # Registration
+
+
 @register_custom_architecture(
     joint_posterior_attr=False, constant_target_catching=False, batchify_posterior=True
 )
@@ -174,6 +183,7 @@ parameters = [
 
 ### Run DOE iterations with custom surrogate
 # Create campaign
+
 campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=Objective(
@@ -194,6 +204,7 @@ print("Recommendation from campaign:")
 print(recommendation)
 
 # Add some fake results
+
 add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
@@ -201,6 +212,7 @@ campaign.add_measurements(recommendation)
 recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
+
 print("Recommendation from campaign:")
 print(recommendation)
 
@@ -210,6 +222,7 @@ print()
 ### Serialization
 
 # Serialization of custom models is not supported
+
 try:
     campaign.to_json()
 except RuntimeError as e:

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -44,13 +44,10 @@ parameters = [
 
 # Note that this example trains with several helpers built-in to BayBE.
 # This can be done independently (and elsewhere).
-
 # The only requirement that BayBE needs is that the model is in an onnx format.
 # And The format should return both the mean and standard deviation.
-
 # This example is based on a `BayesianRidge` regressor from `sklearn`.
 # Its native conversion to onnx is supported via `skl2onnx`.
-
 # Please also note that this example does not give a useful model.
 # Its purpose is to show the workflow for using pre-trained surrogates in BayBE.
 
@@ -59,6 +56,7 @@ train_x = to_tensor(searchspace.discrete.comp_rep)
 train_y = torch.rand(train_x.size(dim=0))  # train with a random y vector
 
 # Define model and fit
+
 model = BayesianRidge()
 model.fit(train_x, train_y)
 
@@ -66,16 +64,20 @@ model.fit(train_x, train_y)
 ### Convert model to onnx
 
 # Need the option to return standard deviation
+
 options = {type(model): {"return_std": True}}
 
 # Specify what the input name is
+
 ONNX_INPUT_NAME = "example_input_name"
 
 # input dimensions and input type (should always be a float)
+
 input_dim = train_x.size(dim=1)
 initial_type = [(ONNX_INPUT_NAME, FloatTensorType([None, input_dim]))]
 
 # Conversion
+
 onnx_str = convert_sklearn(
     model,
     initial_types=initial_type,
@@ -113,6 +115,7 @@ print("Recommendation from campaign:")
 print(recommendation)
 
 # Add some fake results
+
 add_fake_results(recommendation, campaign)
 campaign.add_measurements(recommendation)
 
@@ -122,6 +125,7 @@ campaign.add_measurements(recommendation)
 recommendation = campaign.recommend(batch_size=2)
 
 # Print second round of recommendations
+
 print("Recommendation from campaign:")
 print(recommendation)
 
@@ -144,8 +148,10 @@ model_from_python = CustomONNXSurrogate(
 model_from_configs = CustomONNXSurrogate.from_dict(CONFIG)
 
 # This configuration creates the same model
+
 assert model_from_python == model_from_configs
 
 # JSON configuration (expects onnx_str to be decoded with `ISO-8859-1`)
+
 model_json = model_from_python.to_json()
 assert model_from_python == CustomONNXSurrogate.from_json(model_json)

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -58,6 +58,7 @@ parameters = [
 
 # Please note that model_params is an optional argument:
 # The defaults will be used if none specified
+
 surrogate_model = NGBoostSurrogate(model_params={"n_estimators": 50, "verbose": True})
 
 ### Validation of model parameters
@@ -92,6 +93,7 @@ campaign = Campaign(
 ### Iterate with recommendations and measurements
 
 # We can print the surrogate model object
+
 print("The model object in json format:")
 print(surrogate_model.to_json(), end="\n" * 3)
 
@@ -108,6 +110,7 @@ campaign.add_measurements(recommendation)
 ### Model Outputs
 
 # Note that this model is only triggered when there is data.
+
 print("Here you will see some model outputs as we set verbose to True")
 
 # Do another round of recommendations
@@ -115,6 +118,7 @@ recommendation = campaign.recommend(batch_size=2)
 
 
 # Print second round of recommendations
+
 print("Recommendation from campaign:")
 print(recommendation)
 
@@ -126,6 +130,7 @@ print(recommendation)
 # Note that the following explicit call `str()` is not strictly necessary.
 # It is included since our method of converting this example to a markdown file does not interpret
 # this part of the code as `python` code if we do not include this call.
+
 CONFIG = str(
     """
 {
@@ -142,4 +147,5 @@ CONFIG = str(
 recreate_model = NGBoostSurrogate.from_json(CONFIG)
 
 # This configuration creates the same model
+
 assert recreate_model == surrogate_model

--- a/examples/Searchspaces/continuous_space_botorch_function.py
+++ b/examples/Searchspaces/continuous_space_botorch_function.py
@@ -51,6 +51,7 @@ WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 
 # Since the searchspace is continuous test, we construct `NumericalContinuousParameter`s
 # We use that data of the test function to deduce bounds and number of parameters.
+
 parameters = [
     NumericalContinuousParameter(
         name=f"x_{k+1}",

--- a/examples/Searchspaces/continuous_space_custom_function.py
+++ b/examples/Searchspaces/continuous_space_custom_function.py
@@ -71,14 +71,17 @@ recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.
 # Furthermore, we need to interpret the row as a list.
+
 target_values = []
 for index, row in recommendation.iterrows():
     target_values.append(TEST_FUNCTION(*row.to_list()))
 
 # We add an additional column with the calculated target values.
+
 recommendation["Target"] = target_values
 
 # Here, we inform the campaign about our measurement.
+
 campaign.add_measurements(recommendation)
 print("\n\nRecommended experiments with measured values: ")
 print(recommendation)

--- a/examples/Searchspaces/discrete_space.py
+++ b/examples/Searchspaces/discrete_space.py
@@ -25,12 +25,14 @@ from baybe.utils.botorch_wrapper import botorch_function_wrapper
 # Note that choosing a different test function requires to change the `import` statement.
 # All test functions that are available in BoTorch are also available here and are later wrapped
 # via the `botorch_function_wrapper`.
+
 DIMENSION = 4
 TestFunctionClass = Rastrigin
 
 # This code checks if the test function is only available for a specific dimension.
 # In that case, we print a warning and replace `DIMENSION`.
 # In addition, it constructs the actual `TestFunction` object.
+
 if not hasattr(TestFunctionClass, "dim"):
     TestFunction = TestFunctionClass(dim=DIMENSION)
 elif TestFunctionClass().dim == DIMENSION:
@@ -95,14 +97,17 @@ recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.
 # Furthermore, we need to interpret the row as a list.
+
 target_values = []
 for index, row in recommendation.iterrows():
     target_values.append(WRAPPED_FUNCTION(*row.to_list()))
 
 # We add an additional column with the calculated target values.
+
 recommendation["Target"] = target_values
 
 # Here, we inform the campaign about our measurement.
+
 campaign.add_measurements(recommendation)
 print("\n\nRecommended experiments with measured values: ")
 print(recommendation)

--- a/examples/Searchspaces/hybrid_space.py
+++ b/examples/Searchspaces/hybrid_space.py
@@ -34,6 +34,7 @@ DIMENSION = 6
 # In particular, if the function that you want to use is only available for a fixed
 # dimension, then these will be overwritten by distributing the first half of the
 # dimension to `DISC_INDICES` and the remaining ones to `CONT_INDICES`.
+
 DISC_INDICES = [0, 1, 2]
 CONT_INDICES = [3, 4, 5]
 
@@ -41,6 +42,7 @@ TestFunctionClass = Rastrigin
 
 # This part checks if the test function already has a fixed dimension.
 # In that case, we print a warning and replace DIMENSION.
+
 if not hasattr(TestFunctionClass, "dim"):
     TestFunction = TestFunctionClass(dim=DIMENSION)
 elif TestFunctionClass().dim == DIMENSION:
@@ -61,6 +63,7 @@ else:
 # If this fails, then either the intersection between the index sets is not empty or the test
 # function has another dimension.
 # Note that this might in particular happen for test functions that ignore the `dim` keyword!
+
 if set(CONT_INDICES + DISC_INDICES) != set(range(DIMENSION)):
     raise ValueError(
         "Either the intersection between CONT_IND and DISC_IND is not empty or your "
@@ -73,9 +76,11 @@ WRAPPED_FUNCTION = botorch_function_wrapper(test_function=TestFunction)
 ### Constructing the hybrid searchspace
 
 # The following parameter decides how many points each discrete dimension should have.
+
 POINTS_PER_DIM = 3
 
 # Construct the continuous parameters as `NumericContinuous` parameters.
+
 cont_parameters = [
     NumericalContinuousParameter(
         name=f"x_{k+1}",
@@ -85,6 +90,7 @@ cont_parameters = [
 ]
 
 # Construct the discrete parameters as `NumericalDiscreteParameters`.
+
 disc_parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k+1}",
@@ -107,7 +113,6 @@ objective = Objective(
 # We use the default choices, which is the `SequentialGreedyRecommender`.
 
 hybrid_recommender = NaiveHybridRecommender()
-
 hybrid_strategy = TwoPhaseStrategy(recommender=hybrid_recommender)
 
 ### Constructing the campaign and performing a recommendation
@@ -125,14 +130,17 @@ recommendation = campaign.recommend(batch_size=BATCH_SIZE)
 # Evaluate the test function.
 # Note that we need iterate through the rows of the recommendation.
 # Furthermore, we need to interpret the row as a list.
+
 target_values = []
 for index, row in recommendation.iterrows():
     target_values.append(WRAPPED_FUNCTION(*row.to_list()))
 
 # We add an additional column with the calculated target values.
+
 recommendation["Target"] = target_values
 
 # Here, we inform the campaign about our measurement.
+
 campaign.add_measurements(recommendation)
 print("\n\nRecommended experiments with measured values: ")
 print(recommendation)

--- a/examples/Serialization/basic_serialization.py
+++ b/examples/Serialization/basic_serialization.py
@@ -67,6 +67,7 @@ campaign = Campaign(
 ### Serialization and de-serialization
 
 # We begin by printing the original campaign
+
 print("Original object")
 print(campaign, end="\n" * 3)
 
@@ -74,10 +75,12 @@ print(campaign, end="\n" * 3)
 # This yields a JSON representation in string format.
 # Since it is rather complex, we do not print this string here.
 # Note: Dataframes are encoded via binary parquet and are hence not human-readable.
+
 string = campaign.to_json()
 
 
 # Deserialize the JSON string back to an object.
+
 print("Deserialized object")
 campaign_recreate = Campaign.from_json(string)
 print(campaign_recreate, end="\n" * 3)

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -92,6 +92,7 @@ CONFIG = str(
 
 # Although we know in this case that the config represents a valid configuration for a
 # campaign. If the config is invalid an exception will be thrown.
+
 campaign = Campaign.from_config(CONFIG)
 
 # We now perform a recommendation as usual and print it.

--- a/examples/Serialization/validate_config.py
+++ b/examples/Serialization/validate_config.py
@@ -159,11 +159,13 @@ INVALID_CONFIG = str(
 
 ### Verification of the two dictionaries
 
-# The first validation should work
+# The first validation should work.
+
 Campaign.validate_config(CONFIG)
 print("The first config seems valid.")
 
 # This should fail.
+
 try:
     Campaign.validate_config(INVALID_CONFIG)
     campaign = Campaign.from_config(INVALID_CONFIG)


### PR DESCRIPTION
This PR fixes a bug that erased the output of the examples in the documentation.

The package `jupytext` which was introduced earlier for the conversion of the examples to jupyter notebooks does not include the output of executed notebooks to a converted markdown **by design**. This PR thus re-introduces `jupyter` for this step of the conversion.

Also, this PR introduces some visual fixes to all of the examples, since the comments were not rendered properly.
**IMPORTANT:** The only changes in the examples are additions and deletions of new empty lines. No other changes were done in the examples, it is thus fully sufficient to locally build the docs and review the examples there.