### PR TITLE
Bayesian recommendations from prior

### DIFF
--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -449,7 +449,7 @@ class SubspaceDiscrete(SerialMixin):
             A dataframe with the parameters in computational representation.
         """
         # If the transformed values are not required, return an empty dataframe
-        if self.empty_encoding or len(data) < 1:
+        if self.empty_encoding:
             comp_rep = pd.DataFrame(index=data.index)
             return comp_rep
 

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -147,8 +147,10 @@ class GaussianProcessSurrogate(Surrogate):
             covar_module=covar_module,
             likelihood=likelihood,
         )
-        mll = ExactMarginalLogLikelihood(self._model.likelihood, self._model)
-        # IMPROVE: The step_limit=100 stems from the former (deprecated)
-        #  `fit_gpytorch_torch` function, for which this was the default. Probably,
-        #   one should use a smarter logic here.
-        fit_gpytorch_mll_torch(mll, step_limit=100)
+
+        if train_x.numel() > 0:
+            mll = ExactMarginalLogLikelihood(self._model.likelihood, self._model)
+            # IMPROVE: The step_limit=100 stems from the former (deprecated)
+            #  `fit_gpytorch_torch` function, for which this was the default. Probably,
+            #   one should use a smarter logic here.
+            fit_gpytorch_mll_torch(mll, step_limit=100)

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -28,12 +28,7 @@ def _prepare_inputs(x: Tensor) -> Tensor:
 
     Returns:
         The prepared input.
-
-    Raises:
-        ValueError: If the model input is empty.
     """
-    if len(x) == 0:
-        raise ValueError("The model input must be non-empty.")
     return x.to(_DTYPE)
 
 

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -148,3 +148,9 @@ def test_iter_recommender_hybrid(campaign, n_iterations, batch_size):
 @pytest.mark.parametrize("strategy", valid_strategies, indirect=True)
 def test_strategies(campaign, n_iterations, batch_size):
     run_iterations(campaign, n_iterations, batch_size)
+
+
+@pytest.mark.parametrize("parameter_names", [["Num_disc_1", "Conti_finite3"]])
+def test_without_data(campaign, batch_size):
+    campaign.strategy = SequentialGreedyRecommender()
+    campaign.recommend(batch_size)


### PR DESCRIPTION
This PR enables the use of Bayesian recommenders for cases where no training data is available (i.e., using the prior only).