### PR TITLE
Refactor parameter tolerance handling

### DIFF
--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -4,15 +4,13 @@ from functools import cached_property
 from typing import Any, ClassVar, Tuple
 
 import cattrs
-import numpy as np
 import pandas as pd
 from attrs import define, field
-from attrs.validators import min_len
+from attrs.validators import ge, min_len
 
-from baybe.exceptions import NumericalUnderflowError
 from baybe.parameters.base import DiscreteParameter, Parameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
-from baybe.utils import DTypeFloatNumpy, InfiniteIntervalError, Interval, convert_bounds
+from baybe.utils import InfiniteIntervalError, Interval, convert_bounds
 
 
 @define(frozen=True, slots=False)
@@ -37,43 +35,11 @@ class NumericalDiscreteParameter(DiscreteParameter):
     )
     """The values the parameter can take."""
 
-    tolerance: float = field(default=0.0)
-    """The absolute tolerance used for deciding whether a value is in range. A tolerance
-        larger than half the minimum distance between parameter values is not allowed
-        because that could cause ambiguity when inputting data points later."""
-
-    @tolerance.validator
-    def _validate_tolerance(  # noqa: DOC101, DOC103
-        self, _: Any, tolerance: float
-    ) -> None:
-        """Validate that the given tolerance is safe.
-
-        The tolerance is the allowed experimental uncertainty when
-        reading in measured values. A tolerance larger than half the minimum
-        distance between parameter values is not allowed because that could cause
-        ambiguity when inputting data points later.
-
-        Raises:
-            ValueError: If the tolerance is not safe.
-        """
-        # For zero tolerance, the only left requirement is that all parameter values
-        # are distinct, which is already ensured by the corresponding validator.
-        if tolerance == 0.0:
-            return
-
-        min_dist = np.diff(self.values).min()
-        if min_dist == (eps := np.nextafter(0, 1, dtype=DTypeFloatNumpy)):
-            raise NumericalUnderflowError(
-                f"The distance between any two parameter values must be at least "
-                f"twice the size of the used floating point resolution of {eps}."
-            )
-
-        if tolerance >= (max_tol := min_dist / 2.0):
-            raise ValueError(
-                f"Parameter '{self.name}' is initialized with tolerance {tolerance} "
-                f"but due to the given parameter values {self.values}, the specified "
-                f"tolerance must be smaller than {max_tol} to avoid ambiguity."
-            )
+    tolerance: float = field(default=0.0, validator=ge(0.0))
+    """The absolute tolerance used for deciding whether a value is considered in range.
+        Everything inside the convex hull of the parameter values is automatically
+        considered in range. If non-zero, the tolerance expands the parameter range
+        at the boundary values."""
 
     @property
     def values(self) -> tuple:  # noqa: D102
@@ -88,10 +54,9 @@ class NumericalDiscreteParameter(DiscreteParameter):
 
     def is_in_range(self, item: float) -> bool:  # noqa: D102
         # See base class.
-        differences_acceptable = [
-            np.abs(val - item) <= self.tolerance for val in self.values
-        ]
-        return any(differences_acceptable)
+        lower = min(self.values) - self.tolerance
+        upper = max(self.values) + self.tolerance
+        return lower <= item <= upper
 
 
 @define(frozen=True, slots=False)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, Iterable, List, Optional, Tuple, cast
+from typing import Any, Collection, Iterable, List, Literal, Optional, Tuple, cast
 
 import numpy as np
 import pandas as pd
@@ -252,21 +252,20 @@ class SubspaceDiscrete(SerialMixin):
     def mark_as_measured(
         self,
         measurements: pd.DataFrame,
-        numerical_measurements_must_be_within_tolerance: bool,
+        on_tolerance_violation: Literal["raise", "warn", "ignore"],
     ) -> None:
         """Mark the given elements of the space as measured.
 
         Args:
             measurements: A dataframe containing parameter settings that should be
                 marked as measured.
-            numerical_measurements_must_be_within_tolerance: See
-                :func:`baybe.utils.dataframe.fuzzy_row_match`.
+            on_tolerance_violation: See :func:`baybe.utils.dataframe.fuzzy_row_match`.
         """
         inds_matched = fuzzy_row_match(
             self.exp_rep,
             measurements,
             self.parameters,
-            numerical_measurements_must_be_within_tolerance,
+            on_tolerance_violation,
         )
         self.metadata.loc[inds_matched, "was_measured"] = True
 

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -78,7 +78,7 @@ import hashlib
 import logging
 import os
 import socket
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -275,7 +275,7 @@ def telemetry_record_recommended_measurement_percentage(
     cached_recommendation: pd.DataFrame,
     measurements: pd.DataFrame,
     parameters: List[Parameter],
-    numerical_measurements_must_be_within_tolerance: bool,
+    on_tolerance_violation: Literal["raise", "warn", "ignore"] = "raise",
 ) -> None:
     """Submit the percentage of added measurements.
 
@@ -293,10 +293,7 @@ def telemetry_record_recommended_measurement_percentage(
         measurements: The measurements which are supposed to be checked against cached
             recommendations.
         parameters: The list of parameters spanning the entire search space.
-        numerical_measurements_must_be_within_tolerance: If ``True``, numerical
-            parameter entries are matched with the reference elements only if there is
-            a match within the parameter tolerance. If ``False``, the closest match
-            is considered, irrespective of the distance.
+        on_tolerance_violation: See :func:`baybe.utils.dataframe.fuzzy_row_match`.
     """
     if is_enabled():
         if len(cached_recommendation) > 0:
@@ -306,7 +303,7 @@ def telemetry_record_recommended_measurement_percentage(
                         cached_recommendation,
                         measurements,
                         parameters,
-                        numerical_measurements_must_be_within_tolerance,
+                        on_tolerance_violation,
                     )
                 )
                 / len(cached_recommendation)

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -1,7 +1,6 @@
 """Hypothesis strategies for parameters."""
 
 import hypothesis.strategies as st
-import numpy as np
 from hypothesis.extra.pandas import columns, data_frames
 
 from baybe.parameters.categorical import (
@@ -88,18 +87,7 @@ def numerical_discrete_parameter(
             unique=True,
         )
     )
-    max_tolerance = np.diff(np.sort(values)).min() / 2
-    if max_tolerance == 0.0:
-        tolerance = 0.0
-    else:
-        tolerance = draw(
-            st.floats(
-                min_value=0.0,
-                max_value=max_tolerance,
-                allow_nan=False,
-                exclude_max=True,
-            )
-        )
+    tolerance = draw(st.floats(min_value=0.0))
     return NumericalDiscreteParameter(name=name, values=values, tolerance=tolerance)
 
 


### PR DESCRIPTION
This PR refactors the tolerance implementation of numerical discrete parameters:
* Allowed tolerance values are no longer upper bounded by half the distance between the closest two parameter values. The original rationale was that larger values would result in matching ambiguities. However, this rationale is based on the unnecessary assumption that the user always targets a specific one of the available parameter values for their experiments. In practice, it doesn't matter if this was the case or not. Instead, we simply ingest the values we observe, no matter how the experiment was planned.
* `add_measurements` now takes an `on_tolerance_violation` parameter which allow to control to behavior when encountering out-of-range measurements

So overall, the mechanism remains similar to the previous one but more user-friendly.