### PR TITLE
Add efficient `from_simplex` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced unmaintained `mordred` dependency by `mordredcommunity`
 - `SearchSpace`s now use `ndarray` instead of `Tensor` 
 
+### Fixed
+- `from_simplex` now efficiently validated in `Campaign.validate_config`
+
 ## [0.8.0] - 2024-02-29
 ### Changed
 - BoTorch dependency bumped to `>=0.9.3`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -655,30 +655,37 @@ def fixture_default_config():
     #   default campaign object instead of hardcoding it here. This avoids redundant
     #   code and automatically keeps them synced.
     cfg = """{
-        "parameters": [
-            {
-                "type": "NumericalDiscreteParameter",
-                "name": "Temp_C",
-                "values": [10, 20, 30, 40]
-            },
-            {
-                "type": "NumericalDiscreteParameter",
-                "name": "Concentration",
-                "values": [0.2, 0.3, 1.4]
-            },
-            __fillin__
-            {
-                "type": "CategoricalParameter",
-                "name": "Base",
-                "values": ["base1", "base2", "base3", "base4", "base5"]
-            }
-        ],
-        "constraints": [],
+        "searchspace": {
+            "constructor": "from_product",
+            "parameters": [
+                {
+                    "type": "NumericalDiscreteParameter",
+                    "name": "Temp_C",
+                    "values": [10, 20, 30, 40]
+                },
+                {
+                    "type": "NumericalDiscreteParameter",
+                    "name": "Concentration",
+                    "values": [0.2, 0.3, 1.4]
+                },
+                __fillin__
+                {
+                    "type": "CategoricalParameter",
+                    "name": "Base",
+                    "values": ["base1", "base2", "base3", "base4", "base5"]
+                }
+            ],
+            "constraints": []
+        },
         "objective": {
-            "mode": "SINGLE",
-            "targets": [
-                {"name": "Yield", "mode": "MAX"}
-            ]
+          "mode": "SINGLE",
+          "targets": [
+            {
+              "type": "NumericalTarget",
+              "name": "Yield",
+              "mode": "MAX"
+            }
+          ]
         },
         "recommender": {
             "type": "TwoPhaseMetaRecommender",
@@ -713,6 +720,51 @@ def fixture_default_config():
                 "encoding": "OHE"
             },""",
     )
+    return cfg
+
+
+@pytest.fixture(name="simplex_config")
+def fixture_default_simplex_config():
+    """The default simplex config to be used if not specified differently."""
+    cfg = """{
+        "searchspace": {
+          "discrete": {
+              "constructor": "from_simplex",
+              "simplex_parameters": [
+                {
+                  "type": "NumericalDiscreteParameter",
+                  "name": "simplex1",
+                  "values": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+                },
+                {
+                  "type": "NumericalDiscreteParameter",
+                  "name": "simplex2",
+                  "values": [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+                }
+              ],
+              "product_parameters": [
+                {
+                  "type": "CategoricalParameter",
+                  "name": "Granularity",
+                  "values": ["coarse", "medium", "fine"]
+                }
+              ],
+              "max_sum": 1.0,
+              "boundary_only": true
+            }
+        },
+        "objective": {
+          "mode": "SINGLE",
+          "targets": [
+            {
+              "type": "NumericalTarget",
+              "name": "Yield",
+              "mode": "MAX"
+            }
+          ]
+        }
+    }"""
+
     return cfg
 
 

--- a/tests/serialization/test_campaign_serialization.py
+++ b/tests/serialization/test_campaign_serialization.py
@@ -20,11 +20,21 @@ def test_campaign_serialization(campaign):
     assert campaign == campaign2
 
 
-def test_valid_config(config):
+def test_valid_product_config(config):
     Campaign.validate_config(config)
 
 
-def test_invalid_config(config):
+def test_invalid_product_config(config):
     config = config.replace("CategoricalParameter", "CatParam")
     with pytest.raises(ClassValidationError):
         Campaign.validate_config(config)
+
+
+def test_valid_simplex_config(simplex_config):
+    Campaign.validate_config(simplex_config)
+
+
+def test_invalid_simplex_config(simplex_config):
+    simplex_config = simplex_config.replace("0.0, ", "-1.0, 0.0, ")
+    with pytest.raises(ClassValidationError):
+        Campaign.validate_config(simplex_config)


### PR DESCRIPTION
Obejct creation form json with the `from_soimplex` constructor has so far been done with the default method which is extensively creating the entire object.

This is ineffective for cartesian-product like search spaces such as made with `from_product` and `from_simplex`

This introduces a separate valdiator for that function. It also consolidates some of the constraint filtering into a small utility.