### PR TITLE
Lazy loading torch - part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- [WIP] `torch` is loaded lazily
+
 ## [0.8.0] - 2024-02-29
 ### Changed
 - BoTorch dependency bumped to `>=0.9.3`

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -1,13 +1,13 @@
 """Base classes for all constraints."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, List, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, List, Tuple
 
 import pandas as pd
-import torch
 from attr import define, field
 from attr.validators import min_len
-from torch import Tensor
 
 from baybe.constraints.conditions import Condition
 from baybe.parameters import NumericalContinuousParameter
@@ -18,6 +18,9 @@ from baybe.serialization import (
     unstructure_base,
 )
 from baybe.utils.numerical import DTypeFloatTorch
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @define
@@ -159,6 +162,8 @@ class ContinuousConstraint(Constraint, ABC):
         Returns:
             The tuple required by botorch.
         """
+        import torch
+
         param_names = [p.name for p in parameters]
         param_indices = [
             param_names.index(p) + idx_offset

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -12,7 +12,7 @@ from baybe.utils.dataframe import to_tensor
 if TYPE_CHECKING:
     from torch import Tensor
 
-_ScaleFun = Callable[[Tensor], Tensor]
+    _ScaleFun = Callable[[Tensor], Tensor]
 
 
 class Scaler(ABC):

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Tuple, Type
+from typing import TYPE_CHECKING, Callable, Dict, Tuple, Type
 
 import pandas as pd
-import torch
-from torch import Tensor
 
 from baybe.utils.dataframe import to_tensor
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 _ScaleFun = Callable[[Tensor], Tensor]
 
@@ -99,6 +100,8 @@ class DefaultScaler(Scaler):
         self, x: Tensor, y: Tensor
     ) -> Tuple[Tensor, Tensor]:
         # See base class.
+
+        import torch
 
         # Get the searchspace boundaries
         searchspace = to_tensor(self.searchspace)

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-import torch
-from torch import Tensor
 
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.targets.enum import TargetMode
 from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
 
 if TYPE_CHECKING:
+    from torch import Tensor
+
     from baybe.campaign import Campaign
     from baybe.parameters import Parameter
 
@@ -38,6 +38,8 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
     #  floats. As a simple fix (this seems to be the most reasonable place to take
     #  care of this) df.values has been changed to df.values.astype(float),
     #  even though this seems like double casting here.
+    import torch
+
     out = (
         torch.from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)
         for df in dfs

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -4,15 +4,17 @@ import sys
 import warnings
 from collections.abc import Iterable
 from functools import singledispatchmethod
-from typing import Any, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, Union
 
 import numpy as np
-import torch
 from attrs import define, field
 from packaging import version
 
 from baybe.serialization import SerialMixin, converter
 from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 # TODO[typing]: Add return type hints to classmethod constructors once ForwardRefs
 #   are supported: https://bugs.python.org/issue41987
@@ -126,8 +128,10 @@ class Interval(SerialMixin):
         """Transform the interval to a :class:`numpy.ndarray`."""
         return np.array([self.lower, self.upper], dtype=DTypeFloatNumpy)
 
-    def to_tensor(self) -> torch.Tensor:
+    def to_tensor(self) -> "Tensor":
         """Transform the interval to a :class:`torch.Tensor`."""
+        import torch
+
         return torch.tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
 
     def contains(self, number: float) -> bool:


### PR DESCRIPTION
This is the first part of optimizing torch imports.

All tests passed on my machine with python 3.10 and 3.11. 