### PR TITLE
Lazy load `torch` in surrogates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `torch` numeric types are now loaded lazily
 - Reorganized acquisition.py into `acquisition` subpackage
-- `surrogates.utils` uses `numerical` types
-- `baybe.utils.numerical` is loaded lazily in `surrogates`
+- `torch` is imported lazily in `surrogates`
 
 ### Fixed
 - `n_task_params` now evaluates to 1 if `task_idx == 0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `torch` numeric types are now loaded lazily
 - Reorganized acquisition.py into `acquisition` subpackage
+- `surrogates.utils` uses `numerical` types
+- `baybe.utils.numerical` is loaded lazily in `surrogates`
 
 ### Fixed
 - `n_task_params` now evaluates to 1 if `task_idx == 0`
@@ -44,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Full lookup backtesting example now tests different substance encodings
 - Replaced unmaintained `mordred` dependency by `mordredcommunity`
-- `SearchSpace`s now use `ndarray` instead of `Tensor` 
+- `SearchSpace`s now use `ndarray` instead of `Tensor`
 
 ### Fixed
 - `from_simplex` now efficiently validated in `Campaign.validate_config`

--- a/baybe/acquisition/partial.py
+++ b/baybe/acquisition/partial.py
@@ -2,9 +2,10 @@
 
 from typing import Optional
 
+import torch
 from attr import define
 from botorch.acquisition import AcquisitionFunction
-from torch import Tensor, cat, squeeze
+from torch import Tensor
 
 
 @define
@@ -56,7 +57,7 @@ class PartialAcquisitionFunction:
             disc_part = partial_part
             cont_part = pinned_part
         # Concat the parts and return the concatenated point
-        full_point = cat((disc_part, cont_part), -1)
+        full_point = torch.cat((disc_part, cont_part), -1)
         return full_point
 
     def __call__(self, variable_part: Tensor) -> Tensor:
@@ -87,6 +88,6 @@ class PartialAcquisitionFunction:
         """
         if X_pending is not None:  # Lift point to hybrid space and add additional dim
             X_pending = self._lift_partial_part(X_pending)
-            X_pending = squeeze(X_pending, -2)
+            X_pending = torch.squeeze(X_pending, -2)
         # Now use the original set_X_pending function
         self.acqf.set_X_pending(X_pending)

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -1,0 +1,25 @@
+"""Utilities for acquisition functions."""
+
+from functools import partial
+
+from botorch.acquisition import (
+    ExpectedImprovement,
+    PosteriorMean,
+    ProbabilityOfImprovement,
+    UpperConfidenceBound,
+    qExpectedImprovement,
+    qProbabilityOfImprovement,
+    qUpperConfidenceBound,
+)
+
+acquisition_function_mapping = {
+    "PM": PosteriorMean,
+    "PI": ProbabilityOfImprovement,
+    "EI": ExpectedImprovement,
+    "UCB": partial(UpperConfidenceBound, beta=1.0),
+    "qEI": qExpectedImprovement,
+    "qPI": qProbabilityOfImprovement,
+    "qUCB": partial(qUpperConfidenceBound, beta=1.0),
+    "VarUCB": partial(UpperConfidenceBound, beta=100.0),
+    "qVarUCB": partial(qUpperConfidenceBound, beta=100.0),
+}

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -1,23 +1,14 @@
 """Base class for all Bayesian recommenders."""
 
 from abc import ABC
-from functools import partial
 from typing import Callable, Literal, Optional
 
 import pandas as pd
 from attrs import define, field
-from botorch.acquisition import (
-    AcquisitionFunction,
-    ExpectedImprovement,
-    PosteriorMean,
-    ProbabilityOfImprovement,
-    UpperConfidenceBound,
-    qExpectedImprovement,
-    qProbabilityOfImprovement,
-    qUpperConfidenceBound,
-)
+from botorch.acquisition import AcquisitionFunction
 
 from baybe.acquisition import debotorchize
+from baybe.acquisition.utils import acquisition_function_mapping
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import _ONNX_INSTALLED, GaussianProcessSurrogate
@@ -53,18 +44,7 @@ class BayesianRecommender(PureRecommender, ABC):
         Returns:
             The debotorchized acquisition function class.
         """
-        mapping = {
-            "PM": PosteriorMean,
-            "PI": ProbabilityOfImprovement,
-            "EI": ExpectedImprovement,
-            "UCB": partial(UpperConfidenceBound, beta=1.0),
-            "qEI": qExpectedImprovement,
-            "qPI": qProbabilityOfImprovement,
-            "qUCB": partial(qUpperConfidenceBound, beta=1.0),
-            "VarUCB": partial(UpperConfidenceBound, beta=100.0),
-            "qVarUCB": partial(qUpperConfidenceBound, beta=100.0),
-        }
-        fun = debotorchize(mapping[self.acquisition_function_cls])
+        fun = debotorchize(acquisition_function_mapping[self.acquisition_function_cls])
         return fun
 
     def setup_acquisition_function(

--- a/baybe/serialization/mixin.py
+++ b/baybe/serialization/mixin.py
@@ -3,6 +3,8 @@
 import json
 from typing import TypeVar
 
+import attrs
+
 from baybe.serialization.core import converter
 
 _T = TypeVar("_T")
@@ -29,7 +31,9 @@ class SerialMixin:
         Returns:
             The reconstructed object.
         """
-        return converter.structure(dictionary, cls)
+        class_type = attrs.resolve_types(cls)
+
+        return converter.structure(dictionary, class_type)
 
     def to_json(self) -> str:
         """Create an object's JSON representation.

--- a/baybe/serialization/mixin.py
+++ b/baybe/serialization/mixin.py
@@ -3,8 +3,6 @@
 import json
 from typing import TypeVar
 
-import attrs
-
 from baybe.serialization.core import converter
 
 _T = TypeVar("_T")
@@ -31,9 +29,7 @@ class SerialMixin:
         Returns:
             The reconstructed object.
         """
-        class_type = attrs.resolve_types(cls)
-
-        return converter.structure(dictionary, class_type)
+        return converter.structure(dictionary, cls)
 
     def to_json(self) -> str:
         """Create an object's JSON representation.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -1,18 +1,21 @@
 """Base functionality for all BayBE surrogates."""
 
+from __future__ import annotations
+
 import gc
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
-import torch
 from attr import define, field
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin, converter, unstructure_base
 from baybe.surrogates.utils import _prepare_inputs, _prepare_targets
 from baybe.utils.basic import get_subclasses
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 # Define constants
 _MIN_VARIANCE = 1e-6
@@ -69,6 +72,8 @@ class Surrogate(ABC, SerialMixin):
             The posterior means and posterior covariance matrices of the t-batched
             candidate points.
         """
+        import torch
+
         # Prepare the input
         candidates = _prepare_inputs(candidates)
 

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -7,12 +7,11 @@ surrogates can be trained and attempts to do so for each new DOE iteration.
 
 It is planned to solve this issue in the future.
 """
+from __future__ import annotations
 
-from typing import Callable, ClassVar
+from typing import TYPE_CHECKING, Callable, ClassVar
 
-import torch
 from attrs import define, field, validators
-from torch import Tensor
 
 from baybe.exceptions import ModelParamsNotSupportedError
 from baybe.parameters import (
@@ -36,6 +35,9 @@ try:
     _ONNX_INSTALLED = True
 except ImportError:
     _ONNX_INSTALLED = False
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 def register_custom_architecture(
@@ -162,6 +164,8 @@ if _ONNX_INSTALLED:
             #   standard deviations. Currently, most available ONNX converters care
             #   about the mean only and it's not clear how this will be handled in the
             #   future. Once there are more choices available, this should be revisited.
+            import torch
+
             return (
                 torch.from_numpy(results[0]).to(DTypeFloatTorch),
                 torch.from_numpy(results[1]).pow(2).to(DTypeFloatTorch),

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -155,6 +155,8 @@ if _ONNX_INSTALLED:
 
         @batchify
         def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
+            import torch
+
             model_inputs = {
                 self.onnx_input_name: candidates.numpy().astype(DTypeFloatONNX)
             }
@@ -164,8 +166,6 @@ if _ONNX_INSTALLED:
             #   standard deviations. Currently, most available ONNX converters care
             #   about the mean only and it's not clear how this will be handled in the
             #   future. Once there are more choices available, this should be revisited.
-            import torch
-
             return (
                 torch.from_numpy(results[0]).to(DTypeFloatTorch),
                 torch.from_numpy(results[1]).pow(2).to(DTypeFloatTorch),

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable, ClassVar
 
-from attrs import define, field, validators
+from attrs import define, field, resolve_types, validators
 
 from baybe.exceptions import ModelParamsNotSupportedError
 from baybe.parameters import (
@@ -215,3 +215,8 @@ if _ONNX_INSTALLED:
                     f"a one-dimensional computational representation or "
                     f"{CustomDiscreteParameter.__name__}."
                 )
+
+    # FIXME: This manual resolve should not be necessary if the classes are declared
+    #   properly. Potentially related to the conditional class definition, which should
+    #   vanish as well.
+    resolve_types(CustomONNXSurrogate)

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -121,8 +121,6 @@ class GaussianProcessSurrogate(Surrogate):
             batch_shape=batch_shape,
             outputscale_prior=outputscale_prior[0],
         )
-        import torch
-
         if outputscale_prior[1] is not None:
             base_covar_module.outputscale = torch.tensor([outputscale_prior[1]])
         if lengthscale_prior[1] is not None:

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -1,8 +1,9 @@
 """Gaussian process surrogates."""
 
-from typing import Any, ClassVar, Optional
+from __future__ import annotations
 
-import torch
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
+
 from attr import define, field
 from botorch import fit_gpytorch_mll
 from botorch.models import SingleTaskGP
@@ -12,11 +13,13 @@ from gpytorch.kernels import IndexKernel, MaternKernel, ScaleKernel
 from gpytorch.likelihoods import GaussianLikelihood
 from gpytorch.means import ConstantMean
 from gpytorch.priors import GammaPrior
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.validation import get_model_params_validator
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @define
@@ -48,9 +51,10 @@ class GaussianProcessSurrogate(Surrogate):
 
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
         # See base class.
-
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
+        import torch
+
         task_idx = searchspace.task_idx
         n_task_params = 1 if task_idx is not None else 0
         numeric_idxs = [i for i in range(train_x.shape[1]) if i != task_idx]
@@ -117,6 +121,8 @@ class GaussianProcessSurrogate(Surrogate):
             batch_shape=batch_shape,
             outputscale_prior=outputscale_prior[0],
         )
+        import torch
+
         if outputscale_prior[1] is not None:
             base_covar_module.outputscale = torch.tensor([outputscale_prior[1]])
         if lengthscale_prior[1] is not None:

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -51,10 +51,11 @@ class GaussianProcessSurrogate(Surrogate):
 
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
         # See base class.
-        # identify the indexes of the task and numeric dimensions
-        # TODO: generalize to multiple task parameters
+
         import torch
 
+        # identify the indexes of the task and numeric dimensions
+        # TODO: generalize to multiple task parameters
         task_idx = searchspace.task_idx
         n_task_params = 1 if task_idx is not None else 0
         numeric_idxs = [i for i in range(train_x.shape[1]) if i != task_idx]

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -49,12 +49,13 @@ class BayesianLinearSurrogate(Surrogate):
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
+
+        import torch
+
         # Get predictions
         dists = self._model.predict(candidates.numpy(), return_std=True)
 
         # Split into posterior mean and variance
-        import torch
-
         mean = torch.from_numpy(dists[0])
         var = torch.from_numpy(dists[1]).pow(2)
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -6,18 +6,20 @@ in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750
 Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
+from __future__ import annotations
 
-from typing import Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-import torch
 from attr import define, field
 from sklearn.linear_model import ARDRegression
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
 from baybe.surrogates.validation import get_model_params_validator
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @catch_constant_targets
@@ -51,6 +53,8 @@ class BayesianLinearSurrogate(Surrogate):
         dists = self._model.predict(candidates.numpy(), return_std=True)
 
         # Split into posterior mean and variance
+        import torch
+
         mean = torch.from_numpy(dists[0])
         var = torch.from_numpy(dists[1]).pow(2)
 

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -1,14 +1,17 @@
 """Naive surrogates."""
 
-from typing import ClassVar, Optional
+from __future__ import annotations
 
-import torch
+from typing import TYPE_CHECKING, ClassVar, Optional
+
 from attr import define, field
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @define
@@ -34,6 +37,8 @@ class MeanPredictionSurrogate(Surrogate):
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         # TODO: use target value bounds for covariance scaling when explicitly provided
+        import torch
+
         mean = self.target_value * torch.ones([len(candidates)])
         var = torch.ones(len(candidates))
         return mean, var

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -36,9 +36,10 @@ class MeanPredictionSurrogate(Surrogate):
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
-        # TODO: use target value bounds for covariance scaling when explicitly provided
+
         import torch
 
+        # TODO: use target value bounds for covariance scaling when explicitly provided
         mean = self.target_value * torch.ones([len(candidates)])
         var = torch.ones(len(candidates))
         return mean, var

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -6,18 +6,20 @@ in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750
 Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
+from __future__ import annotations
 
-from typing import Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-import torch
 from attr import define, field
 from ngboost import NGBRegressor
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
 from baybe.surrogates.validation import get_model_params_validator
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @catch_constant_targets
@@ -57,6 +59,8 @@ class NGBoostSurrogate(Surrogate):
         dists = self._model.pred_dist(candidates)
 
         # Split into posterior mean and variance
+        import torch
+
         mean = torch.from_numpy(dists.mean())
         var = torch.from_numpy(dists.var)
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -55,12 +55,13 @@ class NGBoostSurrogate(Surrogate):
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
+
+        import torch
+
         # Get predictions
         dists = self._model.pred_dist(candidates)
 
         # Split into posterior mean and variance
-        import torch
-
         mean = torch.from_numpy(dists.mean())
         var = torch.from_numpy(dists.var)
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -6,19 +6,21 @@ in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750
 Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
+from __future__ import annotations
 
-from typing import Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import numpy as np
-import torch
 from attr import define, field
 from sklearn.ensemble import RandomForestRegressor
-from torch import Tensor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
 from baybe.surrogates.validation import get_model_params_validator
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @catch_constant_targets
@@ -53,6 +55,8 @@ class RandomForestSurrogate(Surrogate):
         # NOTE: explicit conversion to ndarray is needed due to a pytorch issue:
         # https://github.com/pytorch/pytorch/pull/51731
         # https://github.com/pytorch/pytorch/issues/13918
+        import torch
+
         predictions = torch.from_numpy(
             np.asarray(
                 [

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -51,12 +51,12 @@ class RandomForestSurrogate(Surrogate):
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
+        import torch
+
         # Evaluate all trees
         # NOTE: explicit conversion to ndarray is needed due to a pytorch issue:
         # https://github.com/pytorch/pytorch/pull/51731
         # https://github.com/pytorch/pytorch/issues/13918
-        import torch
-
         predictions = torch.from_numpy(
             np.asarray(
                 [

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -14,9 +14,6 @@ from baybe.searchspace import SearchSpace
 if TYPE_CHECKING:
     from baybe.surrogates.base import Surrogate
 
-# Use float64 (which is recommended at least for BoTorch models)
-_DTYPE = torch.float64
-
 _MIN_TARGET_STD = 1e-6
 
 
@@ -32,9 +29,11 @@ def _prepare_inputs(x: Tensor) -> Tensor:
     Raises:
         ValueError: If the model input is empty.
     """
+    from baybe.utils.torch import DTypeFloatTorch
+
     if len(x) == 0:
         raise ValueError("The model input must be non-empty.")
-    return x.to(_DTYPE)
+    return x.to(DTypeFloatTorch)
 
 
 def _prepare_targets(y: Tensor) -> Tensor:
@@ -49,12 +48,14 @@ def _prepare_targets(y: Tensor) -> Tensor:
     Raises:
         NotImplementedError: If there is more than one target.
     """
+    from baybe.utils.torch import DTypeFloatTorch
+
     if y.shape[1] != 1:
         raise NotImplementedError(
             "The model currently supports only one target or multiple targets in "
             "DESIRABILITY mode."
         )
-    return y.to(_DTYPE)
+    return y.to(DTypeFloatTorch)
 
 
 def catch_constant_targets(model_cls: type[Surrogate]):


### PR DESCRIPTION
`baybe.utils.numerical` imports torch and still appears in the import hierarchy. I'm going to fix it in another PR.

<img width="1134" alt="Screenshot 2024-03-06 at 4 44 39 PM" src="https://github.com/emdgroup/baybe/assets/5112312/baf744e3-52ba-47c4-bbba-1919f53efa2c">
