### PR TITLE
Hotfix: Telemetry Was Accidentally Disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Unhandled exception in telemetry when username could not be inferred on Windows
 - Metadata is now correctly updated for hybrid spaces
+- Unintended deactivation of telemetry due to import problem
 
 ## [0.7.3] - 2024-02-09
 ### Added

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -145,7 +145,8 @@ except ImportError:
     if strtobool(os.environ.get(VARNAME_TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED)):
         warnings.warn(
             "Opentelemetry could not be imported, potentially it is not installed. "
-            "Disabling baybe telemetry."
+            "Disabling baybe telemetry.",
+            UserWarning,
         )
     os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 
@@ -183,7 +184,8 @@ if is_enabled():
             warnings.warn(
                 f"WARNING: Value passed for environment variable "
                 f"{VARNAME_TELEMETRY_VPN_CHECK_TIMEOUT} is not a valid floating point "
-                f"number. Using default of {DEFAULT_TELEMETRY_VPN_CHECK_TIMEOUT}."
+                f"number. Using default of {DEFAULT_TELEMETRY_VPN_CHECK_TIMEOUT}.",
+                UserWarning,
             )
             _TIMEOUT_S = float(DEFAULT_TELEMETRY_VPN_CHECK_TIMEOUT)
 
@@ -221,6 +223,7 @@ if is_enabled():
             f"WARNING: BayBE Telemetry endpoint {_endpoint_url} cannot be reached. "
             "Disabling telemetry. The exception encountered was: "
             f"{type(ex).__name__}, {ex}",
+            UserWarning,
         )
         os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -78,7 +78,7 @@ import hashlib
 import logging
 import os
 import socket
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import Dict, List, Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -137,13 +137,10 @@ try:
     from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
         OTLPMetricExporter,
     )
-    from opentelemetry.metrics import get_meter, set_meter_provider
+    from opentelemetry.metrics import Histogram, get_meter, set_meter_provider
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.resources import Resource
-
-    if TYPE_CHECKING:
-        from opentelemetry.metrics import Histogram
 except ImportError:
     # Failed telemetry install/import should not fail baybe, so telemetry is being
     # disabled in that case


### PR DESCRIPTION
- telemetry was accidentally disabled since mypy was activated for this module
- reason was: import caused an exception at runtime
- that exception was however broad accepted and telemetry disabled
- although this board except has caused a hidden issue here, its still the way to go as we dont want any user affected by any telemetry issue

in this process the old `logger` way of warning was replaced by the `warnings.warn`, as was recently done in various other submodules