### PR TITLE
Include pretty printing for search spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or turn off disk caching entirely
 - Options to control the number of nonzero parameters in `SubspaceDiscrete.from_simplex`
 - Temporarily ignore ONNX vulnerabilities
+- Better human readable `__str__` representation of search spaces
+- `pretty_print_df` function for printing shortened versions of dataframes
 
 ### Changed
 - `Recommender`s now share their core logic via their base class

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,5 @@
   Import optimization
 - Sterling Baird (Acceleration Consortium, Toronto, Canada):
   Documentation and general feedback
+- Rim Rihana (Merck KGaA, Darmstadt, Germany):
+  Human readable output for search spaces

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -55,6 +55,13 @@ class Constraint(ABC, SerialMixin):
                 f"but was: {params}."
             )
 
+    def summary(self) -> dict:
+        """Return a custom summarization of the constraint."""
+        constr_dict = dict(
+            Type=self.__class__.__name__, Affected_Parameters=self.parameters
+        )
+        return constr_dict
+
     @property
     def is_continuous(self) -> bool:
         """Boolean indicating if this is a constraint over continuous parameters."""

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -50,7 +50,7 @@ class Parameter(ABC, SerialMixin):
 
     @abstractmethod
     def summary(self) -> dict:
-        """Return a custom summarization of the parameters."""
+        """Return a custom summarization of the parameter."""
 
 
 @define(frozen=True, slots=False)

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -48,6 +48,10 @@ class Parameter(ABC, SerialMixin):
             ``True`` if the item is within the parameter range, ``False`` otherwise.
         """
 
+    @abstractmethod
+    def summary(self) -> dict:
+        """Return a custom summarization of the parameters."""
+
 
 @define(frozen=True, slots=False)
 class DiscreteParameter(Parameter, ABC):
@@ -95,6 +99,16 @@ class DiscreteParameter(Parameter, ABC):
             transformed = data.to_frame()
 
         return transformed
+
+    def summary(self) -> dict:  # noqa: D102
+        # See base class.
+        param_dict = dict(
+            Name=self.name,
+            Type=self.__class__.__name__,
+            Num_Values=len(self.values),
+            Encoding=self.encoding,
+        )
+        return param_dict
 
 
 @define(frozen=True, slots=False)

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -125,3 +125,13 @@ class NumericalContinuousParameter(ContinuousParameter):
         # See base class.
 
         return self.bounds.contains(item)
+
+    def summary(self) -> dict:  # noqa: D102
+        # See base class.
+        param_dict = dict(
+            Name=self.name,
+            Type=self.__class__.__name__,
+            Lower_Bound=self.bounds.lower,
+            Upper_Bound=self.bounds.upper,
+        )
+        return param_dict

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -15,7 +15,6 @@ from baybe.constraints import (
 )
 from baybe.parameters import NumericalContinuousParameter
 from baybe.parameters.utils import get_parameters_from_dataframe
-from baybe.searchspace.discrete import parameter_cartesian_prod_to_df
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.dataframe import pretty_print_dataframe
@@ -52,18 +51,26 @@ class SubspaceContinuous(SerialMixin):
         end_bold = "\033[0m"
 
         # Convert the lists to dataFrames to be able to use pretty_printing
-        par_df = parameter_cartesian_prod_to_df(self.parameters)
-        const_lin_eq_df = parameter_cartesian_prod_to_df(self.constraints_lin_eq)
-        const_lin_ineq_df = parameter_cartesian_prod_to_df(self.constraints_lin_ineq)
+        param_dict = list()
+        for param in self.parameters:
+            param_dict.append(param.summary())
+        eq_constraints_dict = list()
+        for constr in self.constraints_lin_eq:
+            eq_constraints_dict.append(constr.summary())
+        ineq_constraints_dict = list()
+        for constr in self.constraints_lin_ineq:
+            ineq_constraints_dict.append(constr.summary())
+        param_df = pd.DataFrame(param_dict)
+        lin_eq_constr_df = pd.DataFrame(eq_constraints_dict)
+        lin_ineq_constr_df = pd.DataFrame(ineq_constraints_dict)
 
         # Put all attributes of the continuous class in one string
-        continuous_str = f"""\n\n {start_bold} |--> The continuous search space
-            \n\nContinuous Parameters{end_bold} \n
-            {pretty_print_dataframe(par_df)}\n\n
-            {start_bold}List of linear equality constraints{end_bold}\n
-            {pretty_print_dataframe(const_lin_eq_df)}\n\n
-            {start_bold}List of linear inequality constraints
-            {end_bold} \n{pretty_print_dataframe(const_lin_ineq_df)}\n\n"""
+        continuous_str = f"""\n\n{start_bold}|--> The continuous search space
+            \nContinuous Parameters{end_bold}\n{pretty_print_dataframe(param_df)}
+            \n{start_bold}List of linear equality constraints{end_bold}
+            \n{pretty_print_dataframe(lin_eq_constr_df)}
+            \n{start_bold}List of linear inequality constraints{end_bold}
+            \n{pretty_print_dataframe(lin_ineq_constr_df)}\n\n"""
 
         return continuous_str
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -17,7 +17,7 @@ from baybe.parameters import NumericalContinuousParameter
 from baybe.parameters.utils import get_parameters_from_dataframe
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
-from baybe.utils.dataframe import pretty_print_dataframe
+from baybe.utils.dataframe import pretty_print_df
 from baybe.utils.numerical import DTypeFloatTorch
 
 
@@ -51,26 +51,22 @@ class SubspaceContinuous(SerialMixin):
         end_bold = "\033[0m"
 
         # Convert the lists to dataFrames to be able to use pretty_printing
-        param_dict = list()
-        for param in self.parameters:
-            param_dict.append(param.summary())
-        eq_constraints_dict = list()
-        for constr in self.constraints_lin_eq:
-            eq_constraints_dict.append(constr.summary())
-        ineq_constraints_dict = list()
-        for constr in self.constraints_lin_ineq:
-            ineq_constraints_dict.append(constr.summary())
-        param_df = pd.DataFrame(param_dict)
-        lin_eq_constr_df = pd.DataFrame(eq_constraints_dict)
-        lin_ineq_constr_df = pd.DataFrame(ineq_constraints_dict)
+        param_list = [param.summary() for param in self.parameters]
+        eq_constraints_list = [constr.summary() for constr in self.constraints_lin_eq]
+        ineq_constraints_list = [
+            constr.summary() for constr in self.constraints_lin_ineq
+        ]
+        param_df = pd.DataFrame(param_list)
+        lin_eq_constr_df = pd.DataFrame(eq_constraints_list)
+        lin_ineq_constr_df = pd.DataFrame(ineq_constraints_list)
 
         # Put all attributes of the continuous class in one string
-        continuous_str = f"""\n\n{start_bold}|--> The continuous search space
-            \nContinuous Parameters{end_bold}\n{pretty_print_dataframe(param_df)}
+        continuous_str = f"""\n\n{start_bold}|--> Continuous search space
+            \nContinuous Parameters{end_bold}\n{pretty_print_df(param_df)}
             \n{start_bold}List of linear equality constraints{end_bold}
-            \n{pretty_print_dataframe(lin_eq_constr_df)}
+            \n{pretty_print_df(lin_eq_constr_df)}
             \n{start_bold}List of linear inequality constraints{end_bold}
-            \n{pretty_print_dataframe(lin_ineq_constr_df)}\n\n"""
+            \n{pretty_print_df(lin_ineq_constr_df)}\n\n"""
 
         return continuous_str
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -18,7 +18,7 @@ from baybe.parameters.utils import get_parameters_from_dataframe
 from baybe.searchspace.discrete import parameter_cartesian_prod_to_df
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
-from baybe.utils.dataframe import pretty_printing_dataFrame
+from baybe.utils.dataframe import pretty_print_dataframe
 from baybe.utils.numerical import DTypeFloatTorch
 
 
@@ -57,17 +57,17 @@ class SubspaceContinuous(SerialMixin):
             "\n\n \033[1m |--> The continuous search space \n\n \033[0m"
             + "\033[1m Continuous Parameters \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(par_df)
+            + pretty_print_dataframe(par_df)
             + "\n"
             + "\n "
             + "\033[1m List of linear equality constraints \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(const_lin_eq_df)
+            + pretty_print_dataframe(const_lin_eq_df)
             + "\n"
             + "\n"
             + "\033[1m List of linear inequality constraints \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(const_lin_ineq_df)
+            + pretty_print_dataframe(const_lin_ineq_df)
             + "\n\n"
         )
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -47,29 +47,23 @@ class SubspaceContinuous(SerialMixin):
     def __str__(self) -> str:
         if self.is_empty:
             return ""
+
+        start_bold = "\033[1m"
+        end_bold = "\033[0m"
+
         # Convert the lists to dataFrames to be able to use pretty_printing
         par_df = parameter_cartesian_prod_to_df(self.parameters)
         const_lin_eq_df = parameter_cartesian_prod_to_df(self.constraints_lin_eq)
         const_lin_ineq_df = parameter_cartesian_prod_to_df(self.constraints_lin_ineq)
 
         # Put all attributes of the continuous class in one string
-        continuous_str = (
-            "\n\n \033[1m |--> The continuous search space \n\n \033[0m"
-            + "\033[1m Continuous Parameters \033[0m"
-            + " \n"
-            + pretty_print_dataframe(par_df)
-            + "\n"
-            + "\n "
-            + "\033[1m List of linear equality constraints \033[0m"
-            + " \n"
-            + pretty_print_dataframe(const_lin_eq_df)
-            + "\n"
-            + "\n"
-            + "\033[1m List of linear inequality constraints \033[0m"
-            + " \n"
-            + pretty_print_dataframe(const_lin_ineq_df)
-            + "\n\n"
-        )
+        continuous_str = f"""\n\n {start_bold} |--> The continuous search space
+            \n\nContinuous Parameters{end_bold} \n
+            {pretty_print_dataframe(par_df)}\n\n
+            {start_bold}List of linear equality constraints{end_bold}\n
+            {pretty_print_dataframe(const_lin_eq_df)}\n\n
+            {start_bold}List of linear inequality constraints
+            {end_bold} \n{pretty_print_dataframe(const_lin_ineq_df)}\n\n"""
 
         return continuous_str
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -15,9 +15,11 @@ from baybe.constraints import (
 )
 from baybe.parameters import NumericalContinuousParameter
 from baybe.parameters.utils import get_parameters_from_dataframe
+from baybe.searchspace.discrete import parameter_cartesian_prod_to_df
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.numerical import DTypeFloatTorch
+from baybe.utils.dataframe import pretty_printing_dataFrame
 
 
 @define
@@ -41,6 +43,34 @@ class SubspaceContinuous(SerialMixin):
         factory=list
     )
     """List of linear inequality constraints."""
+
+    def __repr__(self) -> str:
+        """Override the standard __repr__."""
+        # Convert the lists to dataFrames to be able to use pretty_printing
+        par_df = parameter_cartesian_prod_to_df(self.parameters)
+        const_lin_eq_df = parameter_cartesian_prod_to_df(self.constraints_lin_eq)
+        const_lin_ineq_df = parameter_cartesian_prod_to_df(self.constraints_lin_ineq)
+
+        # Put all attributes of the continuous class in one string
+        continuous_str = (
+            "\n\n \033[1m ***** The continuous Searchspace *****\n\n \033[0m"
+            + "\033[1m Continuous Parameters \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(par_df)
+            + "\n"
+            + "\n "
+            + "\033[1m List of linear equality constraints \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(const_lin_eq_df)
+            + "\n"
+            + "\n"
+            + "\033[1m List of linear inequality constraints \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(const_lin_ineq_df)
+            + "\n"
+        )
+
+        return continuous_str
 
     @classmethod
     def empty(cls) -> SubspaceContinuous:

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -44,8 +44,7 @@ class SubspaceContinuous(SerialMixin):
     )
     """List of linear inequality constraints."""
 
-    def __repr__(self) -> str:
-        """Override the standard __repr__."""
+    def __str__(self) -> str:
         if self.is_empty:
             return ""
         # Convert the lists to dataFrames to be able to use pretty_printing

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -18,8 +18,8 @@ from baybe.parameters.utils import get_parameters_from_dataframe
 from baybe.searchspace.discrete import parameter_cartesian_prod_to_df
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
-from baybe.utils.numerical import DTypeFloatTorch
 from baybe.utils.dataframe import pretty_printing_dataFrame
+from baybe.utils.numerical import DTypeFloatTorch
 
 
 @define
@@ -46,6 +46,8 @@ class SubspaceContinuous(SerialMixin):
 
     def __repr__(self) -> str:
         """Override the standard __repr__."""
+        if self.is_empty:
+            return ""
         # Convert the lists to dataFrames to be able to use pretty_printing
         par_df = parameter_cartesian_prod_to_df(self.parameters)
         const_lin_eq_df = parameter_cartesian_prod_to_df(self.constraints_lin_eq)
@@ -53,7 +55,7 @@ class SubspaceContinuous(SerialMixin):
 
         # Put all attributes of the continuous class in one string
         continuous_str = (
-            "\n\n \033[1m ***** The continuous Searchspace *****\n\n \033[0m"
+            "\n\n \033[1m |--> The continuous search space \n\n \033[0m"
             + "\033[1m Continuous Parameters \033[0m"
             + " \n"
             + pretty_printing_dataFrame(par_df)
@@ -67,7 +69,7 @@ class SubspaceContinuous(SerialMixin):
             + "\033[1m List of linear inequality constraints \033[0m"
             + " \n"
             + pretty_printing_dataFrame(const_lin_ineq_df)
-            + "\n"
+            + "\n\n"
         )
 
         return continuous_str

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -66,7 +66,9 @@ class SearchSpace(SerialMixin):
     """The (potentially empty) continuous subspace of the overall search space."""
 
     def __str__(self) -> str:
-        print("\n\n \033[1m ***** SEARCH SPACE *****\n \033[0m")
+        start_bold = "\033[1m"
+        end_bold = "\033[0m"
+        print(f"\n\n{start_bold}***** SEARCH SPACE *****\n {end_bold}")
 
         return str(self.discrete) + str(self.continuous)
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -68,7 +68,10 @@ class SearchSpace(SerialMixin):
     def __str__(self) -> str:
         start_bold = "\033[1m"
         end_bold = "\033[0m"
-        print(f"\n\n{start_bold}***** SEARCH SPACE *****\n {end_bold}")
+        print(
+            f"""\n\n{start_bold}***** SEARCH SPACE *****
+        \nSearch space type: {end_bold}{self.type.name}\n"""
+        )
 
         return str(self.discrete) + str(self.continuous)
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -65,8 +65,7 @@ class SearchSpace(SerialMixin):
     continuous: SubspaceContinuous = field(factory=SubspaceContinuous.empty)
     """The (potentially empty) continuous subspace of the overall search space."""
 
-    def __repr__(self) -> str:
-        """Override the standard __repr__."""
+    def __str__(self) -> str:
         print("\n\n \033[1m ***** SEARCH SPACE *****\n \033[0m")
 
         return str(self.discrete) + str(self.continuous)

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -65,6 +65,12 @@ class SearchSpace(SerialMixin):
     continuous: SubspaceContinuous = field(factory=SubspaceContinuous.empty)
     """The (potentially empty) continuous subspace of the overall search space."""
 
+    def __repr__(self) -> str:
+        """Override the standard __repr__."""
+        print("\n\n \033[1m ***** SEARCH SPACE *****\n \033[0m")
+
+        return str(self.discrete) + str(self.continuous)
+
     def __attrs_post_init__(self):
         """Perform validation and record telemetry values."""
         validate_parameters(self.parameters)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -26,7 +26,7 @@ from baybe.utils.boolean import eq_dataframe
 from baybe.utils.dataframe import (
     df_drop_single_value_columns,
     fuzzy_row_match,
-    pretty_print_dataframe,
+    pretty_print_df,
 )
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
@@ -72,24 +72,28 @@ class SubspaceDiscrete(SerialMixin):
         end_bold = "\033[0m"
 
         # Convert the lists to dataFrames to be able to use pretty_printing
-        param_dict = list()
-        for param in self.parameters:
-            param_dict.append(param.summary())
-        constraints_dict = list()
-        for constr in self.constraints:
-            constraints_dict.append(constr.summary())
-        param_df = pd.DataFrame(param_dict)
-        constraints_df = pd.DataFrame(constraints_dict)
+        param_list = [param.summary() for param in self.parameters]
+        constraints_list = [constr.summary() for constr in self.constraints]
+        param_df = pd.DataFrame(param_list)
+        constraints_df = pd.DataFrame(constraints_list)
+
+        # Get summary information from metadata
+        was_recommended_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[0]]])
+        was_measured_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[1]]])
+        dont_recommend_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[2]]])
+        metadata_count = len(self.metadata)
 
         # Put all attributes of the discrete class in one string.
-        discrete_str = f"""{start_bold}|--> The discrete search space
-            \nDiscrete Parameters{end_bold}\n{pretty_print_dataframe(param_df)}
+        discrete_str = f"""{start_bold}|--> Discrete search space
+            \nDiscrete Parameters{end_bold}\n{pretty_print_df(param_df)}
             \n{start_bold}Experimental Representation{end_bold}
-            \n{pretty_print_dataframe(self.exp_rep)}
-            \n{start_bold}Metadata {end_bold}\n{pretty_print_dataframe(self.metadata)}
-            \n{start_bold}Constraints{end_bold}{pretty_print_dataframe(constraints_df)}
+            \n{pretty_print_df(self.exp_rep)}\n{start_bold}\nMetadata:{end_bold}
+            \r{_METADATA_COLUMNS[0]}: {was_recommended_count}/{metadata_count}
+            \r{_METADATA_COLUMNS[1]}: {was_measured_count}/{metadata_count}
+            \r{_METADATA_COLUMNS[2]}: {dont_recommend_count}/{metadata_count}
+            \n{start_bold}Constraints{end_bold}\n{pretty_print_df(constraints_df)}
             \n{start_bold}Computational representation of the space{end_bold}
-            \n{pretty_print_dataframe(self.comp_rep)}\n\n"""
+            \n{pretty_print_df(self.comp_rep)}\n\n"""
 
         return discrete_str
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -23,7 +23,7 @@ from baybe.parameters.utils import get_parameters_from_dataframe
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.boolean import eq_dataframe
-from baybe.utils.dataframe import df_drop_single_value_columns, fuzzy_row_match
+from baybe.utils.dataframe import df_drop_single_value_columns, fuzzy_row_match, pretty_printing_dataFrame
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
 
@@ -59,6 +59,47 @@ class SubspaceDiscrete(SerialMixin):
     as an optional initializer argument to allow ingestion from e.g. serialized objects
     and thereby speed up construction. If not provided, the default hook will derive it
     from ``exp_rep``."""
+
+    def __repr__(self) -> str:
+        """Override the standard __repr__."""
+        # Convert the lists to dataFrames to be able to use pretty_printing
+        par_df = parameter_cartesian_prod_to_df(self.parameters)
+        const_df = parameter_cartesian_prod_to_df(self.constraints)
+
+        # Put all attributes of the discrete class in one string.
+        discrete_str = (
+            "\n"
+            + "\033[1m Discrete Parameters \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(par_df)
+            + "\n"
+            + "\n "
+            + "\033[1m Experimental Representation \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(self.exp_rep)
+            + "\n"
+            + "\n"
+            + "\033[1m  Metadata \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(self.metadata)
+            + "\n"
+            + "\n"
+            + "\033[1m  Empty Encoding Used: \033[0m"
+            + str(self.empty_encoding)
+            + "\n"
+            + "\n"
+            + "\033[1m  Constraints \033[0m"
+            + "  \n"
+            + pretty_printing_dataFrame(const_df)
+            + "\n"
+            + "\n"
+            + "\033[1m  Computational representation of the space \033[0m"
+            + " \n"
+            + pretty_printing_dataFrame(self.comp_rep)
+            + "\n"
+        )
+
+        return discrete_str
 
     @exp_rep.validator
     def _validate_exp_rep(  # noqa: DOC101, DOC103

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -23,7 +23,11 @@ from baybe.parameters.utils import get_parameters_from_dataframe
 from baybe.searchspace.validation import validate_parameter_names
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.boolean import eq_dataframe
-from baybe.utils.dataframe import df_drop_single_value_columns, fuzzy_row_match, pretty_printing_dataFrame
+from baybe.utils.dataframe import (
+    df_drop_single_value_columns,
+    fuzzy_row_match,
+    pretty_printing_dataFrame,
+)
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
 
@@ -62,13 +66,15 @@ class SubspaceDiscrete(SerialMixin):
 
     def __repr__(self) -> str:
         """Override the standard __repr__."""
+        if self.is_empty:
+            return ""
         # Convert the lists to dataFrames to be able to use pretty_printing
         par_df = parameter_cartesian_prod_to_df(self.parameters)
         const_df = parameter_cartesian_prod_to_df(self.constraints)
 
         # Put all attributes of the discrete class in one string.
         discrete_str = (
-            "\n"
+            "\n\n \033[1m |--> The discrete search space \n\n \033[0m"
             + "\033[1m Discrete Parameters \033[0m"
             + " \n"
             + pretty_printing_dataFrame(par_df)
@@ -79,24 +85,24 @@ class SubspaceDiscrete(SerialMixin):
             + pretty_printing_dataFrame(self.exp_rep)
             + "\n"
             + "\n"
-            + "\033[1m  Metadata \033[0m"
+            + "\033[1m Metadata \033[0m"
             + " \n"
             + pretty_printing_dataFrame(self.metadata)
             + "\n"
             + "\n"
-            + "\033[1m  Empty Encoding Used: \033[0m"
+            + "\033[1m Empty Encoding Used: \033[0m"
             + str(self.empty_encoding)
             + "\n"
             + "\n"
-            + "\033[1m  Constraints \033[0m"
+            + "\033[1m Constraints \033[0m"
             + "  \n"
             + pretty_printing_dataFrame(const_df)
             + "\n"
             + "\n"
-            + "\033[1m  Computational representation of the space \033[0m"
+            + "\033[1m Computational representation of the space \033[0m"
             + " \n"
             + pretty_printing_dataFrame(self.comp_rep)
-            + "\n"
+            + "\n\n"
         )
 
         return discrete_str

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -26,7 +26,7 @@ from baybe.utils.boolean import eq_dataframe
 from baybe.utils.dataframe import (
     df_drop_single_value_columns,
     fuzzy_row_match,
-    pretty_printing_dataFrame,
+    pretty_print_dataframe,
 )
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
@@ -76,17 +76,17 @@ class SubspaceDiscrete(SerialMixin):
             "\n\n \033[1m |--> The discrete search space \n\n \033[0m"
             + "\033[1m Discrete Parameters \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(par_df)
+            + pretty_print_dataframe(par_df)
             + "\n"
             + "\n "
             + "\033[1m Experimental Representation \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(self.exp_rep)
+            + pretty_print_dataframe(self.exp_rep)
             + "\n"
             + "\n"
             + "\033[1m Metadata \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(self.metadata)
+            + pretty_print_dataframe(self.metadata)
             + "\n"
             + "\n"
             + "\033[1m Empty Encoding Used: \033[0m"
@@ -95,12 +95,12 @@ class SubspaceDiscrete(SerialMixin):
             + "\n"
             + "\033[1m Constraints \033[0m"
             + "  \n"
-            + pretty_printing_dataFrame(const_df)
+            + pretty_print_dataframe(const_df)
             + "\n"
             + "\n"
             + "\033[1m Computational representation of the space \033[0m"
             + " \n"
-            + pretty_printing_dataFrame(self.comp_rep)
+            + pretty_print_dataframe(self.comp_rep)
             + "\n\n"
         )
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -72,18 +72,22 @@ class SubspaceDiscrete(SerialMixin):
         end_bold = "\033[0m"
 
         # Convert the lists to dataFrames to be able to use pretty_printing
-        par_df = pd.DataFrame(self.parameters)
-        const_df = parameter_cartesian_prod_to_df(self.constraints)
+        param_dict = list()
+        for param in self.parameters:
+            param_dict.append(param.summary())
+        constraints_dict = list()
+        for constr in self.constraints:
+            constraints_dict.append(constr.summary())
+        param_df = pd.DataFrame(param_dict)
+        constraints_df = pd.DataFrame(constraints_dict)
 
         # Put all attributes of the discrete class in one string.
         discrete_str = f"""{start_bold}|--> The discrete search space
-            \n\nDiscrete Parameters
-            {end_bold} \n{pretty_print_dataframe(par_df)}
-            \n{start_bold}Experimental Representation {end_bold}
+            \nDiscrete Parameters{end_bold}\n{pretty_print_dataframe(param_df)}
+            \n{start_bold}Experimental Representation{end_bold}
             \n{pretty_print_dataframe(self.exp_rep)}
-            \n{start_bold}Metadata {end_bold} \n{pretty_print_dataframe(self.metadata)}
-            \n{start_bold}Empty Encoding Used: {end_bold}{str(self.empty_encoding)}
-            \n{start_bold}Constraints{end_bold}\n{pretty_print_dataframe(const_df)}
+            \n{start_bold}Metadata {end_bold}\n{pretty_print_dataframe(self.metadata)}
+            \n{start_bold}Constraints{end_bold}{pretty_print_dataframe(constraints_df)}
             \n{start_bold}Computational representation of the space{end_bold}
             \n{pretty_print_dataframe(self.comp_rep)}\n\n"""
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -67,42 +67,25 @@ class SubspaceDiscrete(SerialMixin):
     def __str__(self) -> str:
         if self.is_empty:
             return ""
+
+        start_bold = "\033[1m"
+        end_bold = "\033[0m"
+
         # Convert the lists to dataFrames to be able to use pretty_printing
-        par_df = parameter_cartesian_prod_to_df(self.parameters)
+        par_df = pd.DataFrame(self.parameters)
         const_df = parameter_cartesian_prod_to_df(self.constraints)
 
         # Put all attributes of the discrete class in one string.
-        discrete_str = (
-            "\n\n \033[1m |--> The discrete search space \n\n \033[0m"
-            + "\033[1m Discrete Parameters \033[0m"
-            + " \n"
-            + pretty_print_dataframe(par_df)
-            + "\n"
-            + "\n "
-            + "\033[1m Experimental Representation \033[0m"
-            + " \n"
-            + pretty_print_dataframe(self.exp_rep)
-            + "\n"
-            + "\n"
-            + "\033[1m Metadata \033[0m"
-            + " \n"
-            + pretty_print_dataframe(self.metadata)
-            + "\n"
-            + "\n"
-            + "\033[1m Empty Encoding Used: \033[0m"
-            + str(self.empty_encoding)
-            + "\n"
-            + "\n"
-            + "\033[1m Constraints \033[0m"
-            + "  \n"
-            + pretty_print_dataframe(const_df)
-            + "\n"
-            + "\n"
-            + "\033[1m Computational representation of the space \033[0m"
-            + " \n"
-            + pretty_print_dataframe(self.comp_rep)
-            + "\n\n"
-        )
+        discrete_str = f"""{start_bold}|--> The discrete search space
+            \n\nDiscrete Parameters
+            {end_bold} \n{pretty_print_dataframe(par_df)}
+            \n{start_bold}Experimental Representation {end_bold}
+            \n{pretty_print_dataframe(self.exp_rep)}
+            \n{start_bold}Metadata {end_bold} \n{pretty_print_dataframe(self.metadata)}
+            \n{start_bold}Empty Encoding Used: {end_bold}{str(self.empty_encoding)}
+            \n{start_bold}Constraints{end_bold}\n{pretty_print_dataframe(const_df)}
+            \n{start_bold}Computational representation of the space{end_bold}
+            \n{pretty_print_dataframe(self.comp_rep)}\n\n"""
 
         return discrete_str
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -64,8 +64,7 @@ class SubspaceDiscrete(SerialMixin):
     and thereby speed up construction. If not provided, the default hook will derive it
     from ``exp_rep``."""
 
-    def __repr__(self) -> str:
-        """Override the standard __repr__."""
+    def __str__(self) -> str:
         if self.is_empty:
             return ""
         # Convert the lists to dataFrames to be able to use pretty_printing

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -420,12 +420,11 @@ def fuzzy_row_match(
     return pd.Index(inds_matched)
 
 
-def pretty_print_dataframe(df: pd.DataFrame) -> str:
-    """Return a pretty/readable str object.
+def pretty_print_df(df: pd.DataFrame) -> str:
+    """Convert a dataframe into a pretty/readable str object.
 
-    This function checks the size of the dataframe first. If the dataframe
-    has more than 10
-    rows or more than 5 columns, the extra values will be extracted.
+    This function returns the first 10 rows and 7 columns from the dataframe.
+    In case the dataframe is empty, it returns a corresponding statement.
 
     Args:
         df: The dataframe to be printed.
@@ -433,30 +432,9 @@ def pretty_print_dataframe(df: pd.DataFrame) -> str:
     Returns:
         The values to be printed as a str table.
     """
-    # TODO: remove hard coded numbers and allow user defined specifications
-
-    str_df = ""
-
-    # Handling with Empty dataFrame
-    if len(df) == 0:
-        return "This attribute is empty. "
-
-    # Extract extra rows and columns
-    """elif len(df) > 10 and len(df.columns) > 5:
-        str_df = str_df + (
-            f"\nPrinting first 10/{len(df)} rows and 5/{len(df.columns)} columns\n"
-        )
-        df = df.T.head(5).T
-        df = df.head(10)
-
-    elif len(df) > 10:
-        str_df = str_df + (f"\nPrinting first 10/{len(df)} rows\n")
-        df = df.head(10)"""
-    # Do not break the table in two lines and center table content
-    pd.set_option(
-        "display.max_rows", 10, "display.max_column", 6, "expand_frame_repr", False
-    )
-
-    # Convert the dataFrame to a string table
-    str_df = f"\n{df} {str_df} "
+    # Get first 10 rows and 7 columns and do not break the table in two lines
+    with pd.option_context(
+        "display.max_rows", 10, "display.max_columns", 7, "expand_frame_repr", False
+    ):
+        str_df = str(df)
     return str_df

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -421,9 +421,10 @@ def fuzzy_row_match(
 
 
 def pretty_print_df(df: pd.DataFrame) -> str:
-    """Convert a dataframe into a pretty/readable str object.
+    """Convert a dataframe into a pretty/readable format.
 
-    This function returns the first 10 rows and 7 columns from the dataframe.
+    This function returns a string representation containing at most the
+    first 10 rows and 7 columns of the dataframe.
     In case the dataframe is empty, it returns a corresponding statement.
 
     Args:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -420,22 +420,28 @@ def fuzzy_row_match(
     return pd.Index(inds_matched)
 
 
-def pretty_print_df(df: pd.DataFrame) -> str:
+def pretty_print_df(df: pd.DataFrame, max_rows: int = 6, max_columns: int = 4) -> str:
     """Convert a dataframe into a pretty/readable format.
 
-    This function returns a string representation containing at most the
-    first 10 rows and 7 columns of the dataframe.
+    This function returns a customized str representation of the dataframe.
     In case the dataframe is empty, it returns a corresponding statement.
 
     Args:
         df: The dataframe to be printed.
+        max_rows: Maximum number of rows to display.
+        max_columns: Maximum number of columns to display.
 
     Returns:
         The values to be printed as a str table.
     """
-    # Get first 10 rows and 7 columns and do not break the table in two lines
+    # Get custom str representation via pandas option_context
     with pd.option_context(
-        "display.max_rows", 10, "display.max_columns", 7, "expand_frame_repr", False
+        "display.max_rows",
+        max_rows,
+        "display.max_columns",
+        max_columns,
+        "expand_frame_repr",
+        False,
     ):
         str_df = str(df)
     return str_df

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple
 import numpy as np
 import pandas as pd
 import torch
-from tabulate import tabulate
 from torch import Tensor
 
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
@@ -421,8 +420,12 @@ def fuzzy_row_match(
     return pd.Index(inds_matched)
 
 
-def pretty_printing_dataFrame(df: pd.DataFrame) -> str:
-    """Return a pretyt/readable str Object.
+def pretty_print_dataframe(df: pd.DataFrame) -> str:
+    """Return a pretty/readable str object.
+
+    This function checks the size of the dataframe first. If the dataframe
+    has more than 10
+    rows or more than 5 columns, the extra values will be extracted.
 
     Args:
         df: The dataframe to be printed.
@@ -430,7 +433,6 @@ def pretty_printing_dataFrame(df: pd.DataFrame) -> str:
     Returns:
         The values to be printed as a str table.
     """
-    # select the first 10 rows/values and store them in a str table
     # TODO: remove hard coded numbers and allow user defined specifications
 
     str_df = ""
@@ -439,22 +441,22 @@ def pretty_printing_dataFrame(df: pd.DataFrame) -> str:
     if len(df) == 0:
         return "This attribute is empty. "
 
-    # Extract extra columns
-    if len(df.columns) > 5:
-        df = df.T.head(5).T
-        str_df = (
-            "\n Your dataFrame has too many columns. "
-            + "For a better readable table only the first 5 columns will be printed. \n"
-        )
-
-    # Extract extra rows
-    if len(df) > 10:
-        df = df.head(10)
+    # Extract extra rows and columns
+    """elif len(df) > 10 and len(df.columns) > 5:
         str_df = str_df + (
-            "\n Your dataFrame has too many rows. "
-            + "For a better readable table only the first 10 values will be printed. \n"
+            f"\nPrinting first 10/{len(df)} rows and 5/{len(df.columns)} columns\n"
         )
+        df = df.T.head(5).T
+        df = df.head(10)
+
+    elif len(df) > 10:
+        str_df = str_df + (f"\nPrinting first 10/{len(df)} rows\n")
+        df = df.head(10)"""
+    # Do not break the table in two lines and center table content
+    pd.set_option(
+        "display.max_rows", 10, "display.max_column", 6, "expand_frame_repr", False
+    )
 
     # Convert the dataFrame to a string table
-    str_df = str_df + tabulate(df, headers="keys", tablefmt="pretty")
+    str_df = f"\n{df} {str_df} "
     return str_df

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple
 import numpy as np
 import pandas as pd
 import torch
+from tabulate import tabulate
 from torch import Tensor
 
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
@@ -418,3 +419,42 @@ def fuzzy_row_match(
             inds_matched.extend(inds_found)
 
     return pd.Index(inds_matched)
+
+
+def pretty_printing_dataFrame(df: pd.DataFrame) -> str:
+    """Return a pretyt/readable str Object.
+
+    Args:
+        df: The dataframe to be printed.
+
+    Returns:
+        The values to be printed as a str table.
+    """
+    # select the first 10 rows/values and store them in a str table
+    # TODO: remove hard coded numbers and allow user defined specifications
+
+    str_df = ""
+
+    # Handling with Empty dataFrame
+    if len(df) == 0:
+        return "This attribute is empty. "
+
+    # Extract extra columns
+    if len(df.columns) > 5:
+        df = df.T.head(5).T
+        str_df = (
+            "\n Your dataFrame has too many columns. "
+            + "For a better readable table only the first 5 columns will be printed. \n"
+        )
+
+    # Extract extra rows
+    if len(df) > 10:
+        df = df.head(10)
+        str_df = str_df + (
+            "\n Your dataFrame has too many rows. "
+            + "For a better readable table only the first 10 values will be printed. \n"
+        )
+
+    # Convert the dataFrame to a string table
+    str_df = str_df + tabulate(df, headers="keys", tablefmt="pretty")
+    return str_df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "scikit-learn-extra>=0.3.0",
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
+    "tabulate>=0.9.0",
     "torch>=1.11.0",
     "baybe[telemetry]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "scikit-learn-extra>=0.3.0",
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
-    "tabulate>=0.9.0",
     "torch>=1.11.0",
     "baybe[telemetry]",
 ]


### PR DESCRIPTION
This PR introduces a new printing function that can be used to have a prettier print (compared to the standard one). However, we still need to discuss what exactly a user would like to see in a simplified / pretty print and remove the hard-coded numbers.

But here are some notes:

- The current pretty_printing_dataFrame() prints only the first 10 rows and 5 columns of the handed over dataFrame object.

- The print function only prints the relevant search space, so if the continuous one is not used, then it will not be printed.

- We can get rid of the cartesian functions, but like mentioned before, we need to set our exact goal of the pretty printing function.