### PR TITLE
HOTFIX: Ignore newly found ONNX vulnerabilities

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,9 @@ extras = dev # audit entire environment
 setenv =
     # Add pip-audit exceptions here, like:
     # EXCLUDES=--ignore-vuln EXCEPTION_ID1 --ignore-vuln EXCEPTION_ID2 ...
+    # ONNX Vulnerabilities that appear in versions <= 1.15.0
+    # TODO Check in March once 1.16.0 is being released
+    EXCLUDES=--ignore-vuln GHSA-h8wv-9h96-m4hr --ignore-vuln GHSA-whh8-fjgc-qp73
 commands =
     python --version
     pip-audit {env:EXCLUDES:}


### PR DESCRIPTION
This PR includes two ONNX vulnerabilities that were found just recently and concern all version <=1.15.0

Since version 1.16.0 is planned for March 18, this hotfix will be re-evaluated in March.