### PR TITLE
Fix: n_task_params now evaluates to 1 if task_idx == 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `torch` numeric types are now loaded lazily
 
+### Fixed
+- `n_task_params` now evaluates to 1 if `task_idx == 0`
+
 ## [0.8.2] - 2024-03-27
 ### Added
 - Simulation user guide

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -52,7 +52,7 @@ class GaussianProcessSurrogate(Surrogate):
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
         task_idx = searchspace.task_idx
-        n_task_params = 1 if task_idx not None else 0
+        n_task_params = 1 if task_idx is not None else 0
         numeric_idxs = [i for i in range(train_x.shape[1]) if i != task_idx]
 
         # get the input bounds from the search space in BoTorch Format

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -52,7 +52,7 @@ class GaussianProcessSurrogate(Surrogate):
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
         task_idx = searchspace.task_idx
-        n_task_params = 1 if task_idx else 0
+        n_task_params = 1 if task_idx not None else 0
         numeric_idxs = [i for i in range(train_x.shape[1]) if i != task_idx]
 
         # get the input bounds from the search space in BoTorch Format


### PR DESCRIPTION
fixes inconsistencies treating the `TaskParameter` that could cause errors when the other parts of the searchspace are purely continuous