### PR TITLE
HOTFIX: Downgrade upload-pages-artifact action to v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           pip install tox
           tox -e docs-py39
       - name: Upload docs artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
           path: 'build/docs'
 


### PR DESCRIPTION
This PR downgrades the `upload-pages-artifact` action back to v1.

I tested this version on my fork, where it enabled me to deploy the pages. It is unclear why the deployment does not work for v3 and is something that we will have to look into.