### PR TITLE
Use tox-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run linting
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e lint-${{ matrix.py-version.tox }}
 
   build-docs:
@@ -81,7 +81,7 @@ jobs:
         with: {python-version: "3.12"}
       - name: Build Docs
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e docs-py312 -- -e
           
   typecheck:
@@ -99,7 +99,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run type check
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e mypy-${{ matrix.py-version.tox }}
 
   audit:
@@ -117,7 +117,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run pip-audit
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e audit-${{ matrix.py-version.tox }}
 
   coretest:
@@ -139,7 +139,7 @@ jobs:
           key: coretest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run core tests
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e coretest-${{ matrix.py-version.tox }}
 
   fulltest:
@@ -161,7 +161,7 @@ jobs:
           key: fulltest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run full tests
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e fulltest-${{ matrix.py-version.tox }} -- --cov-report=xml
       - name: "Assert Overall Coverage"
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         with: {python-version: "3.9"}
       - name: Build Docs
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e docs-py39
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -43,7 +43,7 @@ jobs:
         with: {python-version: "3.9"}
       - name: Build Docs
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e docs-py39
 
   lint:
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run linting
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e lint-${{ matrix.py-version.tox }}
 
   typecheck:
@@ -86,7 +86,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run type check
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e mypy-${{ matrix.py-version.tox }}
 
   audit:
@@ -108,7 +108,7 @@ jobs:
           python-version: ${{ matrix.py-version.semantic }}
       - name: Run pip-audit
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e audit-${{ matrix.py-version.tox }}
 
   coretest:
@@ -134,7 +134,7 @@ jobs:
           key: coretest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run core tests
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e coretest-${{ matrix.py-version.tox }}
 
   fulltest:
@@ -160,7 +160,7 @@ jobs:
           key: fulltest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run full tests
         run: |
-          pip install tox
+          pip install tox-uv
           tox -e fulltest-${{ matrix.py-version.tox }} -- --cov-report=xml
       - name: "Assert Overall Coverage"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `onnx` version to fix vulnerability
 - Increased threshold for low-dimensional GP priors
 - Replaced `fit_gpytorch_mll_torch` with `fit_gpytorch_mll`
+- Use `tox-uv` in pipelines
 
 ### Fixed
 - `telemetry` dependency is no longer a group (enables Poetry installation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "baybe[simulation]",
     "baybe[test]",
     "pip-audit>=2.5.5",
-    "tox>=4.10.0",
+    "tox-uv>=1.7.0",
 ]
 
 docs = [


### PR DESCRIPTION
Speedup our environment creation by using `uv` instead of `pip` via `tox-uv`.

The following times were obtained on my local machine by creating environments via `tox --devenv toxenv -e audit-py39` (since `audit` installs all `dev` dependencies):
* tox: 64s
* tox-uv (no cache): 29s
* tox-uv (cached): 4s
