### PR TITLE
Add line wrap for examples in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unhandled exception in telemetry when username could not be inferred on Windows
 - Metadata is now correctly updated for hybrid spaces
 - Unintended deactivation of telemetry due to import problem
+- Line wrapping in examples
 
 ## [0.7.3] - 2024-02-09
 ### Added

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -167,18 +167,18 @@ def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
                 content = markdown_file.read()
                 wrapped_lines = []
                 for line in content.splitlines():
+                    if "![svg]" in line or "![png]" in line or "<Figure size" in line:
+                        continue
                     if len(line) > 88 and "](" not in line:
                         wrapped = textwrap.wrap(line, width=88)
                         wrapped_lines.extend(wrapped)
                     else:
                         wrapped_lines.append(line)
 
-                lines = "\n".join(wrapped_lines)
+            # Add a manual new line to each of the lines
+            lines = [line + "\n" for line in wrapped_lines]
             # Delete lines we do not want to have in our documentation
-            lines = [line for line in lines if "![svg]" not in line]
-            lines = [line for line in lines if "![png]" not in line]
-            lines = [line for line in lines if "<Figure size" not in line]
-
+            # lines = [line for line in lines if "![svg]" not in line]
             # We check whether pre-built light and dark plots exist. If so, we append
             # corresponding lines to our markdown file for including them.
             light_figure = pathlib.Path(sub_directory / (file_name + "_light.svg"))

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import shutil
+import textwrap
 from subprocess import DEVNULL, STDOUT, check_call
 
 from tqdm import tqdm
@@ -158,11 +159,21 @@ def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
             )
 
             # CLEANUP
-            # Remove all lines that try to include a png file
             markdown_path = file.with_suffix(".md")
+            # We wrap lines which are too long as long as they do not contain a link.
+            # To discover whether a line contains a link, we check if the string "]("
+            # is contained.
             with open(markdown_path, "r", encoding="UTF-8") as markdown_file:
-                lines = markdown_file.readlines()
+                content = markdown_file.read()
+                wrapped_lines = []
+                for line in content.splitlines():
+                    if len(line) > 88 and "](" not in line:
+                        wrapped = textwrap.wrap(line, width=88)
+                        wrapped_lines.extend(wrapped)
+                    else:
+                        wrapped_lines.append(line)
 
+                lines = "\n".join(wrapped_lines)
             # Delete lines we do not want to have in our documentation
             lines = [line for line in lines if "![svg]" not in line]
             lines = [line for line in lines if "![png]" not in line]


### PR DESCRIPTION
This PR ensures that long lines are wrapped in the files that are created when executing the examples as jupyter notebooks.

A line is now wrapped when it is longer than the size that we allow for our python code, which is 88 characters. The only exception is when a link in detected since a line wrap might break this link.  This is done by checking whether the sequence `](` is present in the line.