### PR TITLE
Fix docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.11"}
+        with: {python-version: "3.10"}
       - name: Build Docs
         run: |
           pip install tox
-          tox -e docs-py311
+          tox -e docs-py310
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
The docs pipeline currently fails due to some issue with `__pycache__` and py311. This PR thus changes the docs pipeline version to 310 and allow manual triggering to ship the docs for the latest 0.7.3 release.