### PR TITLE
Extend `from_simplex` with constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better human readable `__str__` representation of campaign
 - README now contains an example on substance encoding results
 - Transfer Learning User Guide
+- `from_simplex` constructor now also takes and applies optional constraints
 
 ### Changed
 - [WIP] `torch` is loaded lazily

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -11,7 +11,7 @@ import torch
 from attr import define, field
 from cattrs import IterableValidationError
 
-from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER
+from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
 from baybe.constraints.base import DiscreteConstraint
 from baybe.parameters import (
     CategoricalParameter,
@@ -213,8 +213,8 @@ class SubspaceDiscrete(SerialMixin):
 
         # Remove entries that violate parameter constraints:
         for constraint in (c for c in constraints if c.eval_during_creation):
-            inds = constraint.get_invalid(exp_rep)
-            exp_rep.drop(index=inds, inplace=True)
+            idxs = constraint.get_invalid(exp_rep)
+            exp_rep.drop(index=idxs, inplace=True)
         exp_rep.reset_index(inplace=True, drop=True)
 
         return SubspaceDiscrete(
@@ -274,6 +274,7 @@ class SubspaceDiscrete(SerialMixin):
         max_sum: float,
         simplex_parameters: List[NumericalDiscreteParameter],
         product_parameters: Optional[List[DiscreteParameter]] = None,
+        constraints: Optional[List[DiscreteConstraint]] = None,
         min_nonzero: int = 0,
         max_nonzero: Optional[int] = None,
         boundary_only: bool = False,
@@ -297,6 +298,7 @@ class SubspaceDiscrete(SerialMixin):
             simplex_parameters: The parameters to be used for the simplex construction.
             product_parameters: Optional parameters that enter in form of a Cartesian
                 product.
+            constraints: See :class:`baybe.searchspace.core.SearchSpace`
             min_nonzero: Optional restriction on the minimum number of nonzero
                 parameter values in the simplex construction.
             max_nonzero: Optional restriction on the maximum number of nonzero
@@ -321,8 +323,13 @@ class SubspaceDiscrete(SerialMixin):
         # Resolve defaults
         if product_parameters is None:
             product_parameters = []
+        if constraints is None:
+            constraints = []
         if max_nonzero is None:
             max_nonzero = len(simplex_parameters)
+
+        # Validate constraints
+        validate_constraints(constraints, simplex_parameters + product_parameters)
 
         # Validate parameter types
         if not (
@@ -456,10 +463,17 @@ class SubspaceDiscrete(SerialMixin):
         if product_parameters:
             exp_rep = pd.merge(exp_rep, product_space, how="cross")
 
-        # Reset the index
-        exp_rep.reset_index(drop=True, inplace=True)
+        # Remove entries that violate parameter constraints:
+        for constraint in (c for c in constraints if c.eval_during_creation):
+            idxs = constraint.get_invalid(exp_rep)
+            exp_rep.drop(index=idxs, inplace=True)
+        exp_rep.reset_index(inplace=True, drop=True)
 
-        return cls(parameters=simplex_parameters + product_parameters, exp_rep=exp_rep)
+        return cls(
+            parameters=simplex_parameters + product_parameters,
+            exp_rep=exp_rep,
+            constraints=constraints,
+        )
 
     @property
     def is_empty(self) -> bool:
@@ -498,13 +512,13 @@ class SubspaceDiscrete(SerialMixin):
             numerical_measurements_must_be_within_tolerance: See
                 :func:`baybe.utils.dataframe.fuzzy_row_match`.
         """
-        inds_matched = fuzzy_row_match(
+        idxs_matched = fuzzy_row_match(
             self.exp_rep,
             measurements,
             self.parameters,
             numerical_measurements_must_be_within_tolerance,
         )
-        self.metadata.loc[inds_matched, "was_measured"] = True
+        self.metadata.loc[idxs_matched, "was_measured"] = True
 
     def get_candidates(
         self,

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -298,7 +298,7 @@ class SubspaceDiscrete(SerialMixin):
             simplex_parameters: The parameters to be used for the simplex construction.
             product_parameters: Optional parameters that enter in form of a Cartesian
                 product.
-            constraints: See :class:`baybe.searchspace.core.SearchSpace`
+            constraints: See :class:`baybe.searchspace.core.SearchSpace`.
             min_nonzero: Optional restriction on the minimum number of nonzero
                 parameter values in the simplex construction.
             max_nonzero: Optional restriction on the maximum number of nonzero

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -38,7 +38,7 @@ SUM_TOLERANCE = 1.0
 SMOKE_TEST = "SMOKE_TEST" in os.environ
 
 # This parameter denotes the resolution of the discretization of the parameters
-RESOLUTION = 3 if SMOKE_TEST else 12
+RESOLUTION = 5 if SMOKE_TEST else 12
 
 dict_solvents = {
     "water": "O",
@@ -161,7 +161,7 @@ for kIter in range(N_ITERATIONS):
     )
     print(
         f"No. of unique 2-solvent entries (exp."
-        f" {math.comb(len(dict_solvents), 2)*(12-2)})",
+        f" {math.comb(len(dict_solvents), 2)*(RESOLUTION-2)})",
         (campaign.searchspace.discrete.exp_rep[["Frac1", "Frac2", "Frac3"]] == 0.0)
         .sum(axis=1)
         .eq(1)
@@ -169,7 +169,7 @@ for kIter in range(N_ITERATIONS):
     )
     print(
         f"No. of unique 3-solvent entries (exp."
-        f" {math.comb(len(dict_solvents), 3)*((12-3)*(12-2))//2})",
+        f" {math.comb(len(dict_solvents), 3)*((RESOLUTION-3)*(RESOLUTION-2))//2})",
         (campaign.searchspace.discrete.exp_rep[["Frac1", "Frac2", "Frac3"]] == 0.0)
         .sum(axis=1)
         .eq(0)


### PR DESCRIPTION
- Adds constraints to from_simplex. While the simplex constructor takes care of the overall sum constraint, it was not possible to add other constraints, which is now enabled
- Also fixes a bug in an example not printing the correct asserts in SMOKE_TEST