### PR TITLE
Configurable Cache Dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON file for plotting themes
 - Smoke testing in relevant tox environments
 - `ContinuousParameter` base class
+- New environment variable `BAYBE_CACHE_DIR` that can customize the disk cache directory
+  or turn off disk caching entirely
 
 ### Changed
 - `Recommender`s now share their core logic via their base class

--- a/baybe/utils/chemistry.py
+++ b/baybe/utils/chemistry.py
@@ -1,6 +1,7 @@
 """Chemistry tools."""
 import os
 import ssl
+import tempfile
 import urllib.request
 from functools import lru_cache
 from pathlib import Path
@@ -26,7 +27,9 @@ _mordred_calculator = Calculator(descriptors)
 
 
 # Caching
-_cachedir = os.environ.get("BAYBE_CACHE_DIR", str(Path.home() / ".baybe_cache"))
+_cachedir = os.environ.get(
+    "BAYBE_CACHE_DIR", str(Path(tempfile.gettempdir()) / ".baybe_cache")
+)
 
 
 def _dummy_wrapper(func):

--- a/baybe/utils/chemistry.py
+++ b/baybe/utils/chemistry.py
@@ -36,11 +36,7 @@ def _dummy_wrapper(func):
     return func
 
 
-_disk_cache = (
-    _dummy_wrapper
-    if _cachedir == ""
-    else Memory(Path(_cachedir) / "utils" / "chemistry").cache
-)
+_disk_cache = _dummy_wrapper if _cachedir == "" else Memory(Path(_cachedir)).cache
 
 
 def name_to_smiles(name: str) -> str:

--- a/baybe/utils/chemistry.py
+++ b/baybe/utils/chemistry.py
@@ -1,5 +1,5 @@
 """Chemistry tools."""
-
+import os
 import ssl
 import urllib.request
 from functools import lru_cache
@@ -26,8 +26,18 @@ _mordred_calculator = Calculator(descriptors)
 
 
 # Caching
-_cachedir = Path.home() / ".baybe_cache"
-_memory_utils = Memory(_cachedir / "utils")
+_cachedir = os.environ.get("BAYBE_CACHE_DIR", str(Path.home() / ".baybe_cache"))
+
+
+def _dummy_wrapper(func):
+    return func
+
+
+_disk_cache = (
+    _dummy_wrapper
+    if _cachedir == ""
+    else Memory(Path(_cachedir) / "utils" / "chemistry").cache
+)
 
 
 def name_to_smiles(name: str) -> str:
@@ -65,7 +75,7 @@ def name_to_smiles(name: str) -> str:
 
 
 @lru_cache(maxsize=None)
-@_memory_utils.cache
+@_disk_cache
 def _smiles_to_mordred_features(smiles: str) -> np.ndarray:
     """Memory- and disk-cached computation of Mordred descriptors.
 


### PR DESCRIPTION
Make the cache directory configurable
This unblocks sue cases that could not sue baybe because a cache directory could not be created due to permission issues

- new environment variable `BAYBE_CACHE_DIR`
- CHANGED: if its not present, the folder `tempdir/.baybe_cache` will be used, `tempdir` is found via the builtin `tempfile` package which scans for folders enabled where the current user can write files, maybe theres a higher chance that this works compared to the userhome (eg in cases where theres no normal user like on foundry or docker etc)
- if its equal to "", disk caching is not done at all
- if its anything else it caches into the specified folder

Note that it would prob make sense to move some if this to a `utils/caching.py` but given its not used anywhere else I've not done that yet and its easily done when needed later