### PR TITLE
Enable Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.11, except the fulltest which is also run in 3.9
+# - This runs everything in Python 3.12, except the fulltest which is also run in 3.9
 # - Only coretest and fulltest environments are cached due to space limit
 
 name: Continuous Integration
@@ -53,7 +53,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        py-version: [ {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.12', tox: 'py312'} ]
     name: Lint ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -78,17 +78,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.11"}
+        with: {python-version: "3.12"}
       - name: Build Docs
         run: |
           pip install tox
-          tox -e docs-py311 -- -e
+          tox -e docs-py312 -- -e
           
   typecheck:
     needs: [lint]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.12', tox: 'py312'} ]
     name: Type Check ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -106,7 +106,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.12', tox: 'py312'} ]
     name: Audit ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -146,7 +146,7 @@ jobs:
     needs: [typecheck, audit]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.12', tox: 'py312'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -1,6 +1,6 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.9, 3.10 and 3.11
+# - This runs everything in Python 3.9, 3.10, 3.11 and 3.12
 # - No environments are cached due to space limit
 
 name: Regular Checks
@@ -40,17 +40,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.9"}
+        with: {python-version: "3.12"}
       - name: Build Docs
         run: |
           pip install tox
-          tox -e docs-py39
+          tox -e docs-py312
 
   lint:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.10', tox: 'py310'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'},
+                      {semantic: '3.10', tox: 'py310'},
+                      {semantic: '3.11', tox: 'py311'},
+                      {semantic: '3.12', tox: 'py312'} ]
     name: Lint ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +72,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.10', tox: 'py310'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'},
+                      {semantic: '3.10', tox: 'py310'},
+                      {semantic: '3.11', tox: 'py311'},
+                      {semantic: '3.12', tox: 'py312'} ]
     name: Type Check ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +94,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.10', tox: 'py310'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'},
+                      {semantic: '3.10', tox: 'py310'},
+                      {semantic: '3.11', tox: 'py311'},
+                      {semantic: '3.12', tox: 'py312'} ]
     name: Audit ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +116,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.10', tox: 'py310'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'},
+                      {semantic: '3.10', tox: 'py310'},
+                      {semantic: '3.11', tox: 'py311'},
+                      {semantic: '3.12', tox: 'py312'} ]
     name: Core Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -130,7 +142,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.10', tox: 'py310'}, {semantic: '3.11', tox: 'py311'} ]
+        py-version: [ {semantic: '3.9', tox: 'py39'},
+                      {semantic: '3.10', tox: 'py310'},
+                      {semantic: '3.11', tox: 'py311'},
+                      {semantic: '3.12', tox: 'py312'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -40,11 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.12"}
+        with: {python-version: "3.9"}
       - name: Build Docs
         run: |
           pip install tox
-          tox -e docs-py312
+          tox -e docs-py39
 
   lint:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Clean
         run: |
           python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist")]'
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install test-package
         run: |
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ baybe==${{  github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now contains an example on substance encoding results
 - Transfer learning user guide
 - `from_simplex` constructor now also takes and applies optional constraints
+- Support for Python 3.12
 
 ### Changed
 - Full lookup backtesting example now tests different substance encodings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,9 @@ we recommend the following workflow:
    You can retrieve all available environments via `tox list`.
    For more information, see our [README about tests](https://github.com/emdgroup/baybe/blob/main/tests/README.md).
    
-   For instance, running all code tests in Python 3.11 can be achieved via:
+   For instance, running all code tests in Python 3.12 can be achieved via:
    ```console
-   tox -e fulltest-py311
+   tox -e fulltest-py312
    ```
 
    If you want to challenge your machine, you can run all checks in all Python versions

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -28,12 +28,6 @@ from baybe.telemetry import (
 )
 from baybe.utils.boolean import eq_dataframe
 
-# Converter for config validation
-_validation_converter = converter.copy()
-_validation_converter.register_structure_hook(
-    SearchSpace, validate_searchspace_from_config
-)
-
 
 @define
 class Campaign(SerialMixin):
@@ -342,3 +336,10 @@ converter.register_unstructure_hook(
     Campaign, lambda x: _add_version(unstructure_hook(x))
 )
 converter.register_structure_hook(Campaign, structure_hook)
+
+
+# Converter for config validation
+_validation_converter = converter.copy()
+_validation_converter.register_structure_hook(
+    SearchSpace, validate_searchspace_from_config
+)

--- a/docs/userguide/transfer_learning.md
+++ b/docs/userguide/transfer_learning.md
@@ -59,7 +59,7 @@ TaskParameter(
     active_values=["3,5-dimethylisoxazole"],
 )
 TaskParameter(
-    name="Month",
+    name="Cell_Line",
     values=["Liver cell", "Heart cell", "Hamster brain cell"],
     active_values=["Liver cell"],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python =">=3.9,<3.12"
+requires-python =">=3.9,<3.13"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,13 +68,13 @@ tox -e fulltest-py39
 ``` 
 will run pytest on baybe with all optional features in python 3.9, while 
 ```bash
-tox -e coretest-py311
+tox -e coretest-py312
 ```
-will run pytest on baybe without additional features in python 3.11.
+will run pytest on baybe without additional features in python 3.12.
 ```bash
-tox -e lint-py311
+tox -e lint-py312
 ```
-will run the linters with python 3.11.
+will run the linters with python 3.12.
 
 For a full overview of all available environments, type:
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 min_version = 4.9
-env_list = {fulltest,coretest,lint,mypy,audit}-py{39,310,311}
+env_list = {fulltest,coretest,lint,mypy,audit}-py{39,310,311,312}
 isolated_build = True
 
-[testenv:fulltest,fulltest-py{39,310,311}]
+[testenv:fulltest,fulltest-py{39,310,311,312}]
 description = Run PyTest with all extra functionality
 extras = test,chem,examples,simulation,onnx
 passenv = CI
@@ -13,7 +13,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:coretest,coretest-py{39,310,311}]
+[testenv:coretest,coretest-py{39,310,311,312}]
 description = Run PyTest with core functionality
 extras = test
 passenv = CI
@@ -23,7 +23,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:lint,lint-py{39,310,311}]
+[testenv:lint,lint-py{39,310,311,312}]
 description = Run linters and format checkers
 extras = lint,examples
 skip_install = True
@@ -32,7 +32,7 @@ commands =
     python --version
     pre-commit run --all-files {posargs:--show-diff-on-failure}
 
-[testenv:mypy,mypy-py{39,310,311}]
+[testenv:mypy,mypy-py{39,310,311,312}]
 description = Run mypy
 extras = mypy
 setenv =
@@ -41,7 +41,7 @@ commands =
     python --version
     mypy
 
-[testenv:audit,audit-py{39,310,311}]
+[testenv:audit,audit-py{39,310,311,312}]
 description = Run pip-audit
 extras = dev # audit entire environment
 setenv =
@@ -54,7 +54,7 @@ commands =
     python --version
     pip-audit {env:EXCLUDES:}
 
-[testenv:docs,docs-py{39,310,311}]
+[testenv:docs,docs-py{39,310,311,312}]
 description = Build documentation
 extras = docs
 passenv = BAYBE_DOCS_LINKCHECK_IGNORE


### PR DESCRIPTION
(Written by Adrian) Enables Python 3.12 and fixes a bug with the validation converter, which also happens to fix the `cattrs` issue that originally blocked this PR (see details in PR comment).