### PR TITLE
Enable flexible dataframe de-serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example for transfer learning backtest utility
 - `pyupgrade` pre-commit hook
 - Better human readable `__str__` representation of objective and targets
+- Alternative dataframe deserialization from pd.DataFrame constructors
 
 ### Changed
 - More detailed and sophisticated search space user guide
+- Support for Python 3.12
 - Upgraded syntax to Python 3.9
 
 ## [0.8.1] - 2024-03-11
@@ -21,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now contains an example on substance encoding results
 - Transfer learning user guide
 - `from_simplex` constructor now also takes and applies optional constraints
-- Support for Python 3.12
 
 ### Changed
 - Full lookup backtesting example now tests different substance encodings

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -73,7 +73,13 @@ def _structure_dataframe_hook(obj: Union[str, dict], _) -> pd.DataFrame:
         return pickle.loads(pickled_df)
     elif isinstance(obj, dict):
         if constructor := obj.pop("constructor", None):
-            return getattr(pd, constructor)(**obj)
+            try:
+                # try to get constructor from pandas.DataFrame
+                func = getattr(pd.DataFrame, constructor)
+            except AttributeError:
+                # try to get constructor from pandas
+                func = getattr(pd, constructor)
+            return func(**obj)
         else:
             raise ValueError(
                 "For deserializing a dataframe from a dictionary, the 'constructor' "

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -73,12 +73,8 @@ def _structure_dataframe_hook(obj: Union[str, dict], _) -> pd.DataFrame:
         return pickle.loads(pickled_df)
     elif isinstance(obj, dict):
         if constructor := obj.pop("constructor", None):
-            try:
-                # try to get constructor from pandas.DataFrame
-                func = getattr(pd.DataFrame, constructor)
-            except AttributeError:
-                # try to get constructor from pandas
-                func = getattr(pd, constructor)
+            # try to get constructor from pandas.DataFrame
+            func = getattr(pd.DataFrame, constructor)
             return func(**obj)
         else:
             raise ValueError(

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -72,12 +72,18 @@ def _structure_dataframe_hook(obj: Union[str, dict], _) -> pd.DataFrame:
         pickled_df = base64.b64decode(obj.encode("utf-8"))
         return pickle.loads(pickled_df)
     elif isinstance(obj, dict):
-        if constructor := obj.pop("constructor"):
+        if constructor := obj.pop("constructor", None):
             return getattr(pd, constructor)(**obj)
         else:
             raise ValueError(
-                f"Invalid choice for constructor '{constructor}'",
+                "For deserializing a dataframe from a dictionary, the 'constructor' "
+                "keyword must be provided as key.",
             )
+    else:
+        raise ValueError(
+            "Unknown object type for deserializing a dataframe. Supported types are "
+            "strings and dictionaries.",
+        )
 
 
 def _unstructure_dataframe_hook(df: pd.DataFrame) -> str:

--- a/tests/serialization/test_dataframe_serialization.py
+++ b/tests/serialization/test_dataframe_serialization.py
@@ -2,8 +2,10 @@
 
 import pandas as pd
 from hypothesis import given
+from pytest import mark
 
 from baybe.serialization import deserialize_dataframe, serialize_dataframe
+from baybe.serialization.core import _unstructure_dataframe_hook
 from tests.hypothesis_strategies.dataframes import random_dataframes
 
 
@@ -13,3 +15,29 @@ def test_dataframe_roundtrip(df: pd.DataFrame):
     string = serialize_dataframe(df)
     df2 = deserialize_dataframe(string)
     assert df.equals(df2), (df, df2)
+
+
+@mark.parametrize(
+    "obj",
+    [
+        _unstructure_dataframe_hook(pd.DataFrame({"c1": [1, 2], "c2": [3, 4]})),
+        {
+            "constructor": "read_json",
+            "path_or_buf": '[{"c1":"a","c2":"b"},{"c1":"c","c2":"d"}]',
+            "orient": "records",
+        },
+        {
+            "constructor": "read_json",
+            "path_or_buf": '{"r1":{"c1":"a","c2":"b"},"r2":{"c1":"c","c2":"d"}}',
+            "orient": "index",
+        },
+        {
+            "constructor": "read_json",
+            "path_or_buf": '{"columns":["c1","c2"],"index":["r1","r2"],'
+            '"data":[["a","b"],["c","d"]]}',
+            "orient": "split",
+        },
+    ],
+)
+def test_dataframe_constructors(obj):
+    deserialize_dataframe(obj)

--- a/tests/serialization/test_dataframe_serialization.py
+++ b/tests/serialization/test_dataframe_serialization.py
@@ -22,6 +22,20 @@ def test_dataframe_roundtrip(df: pd.DataFrame):
     [
         _unstructure_dataframe_hook(pd.DataFrame({"c1": [1, 2], "c2": [3, 4]})),
         {
+            "constructor": "from_records",
+            "data": [
+                {"col_1": 3, "col_2": "a"},
+                {"col_1": 2, "col_2": "b"},
+                {"col_1": 1, "col_2": "c"},
+                {"col_1": 0, "col_2": "d"},
+            ],
+        },
+        {
+            "constructor": "from_dict",
+            "data": {"row_1": [3, 2, 1, 0], "row_2": ["a", "b", "c", "d"]},
+            "orient": "index",
+        },
+        {
             "constructor": "read_json",
             "path_or_buf": '[{"c1":"a","c2":"b"},{"c1":"c","c2":"d"}]',
             "orient": "records",

--- a/tests/serialization/test_dataframe_serialization.py
+++ b/tests/serialization/test_dataframe_serialization.py
@@ -27,29 +27,33 @@ def test_dataframe_roundtrip(df: pd.DataFrame):
                 {"col_1": 3, "col_2": "a"},
                 {"col_1": 2, "col_2": "b"},
                 {"col_1": 1, "col_2": "c"},
-                {"col_1": 0, "col_2": "d"},
             ],
         },
         {
+            "constructor": "from_records",
+            "data": [[1, "a"], [2, "b"], [3, "c"]],
+            "columns": ["number_col", "string_col"],
+        },
+        {
             "constructor": "from_dict",
-            "data": {"row_1": [3, 2, 1, 0], "row_2": ["a", "b", "c", "d"]},
+            "data": {"col_1": [3, 2, 1, 0], "col_2": ["a", "b", "c", "d"]},
+        },
+        {
+            "constructor": "from_dict",
+            "data": {"row_1": [0, "a", 1, "b"], "row_2": [2, "b", 3, "d"]},
             "orient": "index",
+            "columns": ["col_1", "col_2", "col_3", "col_4"],
         },
         {
-            "constructor": "read_json",
-            "path_or_buf": '[{"c1":"a","c2":"b"},{"c1":"c","c2":"d"}]',
-            "orient": "records",
-        },
-        {
-            "constructor": "read_json",
-            "path_or_buf": '{"r1":{"c1":"a","c2":"b"},"r2":{"c1":"c","c2":"d"}}',
-            "orient": "index",
-        },
-        {
-            "constructor": "read_json",
-            "path_or_buf": '{"columns":["c1","c2"],"index":["r1","r2"],'
-            '"data":[["a","b"],["c","d"]]}',
-            "orient": "split",
+            "constructor": "from_dict",
+            "data": {
+                "index": [("a", "b"), ("a", "c")],
+                "columns": [("x", 1), ("y", 2)],
+                "data": [[1, 3], [2, 4]],
+                "index_names": ["n1", "n2"],
+                "column_names": ["z1", "z2"],
+            },
+            "orient": "tight",
         },
     ],
 )


### PR DESCRIPTION
This enables dataframe de-serialziation also from human readable strings instead of only decoded strings

@danielweber90 as per our discussion for BayChem, see the tests for examples