### PR TITLE
`ContinuousParameter` base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-style plotting capabilities for generated example plots
 - JSON file for plotting themes
 - Smoke testing in relevant tox environments
+- `ContinuousParameter` base class
 
 ### Changed
 - `Recommender`s now share their core logic via their base class

--- a/baybe/constraints/validation.py
+++ b/baybe/constraints/validation.py
@@ -4,7 +4,7 @@ from typing import List
 
 from baybe.constraints.base import Constraint
 from baybe.constraints.discrete import DiscreteDependenciesConstraint
-from baybe.parameters.base import Parameter
+from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parameter
 
 
 def validate_constraints(  # noqa: DOC101, DOC103
@@ -26,8 +26,12 @@ def validate_constraints(  # noqa: DOC101, DOC103
         )
 
     param_names_all = [p.name for p in parameters]
-    param_names_discrete = [p.name for p in parameters if p.is_discrete]
-    param_names_continuous = [p.name for p in parameters if not p.is_discrete]
+    param_names_discrete = [
+        p.name for p in parameters if isinstance(p, DiscreteParameter)
+    ]
+    param_names_continuous = [
+        p.name for p in parameters if isinstance(p, ContinuousParameter)
+    ]
     for constraint in constraints:
         if not all(p in param_names_all for p in constraint.parameters):
             raise ValueError(

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -33,9 +33,6 @@ class Parameter(ABC, SerialMixin):
     is_numeric: ClassVar[bool]
     """Class variable encoding whether this parameter is numeric."""
 
-    is_discrete: ClassVar[bool]
-    """Class variable encoding whether this parameter is discrete."""
-
     # object variables
     name: str = field(validator=(instance_of(str), min_len(1)))
     """The name of the parameter"""
@@ -59,9 +56,6 @@ class DiscreteParameter(Parameter, ABC):
     # TODO [15280]: needs to be refactored
 
     # class variables
-    is_discrete: ClassVar[bool] = True
-    # See base class.
-
     encoding: Optional[ParameterEncoding] = field(init=False, default=None)
     """An optional encoding strategy for the parameter."""
 
@@ -101,6 +95,11 @@ class DiscreteParameter(Parameter, ABC):
             transformed = data.to_frame()
 
         return transformed
+
+
+@define(frozen=True, slots=False)
+class ContinuousParameter(Parameter):
+    """Abstract class for continuous parameters."""
 
 
 # Register (un-)structure hooks

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -10,7 +10,7 @@ from attrs import define, field
 from attrs.validators import min_len
 
 from baybe.exceptions import NumericalUnderflowError
-from baybe.parameters.base import DiscreteParameter, Parameter
+from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
 from baybe.utils.interval import InfiniteIntervalError, Interval, convert_bounds
 from baybe.utils.numerical import DTypeFloatNumpy
@@ -96,14 +96,11 @@ class NumericalDiscreteParameter(DiscreteParameter):
 
 
 @define(frozen=True, slots=False)
-class NumericalContinuousParameter(Parameter):
+class NumericalContinuousParameter(ContinuousParameter):
     """Parameter class for continuous numerical parameters."""
 
     # class variables
     is_numeric: ClassVar[bool] = True
-    # See base class.
-
-    is_discrete: ClassVar[bool] = False
     # See base class.
 
     # object variables

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -16,11 +16,10 @@ from baybe.constraints import (
 )
 from baybe.constraints.base import Constraint, DiscreteConstraint
 from baybe.parameters import (
-    NumericalContinuousParameter,
     SubstanceEncoding,
     TaskParameter,
 )
-from baybe.parameters.base import DiscreteParameter, Parameter
+from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parameter
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.searchspace.validation import validate_parameters
@@ -118,20 +117,14 @@ class SearchSpace(SerialMixin):
             constraints = []
 
         discrete: SubspaceDiscrete = SubspaceDiscrete.from_product(
-            parameters=[
-                cast(DiscreteParameter, p) for p in parameters if p.is_discrete
-            ],
+            parameters=[p for p in parameters if isinstance(p, DiscreteParameter)],
             constraints=[
                 cast(DiscreteConstraint, c) for c in constraints if c.is_discrete
             ],
             empty_encoding=empty_encoding,
         )
         continuous: SubspaceContinuous = SubspaceContinuous(
-            parameters=[
-                cast(NumericalContinuousParameter, p)
-                for p in parameters
-                if not p.is_discrete
-            ],
+            parameters=[p for p in parameters if isinstance(p, ContinuousParameter)],
             constraints_lin_eq=[
                 cast(ContinuousLinearEqualityConstraint, c)
                 for c in constraints
@@ -177,8 +170,8 @@ class SearchSpace(SerialMixin):
                 "parameter names."
             )
 
-        disc_params = [p for p in parameters if p.is_discrete]
-        cont_params = [p for p in parameters if not p.is_discrete]
+        disc_params = [p for p in parameters if isinstance(p, DiscreteParameter)]
+        cont_params = [p for p in parameters if isinstance(p, ContinuousParameter)]
 
         return SearchSpace(
             discrete=SubspaceDiscrete.from_dataframe(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import zip_longest
-from typing import Any, Collection, Iterable, List, Optional, Tuple, cast
+from typing import Any, Collection, Iterable, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -484,14 +484,14 @@ def parameter_cartesian_prod_to_df(
     Returns:
         A dataframe containing all possible discrete parameter value combinations.
     """
-    lst_of_values = [
-        cast(DiscreteParameter, p).values for p in parameters if p.is_discrete
-    ]
-    lst_of_names = [p.name for p in parameters if p.is_discrete]
-    if len(lst_of_names) < 1:
+    discrete_parameters = [p for p in parameters if isinstance(p, DiscreteParameter)]
+    if not discrete_parameters:
         return pd.DataFrame()
 
-    index = pd.MultiIndex.from_product(lst_of_values, names=lst_of_names)
+    index = pd.MultiIndex.from_product(
+        [p.values for p in discrete_parameters],
+        names=[p.name for p in discrete_parameters],
+    )
     ret = pd.DataFrame(index=index).reset_index()
 
     return ret

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -10,6 +10,7 @@ import pandas as pd
 import torch
 from torch import Tensor
 
+from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.targets.enum import TargetMode
 from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
 
@@ -228,7 +229,7 @@ def add_parameter_noise(
             data[param.name] += np.random.uniform(-noise_level, noise_level, len(data))
 
         # Respect continuous intervals
-        if not param.is_discrete:
+        if isinstance(param, ContinuousParameter):
             data[param.name].clip(param.bounds.lower, param.bounds.upper, inplace=True)
 
 
@@ -382,7 +383,11 @@ def fuzzy_row_match(
 
         # Differentiate category-like and discrete numerical parameters
         cat_cols = [p.name for p in parameters if not p.is_numeric]
-        num_cols = [p.name for p in parameters if (p.is_numeric and p.is_discrete)]
+        num_cols = [
+            p.name
+            for p in parameters
+            if (p.is_numeric and isinstance(p, DiscreteParameter))
+        ]
 
         # Discrete parameters must match exactly
         match = left_df[cat_cols].eq(row[cat_cols]).all(axis=1, skipna=False)


### PR DESCRIPTION
This PR adds an abstract `ContinuousParameter` base class for consistency/symmetry reasons. This removes the necessity to maintain an explicit `is_discrete` class variable and allows to implement common methods (such as the new `_summary` method) on the base class.