### PR TITLE
`SubspaceDiscrete.from_simplex` convenience constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mypy` for campaign, constraints and telemetry
 - Top-level example summaries
 - `RecommenderProtocol` as common interface for `Strategy` and `Recommender`
+- `SubspaceDiscrete.from_simplex` convenience constructor
 
 ### Changed
 - Order of README sections

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -265,6 +265,11 @@ class SubspaceDiscrete(SerialMixin):
 
         Returns:
             The created simplex subspace.
+
+        Note:
+            The achieved efficiency gains can vary depending on the particular order in
+            which the parameters are passed to this method, as the configuration space
+            is built up incrementally from the parameter sequence.
         """
         # Validate parameter types
         if not (all(isinstance(p, NumericalDiscreteParameter) for p in parameters)):

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -284,6 +284,11 @@ class SubspaceDiscrete(SerialMixin):
             p for p in parameters if not isinstance(p, NumericalDiscreteParameter)
         ]
 
+        # Construct the product part of the space
+        product_space = parameter_cartesian_prod_to_df(other_parameters)
+        if not numerical_parameters:
+            return cls(parameters=other_parameters, exp_rep=product_space)
+
         # Validate non-negativity
         min_values = [min(p.values) for p in numerical_parameters]
         if not (min(min_values) >= 0.0):
@@ -339,9 +344,7 @@ class SubspaceDiscrete(SerialMixin):
 
         # Augment the Cartesian product created from all other parameter types
         if other_parameters:
-            exp_rep = pd.merge(
-                exp_rep, parameter_cartesian_prod_to_df(other_parameters), how="cross"
-            )
+            exp_rep = pd.merge(exp_rep, product_space, how="cross")
 
         # Reset the index
         exp_rep.reset_index(drop=True, inplace=True)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -315,12 +315,12 @@ class SubspaceDiscrete(SerialMixin):
             """
             row_sums = df.sum(axis=1)
             if boundary_only:
-                rows_to_drop = row_sums[
+                locs_to_drop = row_sums[
                     (row_sums < max_sum - tolerance) | (row_sums > max_sum + tolerance)
                 ].index
             else:
-                rows_to_drop = row_sums[row_sums > max_sum + tolerance].index
-            df.drop(rows_to_drop, inplace=True)
+                locs_to_drop = row_sums[row_sums > max_sum + tolerance].index
+            df.drop(locs_to_drop, inplace=True)
 
         # Get the minimum sum contributions to come in the upcoming joins (the first
         # item is the minimum possible sum of all parameters starting from the

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -241,11 +241,11 @@ class SubspaceDiscrete(SerialMixin):
         """Efficiently create discrete simplex subspaces.
 
         The same result can be achieved using
-        :meth:`baybe.searchspace.discrete.from_product` in combination with appropriate
-        sum constraints. However, such an approach is inefficient because the Cartesian
-        product involved creates an exponentially large set of candidates, most of
-        which do not satisfy the simplex constraints and must be subsequently be
-        filtered out by the method.
+        :meth:`baybe.searchspace.discrete.SubspaceDiscrete.from_product` in combination
+        with appropriate sum constraints. However, such an approach is inefficient
+        because the Cartesian product involved creates an exponentially large set of
+        candidates, most of which do not satisfy the simplex constraints and must be
+        subsequently be filtered out by the method.
 
         By contrast, this method uses a shortcut that removes invalid candidates
         already during the creation of parameter combinations, resulting in a

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -338,9 +338,10 @@ class SubspaceDiscrete(SerialMixin):
             drop_invalid(exp_rep, total, boundary_only=True)
 
         # Augment the Cartesian product created from all other parameter types
-        exp_rep = pd.merge(
-            exp_rep, parameter_cartesian_prod_to_df(other_parameters), how="cross"
-        )
+        if other_parameters:
+            exp_rep = pd.merge(
+                exp_rep, parameter_cartesian_prod_to_df(other_parameters), how="cross"
+            )
 
         # Reset the index
         exp_rep.reset_index(drop=True, inplace=True)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -253,7 +253,7 @@ class SubspaceDiscrete(SerialMixin):
         significantly faster construction.
 
         Args:
-            parameters: The parameter to be used for the simplex construction.
+            parameters: The parameters to be used for the simplex construction.
             total: The desired sum of the parameter values defining the simplex size.
             boundary_only: Flag determining whether to keep only parameter
                 configurations on the simplex boundary.

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -129,7 +129,7 @@ def test_discrete_space_creation_from_simplex_inner(parameters, boundary_only):
         total = max_possible
 
     subspace = SubspaceDiscrete.from_simplex(
-        parameters, total=total, boundary_only=boundary_only, tolerance=tolerance
+        total, parameters, boundary_only=boundary_only, tolerance=tolerance
     )
 
     if boundary_only:
@@ -145,18 +145,20 @@ p_t2 = TaskParameter(name="t2", values=["A", "B"])
 
 
 @pytest.mark.parametrize(
-    ("parameters", "n_elements"),
+    ("simplex_parameters", "product_parameters", "n_elements"),
     [
-        param([p_d1, p_d2, p_t1, p_t2], 6 * 4, id="both"),
-        param([p_d1, p_d2], 6, id="simplex-only"),
-        param([p_t1, p_t2], 4, id="task_only"),
+        param([p_d1, p_d2], [p_t1, p_t2], 6 * 4, id="both"),
+        param([p_d1, p_d2], [], 6, id="simplex-only"),
+        param([], [p_t1, p_t2], 4, id="task_only"),
     ],
 )
-def test_discrete_space_creation_from_simplex_mixed(parameters, n_elements):
+def test_discrete_space_creation_from_simplex_mixed(
+    simplex_parameters, product_parameters, n_elements
+):
     """Additional non-simplex parameters enter in form of a Cartesian product."""
     total = 1.0
     subspace = SubspaceDiscrete.from_simplex(
-        parameters, total=total, boundary_only=False
+        total, simplex_parameters, product_parameters, boundary_only=False
     )
     assert len(subspace.exp_rep) == n_elements  # <-- (# simplex part) x (# task part)
     assert not any(subspace.exp_rep.duplicated())

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -138,17 +138,25 @@ def test_discrete_space_creation_from_simplex_inner(parameters, boundary_only):
         assert (subspace.exp_rep.sum(axis=1) <= total + tolerance).all()
 
 
-def test_discrete_space_creation_from_simplex_mixed():
+p_d1 = NumericalDiscreteParameter(name="d1", values=[0.0, 0.5, 1.0])
+p_d2 = NumericalDiscreteParameter(name="d2", values=[0.0, 0.5, 1.0])
+p_t1 = TaskParameter(name="t1", values=["A", "B"])
+p_t2 = TaskParameter(name="t2", values=["A", "B"])
+
+
+@pytest.mark.parametrize(
+    ("parameters", "n_elements"),
+    [
+        param([p_d1, p_d2, p_t1, p_t2], 6 * 4, id="both"),
+        param([p_d1, p_d2], 6, id="simplex-only"),
+        param([p_t1, p_t2], 4, id="task_only"),
+    ],
+)
+def test_discrete_space_creation_from_simplex_mixed(parameters, n_elements):
     """Additional non-simplex parameters enter in form of a Cartesian product."""
     total = 1.0
-    parameters = [
-        NumericalDiscreteParameter(name="x1", values=[0.0, 0.5, 1.0]),
-        NumericalDiscreteParameter(name="x2", values=[0.0, 0.5, 1.0]),
-        TaskParameter(name="t1", values=["A", "B"]),
-        TaskParameter(name="t2", values=["A", "B"]),
-    ]
     subspace = SubspaceDiscrete.from_simplex(
         parameters, total=total, boundary_only=False
     )
-    assert len(subspace.exp_rep) == 6 * 4  # <-- (# simplex part) x (# task part)
+    assert len(subspace.exp_rep) == n_elements  # <-- (# simplex part) x (# task part)
     assert not any(subspace.exp_rep.duplicated())

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -106,14 +106,17 @@ def test_searchspace_creation_from_dataframe(df, parameters, expected):
 
 @given(
     parameters=st.lists(
-        numerical_discrete_parameter(min_value=0.1, max_value=1.0),
+        numerical_discrete_parameter(min_value=0.0, max_value=1.0),
         min_size=1,
+        max_size=5,
         unique_by=lambda x: x.name,
     )
 )
 def test_discrete_space_creation_from_simplex_inner(parameters):
     """Candidates from a simplex space satisfy the simplex constraint."""
-    total = 1.0
+    max_possible = sum(max(p.values) for p in parameters)
+    min_possible = sum(min(p.values) for p in parameters)
+    total = (max_possible + min_possible) / 2
     tolerance = 1e-6
     subspace = SubspaceDiscrete.from_simplex(
         parameters, total=total, boundary_only=False, tolerance=tolerance

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -121,21 +121,21 @@ def test_discrete_space_creation_from_simplex_inner(parameters, boundary_only):
 
     if boundary_only:
         # Ensure there exists configurations both inside and outside the simplex
-        total = (max_possible + min_possible) / 2
+        max_sum = (max_possible + min_possible) / 2
     else:
         # We use the maximum parameter sum because it can be exactly achieved (for other
         # values, except for the minimum, it's not guaranteed there actually exists
         # a parameter combination that can exactly hit it)
-        total = max_possible
+        max_sum = max_possible
 
     subspace = SubspaceDiscrete.from_simplex(
-        total, parameters, boundary_only=boundary_only, tolerance=tolerance
+        max_sum, parameters, boundary_only=boundary_only, tolerance=tolerance
     )
 
     if boundary_only:
-        assert np.allclose(subspace.exp_rep.sum(axis=1), total, atol=tolerance)
+        assert np.allclose(subspace.exp_rep.sum(axis=1), max_sum, atol=tolerance)
     else:
-        assert (subspace.exp_rep.sum(axis=1) <= total + tolerance).all()
+        assert (subspace.exp_rep.sum(axis=1) <= max_sum + tolerance).all()
 
 
 p_d1 = NumericalDiscreteParameter(name="d1", values=[0.0, 0.5, 1.0])
@@ -156,9 +156,9 @@ def test_discrete_space_creation_from_simplex_mixed(
     simplex_parameters, product_parameters, n_elements
 ):
     """Additional non-simplex parameters enter in form of a Cartesian product."""
-    total = 1.0
+    max_sum = 1.0
     subspace = SubspaceDiscrete.from_simplex(
-        total, simplex_parameters, product_parameters, boundary_only=False
+        max_sum, simplex_parameters, product_parameters, boundary_only=False
     )
     assert len(subspace.exp_rep) == n_elements  # <-- (# simplex part) x (# task part)
     assert not any(subspace.exp_rep.duplicated())

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -1,8 +1,9 @@
 """Hypothesis strategies for parameters."""
 
+from typing import Optional
+
 import hypothesis.strategies as st
 import numpy as np
-from altair import Optional
 from hypothesis.extra.pandas import columns, data_frames
 
 from baybe.parameters.categorical import (

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -2,6 +2,7 @@
 
 import hypothesis.strategies as st
 import numpy as np
+from altair import Optional
 from hypothesis.extra.pandas import columns, data_frames
 
 from baybe.parameters.categorical import (
@@ -76,14 +77,20 @@ def custom_descriptors(draw: st.DrawFn):
 @st.composite
 def numerical_discrete_parameter(
     draw: st.DrawFn,
+    min_value: Optional[float] = None,
+    max_value: Optional[float] = None,
 ):
     """Generate :class:`baybe.parameters.numerical.NumericalDiscreteParameter`."""
     name = draw(parameter_name)
     values = draw(
         st.lists(
             st.one_of(
-                st.integers(),
-                st.floats(allow_infinity=False, allow_nan=False),
+                st.floats(
+                    allow_infinity=False,
+                    allow_nan=False,
+                    min_value=min_value,
+                    max_value=max_value,
+                ),
             ),
             min_size=2,
             unique=True,

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -85,13 +85,11 @@ def numerical_discrete_parameter(
     name = draw(parameter_name)
     values = draw(
         st.lists(
-            st.one_of(
-                st.floats(
-                    allow_infinity=False,
-                    allow_nan=False,
-                    min_value=min_value,
-                    max_value=max_value,
-                ),
+            st.floats(
+                allow_infinity=False,
+                allow_nan=False,
+                min_value=min_value,
+                max_value=max_value,
             ),
             min_size=2,
             unique=True,

--- a/tests/serialization/test_searchspace_serialization.py
+++ b/tests/serialization/test_searchspace_serialization.py
@@ -4,7 +4,10 @@ import json
 
 import pytest
 
+from baybe.parameters.numerical import NumericalDiscreteParameter
 from baybe.searchspace import SearchSpace
+from baybe.searchspace.discrete import SubspaceDiscrete
+from baybe.serialization.core import converter
 
 
 @pytest.mark.parametrize(
@@ -40,3 +43,25 @@ def test_from_dataframe_deserialization(searchspace):
     )
     deserialized = SearchSpace.from_json(config)
     assert searchspace == deserialized, (searchspace, deserialized)
+
+
+def test_from_simplex_deserialization():
+    """Deserialization from simplex yields back the original object."""
+    parameters = [
+        NumericalDiscreteParameter("p1", [0, 0.5, 1]),
+        NumericalDiscreteParameter("p2", [0, 0.5, 1]),
+    ]
+    max_sum = 1.0
+    subspace = SubspaceDiscrete.from_simplex(max_sum, simplex_parameters=parameters)
+    parameters_string = json.dumps(converter.unstructure(parameters))
+    config = """
+    {
+        "constructor": "from_simplex",
+        "max_sum": __fillin__max_sum__,
+        "simplex_parameters": __fillin__parameters__
+    }
+    """.replace("__fillin__max_sum__", str(max_sum)).replace(
+        "__fillin__parameters__", parameters_string
+    )
+    deserialized = SubspaceDiscrete.from_json(config)
+    assert subspace == deserialized, (subspace, deserialized)


### PR DESCRIPTION
This PR adds a new `SubspaceDiscrete.from_simplex` convenience constructor that is useful for mixture use cases. In particular, it enables such cases when an API is involved, as the two existing alternatives will not work here:
* `from_product` in combination with sum constraints suffers from the exponential blowup of parameter configurations
* `from_dataframe` requires sending excessively large requests to the API (since the requests need to contain the full enumerated search space)