### PR TITLE
Change docs pipeline python version to 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.10"}
+        with: {python-version: "3.9"}
       - name: Build Docs
         run: |
           pip install tox
-          tox -e docs-py310
+          tox -e docs-py39
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ For our example, we combine two selection strategies:
 
 For more details on the different strategies, their underlying algorithmic
 details, and their configuration settings, see the
-[strategies section](https://emdgroup.github.io/baybe/userguide/strategy.html) of the user guide.
+[strategies section](https://emdgroup.github.io/baybe/userguide/strategies.html)
+of the user guide.
 
 ```python
 from baybe.strategies import TwoPhaseStrategy


### PR DESCRIPTION
The `__pycache__` error also occurs on py310 and needs to be further investigated. Thus, temporarily changing to py39.