### PR TITLE
Refactor recommender methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Subpackages for the available recommender types
 
+### Changed
+- `Recommender`s now share their core logic via their base class
+
 ## [0.7.3] - 2024-02-09
 ### Added
 - Copy button for code blocks in documentation

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -196,7 +196,7 @@ class Recommender(ABC, RecommenderProtocol):
     def _select_candidates_and_recommend(
         self,
         subspace_discrete: SubspaceDiscrete,
-        batch_size: int = 1,
+        batch_size: int,
     ) -> pd.DataFrame:
         """Get candidates in a discrete search space and generate recommendations.
 

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -68,19 +68,9 @@ class Recommender(ABC, RecommenderProtocol):
         # See base class.
 
         if searchspace.type == SearchSpaceType.DISCRETE:
-            allow_repeated = (
-                self.allow_repeated_recommendations
-                or not searchspace.continuous.is_empty
-            )
-            allow_measured = (
-                self.allow_recommending_already_measured
-                or not searchspace.continuous.is_empty
-            )
             return self._select_candidates_and_recommend(
                 searchspace.discrete,
                 batch_size,
-                allow_repeated_recommendations=allow_repeated,
-                allow_recommending_already_measured=allow_measured,
             )
         if searchspace.type == SearchSpaceType.CONTINUOUS:
             return self._recommend_continuous(
@@ -196,8 +186,6 @@ class Recommender(ABC, RecommenderProtocol):
         self,
         subspace_discrete: SubspaceDiscrete,
         batch_size: int = 1,
-        allow_repeated_recommendations: bool = False,
-        allow_recommending_already_measured: bool = True,
     ) -> pd.DataFrame:
         """Select candidates in a discrete search space and recommend them.
 
@@ -209,10 +197,6 @@ class Recommender(ABC, RecommenderProtocol):
         Args:
             subspace_discrete: The discrete subspace.
             batch_size: The chosen batch size.
-            allow_repeated_recommendations: Allow to make recommendations that were
-                already recommended earlier.
-            allow_recommending_already_measured: Allow to output recommendations that
-                were measured previously.
 
         Returns:
             The recommendation in experimental representation.
@@ -225,11 +209,10 @@ class Recommender(ABC, RecommenderProtocol):
         #   among all purely discrete recommenders (without introducing complicates
         #   class hierarchies).
 
-        # Get discrete candidates. The metadata flags are ignored if the search space
-        # has a continuous component.
+        # Get discrete candidates
         _, candidates_comp = subspace_discrete.get_candidates(
-            allow_repeated_recommendations=allow_repeated_recommendations,
-            allow_recommending_already_measured=allow_recommending_already_measured,
+            allow_repeated_recommendations=self.allow_repeated_recommendations,
+            allow_recommending_already_measured=self.allow_recommending_already_measured,
         )
 
         # Check if enough candidates are left

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -1,7 +1,7 @@
 """Base classes for all recommenders."""
 
 from abc import ABC
-from typing import Callable, ClassVar, Optional, Protocol
+from typing import ClassVar, Optional, Protocol
 
 import cattrs
 import pandas as pd
@@ -78,7 +78,6 @@ class Recommender(ABC, RecommenderProtocol):
             )
             return self._select_candidates_and_recommend(
                 searchspace.discrete,
-                self._recommend_discrete,
                 batch_size,
                 allow_repeated_recommendations=allow_repeated,
                 allow_recommending_already_measured=allow_measured,
@@ -196,7 +195,6 @@ class Recommender(ABC, RecommenderProtocol):
     def _select_candidates_and_recommend(
         self,
         subspace_discrete: SubspaceDiscrete,
-        recommend_discrete: Callable[[SubspaceDiscrete, pd.DataFrame, int], pd.Index],
         batch_size: int = 1,
         allow_repeated_recommendations: bool = False,
         allow_recommending_already_measured: bool = True,
@@ -210,8 +208,6 @@ class Recommender(ABC, RecommenderProtocol):
 
         Args:
             subspace_discrete: The discrete subspace.
-            recommend_discrete: The Callable representing the discrete recommendation
-                function.
             batch_size: The chosen batch size.
             allow_repeated_recommendations: Allow to make recommendations that were
                 already recommended earlier.
@@ -249,7 +245,7 @@ class Recommender(ABC, RecommenderProtocol):
             )
 
         # Get recommendations
-        idxs = recommend_discrete(subspace_discrete, candidates_comp, batch_size)
+        idxs = self._recommend_discrete(subspace_discrete, candidates_comp, batch_size)
         rec = subspace_discrete.exp_rep.loc[idxs, :]
 
         # Update metadata

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -61,6 +61,33 @@ class Recommender(ABC, RecommenderProtocol):
     """Allow to output recommendations that were measured previously. This only has an
     influence in discrete search spaces."""
 
+    def recommend(  # noqa: D102
+        self,
+        searchspace: SearchSpace,
+        batch_size: int = 1,
+        train_x: Optional[pd.DataFrame] = None,
+        train_y: Optional[pd.DataFrame] = None,
+    ) -> pd.DataFrame:
+        # See base class.
+
+        if searchspace.type == SearchSpaceType.DISCRETE:
+            return self._select_candidates_and_recommend(
+                searchspace,
+                self._recommend_discrete,
+                batch_size,
+                self.allow_repeated_recommendations,
+                self.allow_recommending_already_measured,
+            )
+        if searchspace.type == SearchSpaceType.CONTINUOUS:
+            return self._recommend_continuous(
+                subspace_continuous=searchspace.continuous, batch_size=batch_size
+            )
+        if searchspace.type == SearchSpaceType.HYBRID:
+            return self._recommend_hybrid(
+                searchspace=searchspace, batch_size=batch_size
+            )
+        raise RuntimeError("This line should be impossible to reach.")
+
     def _select_candidates_and_recommend(
         self,
         searchspace: SearchSpace,

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -68,14 +68,20 @@ class Recommender(ABC, RecommenderProtocol):
         # See base class.
 
         if searchspace.type == SearchSpaceType.DISCRETE:
+            allow_repeated = (
+                self.allow_repeated_recommendations
+                or not searchspace.continuous.is_empty
+            )
+            allow_measured = (
+                self.allow_recommending_already_measured
+                or not searchspace.continuous.is_empty
+            )
             return self._select_candidates_and_recommend(
                 searchspace.discrete,
                 self._recommend_discrete,
                 batch_size,
-                allow_repeated_recommendations=self.allow_repeated_recommendations
-                or not searchspace.continuous.is_empty,
-                allow_recommending_already_measured=self.allow_recommending_already_measured
-                or not searchspace.continuous.is_empty,
+                allow_repeated_recommendations=allow_repeated,
+                allow_recommending_already_measured=allow_measured,
             )
         if searchspace.type == SearchSpaceType.CONTINUOUS:
             return self._recommend_continuous(

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -61,8 +61,8 @@ class Recommender(ABC, RecommenderProtocol):
     """Allow to output recommendations that were measured previously. This only has an
     influence in discrete search spaces."""
 
-    @staticmethod
     def _select_candidates_and_recommend(
+        self,
         searchspace: SearchSpace,
         recommend_discrete: Callable[[SubspaceDiscrete, pd.DataFrame, int], pd.Index],
         batch_size: int = 1,

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -111,9 +111,7 @@ class Recommender(ABC, RecommenderProtocol):
         """
         try:
             return self._recommend_hybrid(
-                searchspace=SearchSpace(
-                    discrete=subspace_discrete, continuous=SubspaceContinuous.empty()
-                ),
+                searchspace=SearchSpace(discrete=subspace_discrete),
                 candidates_comp=candidates_comp,
                 batch_size=batch_size,
             ).index
@@ -148,9 +146,7 @@ class Recommender(ABC, RecommenderProtocol):
         # _recommend_hybrid instead.
         try:
             return self._recommend_hybrid(
-                searchspace=SearchSpace(
-                    discrete=SubspaceDiscrete.empty(), continuous=subspace_continuous
-                ),
+                searchspace=SearchSpace(continuous=subspace_continuous),
                 candidates_comp=pd.DataFrame(),
                 batch_size=batch_size,
             )

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -9,11 +9,8 @@ from attrs import define, field
 
 from baybe.exceptions import NotEnoughPointsLeftError
 from baybe.recommenders.deprecation import structure_recommender_protocol
-from baybe.searchspace import (
-    SearchSpace,
-    SearchSpaceType,
-    SubspaceDiscrete,
-)
+from baybe.searchspace import SearchSpace, SearchSpaceType, SubspaceDiscrete
+from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.serialization import (
     converter,
     unstructure_base,
@@ -87,6 +84,106 @@ class Recommender(ABC, RecommenderProtocol):
                 searchspace=searchspace, batch_size=batch_size
             )
         raise RuntimeError("This line should be impossible to reach.")
+
+    def _recommend_discrete(
+        self,
+        subspace_discrete: SubspaceDiscrete,
+        candidates_comp: pd.DataFrame,
+        batch_size: int,
+    ) -> pd.Index:
+        """Calculate recommendations in a discrete search space.
+
+        Args:
+            subspace_discrete: The discrete subspace in which the recommendations
+                should be made.
+            candidates_comp: The computational representation of all possible candidates
+            batch_size: The size of the calculated batch.
+
+        Raises:
+            NotImplementedError: If the function is not implemented by the child class.
+
+        Returns:
+            The indices of the recommended points with respect to the
+            computational representation.
+        """
+        try:
+            return self._recommend_hybrid(
+                searchspace=SearchSpace(
+                    discrete=subspace_discrete, continuous=SubspaceContinuous.empty()
+                ),
+                batch_size=batch_size,
+                candidates_comp=candidates_comp,
+            ).index
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                """Hybrid recommender could not be used as fallback when trying to
+                optimize a discrete space. This is probably due to your search space and
+                recommender not being compatible. Please verify that your search space
+                is purely discrete and that you are either using a discrete or hybrid
+                recommender."""
+            ) from exc
+
+    def _recommend_continuous(
+        self, subspace_continuous: SubspaceContinuous, batch_size: int
+    ) -> pd.DataFrame:
+        """Calculate recommendations in a continuous search space.
+
+        Args:
+            subspace_continuous: The continuous subspace in which the recommendations
+                should be made.
+            batch_size: The size of the calculated batch.
+
+        Raises:
+            NotImplementedError: If the function is not implemented by the child class.
+
+        Returns:
+            The recommended points.
+        """
+        # If this method is not implemented by a children class, try to call
+        # _recommend_hybrid instead.
+        try:
+            return self._recommend_hybrid(
+                searchspace=SearchSpace(
+                    discrete=SubspaceDiscrete.empty(), continuous=subspace_continuous
+                ),
+                batch_size=batch_size,
+            )
+        except NotImplementedError as exc:
+            raise NotImplementedError(
+                """Hybrid recommender could not be used as fallback when trying to
+                optimize a continuous space. This is probably due to your search space
+                and  recommender not being compatible. Please verify that your
+                search space is purely continuous and that you are either using a
+                continuous or hybrid recommender."""
+            ) from exc
+
+    def _recommend_hybrid(
+        self,
+        searchspace: SearchSpace,
+        batch_size: int,
+        candidates_comp: Optional[pd.DataFrame] = None,
+    ) -> pd.DataFrame:
+        """Calculate recommendations in a hybrid search space.
+
+        If the recommender does not implement additional functions for discrete and
+        continuous search spaces, this method is used as a fallback for those spaces
+        as well.
+
+        Args:
+            searchspace: The hybrid search space in which the recommendations should
+                be made.
+            batch_size: The size of the calculated batch.
+            candidates_comp: The computational representation of the candidates. This
+                is necessary for using this function as a fallback mechanism for
+                recommendations in discrete search spaces.
+
+        Raises:
+            NotImplementedError: If the function is not implemented by the child class.
+
+        Returns:
+            The recommended points.
+        """
+        raise NotImplementedError("Hybrid recommender is not implemented.")
 
     def _select_candidates_and_recommend(
         self,

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -20,73 +20,6 @@ from baybe.serialization import (
 )
 
 
-def _select_candidates_and_recommend(
-    searchspace: SearchSpace,
-    recommend_discrete: Callable[[SubspaceDiscrete, pd.DataFrame, int], pd.Index],
-    batch_size: int = 1,
-    allow_repeated_recommendations: bool = False,
-    allow_recommending_already_measured: bool = True,
-) -> pd.DataFrame:
-    """Select candidates in a discrete search space and recommend them.
-
-    This function is a workaround as this functionality is required for all purely
-    discrete recommenders and avoids the introduction of complicate class hierarchies.
-    It is also used to select candidates in the discrete part of hybrid search spaces,
-    ignoring the continuous part.
-
-    Args:
-        searchspace: The search space.
-        recommend_discrete: The Callable representing the discrete recommendation
-            function.
-        batch_size: The chosen batch size.
-        allow_repeated_recommendations: Allow to make recommendations that were already
-            recommended earlier.
-        allow_recommending_already_measured: Allow to output recommendations that were
-            measured previously.
-
-    Returns:
-        The recommendation in experimental representation.
-
-    Raises:
-        NotEnoughPointsLeftError: If there are fewer than ``batch_size`` points
-            left for potential recommendation.
-    """
-    # IMPROVE: See if the there is a more elegant way to share this functionality
-    #   among all purely discrete recommenders (without introducing complicates class
-    #   hierarchies).
-
-    # Get discrete candidates. The metadata flags are ignored if the search space
-    # has a continuous component.
-    _, candidates_comp = searchspace.discrete.get_candidates(
-        allow_repeated_recommendations=allow_repeated_recommendations
-        or not searchspace.continuous.is_empty,
-        allow_recommending_already_measured=allow_recommending_already_measured
-        or not searchspace.continuous.is_empty,
-    )
-
-    # Check if enough candidates are left
-    # TODO [15917]: This check is not perfectly correct.
-    if len(candidates_comp) < batch_size:
-        raise NotEnoughPointsLeftError(
-            f"Using the current settings, there are fewer than {batch_size} "
-            "possible data points left to recommend. This can be "
-            "either because all data points have been measured at some point "
-            "(while 'allow_repeated_recommendations' or "
-            "'allow_recommending_already_measured' being False) "
-            "or because all data points are marked as 'dont_recommend'."
-        )
-
-    # Get recommendations
-    idxs = recommend_discrete(searchspace.discrete, candidates_comp, batch_size)
-    rec = searchspace.discrete.exp_rep.loc[idxs, :]
-
-    # Update metadata
-    searchspace.discrete.metadata.loc[idxs, "was_recommended"] = True
-
-    # Return recommendations
-    return rec
-
-
 class RecommenderProtocol(Protocol):
     """Type protocol specifying the interface recommenders need to implement."""
 
@@ -127,6 +60,73 @@ class Recommender(ABC, RecommenderProtocol):
     allow_recommending_already_measured: bool = field(default=True, kw_only=True)
     """Allow to output recommendations that were measured previously. This only has an
     influence in discrete search spaces."""
+
+    @staticmethod
+    def _select_candidates_and_recommend(
+        searchspace: SearchSpace,
+        recommend_discrete: Callable[[SubspaceDiscrete, pd.DataFrame, int], pd.Index],
+        batch_size: int = 1,
+        allow_repeated_recommendations: bool = False,
+        allow_recommending_already_measured: bool = True,
+    ) -> pd.DataFrame:
+        """Select candidates in a discrete search space and recommend them.
+
+        This function is a workaround as this functionality is required for all purely
+        discrete recommenders and avoids the introduction of complicate class
+        hierarchies. It is also used to select candidates in the discrete part of hybrid
+        search spaces, ignoring the continuous part.
+
+        Args:
+            searchspace: The search space.
+            recommend_discrete: The Callable representing the discrete recommendation
+                function.
+            batch_size: The chosen batch size.
+            allow_repeated_recommendations: Allow to make recommendations that were
+                already recommended earlier.
+            allow_recommending_already_measured: Allow to output recommendations that
+                were measured previously.
+
+        Returns:
+            The recommendation in experimental representation.
+
+        Raises:
+            NotEnoughPointsLeftError: If there are fewer than ``batch_size`` points
+                left for potential recommendation.
+        """
+        # IMPROVE: See if the there is a more elegant way to share this functionality
+        #   among all purely discrete recommenders (without introducing complicates
+        #   class hierarchies).
+
+        # Get discrete candidates. The metadata flags are ignored if the search space
+        # has a continuous component.
+        _, candidates_comp = searchspace.discrete.get_candidates(
+            allow_repeated_recommendations=allow_repeated_recommendations
+            or not searchspace.continuous.is_empty,
+            allow_recommending_already_measured=allow_recommending_already_measured
+            or not searchspace.continuous.is_empty,
+        )
+
+        # Check if enough candidates are left
+        # TODO [15917]: This check is not perfectly correct.
+        if len(candidates_comp) < batch_size:
+            raise NotEnoughPointsLeftError(
+                f"Using the current settings, there are fewer than {batch_size} "
+                "possible data points left to recommend. This can be "
+                "either because all data points have been measured at some point "
+                "(while 'allow_repeated_recommendations' or "
+                "'allow_recommending_already_measured' being False) "
+                "or because all data points are marked as 'dont_recommend'."
+            )
+
+        # Get recommendations
+        idxs = recommend_discrete(searchspace.discrete, candidates_comp, batch_size)
+        rec = searchspace.discrete.exp_rep.loc[idxs, :]
+
+        # Update metadata
+        searchspace.discrete.metadata.loc[idxs, "was_recommended"] = True
+
+        # Return recommendations
+        return rec
 
 
 # Register (un-)structure hooks

--- a/baybe/recommenders/bayesian/base.py
+++ b/baybe/recommenders/bayesian/base.py
@@ -21,7 +21,6 @@ from baybe.acquisition import debotorchize
 from baybe.recommenders.base import Recommender
 from baybe.searchspace import (
     SearchSpace,
-    SearchSpaceType,
     SubspaceContinuous,
     SubspaceDiscrete,
 )
@@ -135,17 +134,7 @@ class BayesianRecommender(Recommender, ABC):
 
         self.setup_acquisition_function(searchspace, train_x, train_y)
 
-        if searchspace.type == SearchSpaceType.DISCRETE:
-            return self._select_candidates_and_recommend(
-                searchspace,
-                self._recommend_discrete,
-                batch_size,
-                self.allow_repeated_recommendations,
-                self.allow_recommending_already_measured,
-            )
-        if searchspace.type == SearchSpaceType.CONTINUOUS:
-            return self._recommend_continuous(searchspace.continuous, batch_size)
-        return self._recommend_hybrid(searchspace, batch_size)
+        return super().recommend(searchspace, batch_size, train_x, train_y)
 
     def _recommend_discrete(
         self,

--- a/baybe/recommenders/bayesian/base.py
+++ b/baybe/recommenders/bayesian/base.py
@@ -18,7 +18,7 @@ from botorch.acquisition import (
 )
 
 from baybe.acquisition import debotorchize
-from baybe.recommenders.base import Recommender, _select_candidates_and_recommend
+from baybe.recommenders.base import Recommender
 from baybe.searchspace import (
     SearchSpace,
     SearchSpaceType,
@@ -136,7 +136,7 @@ class BayesianRecommender(Recommender, ABC):
         self.setup_acquisition_function(searchspace, train_x, train_y)
 
         if searchspace.type == SearchSpaceType.DISCRETE:
-            return _select_candidates_and_recommend(
+            return self._select_candidates_and_recommend(
                 searchspace,
                 self._recommend_discrete,
                 batch_size,

--- a/baybe/recommenders/bayesian/base.py
+++ b/baybe/recommenders/bayesian/base.py
@@ -19,15 +19,8 @@ from botorch.acquisition import (
 
 from baybe.acquisition import debotorchize
 from baybe.recommenders.base import Recommender
-from baybe.searchspace import (
-    SearchSpace,
-    SubspaceContinuous,
-    SubspaceDiscrete,
-)
-from baybe.surrogates import (
-    _ONNX_INSTALLED,
-    GaussianProcessSurrogate,
-)
+from baybe.searchspace import SearchSpace
+from baybe.surrogates import _ONNX_INSTALLED, GaussianProcessSurrogate
 from baybe.surrogates.base import Surrogate
 from baybe.utils.dataframe import to_tensor
 
@@ -135,67 +128,3 @@ class BayesianRecommender(Recommender, ABC):
         self.setup_acquisition_function(searchspace, train_x, train_y)
 
         return super().recommend(searchspace, batch_size, train_x, train_y)
-
-    def _recommend_discrete(
-        self,
-        subspace_discrete: SubspaceDiscrete,
-        candidates_comp: pd.DataFrame,
-        batch_size: int,
-    ) -> pd.Index:
-        """Calculate recommendations in a discrete search space.
-
-        Args:
-            subspace_discrete: The discrete subspace in which the recommendations
-                should be made.
-            candidates_comp: The computational representation of all possible
-                candidates.
-            batch_size: The size of the calculated batch.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The indices of the recommended points with respect to the
-            computational representation.
-        """
-        raise NotImplementedError()
-
-    def _recommend_continuous(
-        self,
-        subspace_continuous: SubspaceContinuous,
-        batch_size: int,
-    ) -> pd.DataFrame:
-        """Calculate recommendations in a continuous search space.
-
-        Args:
-            subspace_continuous: The continuous subspace in which the recommendations
-                should be made.
-            batch_size: The size of the calculated batch.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The recommended points.
-        """
-        raise NotImplementedError()
-
-    def _recommend_hybrid(
-        self,
-        searchspace: SearchSpace,
-        batch_size: int,
-    ) -> pd.DataFrame:
-        """Calculate recommendations in a hybrid search space.
-
-        Args:
-            searchspace: The hybrid search space in which the recommendations should
-                be made.
-            batch_size: The size of the calculated batch.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The recommended points.
-        """
-        raise NotImplementedError()

--- a/baybe/recommenders/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/bayesian/sequential_greedy.py
@@ -137,6 +137,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
+        candidates_comp: pd.DataFrame,
         batch_size: int,
     ) -> pd.DataFrame:
         """Recommend points using the ``optimize_acqf_mixed`` function of BoTorch.
@@ -150,6 +151,8 @@ class SequentialGreedyRecommender(BayesianRecommender):
 
         Args:
             searchspace: The search space in which the recommendations should be made.
+            candidates_comp: The computational representation of the candidates
+                of the discrete subspace.
             batch_size: The size of the calculated batch.
 
         Returns:
@@ -159,12 +162,6 @@ class SequentialGreedyRecommender(BayesianRecommender):
             NoMCAcquisitionFunctionError: If a non Monte Carlo acquisition function
                 is chosen.
         """
-        # Get discrete candidates.
-        _, candidates_comp = searchspace.discrete.get_candidates(
-            allow_repeated_recommendations=True,
-            allow_recommending_already_measured=True,
-        )
-
         # Calculate the number of samples from the given percentage
         n_candidates = int(self.sampling_percentage * len(candidates_comp.index))
 

--- a/baybe/recommenders/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/bayesian/sequential_greedy.py
@@ -162,22 +162,27 @@ class SequentialGreedyRecommender(BayesianRecommender):
             NoMCAcquisitionFunctionError: If a non Monte Carlo acquisition function
                 is chosen.
         """
-        # Calculate the number of samples from the given percentage
-        n_candidates = int(self.sampling_percentage * len(candidates_comp.index))
+        if len(candidates_comp) > 0:
+            # Calculate the number of samples from the given percentage
+            n_candidates = int(self.sampling_percentage * len(candidates_comp.index))
 
-        # Potential sampling of discrete candidates
-        if self.hybrid_sampler == "Farthest":
-            ilocs = farthest_point_sampling(candidates_comp.values, n_candidates)
-            candidates_comp = candidates_comp.iloc[ilocs]
-        elif self.hybrid_sampler == "Random":
-            candidates_comp = candidates_comp.sample(n_candidates)
+            # Potential sampling of discrete candidates
+            if self.hybrid_sampler == "Farthest":
+                ilocs = farthest_point_sampling(candidates_comp.values, n_candidates)
+                candidates_comp = candidates_comp.iloc[ilocs]
+            elif self.hybrid_sampler == "Random":
+                candidates_comp = candidates_comp.sample(n_candidates)
 
-        # Prepare all considered discrete configurations in the List[Dict[int, float]]
-        # format expected by BoTorch
-        # TODO: Currently assumes that discrete parameters are first and continuous
-        #   second. Once parameter redesign [11611] is completed, we might adjust this.
-        candidates_comp.columns = list(range(len(candidates_comp.columns)))
-        fixed_features_list = candidates_comp.to_dict("records")
+            # Prepare all considered discrete configurations in the
+            # List[Dict[int, float]] format expected by BoTorch.
+            # TODO: Currently assumes that discrete parameters are first and continuous
+            #   second. Once parameter redesign [11611] is completed, we might adjust
+            #   this.
+            candidates_comp.columns = list(range(len(candidates_comp.columns)))
+            fixed_features_list = candidates_comp.to_dict("records")
+
+        else:
+            fixed_features_list = None
 
         # Actual call of the BoTorch optimization routine
         try:

--- a/baybe/recommenders/nonpredictive/base.py
+++ b/baybe/recommenders/nonpredictive/base.py
@@ -6,7 +6,7 @@ from typing import Optional
 import pandas as pd
 from attrs import define
 
-from baybe.recommenders.base import Recommender, _select_candidates_and_recommend
+from baybe.recommenders.base import Recommender
 from baybe.searchspace import (
     SearchSpace,
     SearchSpaceType,
@@ -29,7 +29,7 @@ class NonPredictiveRecommender(Recommender, ABC):
         # See base class.
 
         if searchspace.type == SearchSpaceType.DISCRETE:
-            return _select_candidates_and_recommend(
+            return self._select_candidates_and_recommend(
                 searchspace,
                 self._recommend_discrete,
                 batch_size,

--- a/baybe/recommenders/nonpredictive/base.py
+++ b/baybe/recommenders/nonpredictive/base.py
@@ -9,4 +9,4 @@ from baybe.recommenders.base import Recommender
 
 @define
 class NonPredictiveRecommender(Recommender, ABC):
-    """Abstract base class for recommenders that are non-predictive."""
+    """Abstract base class for all nonpredictive recommenders."""

--- a/baybe/recommenders/nonpredictive/base.py
+++ b/baybe/recommenders/nonpredictive/base.py
@@ -9,7 +9,6 @@ from attrs import define
 from baybe.recommenders.base import Recommender
 from baybe.searchspace import (
     SearchSpace,
-    SearchSpaceType,
     SubspaceContinuous,
     SubspaceDiscrete,
 )
@@ -18,29 +17,6 @@ from baybe.searchspace import (
 @define
 class NonPredictiveRecommender(Recommender, ABC):
     """Abstract base class for recommenders that are non-predictive."""
-
-    def recommend(  # noqa: D102
-        self,
-        searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
-    ) -> pd.DataFrame:
-        # See base class.
-
-        if searchspace.type == SearchSpaceType.DISCRETE:
-            return self._select_candidates_and_recommend(
-                searchspace,
-                self._recommend_discrete,
-                batch_size,
-                self.allow_repeated_recommendations,
-                self.allow_recommending_already_measured,
-            )
-        if searchspace.type == SearchSpaceType.CONTINUOUS:
-            return self._recommend_continuous(
-                subspace_continuous=searchspace.continuous, batch_size=batch_size
-            )
-        return self._recommend_hybrid(searchspace=searchspace, batch_size=batch_size)
 
     def _recommend_discrete(
         self,

--- a/baybe/recommenders/nonpredictive/base.py
+++ b/baybe/recommenders/nonpredictive/base.py
@@ -1,119 +1,12 @@
 """Base class for all nonpredictive recommenders."""
 
 from abc import ABC
-from typing import Optional
 
-import pandas as pd
 from attrs import define
 
 from baybe.recommenders.base import Recommender
-from baybe.searchspace import (
-    SearchSpace,
-    SubspaceContinuous,
-    SubspaceDiscrete,
-)
 
 
 @define
 class NonPredictiveRecommender(Recommender, ABC):
     """Abstract base class for recommenders that are non-predictive."""
-
-    def _recommend_discrete(
-        self,
-        subspace_discrete: SubspaceDiscrete,
-        candidates_comp: pd.DataFrame,
-        batch_size: int,
-    ) -> pd.Index:
-        """Calculate recommendations in a discrete search space.
-
-        Args:
-            subspace_discrete: The discrete subspace in which the recommendations
-                should be made.
-            candidates_comp: The computational representation of all possible candidates
-            batch_size: The size of the calculated batch.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The indices of the recommended points with respect to the
-            computational representation.
-        """
-        try:
-            return self._recommend_hybrid(
-                searchspace=SearchSpace(
-                    discrete=subspace_discrete, continuous=SubspaceContinuous.empty()
-                ),
-                batch_size=batch_size,
-                candidates_comp=candidates_comp,
-            ).index
-        except NotImplementedError as exc:
-            raise NotImplementedError(
-                """Hybrid recommender could not be used as fallback when trying to
-                optimize a discrete space. This is probably due to your search space and
-                recommender not being compatible. Please verify that your search space
-                is purely discrete and that you are either using a discrete or hybrid
-                recommender."""
-            ) from exc
-
-    def _recommend_continuous(
-        self, subspace_continuous: SubspaceContinuous, batch_size: int
-    ) -> pd.DataFrame:
-        """Calculate recommendations in a continuous search space.
-
-        Args:
-            subspace_continuous: The continuous subspace in which the recommendations
-                should be made.
-            batch_size: The size of the calculated batch.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The recommended points.
-        """
-        # If this method is not implemented by a children class, try to call
-        # _recommend_hybrid instead.
-        try:
-            return self._recommend_hybrid(
-                searchspace=SearchSpace(
-                    discrete=SubspaceDiscrete.empty(), continuous=subspace_continuous
-                ),
-                batch_size=batch_size,
-            )
-        except NotImplementedError as exc:
-            raise NotImplementedError(
-                """Hybrid recommender could not be used as fallback when trying to
-                optimize a continuous space. This is probably due to your search space
-                and  recommender not being compatible. Please verify that your
-                search space is purely continuous and that you are either using a
-                continuous or hybrid recommender."""
-            ) from exc
-
-    def _recommend_hybrid(
-        self,
-        searchspace: SearchSpace,
-        batch_size: int,
-        candidates_comp: Optional[pd.DataFrame] = None,
-    ) -> pd.DataFrame:
-        """Calculate recommendations in a hybrid search space.
-
-        If the recommender does not implement additional functions for discrete and
-        continuous search spaces, this method is used as a fallback for those spaces
-        as well.
-
-        Args:
-            searchspace: The hybrid search space in which the recommendations should
-                be made.
-            batch_size: The size of the calculated batch.
-            candidates_comp: The computational representation of the candidates. This
-                is necessary for using this function as a fallback mechanism for
-                recommendations in discrete search spaces.
-
-        Raises:
-            NotImplementedError: If the function is not implemented by the child class.
-
-        Returns:
-            The recommended points.
-        """
-        raise NotImplementedError("Hybrid recommender is not implemented.")

--- a/baybe/recommenders/nonpredictive/sampling.py
+++ b/baybe/recommenders/nonpredictive/sampling.py
@@ -1,6 +1,6 @@
 """Recommendation strategies based on sampling."""
 
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import numpy as np
 import pandas as pd
@@ -21,22 +21,18 @@ class RandomRecommender(NonPredictiveRecommender):
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
+        candidates_comp: pd.DataFrame,
         batch_size: int,
-        candidates_comp: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
 
         if searchspace.type == SearchSpaceType.DISCRETE:
-            if candidates_comp is None:
-                raise TypeError(
-                    """You did not provide a dataframe of candidates when applying the
-                    random recommender to a purely discrete space. Please ensure that
-                    this dataframe is not None."""
-                )
             return candidates_comp.sample(batch_size)
+
         cont_random = searchspace.continuous.samples_random(n_points=batch_size)
         if searchspace.type == SearchSpaceType.CONTINUOUS:
             return cont_random
+
         disc_candidates, _ = searchspace.discrete.get_candidates(True, True)
 
         # TODO decide mechanism if number of possible discrete candidates is smaller


### PR DESCRIPTION
This PR refactors the recommender methods and finally removes much of the boilerplate code that was caused by suboptimal class layouts/hierarchies. In particular:
* Common logic is now consistently pulled up to the base classes (e.g. the default `_recommend_*` methods and their fallback logic)
* The `_select_candidates_and_recommend` helper function has been decoupled from `SearchSpace` and is now integrated into the base class logic, avoiding unnecessary passing around of callables and flags
* With the new lean hierarchy, the signatures of all recommend-related methods have been unified across subclasses. In particular `_recommend_hybrid` now always expects the pre-selected discrete candidates, which are passed down from the highest hierarchy level. This provides a common interface, avoids confusing resetting of `allow_*` flags in subclasses, and passing these flags around in the first place.

Also, it fixes a bug when calling `optimize_acqf_mixed` with empty fixed features, which happens when hybrid recommendation is used a fallback for non-implemented continuous recommendation.