### PR TITLE
Include SMOKE_TEST in examples

### DIFF
--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -12,6 +12,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -33,8 +35,16 @@ from baybe.targets import NumericalTarget
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 
-N_MC_ITERATIONS = 2
-N_DOE_ITERATIONS = 2
+# The parameter `POINTS_PER_DIM` controls the number of points per dimension.
+# Note that the searchspace will have `POINTS_PER_DIM**DIMENSION` many points.
+
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 5
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 5
+DIMENSION = 4
+BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
+POINTS_PER_DIM = 3 if SMOKE_TEST else 10
 
 ### Defining the test function
 
@@ -49,22 +59,15 @@ def sum_of_squares(*x: float) -> float:
     return res
 
 
-DIMENSION = 4
-BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
-
 ### Creating the searchspace and the objective
 
 # As we expect it to be the most common use case, we construct a purely discrete space here.
 # Details on how to adjust this for other spaces can be found in the searchspace examples.
 
-# The parameter `POINTS_PER_DIM` controls the number of points per dimension.
-# Note that the searchspace will have `POINTS_PER_DIM**DIMENSION` many points.
-
-POINTS_PER_DIM = 10
 parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k+1}",
-        values=list(np.linspace(*BOUNDS[k], 15)),
+        values=list(np.linspace(*BOUNDS[k], POINTS_PER_DIM)),
         tolerance=0.01,
     )
     for k in range(DIMENSION)

--- a/examples/Backtesting/full_initial_data.py
+++ b/examples/Backtesting/full_initial_data.py
@@ -10,6 +10,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -28,7 +30,10 @@ from baybe.targets import NumericalTarget
 # Since this example uses initial data, we only need to define the number of iterations per run.
 # The number of runs is determined by the number of initial data points provided.
 
-N_DOE_ITERATIONS = 5
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 5
+BATCH_SIZE = 1 if SMOKE_TEST else 3
 
 ### Lookup functionality and data creation
 
@@ -127,7 +132,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_size=3,
+    batch_size=BATCH_SIZE,
     n_doe_iterations=N_DOE_ITERATIONS,
     initial_data=initial_data,
 )

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -8,6 +8,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -25,8 +27,11 @@ from baybe.targets import NumericalTarget
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 
-N_DOE_ITERATIONS = 5
-N_MC_ITERATIONS = 3
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 5
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 3
+BATCH_SIZE = 1 if SMOKE_TEST else 3
 
 ### Lookup functionality and data creation
 
@@ -119,7 +124,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_size=3,
+    batch_size=BATCH_SIZE,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -9,6 +9,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
 import seaborn as sns
@@ -30,9 +32,14 @@ from baybe.targets import NumericalTarget
 
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
+# `POINTS_PER_DIM` denotes how many points each discrete dimension should contain.
 
-N_MC_ITERATIONS = 2
-N_DOE_ITERATIONS = 2
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 5
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 5
+POINTS_PER_DIM = 3 if SMOKE_TEST else 6
+
 
 ### Defining the test function.
 
@@ -72,13 +79,6 @@ if set(CONT_INDICES + DISC_INDICES) != set(range(DIMENSION)):
         "indices do not match."
     )
 
-# The following parameter decides how many points each discrete dimension should have.
-# Note that this example uses the `SequentialGreedyRecommender` (among others).
-# This recommender performs a brute-force optimization over the discrete subspace.
-# We thus heavily advise to keep the number of discrete parameters and points rather small here.
-
-POINTS_PER_DIM = 6
-
 
 # Construct the continuous parameters as NumericContinuous parameters.
 
@@ -114,7 +114,7 @@ objective = Objective(
 ### Constructing campaigns for the simulation loop
 
 # This example compares three different available hybrid recommenders:
-# The `SequentialGreedyRecommender`, the `NaiveHybridSpaceRecommedner` and the `RandomRecommender`.
+# The `SequentialGreedyRecommender`, the `NaiveHybridSpaceRecommender` and the `RandomRecommender`.
 # For each of them, we initialize one recommender object.
 # Note that it is possible to further specify the behavior of the `SequentialGreedyRecommender`.
 # Using the two keywords `hybrid_sampler` and `sampling_percentage`, one can control

--- a/examples/Backtesting/impute_mode.py
+++ b/examples/Backtesting/impute_mode.py
@@ -9,6 +9,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -26,8 +28,11 @@ from baybe.targets import NumericalTarget
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 
-N_MC_ITERATIONS = 2
-N_DOE_ITERATIONS = 5
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 5
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 5
+BATCH_SIZE = 1 if SMOKE_TEST else 3
 
 ### Lookup functionality and data creation
 
@@ -127,7 +132,7 @@ scenarios = {"Test_Scenario": campaign, "Random": campaign_rand}
 results = simulate_scenarios(
     scenarios,
     lookup,
-    batch_size=3,
+    batch_size=BATCH_SIZE,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
     impute_mode="best",

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -11,6 +11,7 @@
 
 ### Necessary imports for this example
 
+import os
 from typing import Tuple
 
 import numpy as np
@@ -27,11 +28,17 @@ from baybe.targets import NumericalTarget
 # For the full simulation, we need to define some additional parameters.
 # These are the number of Monte Carlo runs and the number of experiments to be conducted per run.
 
-N_MC_ITERATIONS = 2
-N_DOE_ITERATIONS = 4
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 5
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 4
+BATCH_SIZE = 1 if SMOKE_TEST else 2
+DIMENSION = 4
+BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
+POINTS_PER_DIM = 3 if SMOKE_TEST else 10
+
 
 ### Defining the test function
-
 
 # See [`custom_analytical`](./custom_analytical.md) for details.
 
@@ -44,9 +51,6 @@ def sum_of_squares(*x: float) -> Tuple[float, float]:
     return res, 2 * res**2 - 1
 
 
-DIMENSION = 4
-BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
-
 ### Creating the searchspace
 
 # In this example, we construct a purely discrete space with 10 points per dimension.
@@ -54,7 +58,7 @@ BOUNDS = [(-2, 2), (-2, 2), (-2, 2), (-2, 2)]
 parameters = [
     NumericalDiscreteParameter(
         name=f"x_{k+1}",
-        values=list(np.linspace(*BOUNDS[k], 10)),
+        values=list(np.linspace(*BOUNDS[k], POINTS_PER_DIM)),
         tolerance=0.01,
     )
     for k in range(DIMENSION)
@@ -103,7 +107,7 @@ scenarios = {"BayBE": campaign}
 results = simulate_scenarios(
     scenarios,
     sum_of_squares,
-    batch_size=2,
+    batch_size=BATCH_SIZE,
     n_doe_iterations=N_DOE_ITERATIONS,
     n_mc_iterations=N_MC_ITERATIONS,
 )

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -12,6 +12,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import numpy as np
 from botorch.test_functions import Rastrigin
 
@@ -88,8 +90,12 @@ campaign = Campaign(
     objective=objective,
 )
 
-BATCH_SIZE = 3
-N_ITERATIONS = 3
+# Improve running time for CI via SMOKE_TEST
+
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+BATCH_SIZE = 2 if SMOKE_TEST else 3
+N_ITERATIONS = 2 if SMOKE_TEST else 3
 
 for k in range(N_ITERATIONS):
     recommendation = campaign.recommend(batch_size=BATCH_SIZE)

--- a/examples/Constraints_Discrete/custom_constraints.py
+++ b/examples/Constraints_Discrete/custom_constraints.py
@@ -8,6 +8,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import numpy as np
 import pandas as pd
 
@@ -26,6 +28,11 @@ from baybe.utils.dataframe import add_fake_results
 ### Experiment setup
 
 # We begin by setting up some parameters for our experiments.
+# `TEMPERATURE_RESOLUTION` describes the number of different temperatures used.
+
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+TEMPERATURE_RESOLUTION = 3 if SMOKE_TEST else 10
+
 dict_solvent = {
     "water": "O",
     "C1": "C",
@@ -41,7 +48,9 @@ speed = CategoricalParameter(
     "Speed", values=["very slow", "slow", "normal", "fast", "very fast"], encoding="INT"
 )
 temperature = NumericalDiscreteParameter(
-    "Temperature", values=list(np.linspace(100, 200, 10)), tolerance=0.5
+    "Temperature",
+    values=list(np.linspace(100, 200, TEMPERATURE_RESOLUTION)),
+    tolerance=0.5,
 )
 concentration = NumericalDiscreteParameter(
     "Concentration", values=[1, 2, 5, 10], tolerance=0.4

--- a/examples/Constraints_Discrete/dependency_constraints.py
+++ b/examples/Constraints_Discrete/dependency_constraints.py
@@ -9,6 +9,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import numpy as np
 
 from baybe import Campaign
@@ -25,6 +27,9 @@ from baybe.utils.dataframe import add_fake_results
 
 ### Experiment setup
 
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+FRAC_RESOLUTION = 3 if SMOKE_TEST else 7
+
 dict_solvent = {
     "water": "O",
     "C1": "C",
@@ -33,7 +38,7 @@ solvent = SubstanceParameter(name="Solv", data=dict_solvent, encoding="MORDRED")
 switch1 = CategoricalParameter(name="Switch1", values=["on", "off"])
 switch2 = CategoricalParameter(name="Switch2", values=["left", "right"])
 fraction1 = NumericalDiscreteParameter(
-    name="Frac1", values=list(np.linspace(0, 100, 7)), tolerance=0.2
+    name="Frac1", values=list(np.linspace(0, 100, FRAC_RESOLUTION)), tolerance=0.2
 )
 frame1 = CategoricalParameter(name="FrameA", values=["A", "B"])
 frame2 = CategoricalParameter(name="FrameB", values=["A", "B"])
@@ -72,7 +77,7 @@ print(campaign)
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 
-N_ITERATIONS = 5
+N_ITERATIONS = 2 if SMOKE_TEST else 5
 for kIter in range(N_ITERATIONS):
     print(f"\n#### ITERATION {kIter+1} ####")
 

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -11,6 +11,7 @@
 ### Necessary imports for this example
 
 import math
+import os
 
 import numpy as np
 
@@ -34,6 +35,11 @@ from baybe.utils.dataframe import add_fake_results
 
 SUM_TOLERANCE = 1.0
 
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+# This parameter denotes the resolution of the discretization of the parameters
+RESOLUTION = 3 if SMOKE_TEST else 12
+
 dict_solvents = {
     "water": "O",
     "C1": "C",
@@ -47,13 +53,13 @@ solvent3 = SubstanceParameter(name="Solv3", data=dict_solvents, encoding="MORDRE
 # Parameters for representing the fraction.
 
 fraction1 = NumericalDiscreteParameter(
-    name="Frac1", values=list(np.linspace(0, 100, 12)), tolerance=0.2
+    name="Frac1", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.2
 )
 fraction2 = NumericalDiscreteParameter(
-    name="Frac2", values=list(np.linspace(0, 100, 12)), tolerance=0.2
+    name="Frac2", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.2
 )
 fraction3 = NumericalDiscreteParameter(
-    name="Frac3", values=list(np.linspace(0, 100, 12)), tolerance=0.2
+    name="Frac3", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.2
 )
 
 parameters = [solvent1, solvent2, solvent3, fraction1, fraction2, fraction3]
@@ -113,7 +119,7 @@ print(campaign)
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 
-N_ITERATIONS = 3
+N_ITERATIONS = 2 if SMOKE_TEST else 3
 for kIter in range(N_ITERATIONS):
     print(f"\n#### ITERATION {kIter+1} ####")
 

--- a/examples/Constraints_Discrete/prodsum_constraints.py
+++ b/examples/Constraints_Discrete/prodsum_constraints.py
@@ -7,6 +7,8 @@
 
 ### Necessary imports for this example
 
+import os
+
 import numpy as np
 
 from baybe import Campaign
@@ -27,6 +29,10 @@ from baybe.utils.dataframe import add_fake_results
 
 ### Experiment setup
 
+SMOKE_TEST = "SMOKE_TEST" in os.environ
+
+RESOLUTION = 3 if SMOKE_TEST else 5
+
 dict_solvent = {
     "water": "O",
     "C1": "C",
@@ -37,22 +43,22 @@ speed = CategoricalParameter(
     name="Speed", values=["slow", "normal", "fast"], encoding="INT"
 )
 num_parameter_1 = NumericalDiscreteParameter(
-    name="NumParam1", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam1", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 num_parameter_2 = NumericalDiscreteParameter(
-    name="NumParam2", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam2", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 num_parameter_3 = NumericalDiscreteParameter(
-    name="NumParam3", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam3", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 num_parameter_4 = NumericalDiscreteParameter(
-    name="NumParam4", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam4", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 num_parameter_5 = NumericalDiscreteParameter(
-    name="NumParam5", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam5", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 num_parameter_6 = NumericalDiscreteParameter(
-    name="NumParam6", values=list(np.linspace(0, 100, 5)), tolerance=0.5
+    name="NumParam6", values=list(np.linspace(0, 100, RESOLUTION)), tolerance=0.5
 )
 
 parameters = [
@@ -103,7 +109,7 @@ print(campaign)
 
 # The following loop performs some recommendations and manually verifies the given constraints.
 
-N_ITERATIONS = 5
+N_ITERATIONS = 2 if SMOKE_TEST else 5
 for kIter in range(N_ITERATIONS):
     print(f"\n\n#### ITERATION {kIter+1} ####")
 


### PR DESCRIPTION
This PR activates SMOKE_TEST in all of the examples.

Most parameters are set to 2 or 3 when SMOKE_TEST is set. The values chosen when SMOKE_TEST is not being activated are mostly those that were used previously or some slightly larger numbers than 2 or 3 if these were already used previously.