### PR TITLE
Lazy load DTypeFloatTorch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- `torch` numeric types are now loaded lazily
+
 ## [0.8.2] - 2024-03-27
 ### Added
 - Simulation user guide

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -17,7 +17,6 @@ from baybe.serialization import (
     get_base_structure_hook,
     unstructure_base,
 )
-from baybe.utils.numerical import DTypeFloatTorch
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -163,6 +162,8 @@ class ContinuousConstraint(Constraint, ABC):
             The tuple required by botorch.
         """
         import torch
+
+        from baybe.utils.numerical import DTypeFloatTorch
 
         param_names = [p.name for p in parameters]
         param_indices = [

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -163,7 +163,7 @@ class ContinuousConstraint(Constraint, ABC):
         """
         import torch
 
-        from baybe.utils.numerical import DTypeFloatTorch
+        from baybe.utils.torch import DTypeFloatTorch
 
         param_names = [p.name for p in parameters]
         param_indices = [

--- a/baybe/objective.py
+++ b/baybe/objective.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -12,8 +12,9 @@ from attr.validators import deep_iterable, in_, instance_of, min_len
 
 from baybe.serialization import SerialMixin
 from baybe.targets.base import Target
-from baybe.targets.numerical import NumericalTarget
-from baybe.utils.numerical import geom_mean
+
+if TYPE_CHECKING:
+    from baybe.targets.numerical import NumericalTarget
 
 
 def _normalize_weights(weights: list[float]) -> list[float]:
@@ -133,6 +134,8 @@ class Objective(SerialMixin):
         Raises:
             ValueError: If the specified averaging function is unknown.
         """
+        from baybe.utils.numerical import geom_mean
+
         # Perform transformations that are required independent of the mode
         transformed = data[[t.name for t in self.targets]].copy()
         for target in self.targets:

--- a/baybe/objective.py
+++ b/baybe/objective.py
@@ -12,6 +12,7 @@ from attr.validators import deep_iterable, in_, instance_of, min_len
 
 from baybe.serialization import SerialMixin
 from baybe.targets.base import Target
+from baybe.utils.numerical import geom_mean
 
 if TYPE_CHECKING:
     from baybe.targets.numerical import NumericalTarget
@@ -134,8 +135,6 @@ class Objective(SerialMixin):
         Raises:
             ValueError: If the specified averaging function is unknown.
         """
-        from baybe.utils.numerical import geom_mean
-
         # Perform transformations that are required independent of the mode
         transformed = data[[t.name for t in self.targets]].copy()
         for target in self.targets:

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -13,7 +13,6 @@ from baybe.exceptions import NumericalUnderflowError
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
 from baybe.utils.interval import InfiniteIntervalError, Interval, convert_bounds
-from baybe.utils.numerical import DTypeFloatNumpy
 
 
 @define(frozen=True, slots=False)
@@ -57,6 +56,8 @@ class NumericalDiscreteParameter(DiscreteParameter):
         Raises:
             ValueError: If the tolerance is not safe.
         """
+        from baybe.utils.numerical import DTypeFloatNumpy
+
         # For zero tolerance, the only left requirement is that all parameter values
         # are distinct, which is already ensured by the corresponding validator.
         if tolerance == 0.0:

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -13,6 +13,7 @@ from baybe.exceptions import NumericalUnderflowError
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
 from baybe.utils.interval import InfiniteIntervalError, Interval, convert_bounds
+from baybe.utils.numerical import DTypeFloatNumpy
 
 
 @define(frozen=True, slots=False)
@@ -56,8 +57,6 @@ class NumericalDiscreteParameter(DiscreteParameter):
         Raises:
             ValueError: If the tolerance is not safe.
         """
-        from baybe.utils.numerical import DTypeFloatNumpy
-
         # For zero tolerance, the only left requirement is that all parameter values
         # are distinct, which is already ensured by the corresponding validator.
         if tolerance == 0.0:

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -27,7 +27,8 @@ from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets
 from baybe.surrogates.validation import validate_custom_architecture_cls
-from baybe.utils.numerical import DTypeFloatONNX, DTypeFloatTorch
+from baybe.utils.numerical import DTypeFloatONNX
+from baybe.utils.torch import DTypeFloatTorch
 
 try:
     import onnxruntime as ort

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -11,7 +11,6 @@ import pandas as pd
 
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.targets.enum import TargetMode
-from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -40,6 +39,8 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
     #  care of this) df.values has been changed to df.values.astype(float),
     #  even though this seems like double casting here.
     import torch
+
+    from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
 
     out = (
         torch.from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.targets.enum import TargetMode
+from baybe.utils.numerical import DTypeFloatNumpy
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -40,7 +41,7 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
     #  even though this seems like double casting here.
     import torch
 
-    from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
+    from baybe.utils.torch import DTypeFloatTorch
 
     out = (
         torch.from_numpy(df.values.astype(DTypeFloatNumpy)).to(DTypeFloatTorch)

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -11,7 +11,6 @@ from attrs import define, field
 from packaging import version
 
 from baybe.serialization import SerialMixin, converter
-from baybe.utils.numerical import DTypeFloatNumpy, DTypeFloatTorch
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -126,11 +125,15 @@ class Interval(SerialMixin):
 
     def to_ndarray(self) -> np.ndarray:
         """Transform the interval to a :class:`numpy.ndarray`."""
+        from baybe.utils.numerical import DTypeFloatNumpy
+
         return np.array([self.lower, self.upper], dtype=DTypeFloatNumpy)
 
     def to_tensor(self) -> "Tensor":
         """Transform the interval to a :class:`torch.Tensor`."""
         import torch
+
+        from baybe.utils.numerical import DTypeFloatTorch
 
         return torch.tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
 

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -133,7 +133,7 @@ class Interval(SerialMixin):
         """Transform the interval to a :class:`torch.Tensor`."""
         import torch
 
-        from baybe.utils.numerical import DTypeFloatTorch
+        from baybe.utils.torch import DTypeFloatTorch
 
         return torch.tensor([self.lower, self.upper], dtype=DTypeFloatTorch)
 

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -11,6 +11,7 @@ from attrs import define, field
 from packaging import version
 
 from baybe.serialization import SerialMixin, converter
+from baybe.utils.numerical import DTypeFloatNumpy
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -125,8 +126,6 @@ class Interval(SerialMixin):
 
     def to_ndarray(self) -> np.ndarray:
         """Transform the interval to a :class:`numpy.ndarray`."""
-        from baybe.utils.numerical import DTypeFloatNumpy
-
         return np.array([self.lower, self.upper], dtype=DTypeFloatNumpy)
 
     def to_tensor(self) -> "Tensor":

--- a/baybe/utils/numerical.py
+++ b/baybe/utils/numerical.py
@@ -1,13 +1,9 @@
 """Utilities for numeric operations."""
 
 import numpy as np
-import torch
 
 DTypeFloatNumpy = np.float64
 """Floating point data type used for numpy arrays."""
-
-DTypeFloatTorch = torch.float64
-"""Floating point data type used for torch tensors."""
 
 DTypeFloatONNX = np.float32
 """Floating point data type used for ONNX models.

--- a/baybe/utils/torch.py
+++ b/baybe/utils/torch.py
@@ -1,0 +1,6 @@
+"""Torch utilities shipped as separate module for lazy-loading."""
+
+import torch
+
+DTypeFloatTorch = torch.float64
+"""Floating point data type used for torch tensors."""


### PR DESCRIPTION
As I discussed in the previous PRs we need to import `baybe.utils.numerical` lazily to completely get rid of `torch`.

I didn't touch `surrogates` because it's already fixed in previous PR.