### PR TITLE
Remove progress bar in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `Recommender`s now share their core logic via their base class
+- Remove progress bars in examples
 
 ### Fixed
 - Unhandled exception in telemetry when username could not be inferred on Windows

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -166,8 +166,15 @@ def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
             with open(markdown_path, "r", encoding="UTF-8") as markdown_file:
                 content = markdown_file.read()
                 wrapped_lines = []
+                ignored_substrings = (
+                    "![svg]",
+                    "![png]",
+                    "<Figure size",
+                    "it/s",
+                    "s/it",
+                )
                 for line in content.splitlines():
-                    if "![svg]" in line or "![png]" in line or "<Figure size" in line:
+                    if any(substring in line for substring in ignored_substrings):
                         continue
                     if len(line) > 88 and "](" not in line:
                         wrapped = textwrap.wrap(line, width=88)


### PR DESCRIPTION
This PR removes the ugly progress bars in the executed examples.

The progress bars are automatically created by `xzypy` when executing our various simulation methods. Since I did not want to change these functionalities and since I did not find any "global" way of deactivating the progress bars, they are now removed in the post-processing of the example scripts. The corresponding lines are identified via the substring `s/it` and `it/s` and are removed.