### PR TITLE
Feature/pretty print campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Better human readable `__str__` representation of campaign
+
 ### Changed
 - [WIP] `torch` is loaded lazily
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -82,6 +82,21 @@ class Campaign(SerialMixin):
     numerical_measurements_must_be_within_tolerance: bool = field(default=None)
     """Deprecated! Raises an error when used."""
 
+    def __str__(self) -> str:
+        start_bold = "\033[1m"
+        end_bold = "\033[0m"
+
+        # Get str representation of campaign fields
+        fields_to_print = [self.searchspace, self.objective, self.recommender]
+        fields_str = "\n\n".join(str(x) for x in fields_to_print)
+
+        # Put all relevant attributes of the campaign in one string
+        campaign_str = f"""{start_bold}Campaign{end_bold}
+        \n{start_bold}Meta Data{end_bold}\nBatches Done: {self.n_batches_done}
+        \rFits Done: {self.n_fits_done}\n\n{fields_str}\n"""
+
+        return campaign_str.replace("\n", "\n ").replace("\r", "\r ")
+
     strategy: RecommenderProtocol = field(default=None)
     """Deprecated! Raises an error when used."""
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -61,14 +61,14 @@ class SubspaceContinuous(SerialMixin):
         lin_ineq_constr_df = pd.DataFrame(ineq_constraints_list)
 
         # Put all attributes of the continuous class in one string
-        continuous_str = f"""\n\n{start_bold}|--> Continuous search space
-            \nContinuous Parameters{end_bold}\n{pretty_print_df(param_df)}
-            \n{start_bold}List of linear equality constraints{end_bold}
-            \n{pretty_print_df(lin_eq_constr_df)}
-            \n{start_bold}List of linear inequality constraints{end_bold}
-            \n{pretty_print_df(lin_ineq_constr_df)}\n\n"""
+        continuous_str = f"""{start_bold}Continuous Search Space{end_bold}
+            \n{start_bold}Continuous Parameters{end_bold}\n{pretty_print_df(param_df)}
+            \n{start_bold}List of Linear Equality Constraints{end_bold}
+            \r{pretty_print_df(lin_eq_constr_df)}
+            \n{start_bold}List of Linear Inequality Constraints{end_bold}
+            \r{pretty_print_df(lin_ineq_constr_df)}"""
 
-        return continuous_str
+        return continuous_str.replace("\n", "\n ").replace("\r", "\r ")
 
     @classmethod
     def empty(cls) -> SubspaceContinuous:

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -68,12 +68,11 @@ class SearchSpace(SerialMixin):
     def __str__(self) -> str:
         start_bold = "\033[1m"
         end_bold = "\033[0m"
-        print(
-            f"""\n\n{start_bold}***** SEARCH SPACE *****
-        \nSearch space type: {end_bold}{self.type.name}\n"""
-        )
-
-        return str(self.discrete) + str(self.continuous)
+        searchspace_str = f"""{start_bold}Search Space{end_bold}
+        \n{start_bold}Search Space Type: {end_bold}{self.type.name}
+        \n{self.discrete}
+        \n{self.continuous}"""
+        return searchspace_str.replace("\n", "\n ").replace("\r", "\r ")
 
     def __attrs_post_init__(self):
         """Perform validation and record telemetry values."""

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -84,18 +84,18 @@ class SubspaceDiscrete(SerialMixin):
         metadata_count = len(self.metadata)
 
         # Put all attributes of the discrete class in one string.
-        discrete_str = f"""{start_bold}|--> Discrete search space
-            \nDiscrete Parameters{end_bold}\n{pretty_print_df(param_df)}
+        discrete_str = f"""{start_bold}Discrete Search Space{end_bold}
+            \n{start_bold}Discrete Parameters{end_bold}\n{pretty_print_df(param_df)}
             \n{start_bold}Experimental Representation{end_bold}
-            \n{pretty_print_df(self.exp_rep)}\n{start_bold}\nMetadata:{end_bold}
+            \r{pretty_print_df(self.exp_rep)}\n\n{start_bold}Metadata:{end_bold}
             \r{_METADATA_COLUMNS[0]}: {was_recommended_count}/{metadata_count}
             \r{_METADATA_COLUMNS[1]}: {was_measured_count}/{metadata_count}
             \r{_METADATA_COLUMNS[2]}: {dont_recommend_count}/{metadata_count}
             \n{start_bold}Constraints{end_bold}\n{pretty_print_df(constraints_df)}
-            \n{start_bold}Computational representation of the space{end_bold}
-            \n{pretty_print_df(self.comp_rep)}\n\n"""
+            \n{start_bold}Computational Representation{end_bold}
+            \r{pretty_print_df(self.comp_rep)}"""
 
-        return discrete_str
+        return discrete_str.replace("\n", "\n ").replace("\r", "\r ")
 
     @exp_rep.validator
     def _validate_exp_rep(  # noqa: DOC101, DOC103


### PR DESCRIPTION
This PR applies the pretty printing concept to campaign. 

- implement the `__str__`  of campaign 
- re-formate the `__str__` of search space  to fix the output order

The current output after executing `print(campaign)` looks like this:
![image](https://github.com/emdgroup/baybe/assets/118910837/ecda7cce-58da-442f-b57f-05d52be6aade)
![image](https://github.com/emdgroup/baybe/assets/118910837/0a92aa56-ebf4-4679-8d3b-09aca8acc67f)

