### PR TITLE
Change order in sidebar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ License <misc/license_link>
    :toctree: _autosummary
    :template: custom-module-template.rst
    :recursive:
-   :caption: Package documentation
+   :caption: Package
 
    baybe
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,37 +5,35 @@
 :hidden:
 
 Readme <self>
-User Guide <userguide/userguide>
-Examples <examples/examples>
 Contribute <misc/contributing_link>
+Known Issues <known_issues>
+Changelog <misc/changelog_link>
+Github <https://github.com/emdgroup/baybe/>
+Contributors <misc/contributors_link>
+License <misc/license_link>
 ```
 
 ```{include} ../README.md
 :relative-docs: docs/
 ```
 
-# Package documentation
 ```{eval-rst}
 .. autosummary::
    :toctree: _autosummary
    :template: custom-module-template.rst
    :recursive:
-   :caption: Package
+   :caption: Package documentation
 
    baybe
 ```
 
 ```{toctree}
-    :maxdepth: 2
-    :titlesonly:
-    :caption: Misc
-    :hidden:
+:maxdepth: 2
+:titlesonly:
+:hidden:
 
-    Known Issues <known_issues>
-    Changelog <misc/changelog_link>
-    Github <https://github.com/emdgroup/baybe/>
-    Contributors <misc/contributors_link>
-    License <misc/license_link>
+User Guide <userguide/userguide>
+Examples <examples/examples>
 ```
 
 # Indices and Tables


### PR DESCRIPTION
This PR changes the order of the items in the left sidebar of the documentation.

This is necessary since the current order makes certain items of the sidebar disappear. For testing purposes, this was thus first built and tested on my fork, and the documentation based on this branch can be seen here: https://avhopp.github.io/baybe_dev/