### PR TITLE
Remove `SubstanceParameter` from basic serialization example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   search space contains only one task parameter value
 - Failing `baybe` import from environments containing only core dependencies caused by
   eagerly loading `chem` dependencies
-- tox `coretest` now uses correct environment and skips unavailable tests
+- `tox` `coretest` now uses correct environment and skips unavailable tests
+- Basic serialization example no longer requires optional `chem` dependencies
 
 ### Removed
 - Detailed headings in table of contents of examples

--- a/examples/Serialization/basic_serialization.py
+++ b/examples/Serialization/basic_serialization.py
@@ -15,7 +15,6 @@ from baybe.objective import Objective
 from baybe.parameters import (
     CategoricalParameter,
     NumericalDiscreteParameter,
-    SubstanceParameter,
 )
 from baybe.recommenders import FPSRecommender, SequentialGreedyRecommender
 from baybe.searchspace import SearchSpace
@@ -38,16 +37,6 @@ parameters = [
     NumericalDiscreteParameter(
         name="Temperature[degree_C]",
         values=np.linspace(100, 200, 10),
-    ),
-    SubstanceParameter(
-        name="Solvent",
-        data={
-            "Solvent A": "COC",
-            "Solvent B": "CCC",
-            "Solvent C": "O",
-            "Solvent D": "CS(=O)C",
-        },
-        encoding="MORDRED",
     ),
 ]
 


### PR DESCRIPTION
Remove the `SubstanceParameter` from the basic serialization example so that it can run without requiring `chem` dependencies