### PR TITLE
Hotfix: Fallback for Windows-related getuser() issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Recommender`s now share their core logic via their base class
 
+### Fixed
+- Unhandled exception in telemetry when username could not be inferred on Windows
+
 ## [0.7.3] - 2024-02-09
 ### Added
 - Copy button for code blocks in documentation

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -111,8 +111,8 @@ try:
         hashlib.sha256(getpass.getuser().upper().encode()).hexdigest().upper()[:10]
     )  # this hash is irreversible and cannot identify the user or their machine
 except ModuleNotFoundError:
-    # getpass.getuser() does not work on Windows if none of the environment variables
-    # it checks are non-empty. Since then there is no way of inferring the username, we
+    # getpass.getuser() does not work on Windows if all the environment variables
+    # it checks are empty. Since then there is no way of inferring the username, we
     # use UNKNOWN as fallback.
     DEFAULT_TELEMETRY_USERNAME = "UNKNOWN"
 

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -105,9 +105,17 @@ DEFAULT_TELEMETRY_ENDPOINT = (
 )
 DEFAULT_TELEMETRY_VPN_CHECK = "true"
 DEFAULT_TELEMETRY_VPN_CHECK_TIMEOUT = "0.5"
-DEFAULT_TELEMETRY_USERNAME = (
-    hashlib.sha256(getpass.getuser().upper().encode()).hexdigest().upper()[:10]
-)  # this hash is irreversible and cannot identify the user or their machine
+
+try:
+    DEFAULT_TELEMETRY_USERNAME = (
+        hashlib.sha256(getpass.getuser().upper().encode()).hexdigest().upper()[:10]
+    )  # this hash is irreversible and cannot identify the user or their machine
+except ModuleNotFoundError:
+    # getpass.getuser() does not work on Windows if none of the environment variables
+    # it checks are non-empty. Since then there is no way of inferring the username, we
+    # use UNKNOWN as fallback.
+    DEFAULT_TELEMETRY_USERNAME = "UNKNOWN"
+
 DEFAULT_TELEMETRY_HOSTNAME = (
     hashlib.sha256(socket.gethostname().encode()).hexdigest().upper()[:10]
 )  # this hash is irreversible and cannot identify the user or their machine


### PR DESCRIPTION
Telemetry currently sues `getpass.getuser()` as suggested here https://stackoverflow.com/questions/3724634/cross-platform-solution-for-getting-current-login-name-in-python
to get the username of the current user

However, on Windows it can happen that this throws an exception. If non of the checked environment variables contains a username, the function goes via `import cwd` which will result in `ModuleNotFound` error on Windows. 

This hotfix simply catches that case and sets a default username for that case.

This should unblock baybe failing for some Windows users

This PR does NOT optimize order of operations in telemetry which will be revisited when enabling global Telemetry