### PR TITLE
Remove optional telemetry group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.12
 - Upgraded syntax to Python 3.9
 
+### Removed
+- Optional `telemetry` dependency is no longer a group
+
 ## [0.8.1] - 2024-03-11
 ### Added
 - Better human readable `__str__` representation of campaign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.12
 - Upgraded syntax to Python 3.9
 
-### Removed
-- Optional `telemetry` dependency is no longer a group
+### Fixed
+- `telemetry` dependency is no longer a group (enables Poetry installation)
 
 ## [0.8.1] - 2024-03-11
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,14 @@ dependencies = [
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
     "torch>=1.13.1",
-    "opentelemetry-sdk>=1.16.0", # Telemetry
-    "opentelemetry-propagator-aws-xray>=1.0.0", # Telemetry
-    "opentelemetry-exporter-otlp>=1.16.0", # Telemetry
-    "opentelemetry-sdk-extension-aws>=2.0.0", # Telemetry
-    "requests>=2.31.0", # see AUDIT NOTE # Telemetry
-    "urllib3>=2.0.7", # see AUDIT NOTE # Telemetry
+
+    # Telemetry:
+    "opentelemetry-sdk>=1.16.0",
+    "opentelemetry-propagator-aws-xray>=1.0.0",
+    "opentelemetry-exporter-otlp>=1.16.0",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
+    "requests>=2.31.0", # see AUDIT NOTE
+    "urllib3>=2.0.7", # see AUDIT NOTE
 ]
 
 [project.urls]
@@ -65,10 +67,6 @@ Issues = "https://github.com/emdgroup/baybe/issues/"
 # AUDIT NOTE: The marked packages are secondary dependencies but their versions are
 # set explicitly because the otherwise installed default versions have been flagged
 # for vulnerabilities by pip-audit
-
-# TELEMETRY NOTE: Some of the packages are only necessary for telemetry reasons.
-# Since these cannot be put in an dependency group due to potential installation issues,
-# these are instead marked by a comment.
 
 [project.optional-dependencies]
 chem = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,12 @@ dependencies = [
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
     "torch>=1.13.1",
-    # Following packages are necessary for telemetry. Due to issue with poetry
-    # installations, they are not contained in a group but added explicitly.
-    "opentelemetry-sdk>=1.16.0",
-    "opentelemetry-propagator-aws-xray>=1.0.0",
-    "opentelemetry-exporter-otlp>=1.16.0",
-    "opentelemetry-sdk-extension-aws>=2.0.0",
-    "requests>=2.31.0", # see AUDIT NOTE
-    "urllib3>=2.0.7", # see AUDIT NOTE
+    "opentelemetry-sdk>=1.16.0", # Telemetry
+    "opentelemetry-propagator-aws-xray>=1.0.0", # Telemetry
+    "opentelemetry-exporter-otlp>=1.16.0", # Telemetry
+    "opentelemetry-sdk-extension-aws>=2.0.0", # Telemetry
+    "requests>=2.31.0", # see AUDIT NOTE # Telemetry
+    "urllib3>=2.0.7", # see AUDIT NOTE # Telemetry
 ]
 
 [project.urls]
@@ -67,6 +65,10 @@ Issues = "https://github.com/emdgroup/baybe/issues/"
 # AUDIT NOTE: The marked packages are secondary dependencies but their versions are
 # set explicitly because the otherwise installed default versions have been flagged
 # for vulnerabilities by pip-audit
+
+# TELEMETRY NOTE: Some of the packages are only necessary for telemetry reasons.
+# Since these cannot be put in an dependency group due to potential installation issues,
+# these are instead marked by a comment.
 
 [project.optional-dependencies]
 chem = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,14 +90,6 @@ dev = [
     "baybe[test]",
     "pip-audit>=2.5.5",
     "tox>=4.10.0",
-    # Following packages are necessary for telemetry. Due to issue with poetry
-    # installations, they are not contained in a group but added explicitly.
-    "opentelemetry-sdk>=1.16.0",
-    "opentelemetry-propagator-aws-xray>=1.0.0",
-    "opentelemetry-exporter-otlp>=1.16.0",
-    "opentelemetry-sdk-extension-aws>=2.0.0",
-    "requests>=2.31.0", # see AUDIT NOTE
-    "urllib3>=2.0.7", # see AUDIT NOTE
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,14 @@ dependencies = [
     "scipy>=1.10.1",
     "setuptools-scm>=7.1.0",
     "torch>=1.13.1",
-    "baybe[telemetry]",
+    # Following packages are necessary for telemetry. Due to issue with poetry
+    # installations, they are not contained in a group but added explicitly.
+    "opentelemetry-sdk>=1.16.0",
+    "opentelemetry-propagator-aws-xray>=1.0.0",
+    "opentelemetry-exporter-otlp>=1.16.0",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
+    "requests>=2.31.0", # see AUDIT NOTE
+    "urllib3>=2.0.7", # see AUDIT NOTE
 ]
 
 [project.urls]
@@ -80,10 +87,17 @@ dev = [
     "baybe[mypy]",
     "baybe[onnx]",
     "baybe[simulation]",
-    "baybe[telemetry]",
     "baybe[test]",
     "pip-audit>=2.5.5",
     "tox>=4.10.0",
+    # Following packages are necessary for telemetry. Due to issue with poetry
+    # installations, they are not contained in a group but added explicitly.
+    "opentelemetry-sdk>=1.16.0",
+    "opentelemetry-propagator-aws-xray>=1.0.0",
+    "opentelemetry-exporter-otlp>=1.16.0",
+    "opentelemetry-sdk-extension-aws>=2.0.0",
+    "requests>=2.31.0", # see AUDIT NOTE
+    "urllib3>=2.0.7", # see AUDIT NOTE
 ]
 
 docs = [
@@ -128,15 +142,6 @@ mypy = [
 
 simulation = [
     "xyzpy>=1.2.1",
-]
-
-telemetry = [
-    "opentelemetry-sdk>=1.16.0",
-    "opentelemetry-propagator-aws-xray>=1.0.0",
-    "opentelemetry-exporter-otlp>=1.16.0",
-    "opentelemetry-sdk-extension-aws>=2.0.0",
-    "requests>=2.31.0", # see AUDIT NOTE
-    "urllib3>=2.0.7", # see AUDIT NOTE
 ]
 
 test = [


### PR DESCRIPTION
This PR removes the optional `telemetry` group from `pyproject.toml`. The corresponding packages are now directly included without having them as a separate group.

This was necessary since there were problems with installing `baybe` via `poetry` since the `dependencies` contained this explicit dependency. To enable installation with poetry, this was thus changed.