### PR TITLE
Python syntax upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
   rev: v0.1.6
   hooks:
   - id: ruff
-    name: "ruff"
   - id: ruff-format
 - repo: https://github.com/crate-ci/typos
   rev: v1.16.23
@@ -20,4 +19,9 @@ repos:
     - id: typos
       exclude_types: [svg]
       args: [] # empty args to avoid typos automatically correcting the typos
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.1
+  hooks:
+  - id: pyupgrade
+    args: [--py39-plus, --keep-runtime-typing]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- More detailed and sophisticated search space user guide
-
 ### Added
 - Simulation user guide
 - Example for transfer learning backtest utility
+- `pyupgrade` pre-commit hook
+
+### Changed
+- More detailed and sophisticated search space user guide
+- Upgraded syntax to Python 3.9
 
 ## [0.8.1] - 2024-03-11
 ### Added
@@ -271,7 +273,7 @@ or continuous parameters
 
 ## [0.4.2] - 2023-08-29
 ### Added
-- Test environments for multiple python versions via `tox`
+- Test environments for multiple Python versions via `tox`
 
 ### Changed
 - Removed `environment.yml`

--- a/baybe/acquisition.py
+++ b/baybe/acquisition.py
@@ -1,7 +1,7 @@
 """Adapter for making BoTorch's acquisition functions work with other models."""
 
 from inspect import signature
-from typing import Any, Callable, List, Optional, Type
+from typing import Any, Callable, Optional
 
 import gpytorch.distributions
 from attr import define
@@ -14,7 +14,7 @@ from torch import Tensor, cat, squeeze
 from baybe.surrogates.base import Surrogate
 
 
-def debotorchize(acqf_cls: Type[AcquisitionFunction]):
+def debotorchize(acqf_cls: type[AcquisitionFunction]):
     """Wrap a given BoTorch acquisition function.
 
     This wrapped function becomes generally usable in combination with other non-BoTorch
@@ -84,7 +84,7 @@ class AdapterModel(Model):
     def posterior(  # noqa: D102
         self,
         X: Tensor,
-        output_indices: Optional[List[int]] = None,
+        output_indices: Optional[list[int]] = None,
         observation_noise: bool = False,
         posterior_transform: Optional[Callable[[Posterior], Posterior]] = None,
         **kwargs: Any,

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import List
 
 import cattrs
 import numpy as np
@@ -119,12 +118,12 @@ class Campaign(SerialMixin):
         return self._measurements_exp
 
     @property
-    def parameters(self) -> List[Parameter]:
+    def parameters(self) -> list[Parameter]:
         """The parameters of the underlying search space."""
         return self.searchspace.parameters
 
     @property
-    def targets(self) -> List[Target]:
+    def targets(self) -> list[Target]:
         """The targets of the underlying objective."""
         return self.objective.targets
 

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, List, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pandas as pd
 from attr import define, field
@@ -40,12 +40,12 @@ class Constraint(ABC, SerialMixin):
     """Class variable encoding whether the condition is evaluated during modeling."""
 
     # Object variables
-    parameters: List[str] = field(validator=min_len(1))
+    parameters: list[str] = field(validator=min_len(1))
     """The list of parameters used for the constraint."""
 
     @parameters.validator
     def _validate_params(  # noqa: DOC101, DOC103
-        self, _: Any, params: List[str]
+        self, _: Any, params: list[str]
     ) -> None:
         """Validate the parameter list.
 
@@ -120,7 +120,7 @@ class ContinuousConstraint(Constraint, ABC):
     # See base class.
 
     # object variables
-    coefficients: List[float] = field()
+    coefficients: list[float] = field()
     """In-/equality coefficient for each entry in ``parameters``."""
 
     rhs: float = field(default=0.0)
@@ -128,7 +128,7 @@ class ContinuousConstraint(Constraint, ABC):
 
     @coefficients.validator
     def _validate_coefficients(  # noqa: DOC101, DOC103
-        self, _: Any, coefficients: List[float]
+        self, _: Any, coefficients: list[float]
     ) -> None:
         """Validate the coefficients.
 
@@ -148,8 +148,8 @@ class ContinuousConstraint(Constraint, ABC):
         return [1.0] * len(self.parameters)
 
     def to_botorch(
-        self, parameters: List[NumericalContinuousParameter], idx_offset: int = 0
-    ) -> Tuple[Tensor, Tensor, float]:
+        self, parameters: list[NumericalContinuousParameter], idx_offset: int = 0
+    ) -> tuple[Tensor, Tensor, float]:
         """Cast the constraint in a format required by botorch.
 
         Used in calling ``optimize_acqf_*`` functions, for details see

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -2,7 +2,7 @@
 
 import operator as ops
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -34,7 +34,7 @@ def _is_not_close(x: ArrayLike, y: ArrayLike, rtol: float, atol: float) -> np.nd
 
 
 # provide threshold operators
-_threshold_operators: Dict[str, Callable] = {
+_threshold_operators: dict[str, Callable] = {
     "<": ops.lt,
     "<=": ops.le,
     "=": rpartial(np.isclose, rtol=0.0),
@@ -135,7 +135,7 @@ class SubSelectionCondition(Condition):
     """Class for defining valid parameter entries."""
 
     # object variables
-    selection: List[Any] = field()
+    selection: list[Any] = field()
     """The list of items which are considered valid."""
 
     def evaluate(self, data: pd.Series) -> pd.Series:  # noqa: D102

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -1,7 +1,7 @@
 """Discrete constraints."""
 
 from functools import reduce
-from typing import Any, Callable, List, Optional, cast
+from typing import Any, Callable, Optional, cast
 
 import pandas as pd
 from attr import define, field
@@ -26,7 +26,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
     """Class for modelling exclusion constraints."""
 
     # object variables
-    conditions: List[Condition] = field(validator=min_len(1))
+    conditions: list[Condition] = field(validator=min_len(1))
     """List of individual conditions."""
 
     combiner: str = field(default="AND", validator=in_(_valid_logic_combiners))
@@ -125,10 +125,10 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
     """
 
     # object variables
-    conditions: List[Condition] = field()
+    conditions: list[Condition] = field()
     """The list of individual conditions."""
 
-    affected_parameters: List[List[str]] = field()
+    affected_parameters: list[list[str]] = field()
     """The parameters affected by the individual conditions."""
 
     # for internal use only
@@ -138,7 +138,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @affected_parameters.validator
     def _validate_affected_parameters(  # noqa: DOC101, DOC103
-        self, _: Any, value: List[List[str]]
+        self, _: Any, value: list[list[str]]
     ) -> None:
         """Validate the affected parameters.
 

--- a/baybe/constraints/validation.py
+++ b/baybe/constraints/validation.py
@@ -1,6 +1,5 @@
 """Validation functionality for constraints."""
 
-from typing import List
 
 from baybe.constraints.base import Constraint
 from baybe.constraints.discrete import DiscreteDependenciesConstraint
@@ -8,7 +7,7 @@ from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parame
 
 
 def validate_constraints(  # noqa: DOC101, DOC103
-    constraints: List[Constraint], parameters: List[Parameter]
+    constraints: list[Constraint], parameters: list[Parameter]
 ) -> None:
     """Assert that a given collection of constraints is valid.
 

--- a/baybe/objective.py
+++ b/baybe/objective.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any, List, Literal
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ from baybe.targets.numerical import NumericalTarget
 from baybe.utils.numerical import geom_mean
 
 
-def _normalize_weights(weights: List[float]) -> List[float]:
+def _normalize_weights(weights: list[float]) -> list[float]:
     """Normalize a collection of weights such that they sum to 100.
 
     Args:
@@ -39,10 +39,10 @@ class Objective(SerialMixin):
     mode: Literal["SINGLE", "DESIRABILITY"] = field()
     """The optimization mode."""
 
-    targets: List[Target] = field(validator=min_len(1))
+    targets: list[Target] = field(validator=min_len(1))
     """The list of targets used for the objective."""
 
-    weights: List[float] = field(converter=_normalize_weights)
+    weights: list[float] = field(converter=_normalize_weights)
     """The weights used to balance the different targets. By default, all
     weights are equally important."""
 
@@ -52,14 +52,14 @@ class Objective(SerialMixin):
     """The function used to combine the different targets."""
 
     @weights.default
-    def _default_weights(self) -> List[float]:
+    def _default_weights(self) -> list[float]:
         """Create the default weights."""
         # By default, all targets are equally important.
         return [1.0] * len(self.targets)
 
     @targets.validator
     def _validate_targets(  # noqa: DOC101, DOC103
-        self, _: Any, targets: List[NumericalTarget]
+        self, _: Any, targets: list[NumericalTarget]
     ) -> None:
         """Validate targets depending on the objective mode.
 
@@ -84,7 +84,7 @@ class Objective(SerialMixin):
 
     @weights.validator
     def _validate_weights(  # noqa: DOC101, DOC103
-        self, _: Any, weights: List[float]
+        self, _: Any, weights: list[float]
     ) -> None:
         """Validate target weights.
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -1,7 +1,7 @@
 """Categorical parameters."""
 
 from functools import cached_property
-from typing import Any, ClassVar, Tuple
+from typing import Any, ClassVar
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,7 @@ class CategoricalParameter(DiscreteParameter):
     # See base class.
 
     # object variables
-    _values: Tuple[str, ...] = field(
+    _values: tuple[str, ...] = field(
         converter=tuple,
         validator=(
             min_len(2),

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -1,7 +1,7 @@
 """Numerical parameters."""
 
 from functools import cached_property
-from typing import Any, ClassVar, Tuple
+from typing import Any, ClassVar
 
 import cattrs
 import numpy as np
@@ -26,9 +26,9 @@ class NumericalDiscreteParameter(DiscreteParameter):
 
     # object variables
     # NOTE: The parameter values are assumed to be sorted by the tolerance validator.
-    _values: Tuple[float, ...] = field(
+    _values: tuple[float, ...] = field(
         # FIXME[typing]: https://github.com/python-attrs/cattrs/issues/111
-        converter=lambda x: sorted(cattrs.structure(x, Tuple[float, ...])),  # type: ignore
+        converter=lambda x: sorted(cattrs.structure(x, tuple[float, ...])),  # type: ignore
         # FIXME[typing]: https://github.com/python-attrs/attrs/issues/1197
         validator=[
             min_len(2),

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -1,7 +1,7 @@
 """Substance parameters."""
 
 from functools import cached_property
-from typing import Any, ClassVar, Dict, Union
+from typing import Any, ClassVar, Union
 
 import pandas as pd
 from attrs import define, field
@@ -39,7 +39,7 @@ class SubstanceParameter(DiscreteParameter):
     # See base class.
 
     # object variables
-    data: Dict[str, Smiles] = field(
+    data: dict[str, Smiles] = field(
         validator=deep_mapping(
             mapping_validator=min_len(2),
             # FIXME[typing]: https://github.com/python-attrs/attrs/issues/1206
@@ -66,7 +66,7 @@ class SubstanceParameter(DiscreteParameter):
 
     @data.validator
     def _validate_substance_data(  # noqa: DOC101, DOC103
-        self, _: Any, data: Dict[str, Smiles]
+        self, _: Any, data: dict[str, Smiles]
     ) -> None:
         """Validate that the substance data, provided as SMILES, is valid.
 

--- a/baybe/parameters/utils.py
+++ b/baybe/parameters/utils.py
@@ -1,6 +1,7 @@
 """Parameter utilities."""
 
-from typing import Any, Callable, Collection, Dict, List, Optional, TypeVar
+from collections.abc import Collection
+from typing import Any, Callable, Optional, TypeVar
 
 import pandas as pd
 
@@ -12,8 +13,8 @@ _TParameter = TypeVar("_TParameter", bound=Parameter)
 def get_parameters_from_dataframe(
     df: pd.DataFrame,
     factory: Callable[[str, Collection[Any]], _TParameter],
-    parameters: Optional[List[_TParameter]] = None,
-) -> List[_TParameter]:
+    parameters: Optional[list[_TParameter]] = None,
+) -> list[_TParameter]:
     """Create a list of parameters from a dataframe.
 
     Returns one parameter for each column of the given dataframe. By default,
@@ -42,7 +43,7 @@ def get_parameters_from_dataframe(
         ValueError: If a parameter was specified for which no match was found.
     """
     # Turn the pre-specified parameters into a dict and check for duplicate names
-    specified_params: Dict[str, _TParameter] = {}
+    specified_params: dict[str, _TParameter] = {}
     if parameters is not None:
         for param in parameters:
             if param.name in specified_params:

--- a/baybe/parameters/validation.py
+++ b/baybe/parameters/validation.py
@@ -1,6 +1,7 @@
 """Validation functionality for parameters."""
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 from attrs.validators import gt, instance_of, lt

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -3,7 +3,8 @@
 #  this file will resolve type errors
 # mypy: disable-error-code="arg-type"
 
-from typing import Iterable, Iterator, List, Literal, Optional
+from collections.abc import Iterable, Iterator
+from typing import Literal, Optional
 
 import pandas as pd
 from attrs import define, field
@@ -99,7 +100,7 @@ class SequentialMetaRecommender(MetaRecommender):
     """
 
     # Exposed
-    recommenders: List[PureRecommender] = field(
+    recommenders: list[PureRecommender] = field(
         converter=list, validator=deep_iterable(instance_of(PureRecommender))
     )
     """A finite-length sequence of recommenders to be used. For infinite-length

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -1,7 +1,7 @@
 """Recommenders based on clustering."""
 
 from abc import ABC
-from typing import ClassVar, List, Type, Union
+from typing import ClassVar, Union
 
 import numpy as np
 import pandas as pd
@@ -40,7 +40,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
     #   that checks if a custom mechanism is implemented and uses default otherwise
     #   (similar to what is done in the recommenders)
 
-    model_class: ClassVar[Type[ClusterMixin]]
+    model_class: ClassVar[type[ClusterMixin]]
     """Class variable describing the model class."""
 
     model_cluster_num_parameter_name: ClassVar[str]
@@ -58,7 +58,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         self,
         model: ClusterMixin,
         candidates_scaled: Union[pd.DataFrame, np.ndarray],
-    ) -> List[int]:
+    ) -> list[int]:
         """Select one candidate from each cluster uniformly at random.
 
         This function is model-agnostic and can be used by any child class.
@@ -81,7 +81,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         self,
         model: ClusterMixin,
         candidates_scaled: Union[pd.DataFrame, np.ndarray],
-    ) -> List[int]:
+    ) -> list[int]:
         """Select candidates from the computed clustering.
 
         This function is model-specific and may be implemented by the derived class.
@@ -135,7 +135,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
 class PAMClusteringRecommender(SKLearnClusteringRecommender):
     """Partitioning Around Medoids (PAM) clustering recommender."""
 
-    model_class: ClassVar[Type[ClusterMixin]] = KMedoids
+    model_class: ClassVar[type[ClusterMixin]] = KMedoids
     # See base class.
 
     model_cluster_num_parameter_name: ClassVar[str] = "n_clusters"
@@ -157,7 +157,7 @@ class PAMClusteringRecommender(SKLearnClusteringRecommender):
         self,
         model: ClusterMixin,
         candidates_scaled: Union[pd.DataFrame, np.ndarray],
-    ) -> List[int]:
+    ) -> list[int]:
         """Select candidates from the computed clustering.
 
         In PAM, cluster centers (medoids) correspond to actual data points,
@@ -179,7 +179,7 @@ class KMeansClusteringRecommender(SKLearnClusteringRecommender):
     """K-means clustering recommender."""
 
     # Class variables
-    model_class: ClassVar[Type[ClusterMixin]] = KMeans
+    model_class: ClassVar[type[ClusterMixin]] = KMeans
     # See base class.
 
     model_cluster_num_parameter_name: ClassVar[str] = "n_clusters"
@@ -201,7 +201,7 @@ class KMeansClusteringRecommender(SKLearnClusteringRecommender):
         self,
         model: ClusterMixin,
         candidates_scaled: Union[pd.DataFrame, np.ndarray],
-    ) -> List[int]:
+    ) -> list[int]:
         """Select candidates from the computed clustering.
 
         For K-means, a reasonable choice is to pick the points closest to each
@@ -231,7 +231,7 @@ class GaussianMixtureClusteringRecommender(SKLearnClusteringRecommender):
     """Gaussian mixture model (GMM) clustering recommender."""
 
     # Class variables
-    model_class: ClassVar[Type[ClusterMixin]] = GaussianMixture
+    model_class: ClassVar[type[ClusterMixin]] = GaussianMixture
     # See base class.
 
     model_cluster_num_parameter_name: ClassVar[str] = "n_components"
@@ -241,7 +241,7 @@ class GaussianMixtureClusteringRecommender(SKLearnClusteringRecommender):
         self,
         model: ClusterMixin,
         candidates_scaled: Union[pd.DataFrame, np.ndarray],
-    ) -> List[int]:
+    ) -> list[int]:
         """Select candidates from the computed clustering.
 
         In a GMM, a reasonable choice is to pick the point with the highest

--- a/baybe/scaler.py
+++ b/baybe/scaler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable, Dict, Tuple, Type
+from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
 
@@ -25,7 +25,7 @@ class Scaler(ABC):
     type: str
     """Class variable encoding the type of the scaler."""
 
-    SUBCLASSES: Dict[str, Type[Scaler]] = {}
+    SUBCLASSES: dict[str, type[Scaler]] = {}
     """Class variable for all subclasses"""
 
     def __init__(self, searchspace: pd.DataFrame):
@@ -39,7 +39,7 @@ class Scaler(ABC):
         self.unscale_s: _ScaleFun
 
     @abstractmethod
-    def fit_transform(self, x: Tensor, y: Tensor) -> Tuple[Tensor, Tensor]:
+    def fit_transform(self, x: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
         """Fit the scaler using the given training data and transform the data.
 
         Args:
@@ -66,7 +66,7 @@ class Scaler(ABC):
             raise RuntimeError("Scaler object must be fitted first.")
         return self.scale_x(x)
 
-    def untransform(self, mean: Tensor, variance: Tensor) -> Tuple[Tensor, Tensor]:
+    def untransform(self, mean: Tensor, variance: Tensor) -> tuple[Tensor, Tensor]:
         """Transform mean values and variances back to the original domain.
 
         Args:
@@ -98,7 +98,7 @@ class DefaultScaler(Scaler):
 
     def fit_transform(  # noqa: D102
         self, x: Tensor, y: Tensor
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         # See base class.
 
         import torch

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, List, Optional
+from collections.abc import Collection
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -29,15 +30,15 @@ class SubspaceContinuous(SerialMixin):
     parameter views.
     """
 
-    parameters: List[NumericalContinuousParameter] = field(
+    parameters: list[NumericalContinuousParameter] = field(
         validator=lambda _1, _2, x: validate_parameter_names(x)
     )
     """The list of parameters of the subspace."""
 
-    constraints_lin_eq: List[ContinuousLinearEqualityConstraint] = field(factory=list)
+    constraints_lin_eq: list[ContinuousLinearEqualityConstraint] = field(factory=list)
     """List of linear equality constraints."""
 
-    constraints_lin_ineq: List[ContinuousLinearInequalityConstraint] = field(
+    constraints_lin_ineq: list[ContinuousLinearInequalityConstraint] = field(
         factory=list
     )
     """List of linear inequality constraints."""
@@ -100,7 +101,7 @@ class SubspaceContinuous(SerialMixin):
     def from_dataframe(
         cls,
         df: pd.DataFrame,
-        parameters: Optional[List[NumericalContinuousParameter]] = None,
+        parameters: Optional[list[NumericalContinuousParameter]] = None,
     ) -> SubspaceContinuous:
         """Create a hyperrectangle-shaped continuous subspace from a dataframe.
 
@@ -139,7 +140,7 @@ class SubspaceContinuous(SerialMixin):
         return len(self.parameters) == 0
 
     @property
-    def param_names(self) -> List[str]:
+    def param_names(self) -> list[str]:
         """Return list of parameter names."""
         return [p.name for p in self.parameters]
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Optional, cast
+from typing import Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -93,8 +93,8 @@ class SearchSpace(SerialMixin):
     @classmethod
     def from_product(
         cls,
-        parameters: List[Parameter],
-        constraints: Optional[List[Constraint]] = None,
+        parameters: list[Parameter],
+        constraints: Optional[list[Constraint]] = None,
         empty_encoding: bool = False,
     ) -> SearchSpace:
         """Create a search space from a cartesian product.
@@ -155,7 +155,7 @@ class SearchSpace(SerialMixin):
     def from_dataframe(
         cls,
         df: pd.DataFrame,
-        parameters: List[Parameter],
+        parameters: list[Parameter],
     ) -> SearchSpace:
         """Create a search space from a specified set of parameter configurations.
 
@@ -176,7 +176,7 @@ class SearchSpace(SerialMixin):
         Raises:
             ValueError: If the dataframe columns do not match with the parameters.
         """
-        if set(p.name for p in parameters) != set(df.columns.values):
+        if {p.name for p in parameters} != set(df.columns.values):
             raise ValueError(
                 "The provided dataframe columns must match exactly with the specified "
                 "parameter names."
@@ -195,12 +195,12 @@ class SearchSpace(SerialMixin):
         )
 
     @property
-    def parameters(self) -> List[Parameter]:
+    def parameters(self) -> list[Parameter]:
         """Return the list of parameters of the search space."""
         return self.discrete.parameters + self.continuous.parameters
 
     @property
-    def constraints(self) -> List[Constraint]:
+    def constraints(self) -> list[Constraint]:
         """Return the constraints of the search space."""
         return (
             self.discrete.constraints
@@ -305,12 +305,12 @@ def validate_searchspace_from_config(specs: dict, _) -> None:
     """Validate the search space specifications while skipping costly creation steps."""
     # Validate product inputs without constructing it
     if specs.get("constructor", None) == "from_product":
-        parameters = converter.structure(specs["parameters"], List[Parameter])
+        parameters = converter.structure(specs["parameters"], list[Parameter])
         validate_parameters(parameters)
 
         constraints = specs.get("constraints", None)
         if constraints:
-            constraints = converter.structure(specs["constraints"], List[Constraint])
+            constraints = converter.structure(specs["constraints"], list[Constraint])
             validate_constraints(constraints, parameters)
 
     else:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Iterable
 from itertools import zip_longest
-from typing import Any, Collection, Iterable, List, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -40,7 +41,7 @@ class SubspaceDiscrete(SerialMixin):
     parameter views.
     """
 
-    parameters: List[DiscreteParameter] = field(
+    parameters: list[DiscreteParameter] = field(
         validator=lambda _1, _2, x: validate_parameter_names(x)
     )
     """The list of parameters of the subspace."""
@@ -54,7 +55,7 @@ class SubspaceDiscrete(SerialMixin):
     empty_encoding: bool = field(default=False)
     """Flag encoding whether an empty encoding is used."""
 
-    constraints: List[DiscreteConstraint] = field(factory=list)
+    constraints: list[DiscreteConstraint] = field(factory=list)
     """A list of constraints for restricting the space."""
 
     comp_rep: pd.DataFrame = field(eq=eq_dataframe)
@@ -198,8 +199,8 @@ class SubspaceDiscrete(SerialMixin):
     @classmethod
     def from_product(
         cls,
-        parameters: List[DiscreteParameter],
-        constraints: Optional[List[DiscreteConstraint]] = None,
+        parameters: list[DiscreteParameter],
+        constraints: Optional[list[DiscreteConstraint]] = None,
         empty_encoding: bool = False,
     ) -> SubspaceDiscrete:
         """See :class:`baybe.searchspace.core.SearchSpace`."""
@@ -223,7 +224,7 @@ class SubspaceDiscrete(SerialMixin):
     def from_dataframe(
         cls,
         df: pd.DataFrame,
-        parameters: Optional[List[DiscreteParameter]] = None,
+        parameters: Optional[list[DiscreteParameter]] = None,
         empty_encoding: bool = False,
     ) -> SubspaceDiscrete:
         """Create a discrete subspace with a specified set of configurations.
@@ -267,9 +268,9 @@ class SubspaceDiscrete(SerialMixin):
     def from_simplex(
         cls,
         max_sum: float,
-        simplex_parameters: List[NumericalDiscreteParameter],
-        product_parameters: Optional[List[DiscreteParameter]] = None,
-        constraints: Optional[List[DiscreteConstraint]] = None,
+        simplex_parameters: list[NumericalDiscreteParameter],
+        product_parameters: Optional[list[DiscreteParameter]] = None,
+        constraints: Optional[list[DiscreteConstraint]] = None,
         min_nonzero: int = 0,
         max_nonzero: Optional[int] = None,
         boundary_only: bool = False,
@@ -516,7 +517,7 @@ class SubspaceDiscrete(SerialMixin):
         self,
         allow_repeated_recommendations: bool = False,
         allow_recommending_already_measured: bool = False,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """Return the set of candidate parameter settings that can be tested.
 
         Args:
@@ -580,7 +581,7 @@ class SubspaceDiscrete(SerialMixin):
         return comp_rep
 
 
-def _apply_constraint_filter(df: pd.DataFrame, constraints: List[DiscreteConstraint]):
+def _apply_constraint_filter(df: pd.DataFrame, constraints: list[DiscreteConstraint]):
     """Remove discrete search space entries inplace based on constraints.
 
     Args:
@@ -631,20 +632,20 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
     """Validate the discrete space while skipping costly creation steps."""
     # Validate product inputs without constructing it
     if specs.get("constructor", None) == "from_product":
-        parameters = converter.structure(specs["parameters"], List[DiscreteParameter])
+        parameters = converter.structure(specs["parameters"], list[DiscreteParameter])
         validate_parameters(parameters)
 
         constraints = specs.get("constraints", None)
         if constraints:
             constraints = converter.structure(
-                specs["constraints"], List[DiscreteConstraint]
+                specs["constraints"], list[DiscreteConstraint]
             )
             validate_constraints(constraints, parameters)
 
     # Validate simplex inputs without constructing it
     elif specs.get("constructor", None) == "from_simplex":
         simplex_parameters = converter.structure(
-            specs["simplex_parameters"], List[NumericalDiscreteParameter]
+            specs["simplex_parameters"], list[NumericalDiscreteParameter]
         )
 
         if not all(min(p.values) >= 0.0 for p in simplex_parameters):
@@ -657,7 +658,7 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
         product_parameters = specs.get("product_parameters", None)
         if product_parameters:
             product_parameters = converter.structure(
-                specs["product_parameters"], List[DiscreteParameter]
+                specs["product_parameters"], list[DiscreteParameter]
             )
 
         validate_parameters(simplex_parameters + product_parameters)
@@ -665,7 +666,7 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
         constraints = specs.get("constraints", None)
         if constraints:
             constraints = converter.structure(
-                specs["constraints"], List[DiscreteConstraint]
+                specs["constraints"], list[DiscreteConstraint]
             )
             validate_constraints(constraints, simplex_parameters + product_parameters)
 

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -1,6 +1,5 @@
 """Validation functionality for search spaces."""
 
-from typing import List
 
 from baybe.exceptions import EmptySearchSpaceError
 from baybe.parameters import TaskParameter
@@ -8,7 +7,7 @@ from baybe.parameters.base import Parameter
 
 
 def validate_parameter_names(  # noqa: DOC101, DOC103
-    parameters: List[Parameter],
+    parameters: list[Parameter],
 ) -> None:
     """Validate the parameter names.
 
@@ -20,7 +19,7 @@ def validate_parameter_names(  # noqa: DOC101, DOC103
         raise ValueError("All parameters must have unique names.")
 
 
-def validate_parameters(parameters: List[Parameter]) -> None:  # noqa: DOC101, DOC103
+def validate_parameters(parameters: list[Parameter]) -> None:  # noqa: DOC101, DOC103
     """Validate the parameters.
 
     Raises:

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -1,7 +1,7 @@
 """Converter and hooks."""
 import base64
 import pickle
-from typing import Any, Callable, Optional, Type, TypeVar, get_type_hints
+from typing import Any, Callable, Optional, TypeVar, get_type_hints
 
 import cattrs
 import pandas as pd
@@ -36,9 +36,9 @@ def unstructure_base(base: Any, overrides: Optional[dict] = None) -> dict:
 
 
 def get_base_structure_hook(
-    base: Type[_T],
+    base: type[_T],
     overrides: Optional[dict] = None,
-) -> Callable[[dict, Type[_T]], _T]:
+) -> Callable[[dict, type[_T]], _T]:
     """Return a hook for structuring a dictionary into an appropriate subclass.
 
     Provides the inverse operation to ``unstructure_base``.
@@ -53,7 +53,7 @@ def get_base_structure_hook(
     # TODO: use include_subclasses (https://github.com/python-attrs/cattrs/issues/434)
     from baybe.utils.basic import get_subclasses
 
-    def structure_base(val: dict, _: Type[_T]) -> _T:
+    def structure_base(val: dict, _: type[_T]) -> _T:
         _type = val.pop("type")
         cls = next((cl for cl in get_subclasses(base) if cl.__name__ == _type), None)
         if cls is None:
@@ -100,7 +100,7 @@ def block_deserialization_hook(_: Any, cls: type) -> None:  # noqa: DOC101, DOC1
     )
 
 
-def select_constructor_hook(specs: dict, cls: Type[_T]) -> _T:
+def select_constructor_hook(specs: dict, cls: type[_T]) -> _T:
     """Use the constructor specified in the 'constructor' field for deserialization."""
     # If a constructor is specified, use it
     specs = specs.copy()

--- a/baybe/serialization/mixin.py
+++ b/baybe/serialization/mixin.py
@@ -1,7 +1,7 @@
 """Serialization mixin class."""
 
 import json
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from baybe.serialization.core import converter
 
@@ -20,7 +20,7 @@ class SerialMixin:
         return converter.unstructure(self)
 
     @classmethod
-    def from_dict(cls: Type[_T], dictionary: dict) -> _T:
+    def from_dict(cls: type[_T], dictionary: dict) -> _T:
         """Create an object from its dictionary representation.
 
         Args:
@@ -40,7 +40,7 @@ class SerialMixin:
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls: Type[_T], string: str) -> _T:
+    def from_json(cls: type[_T], string: str) -> _T:
         """Create an object from its JSON representation.
 
         Args:

--- a/baybe/simulation.py
+++ b/baybe/simulation.py
@@ -26,11 +26,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Literal,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -71,7 +68,7 @@ def simulate_transfer_learning(
     *,
     batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
-    groupby: Optional[List[str]] = None,
+    groupby: Optional[list[str]] = None,
     n_mc_iterations: int = 1,
 ) -> pd.DataFrame:
     """Simulate Bayesian optimization with transfer learning.
@@ -121,7 +118,7 @@ def simulate_transfer_learning(
     task_param = task_params[0]
 
     # Create simulation objects for all tasks
-    scenarios: Dict[Any, Campaign] = {}
+    scenarios: dict[Any, Campaign] = {}
     for task in task_param.values:
         # Create a campaign that focuses only on the current task by excluding
         # off-task configurations from the candidates list
@@ -153,14 +150,14 @@ def simulate_transfer_learning(
 
 
 def simulate_scenarios(
-    scenarios: Dict[Any, Campaign],
+    scenarios: dict[Any, Campaign],
     lookup: Optional[Union[pd.DataFrame, Callable]] = None,
     /,
     *,
     batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
-    initial_data: Optional[List[pd.DataFrame]] = None,
-    groupby: Optional[List[str]] = None,
+    initial_data: Optional[list[pd.DataFrame]] = None,
+    groupby: Optional[list[str]] = None,
     n_mc_iterations: int = 1,
     impute_mode: Literal[
         "error", "worst", "best", "mean", "random", "ignore"
@@ -269,13 +266,13 @@ def simulate_scenarios(
 
 def _simulate_groupby(
     campaign: Campaign,
-    lookup: Optional[Union[pd.DataFrame, Callable[..., Tuple[float, ...]]]] = None,
+    lookup: Optional[Union[pd.DataFrame, Callable[..., tuple[float, ...]]]] = None,
     /,
     *,
     batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     initial_data: Optional[pd.DataFrame] = None,
-    groupby: Optional[List[str]] = None,
+    groupby: Optional[list[str]] = None,
     random_seed: int = _DEFAULT_SEED,
     impute_mode: Literal[
         "error", "worst", "best", "mean", "random", "ignore"
@@ -676,7 +673,7 @@ def _look_up_target_values(
 def _impute_lookup(
     row: pd.Series,
     lookup: pd.DataFrame,
-    targets: List[NumericalTarget],
+    targets: list[NumericalTarget],
     mode: Literal["error", "best", "worst", "mean", "random"] = "error",
 ) -> np.ndarray:
     """Perform data imputation for missing lookup values.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -3,7 +3,7 @@
 import gc
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, List, Tuple, Type
+from typing import Any, ClassVar
 
 import torch
 from attr import define, field
@@ -53,10 +53,10 @@ class Surrogate(ABC, SerialMixin):
     #   exposing the individual model parameters via the constructor, instead of
     #   expecting them in the form of an unstructured dictionary. This would also
     #   remove the need for the current `_get_model_params_validator` logic.
-    model_params: Dict[str, Any] = field(factory=dict)
+    model_params: dict[str, Any] = field(factory=dict)
     """Optional model parameters."""
 
-    def posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """Evaluate the surrogate model at the given candidate points.
 
         Args:
@@ -86,7 +86,7 @@ class Surrogate(ABC, SerialMixin):
         return mean, covar
 
     @abstractmethod
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """Perform the actual posterior evaluation logic.
 
         In contrast to its public counterpart
@@ -220,7 +220,7 @@ def _structure_surrogate(val, _):
     return converter.structure_attrs_fromdict(val, cls)
 
 
-def get_available_surrogates() -> List[Type[Surrogate]]:
+def get_available_surrogates() -> list[type[Surrogate]]:
     """List all available surrogate models.
 
     Returns:

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -8,7 +8,7 @@ surrogates can be trained and attempts to do so for each new DOE iteration.
 It is planned to solve this issue in the future.
 """
 
-from typing import Callable, ClassVar, Tuple
+from typing import Callable, ClassVar
 
 import torch
 from attrs import define, field, validators
@@ -74,7 +74,7 @@ def register_custom_architecture(
             ) -> None:
                 return self.model._fit(searchspace, train_x, train_y)
 
-            def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+            def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
                 return self.model._posterior(candidates)
 
             def __get_attribute__(self, attr):
@@ -151,7 +151,7 @@ if _ONNX_INSTALLED:
                 raise ModelParamsNotSupportedError()
 
         @batchify
-        def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+        def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
             model_inputs = {
                 self.onnx_input_name: candidates.numpy().astype(DTypeFloatONNX)
             }

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -1,6 +1,6 @@
 """Gaussian process surrogates."""
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Optional
 
 import torch
 from attr import define, field
@@ -31,7 +31,7 @@ class GaussianProcessSurrogate(Surrogate):
     # See base class.
 
     # Object variables
-    model_params: Dict[str, Any] = field(
+    model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,
         validator=get_model_params_validator(SingleTaskGP.__init__),
@@ -41,7 +41,7 @@ class GaussianProcessSurrogate(Surrogate):
     _model: Optional[SingleTaskGP] = field(init=False, default=None)
     """The actual model."""
 
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         posterior = self._model.posterior(candidates)
         return posterior.mvn.mean, posterior.mvn.covariance_matrix

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -7,7 +7,7 @@ Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Optional
 
 import torch
 from attr import define, field
@@ -34,7 +34,7 @@ class BayesianLinearSurrogate(Surrogate):
     # See base class.
 
     # Object variables
-    model_params: Dict[str, Any] = field(
+    model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,
         validator=get_model_params_validator(ARDRegression.__init__),
@@ -45,7 +45,7 @@ class BayesianLinearSurrogate(Surrogate):
     """The actual model."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         # Get predictions
         dists = self._model.predict(candidates.numpy(), return_std=True)

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -1,6 +1,6 @@
 """Naive surrogates."""
 
-from typing import ClassVar, Optional, Tuple
+from typing import ClassVar, Optional
 
 import torch
 from attr import define, field
@@ -31,7 +31,7 @@ class MeanPredictionSurrogate(Surrogate):
     """The value of the posterior mean."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         # TODO: use target value bounds for covariance scaling when explicitly provided
         mean = self.target_value * torch.ones([len(candidates)])

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -7,7 +7,7 @@ Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Optional
 
 import torch
 from attr import define, field
@@ -37,7 +37,7 @@ class NGBoostSurrogate(Surrogate):
     """Class variable encoding the default model parameters."""
 
     # Object variables
-    model_params: Dict[str, Any] = field(
+    model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,
         validator=get_model_params_validator(NGBRegressor.__init__),
@@ -51,7 +51,7 @@ class NGBoostSurrogate(Surrogate):
         self.model_params = {**self._default_model_params, **self.model_params}
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         # Get predictions
         dists = self._model.pred_dist(candidates)

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -7,7 +7,7 @@ Since we plan to refactor the surrogates, this part of the documentation will be
 available in the future. Thus, please have a look in the source code directly.
 """
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Optional
 
 import numpy as np
 import torch
@@ -35,7 +35,7 @@ class RandomForestSurrogate(Surrogate):
     # See base class.
 
     # Object variables
-    model_params: Dict[str, Any] = field(
+    model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,
         validator=get_model_params_validator(RandomForestRegressor.__init__),
@@ -46,7 +46,7 @@ class RandomForestSurrogate(Surrogate):
     """The actual model."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
         # Evaluate all trees

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, ClassVar, Tuple, Type
+from typing import TYPE_CHECKING, Callable, ClassVar
 
 import torch
 from torch import Tensor
@@ -57,7 +57,7 @@ def _prepare_targets(y: Tensor) -> Tensor:
     return y.to(_DTYPE)
 
 
-def catch_constant_targets(model_cls: Type[Surrogate]):
+def catch_constant_targets(model_cls: type[Surrogate]):
     """Wrap a ``Surrogate`` class that cannot handle constant training target values.
 
     In the wrapped class, these cases are handled by a separate model type.
@@ -88,7 +88,7 @@ def catch_constant_targets(model_cls: Type[Surrogate]):
             self.__class__.__name__ = self.model.__class__.__name__
             self.model_params = self.model.model_params
 
-        def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+        def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
             """Call the posterior function of the internal model instance."""
             mean, var = self.model._posterior(candidates)
 
@@ -139,7 +139,7 @@ def catch_constant_targets(model_cls: Type[Surrogate]):
     return SplitModel
 
 
-def scale_model(model_cls: Type[Surrogate]):
+def scale_model(model_cls: type[Surrogate]):
     """Wrap a ``Surrogate`` class such that it operates with scaled representations.
 
     Args:
@@ -165,7 +165,7 @@ def scale_model(model_cls: Type[Surrogate]):
             self.model_params = self.model.model_params
             self.scaler = None
 
-        def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+        def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
             """Call the posterior function of the internal model instance.
 
             This call is made on a scaled version of the test data and rescales the
@@ -208,8 +208,8 @@ def scale_model(model_cls: Type[Surrogate]):
 
 
 def batchify(
-    posterior: Callable[[Surrogate, Tensor], Tuple[Tensor, Tensor]]
-) -> Callable[[Surrogate, Tensor], Tuple[Tensor, Tensor]]:
+    posterior: Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]]
+) -> Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]]:
     """Wrap ``Surrogate`` posterior functions to enable proper batching.
 
     More precisely, this wraps model that are incompatible with t- and q-batching such

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -1,8 +1,9 @@
 """Numerical targets."""
 
 import warnings
+from collections.abc import Sequence
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Sequence, cast
+from typing import Any, Callable, Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -19,7 +20,7 @@ from baybe.targets.transforms import (
 )
 from baybe.utils.interval import Interval, convert_bounds
 
-_VALID_TRANSFORMATIONS: Dict[TargetMode, Sequence[TargetTransformation]] = {
+_VALID_TRANSFORMATIONS: dict[TargetMode, Sequence[TargetTransformation]] = {
     TargetMode.MAX: (TargetTransformation.LINEAR,),
     TargetMode.MIN: (TargetTransformation.LINEAR,),
     TargetMode.MATCH: (TargetTransformation.TRIANGULAR, TargetTransformation.BELL),

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -78,7 +78,7 @@ import hashlib
 import os
 import socket
 import warnings
-from typing import Dict, List, Union
+from typing import Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -201,7 +201,7 @@ if is_enabled():
                 raise requests.RequestException("Cannot reach telemetry network.")
 
         # User has connectivity to the telemetry endpoint, so we initialize
-        _instruments: Dict[str, Histogram] = {}
+        _instruments: dict[str, Histogram] = {}
         _resource = Resource.create(
             {"service.namespace": "BayBE", "service.name": "SDK"}
         )
@@ -228,7 +228,7 @@ if is_enabled():
         os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 
 
-def get_user_details() -> Dict[str, str]:
+def get_user_details() -> dict[str, str]:
     """Generate user details.
 
     These are submitted as metadata with requested telemetry stats.
@@ -280,7 +280,7 @@ def _submit_scalar_value(instrument_name: str, value: Union[int, float]) -> None
 def telemetry_record_recommended_measurement_percentage(
     cached_recommendation: pd.DataFrame,
     measurements: pd.DataFrame,
-    parameters: List[Parameter],
+    parameters: list[Parameter],
     numerical_measurements_must_be_within_tolerance: bool,
 ) -> None:
     """Submit the percentage of added measurements.

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -1,8 +1,9 @@
 """Collection of small basic utilities."""
 
 import random
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Callable, Dict, Iterable, List, TypeVar
+from typing import Callable, TypeVar
 
 import numpy as np
 
@@ -23,7 +24,7 @@ class Dummy:
         return "<dummy>"
 
 
-def get_subclasses(cls: _C, recursive: bool = True, abstract: bool = False) -> List[_C]:
+def get_subclasses(cls: _C, recursive: bool = True, abstract: bool = False) -> list[_C]:
     """Return a list of subclasses for the given class.
 
     Args:
@@ -69,7 +70,7 @@ def hilberts_factory(factory: Callable[..., _T]) -> Iterable[_T]:
         yield factory()
 
 
-def group_duplicate_values(dictionary: Dict[_T, _U]) -> Dict[_U, List[_T]]:
+def group_duplicate_values(dictionary: dict[_T, _U]) -> dict[_U, list[_T]]:
     """Identify groups of keys that have the same value.
 
     Args:
@@ -83,7 +84,7 @@ def group_duplicate_values(dictionary: Dict[_T, _U]) -> Dict[_U, List[_T]]:
         >>> group_duplicate_values({"A": 1, "B": 2, "C": 1, "D": 3})
         {1: ['B', 'C']}
     """
-    group: Dict[_U, List[_T]] = {}
+    group: dict[_U, list[_T]] = {}
     for key, value in dictionary.items():
         group.setdefault(value, []).append(key)
     return {k: v for k, v in group.items() if len(v) > 1}

--- a/baybe/utils/chemistry.py
+++ b/baybe/utils/chemistry.py
@@ -5,7 +5,7 @@ import tempfile
 import urllib.request
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Type, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -98,7 +98,7 @@ def _smiles_to_mordred_features(smiles: str) -> np.ndarray:
 
 
 def smiles_to_mordred_features(
-    smiles_list: List[str],
+    smiles_list: list[str],
     prefix: str = "",
     dropna: bool = True,
 ) -> pd.DataFrame:
@@ -125,7 +125,7 @@ def smiles_to_mordred_features(
     return dataframe
 
 
-def smiles_to_molecules(smiles_list: List[str]) -> List[Chem.Mol]:
+def smiles_to_molecules(smiles_list: list[str]) -> list[Chem.Mol]:
     """Convert a given list of SMILES strings into corresponding Molecule objects.
 
     Args:
@@ -152,7 +152,7 @@ def smiles_to_molecules(smiles_list: List[str]) -> List[Chem.Mol]:
 
 
 def smiles_to_rdkit_features(
-    smiles_list: List[str], prefix: str = "", dropna: bool = True
+    smiles_list: list[str], prefix: str = "", dropna: bool = True
 ) -> pd.DataFrame:
     """Compute RDKit chemical descriptors for a list of SMILES strings.
 
@@ -182,9 +182,9 @@ def smiles_to_rdkit_features(
 
 
 def smiles_to_fp_features(
-    smiles_list: List[str],
+    smiles_list: list[str],
     prefix: str = "",
-    dtype: Union[Type[int], Type[float]] = int,
+    dtype: Union[type[int], type[float]] = int,
     radius: int = 4,
     n_bits: int = 1024,
 ) -> pd.DataFrame:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -52,9 +53,9 @@ def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
 def add_fake_results(
     data: pd.DataFrame,
     campaign: Campaign,
-    good_reference_values: Optional[Dict[str, list]] = None,
-    good_intervals: Optional[Dict[str, Tuple[float, float]]] = None,
-    bad_intervals: Optional[Dict[str, Tuple[float, float]]] = None,
+    good_reference_values: Optional[dict[str, list]] = None,
+    good_intervals: Optional[dict[str, tuple[float, float]]] = None,
+    bad_intervals: Optional[dict[str, tuple[float, float]]] = None,
 ) -> None:
     """Add fake results to a dataframe which was the result of a BayBE recommendation.
 
@@ -259,7 +260,7 @@ def df_drop_single_value_columns(
 
 
 def df_drop_string_columns(
-    df: pd.DataFrame, ignore_list: Optional[List[str]] = None
+    df: pd.DataFrame, ignore_list: Optional[list[str]] = None
 ) -> pd.DataFrame:
     """Drop dataframe columns with string values.
 
@@ -280,7 +281,7 @@ def df_drop_string_columns(
 
 
 def df_uncorrelated_features(
-    df: pd.DataFrame, exclude_list: Optional[List[str]] = None, threshold: float = 0.7
+    df: pd.DataFrame, exclude_list: Optional[list[str]] = None, threshold: float = 0.7
 ):
     """Return an uncorrelated set of features.
 
@@ -323,7 +324,7 @@ def df_uncorrelated_features(
 def fuzzy_row_match(
     left_df: pd.DataFrame,
     right_df: pd.DataFrame,
-    parameters: List[Parameter],
+    parameters: list[Parameter],
     numerical_measurements_must_be_within_tolerance: bool,
 ) -> pd.Index:
     """Match row of the right dataframe to the rows of the left dataframe.

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from collections.abc import Iterable
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from attrs import define, field
@@ -120,7 +120,7 @@ class Interval(SerialMixin):
         """Overloaded implementation for creating an interval of an iterable."""
         return Interval(*bounds)
 
-    def to_tuple(self) -> Tuple[float, float]:
+    def to_tuple(self) -> tuple[float, float]:
         """Transform the interval to a tuple."""
         return self.lower, self.upper
 
@@ -160,7 +160,7 @@ def convert_bounds(bounds: Union[None, tuple, Interval]) -> Interval:
     return Interval.create(bounds)
 
 
-def use_fallback_constructor_hook(value: Any, cls: Type[Interval]) -> Interval:
+def use_fallback_constructor_hook(value: Any, cls: type[Interval]) -> Interval:
     """Use the singledispatch mechanism as fallback to parse arbitrary input."""
     if isinstance(value, dict):
         return converter.structure_attrs_fromdict(value, cls)

--- a/baybe/utils/numerical.py
+++ b/baybe/utils/numerical.py
@@ -1,5 +1,4 @@
 """Utilities for numeric operations."""
-from typing import List
 
 import numpy as np
 import torch
@@ -21,7 +20,7 @@ There is no clear documentation but some references can be found here (version 1
 """  # noqa: E501
 
 
-def geom_mean(arr: np.ndarray, weights: List[float]) -> np.ndarray:
+def geom_mean(arr: np.ndarray, weights: list[float]) -> np.ndarray:
     """Calculate the (weighted) geometric mean along the second axis of a 2-D array.
 
     Alternative to ``gmean`` from scipy that avoids logarithms and division errors.

--- a/baybe/utils/plotting.py
+++ b/baybe/utils/plotting.py
@@ -5,7 +5,7 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
@@ -40,7 +40,7 @@ def create_example_plots(
         return
 
     # Define a fallback theme in case no configuration is found
-    fallback: Dict[str, Any] = {
+    fallback: dict[str, Any] = {
         "color": "black",
         "figsize": (24, 8),
         "fontsize": 22,
@@ -88,7 +88,7 @@ def create_example_plots(
         else:
             current_theme = themes[theme_name]
         color: str = current_theme["color"]
-        figsize: Tuple[int, int] = current_theme["figsize"]
+        figsize: tuple[int, int] = current_theme["figsize"]
         fontsize: int = current_theme["fontsize"]
         framealpha: float = current_theme["framealpha"]
 

--- a/baybe/utils/sampling_algorithms.py
+++ b/baybe/utils/sampling_algorithms.py
@@ -1,6 +1,6 @@
 """A collection of point sampling algorithms."""
 
-from typing import List, Literal
+from typing import Literal
 
 import numpy as np
 from sklearn.metrics import pairwise_distances
@@ -10,7 +10,7 @@ def farthest_point_sampling(
     points: np.ndarray,
     n_samples: int = 1,
     initialization: Literal["farthest", "random"] = "farthest",
-) -> List[int]:
+) -> list[int]:
     """Sample points according to a farthest point heuristic.
 
     Creates a subset of a collection of points by successively adding points with the

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -21,7 +21,7 @@ def adjust_pictures(
         light_version: The name of the light mode picture version.
         dark_version: The name of the dark mode picture version.
     """
-    with open(file_path, "r") as file:
+    with open(file_path) as file:
         lines = file.readlines()
 
     line_index = None
@@ -166,7 +166,7 @@ def create_example_documentation(example_dest_dir: str, ignore_examples: bool):
             # We wrap lines which are too long as long as they do not contain a link.
             # To discover whether a line contains a link, we check if the string "]("
             # is contained.
-            with open(markdown_path, "r", encoding="UTF-8") as markdown_file:
+            with open(markdown_path, encoding="UTF-8") as markdown_file:
                 content = markdown_file.read()
                 wrapped_lines = []
                 ignored_substrings = (

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -12,7 +12,6 @@
 ### Necessary imports for this example
 
 import os
-from typing import Tuple
 
 import numpy as np
 
@@ -43,7 +42,7 @@ POINTS_PER_DIM = 3 if SMOKE_TEST else 10
 # See [`custom_analytical`](./custom_analytical.md) for details.
 
 
-def sum_of_squares(*x: float) -> Tuple[float, float]:
+def sum_of_squares(*x: float) -> tuple[float, float]:
     """Calculate the sum of squares."""
     res = 0
     for y in x:

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -8,7 +8,7 @@
 
 ### Necessary imports
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import torch
@@ -55,7 +55,7 @@ class MeanVarEstimator(BaseEstimator, RegressorMixin):
         """No fit needed."""
         return
 
-    def predict(self, data: Tensor) -> Tuple[Tensor, Tensor]:
+    def predict(self, data: Tensor) -> tuple[Tensor, Tensor]:
         """Predict based on ensemble unweighted mean and variance."""
         mean = torch.tensor(data.mean(axis=1))
         var = torch.tensor(data.var(axis=1))
@@ -76,7 +76,7 @@ class StackingRegressorSurrogate:
     def __init__(self):
         self.model: Optional[StackingRegressor] = None
 
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """See :class:`baybe.surrogates.Surrogate`."""
         return self.model.predict(candidates)
 

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -8,7 +8,7 @@
 
 ### Necessary imports
 
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import numpy as np
 import torch
@@ -65,7 +65,7 @@ def _create_linear_block(in_features: int, out_features: int) -> list:
     return [nn.Linear(in_features, out_features), nn.Dropout(p=DROPOUT), nn.ReLU()]
 
 
-def _create_hidden_layers(num_neurons: List[int]) -> list:
+def _create_hidden_layers(num_neurons: list[int]) -> list:
     """Create all hidden layers comprised of linear blocks."""
     layers = []
     for in_features, out_features in zip(num_neurons, num_neurons[1:]):
@@ -116,7 +116,7 @@ class NeuralNetDropoutSurrogate:
     def __init__(self):
         self.model: Optional[nn.Module] = None
 
-    def _posterior(self, candidates: Tensor) -> Tuple[Tensor, Tensor]:
+    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """See :class:`baybe.surrogates.Surrogate`."""
         self.model = self.model.train()  # keep dropout
         # Convert input from double to float

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -13,7 +13,6 @@
 import os
 import sys
 from pathlib import Path
-from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -118,7 +117,7 @@ test_functions = {
 
 grid = np.meshgrid(*[p.values for p in discrete_params])
 
-lookups: Dict[str, pd.DataFrame] = {}
+lookups: dict[str, pd.DataFrame] = {}
 for function_name, function in test_functions.items():
     lookup = pd.DataFrame({f"x{d}": grid_d.ravel() for d, grid_d in enumerate(grid)})
     lookup["Target"] = tuple(lookup.apply(function, axis=1))

--- a/examples/Transfer_Learning/basic_transfer_learning.py
+++ b/examples/Transfer_Learning/basic_transfer_learning.py
@@ -12,7 +12,6 @@
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List
 
 import numpy as np
 import pandas as pd
@@ -119,7 +118,7 @@ test_functions = {
 
 grid = np.meshgrid(*[p.values for p in discrete_params])
 
-lookups: Dict[str, pd.DataFrame] = {}
+lookups: dict[str, pd.DataFrame] = {}
 for function_name, function in test_functions.items():
     lookup = pd.DataFrame({f"x{d}": grid_d.ravel() for d, grid_d in enumerate(grid)})
     lookup["Target"] = lookup.apply(function, axis=1)
@@ -135,7 +134,7 @@ lookup_test_task = lookups["Test_Function"]
 # To average out and reduce statistical effects that might happen due to the random
 # sampling of the provided data, we perform several Monte Carlo runs.
 
-results: List[pd.DataFrame] = []
+results: list[pd.DataFrame] = []
 for p in (0.01, 0.02, 0.05, 0.08, 0.2):
     campaign = Campaign(searchspace=searchspace, objective=objective)
     initial_data = [lookup_training_task.sample(frac=p) for _ in range(N_MC_ITERATIONS)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from itertools import chain
-from typing import List, Tuple, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -202,7 +202,7 @@ def fixture_mock_categories():
 
 @pytest.fixture(name="parameters")
 def fixture_parameters(
-    parameter_names: List[str], mock_substances, mock_categories, n_grid_points
+    parameter_names: list[str], mock_substances, mock_categories, n_grid_points
 ):
     """Provides example parameters via specified names."""
     # FIXME: n_grid_points causes duplicate test cases if the argument is not used
@@ -347,7 +347,7 @@ def fixture_parameters(
 
 
 @pytest.fixture(name="targets")
-def fixture_targets(target_names: List[str]):
+def fixture_targets(target_names: list[str]):
     """Provides example targets via specified names."""
     # Required for the selection to work as intended (if the input was a single string,
     # the list comprehension would match substrings instead)
@@ -391,7 +391,7 @@ def fixture_targets(target_names: List[str]):
 
 
 @pytest.fixture(name="constraints")
-def fixture_constraints(constraint_names: List[str], mock_substances, n_grid_points):
+def fixture_constraints(constraint_names: list[str], mock_substances, n_grid_points):
     """Provides example constraints via specified names."""
     # Required for the selection to work as intended (if the input was a single string,
     # the list comprehension would match substrings instead)
@@ -798,7 +798,7 @@ def fixture_default_onnx_str() -> Union[bytes, None]:
 
 
 @pytest.fixture(name="onnx_surrogate")
-def fixture_default_onnx_surrogate(onnx_str) -> Union["CustomONNXSurrogate", None]:
+def fixture_default_onnx_surrogate(onnx_str) -> Union[CustomONNXSurrogate, None]:
     """The default ONNX model to be used if not specified differently."""
     # TODO [19298]: There should be a cleaner way than returning None.
     if not _ONNX_INSTALLED:
@@ -833,7 +833,7 @@ def run_iterations(
         campaign.add_measurements(rec)
 
 
-def get_dummy_training_data(length: int) -> Tuple[pd.DataFrame, pd.DataFrame]:
+def get_dummy_training_data(length: int) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Create column-less input and target dataframes of specified length."""
     df = pd.DataFrame(np.empty((length, 0)))
     return df, df

--- a/tests/docs/utils.py
+++ b/tests/docs/utils.py
@@ -2,12 +2,12 @@
 
 import re
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 
 def extract_code_blocks(
     path: Union[str, Path], include_tilde: bool = True
-) -> List[str]:
+) -> list[str]:
     """Extract all python code blocks from the specified file."""
     contents = Path(path).read_text()
     pattern = (

--- a/tests/serialization/test_meta_recommender_serialization.py
+++ b/tests/serialization/test_meta_recommender_serialization.py
@@ -14,7 +14,7 @@ from tests.conftest import select_recommender
 
 # Create some recommenders of different class for better differentiation after roundtrip
 RECOMMENDERS = [RandomRecommender(), FPSRecommender()]
-assert len(RECOMMENDERS) == len(set(rec.__class__.__name__ for rec in RECOMMENDERS))
+assert len(RECOMMENDERS) == len({rec.__class__.__name__ for rec in RECOMMENDERS})
 
 
 def roundtrip(recommender: MetaRecommender) -> MetaRecommender:

--- a/tests/test_custom_surrogate.py
+++ b/tests/test_custom_surrogate.py
@@ -67,7 +67,7 @@ def test_validate_architectures():
     """Test architecture class validation."""
     # Scenario: Empty Class
     with pytest.raises(ValueError):
-        register_custom_architecture()(type("EmptyArch"))
+        register_custom_architecture()(str)
 
     # Scenario: Class with just `_fit`
     with pytest.raises(ValueError):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -52,7 +52,7 @@ def test_missing_recommender_type(config):
 
 # Create some recommenders of different class for better differentiation after roundtrip
 RECOMMENDERS = [RandomRecommender(), FPSRecommender()]
-assert len(RECOMMENDERS) == len(set(rec.__class__.__name__ for rec in RECOMMENDERS))
+assert len(RECOMMENDERS) == len({rec.__class__.__name__ for rec in RECOMMENDERS})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Update the syntax to Python 3.9 via `pyupgrade` and add `pyupgrade` as a pre-commit hook.