### PR TITLE
Acquisition function classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `mypy` for search space and objectives
 - Class hierarchy for objectives
-- Deserialization is now possible from optional abbreviations and class name strings
+- Deserialization is now also possible from optional class name abbreviations
 - Hypothesis strategies for acquisition functions
 
 ### Changed
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorganized acquisition.py into `acquisition` subpackage
 - `torch` is imported lazily in `surrogates`
 - Acquisition functions are now their own objects
-- `acquisition_function_cls` renamed to `acqf`
+- `acquisition_function_cls` constructor parameter renamed to `acqf`
 
 ### Fixed
 - `n_task_params` now evaluates to 1 if `task_idx == 0`
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with
   `SingleTargetObjective` and `DesirabilityObjective`
-- `acquisition_function_cls` keyword for the respective recommenders
+- `acquisition_function_cls` constructor parameter for  `BayesianRecommender`
 - `VarUCB` and `qVarUCB` acquisition functions
 
 ## [0.8.2] - 2024-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorganized acquisition.py into `acquisition` subpackage
 - `torch` is imported lazily in `surrogates`
 - Acquisition functions are now their own objects
-- `acquisition_function_cls` constructor parameter renamed to `acqf`
+- `acquisition_function_cls` constructor parameter renamed to `acquisition_function`
 
 ### Fixed
 - `n_task_params` now evaluates to 1 if `task_idx == 0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- `mypy` for search space
+- `mypy` for search space and objectives
 - Class hierarchy for objectives
-- `mypy` for objectives
+- Deserialization is now possible from optional abbreviations and class name strings
+- Hypothesis strategies for acquisition functions
 
 ### Changed
 - `torch` numeric types are now loaded lazily
 - Reorganized acquisition.py into `acquisition` subpackage
 - `torch` is imported lazily in `surrogates`
+- Acquisition functions are now their own objects
+- `acquisition_function_cls` renamed to `acqf`
 
 ### Fixed
 - `n_task_params` now evaluates to 1 if `task_idx == 0`
@@ -21,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with
   `SingleTargetObjective` and `DesirabilityObjective`
+- `acquisition_function_cls` keyword for the respective recommenders
+- `VarUCB` and `qVarUCB` acquisition functions
 
 ## [0.8.2] - 2024-03-27
 ### Added

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -1,10 +1,17 @@
 """Acquisition function wrappers."""
 
+from baybe.acquisition.acqfs import qExpectedImprovement, qUpperConfidenceBound
 from baybe.acquisition.adapter import AdapterModel, debotorchize
 from baybe.acquisition.partial import PartialAcquisitionFunction
 
 __all__ = [
+    # -------
+    # Helpers
     "debotorchize",
     "AdapterModel",
     "PartialAcquisitionFunction",
+    # ---------------------
+    # Acquisition functions
+    "qExpectedImprovement",
+    "qUpperConfidenceBound",
 ]

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -14,8 +14,8 @@ from baybe.acquisition.partial import PartialAcquisitionFunction
 EI = ExpectedImprovement
 PI = ProbabilityOfImprovement
 UCB = UpperConfidenceBound
-aEI = qExpectedImprovement
-aPI = qProbabilityOfImprovement
+qEI = qExpectedImprovement
+qPI = qProbabilityOfImprovement
 qUCB = qUpperConfidenceBound
 
 __all__ = [

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -11,13 +11,15 @@ from baybe.acquisition.acqfs import (
 from baybe.acquisition.adapter import AdapterModel, debotorchize
 from baybe.acquisition.partial import PartialAcquisitionFunction
 
+EI = ExpectedImprovement
+PI = ProbabilityOfImprovement
+UCB = UpperConfidenceBound
+aEI = qExpectedImprovement
+aPI = qProbabilityOfImprovement
+qUCB = qUpperConfidenceBound
+
 __all__ = [
-    # -------
-    # Helpers
-    "debotorchize",
-    "AdapterModel",
-    "PartialAcquisitionFunction",
-    # ---------------------
+    # ---------------------------
     # Acquisition functions
     "ExpectedImprovement",
     "ProbabilityOfImprovement",
@@ -25,4 +27,17 @@ __all__ = [
     "qExpectedImprovement",
     "qProbabilityOfImprovement",
     "qUpperConfidenceBound",
+    # ---------------------------
+    # Abbreviations
+    "EI",
+    "PI",
+    "UCB",
+    "qEI",
+    "qPI",
+    "qUCB",
+    # ---------------------------
+    # Helpers
+    "debotorchize",
+    "AdapterModel",
+    "PartialAcquisitionFunction",
 ]

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -1,6 +1,13 @@
 """Acquisition function wrappers."""
 
-from baybe.acquisition.acqfs import qExpectedImprovement, qUpperConfidenceBound
+from baybe.acquisition.acqfs import (
+    ExpectedImprovement,
+    ProbabilityOfImprovement,
+    UpperConfidenceBound,
+    qExpectedImprovement,
+    qProbabilityOfImprovement,
+    qUpperConfidenceBound,
+)
 from baybe.acquisition.adapter import AdapterModel, debotorchize
 from baybe.acquisition.partial import PartialAcquisitionFunction
 
@@ -12,6 +19,10 @@ __all__ = [
     "PartialAcquisitionFunction",
     # ---------------------
     # Acquisition functions
+    "ExpectedImprovement",
+    "ProbabilityOfImprovement",
+    "UpperConfidenceBound",
     "qExpectedImprovement",
+    "qProbabilityOfImprovement",
     "qUpperConfidenceBound",
 ]

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -1,0 +1,30 @@
+"""Available acquisition functions."""
+
+from typing import ClassVar
+
+from attrs import define, field
+from attrs.validators import ge
+
+from baybe.acquisition.base import AcquisitionFunction
+
+
+@define(frozen=True)
+class qExpectedImprovement(AcquisitionFunction):
+    """Monte Carlo based expected improvement."""
+
+    _abbreviation: ClassVar[str] = "qEI"
+
+
+@define(frozen=True)
+class qUpperConfidenceBound(AcquisitionFunction):
+    """Monte Carlo based upper confidence bound."""
+
+    _abbreviation: ClassVar[str] = "qUCB"
+
+    beta: float = field(converter=float, validator=ge(0.0))
+    """Trade-off parameter for mean and variance.
+
+    A value of zero makes the acquisition mechanism consider the posterior predictive
+    mean only, resulting in pure exploitation. Higher values shift the focus more and
+    more toward exploration.
+    """

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -10,7 +10,7 @@ from baybe.acquisition.base import AcquisitionFunction
 
 @define(frozen=True)
 class PosteriorMean(AcquisitionFunction):
-    """Posterior Mean."""
+    """Posterior mean."""
 
     _abbreviation: ClassVar[str] = "PM"
 

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -49,7 +49,7 @@ class qUpperConfidenceBound(AcquisitionFunction):
 
     _abbreviation: ClassVar[str] = "qUCB"
 
-    beta: float = field(converter=float, validator=ge(0.0))
+    beta: float = field(converter=float, validator=ge(0.0), default=0.2)
     """Trade-off parameter for mean and variance.
 
     A value of zero makes the acquisition mechanism consider the posterior predictive
@@ -64,7 +64,7 @@ class UpperConfidenceBound(AcquisitionFunction):
 
     _abbreviation: ClassVar[str] = "UCB"
 
-    beta: float = field(converter=float, validator=ge(0.0))
+    beta: float = field(converter=float, validator=ge(0.0), default=0.2)
     """Trade-off parameter for mean and variance.
 
     A value of zero makes the acquisition mechanism consider the posterior predictive

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -9,6 +9,13 @@ from baybe.acquisition.base import AcquisitionFunction
 
 
 @define(frozen=True)
+class PosteriorMean(AcquisitionFunction):
+    """Posterior Mean."""
+
+    _abbreviation: ClassVar[str] = "PM"
+
+
+@define(frozen=True)
 class qExpectedImprovement(AcquisitionFunction):
     """Monte Carlo based expected improvement."""
 
@@ -16,10 +23,46 @@ class qExpectedImprovement(AcquisitionFunction):
 
 
 @define(frozen=True)
+class ExpectedImprovement(AcquisitionFunction):
+    """Analytical expected improvement."""
+
+    _abbreviation: ClassVar[str] = "EI"
+
+
+@define(frozen=True)
+class qProbabilityOfImprovement(AcquisitionFunction):
+    """Monte Carlo based probability of improvement."""
+
+    _abbreviation: ClassVar[str] = "qPI"
+
+
+@define(frozen=True)
+class ProbabilityOfImprovement(AcquisitionFunction):
+    """Analytical probability of improvement."""
+
+    _abbreviation: ClassVar[str] = "PI"
+
+
+@define(frozen=True)
 class qUpperConfidenceBound(AcquisitionFunction):
     """Monte Carlo based upper confidence bound."""
 
     _abbreviation: ClassVar[str] = "qUCB"
+
+    beta: float = field(converter=float, validator=ge(0.0))
+    """Trade-off parameter for mean and variance.
+
+    A value of zero makes the acquisition mechanism consider the posterior predictive
+    mean only, resulting in pure exploitation. Higher values shift the focus more and
+    more toward exploration.
+    """
+
+
+@define(frozen=True)
+class UpperConfidenceBound(AcquisitionFunction):
+    """Analytical upper confidence bound."""
+
+    _abbreviation: ClassVar[str] = "UCB"
 
     beta: float = field(converter=float, validator=ge(0.0))
     """Trade-off parameter for mean and variance.

--- a/baybe/acquisition/adapter.py
+++ b/baybe/acquisition/adapter.py
@@ -4,7 +4,7 @@ from inspect import signature
 from typing import Any, Callable, Optional
 
 import gpytorch.distributions
-from botorch.acquisition import AcquisitionFunction
+from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
 from botorch.models.gpytorch import Model
 from botorch.posteriors import Posterior
 from botorch.posteriors.gpytorch import GPyTorchPosterior
@@ -13,7 +13,7 @@ from torch import Tensor
 from baybe.surrogates.base import Surrogate
 
 
-def debotorchize(acqf_cls: type[AcquisitionFunction]):
+def debotorchize(acqf_cls: type[BotorchAcquisitionFunction]):
     """Wrap a given BoTorch acquisition function.
 
     This wrapped function becomes generally usable in combination with other non-BoTorch
@@ -49,13 +49,13 @@ def debotorchize(acqf_cls: type[AcquisitionFunction]):
                 for p, v in {"model": self.model, "best_f": self.best_f}.items()
                 if p in signature(acqf_cls).parameters
             }
-            self.acqf = acqf_cls(**required_params)
+            self.botorch_acqf = acqf_cls(**required_params)
 
         def __call__(self, candidates):
-            return self.acqf(candidates)
+            return self.botorch_acqf(candidates)
 
         def __getattr__(self, item):
-            return getattr(self.acqf, item)
+            return getattr(self.botorch_acqf, item)
 
     return Wrapper
 

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC
-from typing import ClassVar
+from typing import ClassVar, Union
 
 from attrs import define
 
@@ -34,8 +35,37 @@ class AcquisitionFunction(ABC, SerialMixin):
 
 
 # Register de-/serialization hooks
+def _add_deprecation_hook(hook):
+    """Adjust the structuring hook such that it auto-fills missing target types.
+
+    Used for backward compatibility only and will be removed in future versions.
+    """
+
+    def added_deprecation_hook(val: Union[dict, str], cls):
+        if isinstance(val, str):
+            if val == "VarUCB":
+                warnings.warn(
+                    "The use of `VarUCB` is deprecated and will be disabled in a "
+                    "future version. The get the same outcome, use the new UCB class "
+                    "instead with a beta of 100.0.",
+                    DeprecationWarning,
+                )
+                return hook({"type": "UpperConfidenceBound", "beta": 100.0}, cls)
+            elif val == "qVarUCB":
+                warnings.warn(
+                    "The use of `qVarUCB` is deprecated and will be disabled in a "
+                    "future version. The get the same outcome, use the new qUCB class "
+                    "instead with a beta of 100.0.",
+                    DeprecationWarning,
+                )
+                return hook({"type": "qUpperConfidenceBound", "beta": 100.0}, cls)
+        return hook(val, cls)
+
+    return added_deprecation_hook
+
+
 converter.register_structure_hook(
     AcquisitionFunction,
-    get_base_structure_hook(AcquisitionFunction),
+    _add_deprecation_hook(get_base_structure_hook(AcquisitionFunction)),
 )
 converter.register_unstructure_hook(AcquisitionFunction, unstructure_base)

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -1,0 +1,40 @@
+"""Base classes for all acquisition functions."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import ClassVar
+
+from attrs import define
+
+from baybe.acquisition.adapter import debotorchize
+from baybe.serialization.core import (
+    converter,
+    get_base_structure_hook,
+    unstructure_base,
+)
+from baybe.serialization.mixin import SerialMixin
+from baybe.surrogates.base import Surrogate
+
+
+@define(frozen=True)
+class AcquisitionFunction(ABC, SerialMixin):
+    """Abstract base class for all acquisition functions."""
+
+    _abbreviation: ClassVar[str]
+    """An alternative name for type resolution."""
+
+    def to_botorch(self, surrogate: Surrogate, best_f: float):
+        """Create the botorch-ready representation of the function."""
+        import botorch.acquisition as botorch_acqf
+
+        acqf_cls = getattr(botorch_acqf, self.__class__.__name__)
+
+        return debotorchize(acqf_cls)(surrogate, best_f)
+
+
+# Register de-/serialization hooks
+converter.register_structure_hook(
+    AcquisitionFunction, get_base_structure_hook(AcquisitionFunction)
+)
+converter.register_unstructure_hook(AcquisitionFunction, unstructure_base)

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -36,29 +36,25 @@ class AcquisitionFunction(ABC, SerialMixin):
 
 # Register de-/serialization hooks
 def _add_deprecation_hook(hook):
-    """Adjust the structuring hook such that it auto-fills missing target types.
+    """Add deprecation warnings to the default hook.
 
     Used for backward compatibility only and will be removed in future versions.
     """
 
     def added_deprecation_hook(val: Union[dict, str], cls):
         if isinstance(val, str):
-            if val == "VarUCB":
+            UCB_DEPRECATIONS = {
+                "VarUCB": "UpperConfidenceBound",
+                "qVarUCB": "qUpperConfidenceBound",
+            }
+            if val in UCB_DEPRECATIONS:
                 warnings.warn(
-                    "The use of `VarUCB` is deprecated and will be disabled in a "
-                    "future version. The get the same outcome, use the new UCB class "
-                    "instead with a beta of 100.0.",
+                    f"The use of `{val}` is deprecated and will be disabled in a "
+                    f"future version. The get the same outcome, use the new "
+                    f"{UCB_DEPRECATIONS[val]} class instead with a beta of 100.0.",
                     DeprecationWarning,
                 )
-                return hook({"type": "UpperConfidenceBound", "beta": 100.0}, cls)
-            elif val == "qVarUCB":
-                warnings.warn(
-                    "The use of `qVarUCB` is deprecated and will be disabled in a "
-                    "future version. The get the same outcome, use the new qUCB class "
-                    "instead with a beta of 100.0.",
-                    DeprecationWarning,
-                )
-                return hook({"type": "qUpperConfidenceBound", "beta": 100.0}, cls)
+                return hook({"type": {UCB_DEPRECATIONS[val]}, "beta": 100.0}, cls)
         return hook(val, cls)
 
     return added_deprecation_hook

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -35,6 +35,7 @@ class AcquisitionFunction(ABC, SerialMixin):
 
 # Register de-/serialization hooks
 converter.register_structure_hook(
-    AcquisitionFunction, get_base_structure_hook(AcquisitionFunction)
+    AcquisitionFunction,
+    get_base_structure_hook(AcquisitionFunction),
 )
 converter.register_unstructure_hook(AcquisitionFunction, unstructure_base)

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -41,20 +41,20 @@ def _add_deprecation_hook(hook):
     Used for backward compatibility only and will be removed in future versions.
     """
 
-    def added_deprecation_hook(val: Union[dict, str], cls):
-        if isinstance(val, str):
-            UCB_DEPRECATIONS = {
-                "VarUCB": "UpperConfidenceBound",
-                "qVarUCB": "qUpperConfidenceBound",
-            }
-            if val in UCB_DEPRECATIONS:
-                warnings.warn(
-                    f"The use of `{val}` is deprecated and will be disabled in a "
-                    f"future version. The get the same outcome, use the new "
-                    f"{UCB_DEPRECATIONS[val]} class instead with a beta of 100.0.",
-                    DeprecationWarning,
-                )
-                return hook({"type": {UCB_DEPRECATIONS[val]}, "beta": 100.0}, cls)
+    def added_deprecation_hook(val: Union[dict, str], cls: type):
+        UCB_DEPRECATIONS = {
+            "VarUCB": "UpperConfidenceBound",
+            "qVarUCB": "qUpperConfidenceBound",
+        }
+        if (entry := val if isinstance(val, str) else val["type"]) in UCB_DEPRECATIONS:
+            warnings.warn(
+                f"The use of `{entry}` is deprecated and will be disabled in a "
+                f"future version. The get the same outcome, use the new "
+                f"{UCB_DEPRECATIONS[entry]} class instead with a beta of 100.0.",
+                DeprecationWarning,
+            )
+            val = {"type": UCB_DEPRECATIONS[entry], "beta": 100.0}
+
         return hook(val, cls)
 
     return added_deprecation_hook

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -50,7 +50,7 @@ def _add_deprecation_hook(hook):
             warnings.warn(
                 f"The use of `{entry}` is deprecated and will be disabled in a "
                 f"future version. The get the same outcome, use the new "
-                f"{UCB_DEPRECATIONS[entry]} class instead with a beta of 100.0.",
+                f"`{UCB_DEPRECATIONS[entry]}` class instead with a beta of 100.0.",
                 DeprecationWarning,
             )
             val = {"type": UCB_DEPRECATIONS[entry], "beta": 100.0}

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -27,9 +27,9 @@ class AcquisitionFunction(ABC, SerialMixin):
 
     def to_botorch(self, surrogate: Surrogate, best_f: float):
         """Create the botorch-ready representation of the function."""
-        import botorch.acquisition as botorch_acqf
+        import botorch.acquisition as botorch_acquisition
 
-        acqf_cls = getattr(botorch_acqf, self.__class__.__name__)
+        acqf_cls = getattr(botorch_acquisition, self.__class__.__name__)
 
         return debotorchize(acqf_cls)(surrogate, best_f)
 

--- a/baybe/acquisition/partial.py
+++ b/baybe/acquisition/partial.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import torch
 from attr import define
-from botorch.acquisition import AcquisitionFunction
+from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
 from torch import Tensor
 
 
@@ -18,7 +18,7 @@ class PartialAcquisitionFunction:
     defined for the full hybrid space.
     """
 
-    acqf: AcquisitionFunction
+    acqf: BotorchAcquisitionFunction
     """The acquisition function for the hybrid space."""
 
     pinned_part: Tensor

--- a/baybe/acquisition/partial.py
+++ b/baybe/acquisition/partial.py
@@ -18,7 +18,7 @@ class PartialAcquisitionFunction:
     defined for the full hybrid space.
     """
 
-    acqf: BotorchAcquisitionFunction
+    botorch_acqf: BotorchAcquisitionFunction
     """The acquisition function for the hybrid space."""
 
     pinned_part: Tensor
@@ -70,10 +70,10 @@ class PartialAcquisitionFunction:
             The evaluation of the lifted point in the full hybrid space.
         """
         full_point = self._lift_partial_part(variable_part)
-        return self.acqf(full_point)
+        return self.botorch_acqf(full_point)
 
     def __getattr__(self, item):
-        return getattr(self.acqf, item)
+        return getattr(self.botorch_acqf, item)
 
     def set_X_pending(self, X_pending: Optional[Tensor]):
         """Inform the acquisition function about pending design points.
@@ -90,4 +90,4 @@ class PartialAcquisitionFunction:
             X_pending = self._lift_partial_part(X_pending)
             X_pending = torch.squeeze(X_pending, -2)
         # Now use the original set_X_pending function
-        self.acqf.set_X_pending(X_pending)
+        self.botorch_acqf.set_X_pending(X_pending)

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -1,15 +1,41 @@
 """Utilities for acquisition functions."""
-
+import warnings
 from typing import Union
 
+from baybe.acquisition import UpperConfidenceBound, qUpperConfidenceBound
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.utils.basic import get_subclasses
 
 
 def str_to_acqf(name: str, /) -> AcquisitionFunction:
     """Create an ACQF object from a given ACQF name."""
+    if name == "VarUCB":
+        warnings.warn(
+            "The use of `VarUCB` is deprecated and will be disabled in a future "
+            "version. The get the same outcome, use the new UCB class instead with a "
+            "beta of 100.0.",
+            DeprecationWarning,
+        )
+        return UpperConfidenceBound(beta=100.0)
+    elif name == "qVarUCB":
+        warnings.warn(
+            "The use of `qVarUCB` is deprecated and will be disabled in a future "
+            "version. The get the same outcome, use the new qUCB class instead with a "
+            "beta of 100.0.",
+            DeprecationWarning,
+        )
+        return qUpperConfidenceBound(beta=100.0)
+
     acqfs = get_subclasses(AcquisitionFunction)
-    return next(acqf for acqf in acqfs if name in (acqf.__name__, acqf._abbreviation))()
+    acqf = next(
+        (acqf for acqf in acqfs if name in (acqf.__name__, acqf._abbreviation)), None
+    )
+    if acqf is None:
+        raise ValueError(
+            f"{name} is not a recognized name or abbreviation for a BayBE acquisition "
+            f"function."
+        )
+    return acqf()
 
 
 def convert_acqf(acqf: Union[AcquisitionFunction, str], /) -> AcquisitionFunction:

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -1,25 +1,23 @@
 """Utilities for acquisition functions."""
 
-from functools import partial
+from typing import Literal, Union
 
-from botorch.acquisition import (
-    ExpectedImprovement,
-    PosteriorMean,
-    ProbabilityOfImprovement,
-    UpperConfidenceBound,
-    qExpectedImprovement,
-    qProbabilityOfImprovement,
-    qUpperConfidenceBound,
-)
+from baybe.acquisition.base import AcquisitionFunction
+from baybe.utils.basic import get_subclasses
 
-acquisition_function_mapping = {
-    "PM": PosteriorMean,
-    "PI": ProbabilityOfImprovement,
-    "EI": ExpectedImprovement,
-    "UCB": partial(UpperConfidenceBound, beta=1.0),
-    "qEI": qExpectedImprovement,
-    "qPI": qProbabilityOfImprovement,
-    "qUCB": partial(qUpperConfidenceBound, beta=1.0),
-    "VarUCB": partial(UpperConfidenceBound, beta=100.0),
-    "qVarUCB": partial(qUpperConfidenceBound, beta=100.0),
-}
+_ACQF_NAMES = Literal[
+    "PM", "PI", "EI", "UCB", "qPI", "qEI", "qUCB", "VarUCB", "qVarUCB"
+]
+
+
+def str_to_acqf(name: _ACQF_NAMES, /) -> AcquisitionFunction:
+    """Create an ACQF object from a given ACQF name."""
+    acqfs = get_subclasses(AcquisitionFunction)
+    return next(acqf for acqf in acqfs if acqf._abbreviation == name)()
+
+
+def convert_acqf(
+    acqf: Union[AcquisitionFunction, _ACQF_NAMES], /
+) -> AcquisitionFunction:
+    """Convert an ACQF name into an ACQF object (with ACQF object passthrough)."""
+    return acqf if isinstance(acqf, AcquisitionFunction) else str_to_acqf(acqf)

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -1,23 +1,17 @@
 """Utilities for acquisition functions."""
 
-from typing import Literal, Union
+from typing import Union
 
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.utils.basic import get_subclasses
 
-_ACQF_NAMES = Literal[
-    "PM", "PI", "EI", "UCB", "qPI", "qEI", "qUCB", "VarUCB", "qVarUCB"
-]
 
-
-def str_to_acqf(name: _ACQF_NAMES, /) -> AcquisitionFunction:
+def str_to_acqf(name: str, /) -> AcquisitionFunction:
     """Create an ACQF object from a given ACQF name."""
     acqfs = get_subclasses(AcquisitionFunction)
-    return next(acqf for acqf in acqfs if acqf._abbreviation == name)()
+    return next(acqf for acqf in acqfs if name in (acqf.__name__, acqf._abbreviation))()
 
 
-def convert_acqf(
-    acqf: Union[AcquisitionFunction, _ACQF_NAMES], /
-) -> AcquisitionFunction:
+def convert_acqf(acqf: Union[AcquisitionFunction, str], /) -> AcquisitionFunction:
     """Convert an ACQF name into an ACQF object (with ACQF object passthrough)."""
     return acqf if isinstance(acqf, AcquisitionFunction) else str_to_acqf(acqf)

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -9,22 +9,18 @@ from baybe.utils.basic import get_subclasses
 
 def str_to_acqf(name: str, /) -> AcquisitionFunction:
     """Create an ACQF object from a given ACQF name."""
-    if name == "VarUCB":
+    UCB_DEPRECATIONS = {
+        "VarUCB": UpperConfidenceBound,
+        "qVarUCB": qUpperConfidenceBound,
+    }
+    if name in UCB_DEPRECATIONS:
         warnings.warn(
-            "The use of `VarUCB` is deprecated and will be disabled in a future "
-            "version. The get the same outcome, use the new UCB class instead with a "
-            "beta of 100.0.",
+            f"The use of `{name}` is deprecated and will be disabled in a "
+            f"future version. The get the same outcome, use the new "
+            f"{UCB_DEPRECATIONS[name].__name__} class instead with a beta of 100.0.",
             DeprecationWarning,
         )
-        return UpperConfidenceBound(beta=100.0)
-    elif name == "qVarUCB":
-        warnings.warn(
-            "The use of `qVarUCB` is deprecated and will be disabled in a future "
-            "version. The get the same outcome, use the new qUCB class instead with a "
-            "beta of 100.0.",
-            DeprecationWarning,
-        )
-        return qUpperConfidenceBound(beta=100.0)
+        return UCB_DEPRECATIONS[name](beta=100.0)
 
     acqfs = get_subclasses(AcquisitionFunction)
     acqf = next(

--- a/baybe/acquisition/utils.py
+++ b/baybe/acquisition/utils.py
@@ -1,37 +1,12 @@
 """Utilities for acquisition functions."""
-import warnings
 from typing import Union
 
-from baybe.acquisition import UpperConfidenceBound, qUpperConfidenceBound
 from baybe.acquisition.base import AcquisitionFunction
-from baybe.utils.basic import get_subclasses
 
 
 def str_to_acqf(name: str, /) -> AcquisitionFunction:
     """Create an ACQF object from a given ACQF name."""
-    UCB_DEPRECATIONS = {
-        "VarUCB": UpperConfidenceBound,
-        "qVarUCB": qUpperConfidenceBound,
-    }
-    if name in UCB_DEPRECATIONS:
-        warnings.warn(
-            f"The use of `{name}` is deprecated and will be disabled in a "
-            f"future version. The get the same outcome, use the new "
-            f"{UCB_DEPRECATIONS[name].__name__} class instead with a beta of 100.0.",
-            DeprecationWarning,
-        )
-        return UCB_DEPRECATIONS[name](beta=100.0)
-
-    acqfs = get_subclasses(AcquisitionFunction)
-    acqf = next(
-        (acqf for acqf in acqfs if name in (acqf.__name__, acqf._abbreviation)), None
-    )
-    if acqf is None:
-        raise ValueError(
-            f"{name} is not a recognized name or abbreviation for a BayBE acquisition "
-            f"function."
-        )
-    return acqf()
+    return AcquisitionFunction.from_dict({"type": name})
 
 
 def convert_acqf(acqf: Union[AcquisitionFunction, str], /) -> AcquisitionFunction:

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -43,6 +43,7 @@ converter.register_unstructure_hook(
         overrides=dict(
             allow_repeated_recommendations=cattrs.override(omit=True),
             allow_recommending_already_measured=cattrs.override(omit=True),
+            acquisition_function_cls=cattrs.override(omit=True),
         ),
     ),
 )

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -129,9 +129,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
-            self.disc_recommender.setup_acquisition_function(
-                searchspace, train_x, train_y
-            )
+            self.disc_recommender.setup_acqf(searchspace, train_x, train_y)
 
             # Construct the partial acquisition function that attaches cont_part
             # whenever evaluating the acquisition function
@@ -156,7 +154,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         disc_part_tensor = cast(Tensor, to_tensor(disc_part)).unsqueeze(-2)
 
         # Setup a fresh acquisition function for the continuous recommender
-        self.cont_recommender.setup_acquisition_function(searchspace, train_x, train_y)
+        self.cont_recommender.setup_acqf(searchspace, train_x, train_y)
 
         # Construct the continuous space as a standalone space
         cont_acqf_part = PartialAcquisitionFunction(

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -136,12 +136,12 @@ class NaiveHybridSpaceRecommender(PureRecommender):
             # Construct the partial acquisition function that attaches cont_part
             # whenever evaluating the acquisition function
             disc_acqf_part = PartialAcquisitionFunction(
-                acqf=self.disc_recommender._acquisition_function,
+                acqf=self.disc_recommender._botorch_acqf,
                 pinned_part=cont_part_tensor,
                 pin_discrete=False,
             )
 
-            self.disc_recommender._acquisition_function = disc_acqf_part
+            self.disc_recommender._botorch_acqf = disc_acqf_part
 
         # Call the private function of the discrete recommender and get the indices
         disc_rec_idx = self.disc_recommender._recommend_discrete(
@@ -160,11 +160,11 @@ class NaiveHybridSpaceRecommender(PureRecommender):
 
         # Construct the continuous space as a standalone space
         cont_acqf_part = PartialAcquisitionFunction(
-            acqf=self.cont_recommender._acquisition_function,
+            acqf=self.cont_recommender._botorch_acqf,
             pinned_part=disc_part_tensor,
             pin_discrete=True,
         )
-        self.cont_recommender._acquisition_function = cont_acqf_part
+        self.cont_recommender._botorch_acqf = cont_acqf_part
 
         # Call the private function of the continuous recommender
         rec_cont = self.cont_recommender._recommend_continuous(

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -129,7 +129,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
-            self.disc_recommender.setup_acqf(searchspace, train_x, train_y)
+            self.disc_recommender._setup_acqf(searchspace, train_x, train_y)
 
             # Construct the partial acquisition function that attaches cont_part
             # whenever evaluating the acquisition function
@@ -154,7 +154,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         disc_part_tensor = cast(Tensor, to_tensor(disc_part)).unsqueeze(-2)
 
         # Setup a fresh acquisition function for the continuous recommender
-        self.cont_recommender.setup_acqf(searchspace, train_x, train_y)
+        self.cont_recommender._setup_acqf(searchspace, train_x, train_y)
 
         # Construct the continuous space as a standalone space
         cont_acqf_part = PartialAcquisitionFunction(

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -129,12 +129,12 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
-            self.disc_recommender._setup_acqf(searchspace, train_x, train_y)
+            self.disc_recommender._setup_botorch_acqf(searchspace, train_x, train_y)
 
             # Construct the partial acquisition function that attaches cont_part
             # whenever evaluating the acquisition function
             disc_acqf_part = PartialAcquisitionFunction(
-                acqf=self.disc_recommender._botorch_acqf,
+                botorch_acqf=self.disc_recommender._botorch_acqf,
                 pinned_part=cont_part_tensor,
                 pin_discrete=False,
             )
@@ -154,11 +154,11 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         disc_part_tensor = cast(Tensor, to_tensor(disc_part)).unsqueeze(-2)
 
         # Setup a fresh acquisition function for the continuous recommender
-        self.cont_recommender._setup_acqf(searchspace, train_x, train_y)
+        self.cont_recommender._setup_botorch_acqf(searchspace, train_x, train_y)
 
         # Construct the continuous space as a standalone space
         cont_acqf_part = PartialAcquisitionFunction(
-            acqf=self.cont_recommender._botorch_acqf,
+            botorch_acqf=self.cont_recommender._botorch_acqf,
             pinned_part=disc_part_tensor,
             pin_discrete=True,
         )

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -47,7 +47,7 @@ class BayesianRecommender(PureRecommender, ABC):
                 "The flag has been renamed to 'acqf'."
             )
 
-    def setup_acqf(
+    def _setup_acqf(
         self,
         searchspace: SearchSpace,
         train_x: Optional[pd.DataFrame] = None,
@@ -114,6 +114,6 @@ class BayesianRecommender(PureRecommender, ABC):
         if _ONNX_INSTALLED and isinstance(self.surrogate_model, CustomONNXSurrogate):
             CustomONNXSurrogate.validate_compatibility(searchspace)
 
-        self.setup_acqf(searchspace, train_x, train_y)
+        self._setup_acqf(searchspace, train_x, train_y)
 
         return super().recommend(searchspace, batch_size, train_x, train_y)

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -26,7 +26,7 @@ class BayesianRecommender(PureRecommender, ABC):
     surrogate_model: Surrogate = field(factory=GaussianProcessSurrogate)
     """The used surrogate model."""
 
-    acquisition_function_cls: AcquisitionFunction = field(
+    acqf: AcquisitionFunction = field(
         converter=convert_acqf, factory=qExpectedImprovement
     )
     """The used acquisition function class."""
@@ -60,9 +60,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
         best_f = train_y.max().item()
         surrogate_model = self._fit(searchspace, train_x, train_y)
-        self._botorch_acqf = self.acquisition_function_cls.to_botorch(
-            surrogate_model, best_f
-        )
+        self._botorch_acqf = self.acqf.to_botorch(surrogate_model, best_f)
 
     def _fit(
         self,

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -31,7 +31,7 @@ class BayesianRecommender(PureRecommender, ABC):
     )
     """The used acquisition function class."""
 
-    _acquisition_function = field(default=None, init=False)
+    _botorch_acqf = field(default=None, init=False)
     """The current acquisition function."""
 
     def setup_acquisition_function(
@@ -60,7 +60,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
         best_f = train_y.max().item()
         surrogate_model = self._fit(searchspace, train_x, train_y)
-        self._acquisition_function = self.acquisition_function_cls.to_botorch(
+        self._botorch_acqf = self.acquisition_function_cls.to_botorch(
             surrogate_model, best_f
         )
 

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -40,7 +40,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
     @acquisition_function_cls.validator
     def _validate_deprecated_argument(self, _, value) -> None:
-        """Raise a DeprecationError if the tolerance flag is used."""
+        """Raise DeprecationError if old acquisition_function_cls parameter is used."""
         if value is not None:
             raise DeprecationError(
                 "Passing 'acquisition_function_cls' to the constructor is deprecated. "

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -28,7 +28,7 @@ class BayesianRecommender(PureRecommender, ABC):
     """The used surrogate model."""
 
     acqf: AcquisitionFunction = field(
-        converter=convert_acqf, factory=qExpectedImprovement
+        converter=convert_acqf, factory=qExpectedImprovement, kw_only=True
     )
     """The used acquisition function class."""
 
@@ -39,7 +39,7 @@ class BayesianRecommender(PureRecommender, ABC):
     "Deprecated! Raises an error when used."
 
     @acquisition_function_cls.validator
-    def _validate_deprecated_flag(self, _, value) -> None:
+    def _validate_deprecated_argument(self, _, value) -> None:
         """Raise a DeprecationError if the tolerance flag is used."""
         if value is not None:
             raise DeprecationError(

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -6,6 +6,7 @@ from typing import Optional
 import pandas as pd
 from attrs import define, field
 
+from baybe.acquisition.acqfs import qExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.acquisition.utils import convert_acqf
 from baybe.recommenders.pure.base import PureRecommender
@@ -26,7 +27,7 @@ class BayesianRecommender(PureRecommender, ABC):
     """The used surrogate model."""
 
     acquisition_function_cls: AcquisitionFunction = field(
-        converter=convert_acqf, default="qEI"
+        converter=convert_acqf, factory=qExpectedImprovement
     )
     """The used acquisition function class."""
 

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -47,7 +47,7 @@ class BayesianRecommender(PureRecommender, ABC):
                 "The flag has been renamed to 'acqf'."
             )
 
-    def setup_acquisition_function(
+    def setup_acqf(
         self,
         searchspace: SearchSpace,
         train_x: Optional[pd.DataFrame] = None,
@@ -114,6 +114,6 @@ class BayesianRecommender(PureRecommender, ABC):
         if _ONNX_INSTALLED and isinstance(self.surrogate_model, CustomONNXSurrogate):
             CustomONNXSurrogate.validate_compatibility(searchspace)
 
-        self.setup_acquisition_function(searchspace, train_x, train_y)
+        self.setup_acqf(searchspace, train_x, train_y)
 
         return super().recommend(searchspace, batch_size, train_x, train_y)

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -9,6 +9,7 @@ from attrs import define, field
 from baybe.acquisition.acqfs import qExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.acquisition.utils import convert_acqf
+from baybe.exceptions import DeprecationError
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import _ONNX_INSTALLED, GaussianProcessSurrogate
@@ -33,6 +34,18 @@ class BayesianRecommender(PureRecommender, ABC):
 
     _botorch_acqf = field(default=None, init=False)
     """The current acquisition function."""
+
+    acquisition_function_cls: bool = field(default=None)
+    "Deprecated! Raises an error when used."
+
+    @acquisition_function_cls.validator
+    def _validate_deprecated_flag(self, _, value) -> None:
+        """Raise a DeprecationError if the tolerance flag is used."""
+        if value is not None:
+            raise DeprecationError(
+                "Passing 'acquisition_function_cls' to the constructor is deprecated. "
+                "The flag has been renamed to 'acqf'."
+            )
 
     def setup_acquisition_function(
         self,

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -44,7 +44,7 @@ class BayesianRecommender(PureRecommender, ABC):
         if value is not None:
             raise DeprecationError(
                 "Passing 'acquisition_function_cls' to the constructor is deprecated. "
-                "The flag has been renamed to 'acqf'."
+                "The parameter has been renamed to 'acqf'."
             )
 
     def _setup_acqf(

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -47,7 +47,7 @@ class BayesianRecommender(PureRecommender, ABC):
                 "The parameter has been renamed to 'acquisition_function'."
             )
 
-    def _setup_acqf(
+    def _setup_botorch_acqf(
         self,
         searchspace: SearchSpace,
         train_x: Optional[pd.DataFrame] = None,
@@ -116,6 +116,6 @@ class BayesianRecommender(PureRecommender, ABC):
         if _ONNX_INSTALLED and isinstance(self.surrogate_model, CustomONNXSurrogate):
             CustomONNXSurrogate.validate_compatibility(searchspace)
 
-        self._setup_acqf(searchspace, train_x, train_y)
+        self._setup_botorch_acqf(searchspace, train_x, train_y)
 
         return super().recommend(searchspace, batch_size, train_x, train_y)

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -27,7 +27,7 @@ class BayesianRecommender(PureRecommender, ABC):
     surrogate_model: Surrogate = field(factory=GaussianProcessSurrogate)
     """The used surrogate model."""
 
-    acqf: AcquisitionFunction = field(
+    acquisition_function: AcquisitionFunction = field(
         converter=convert_acqf, factory=qExpectedImprovement, kw_only=True
     )
     """The used acquisition function class."""
@@ -44,7 +44,7 @@ class BayesianRecommender(PureRecommender, ABC):
         if value is not None:
             raise DeprecationError(
                 "Passing 'acquisition_function_cls' to the constructor is deprecated. "
-                "The parameter has been renamed to 'acqf'."
+                "The parameter has been renamed to 'acquisition_function'."
             )
 
     def _setup_acqf(
@@ -73,7 +73,9 @@ class BayesianRecommender(PureRecommender, ABC):
 
         best_f = train_y.max().item()
         surrogate_model = self._fit(searchspace, train_x, train_y)
-        self._botorch_acqf = self.acqf.to_botorch(surrogate_model, best_f)
+        self._botorch_acqf = self.acquisition_function.to_botorch(
+            surrogate_model, best_f
+        )
 
     def _fit(
         self,

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -73,7 +73,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
         candidates_tensor = to_tensor(candidates_comp)
         try:
             points, _ = optimize_acqf_discrete(
-                self._acquisition_function, batch_size, candidates_tensor
+                self._botorch_acqf, batch_size, candidates_tensor
             )
         except AttributeError as ex:
             raise NoMCAcquisitionFunctionError(
@@ -106,7 +106,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
 
         try:
             points, _ = optimize_acqf(
-                acq_function=self._acquisition_function,
+                acq_function=self._botorch_acqf,
                 bounds=torch.from_numpy(subspace_continuous.param_bounds_comp),
                 q=batch_size,
                 num_restarts=5,  # TODO make choice for num_restarts
@@ -187,7 +187,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
         # Actual call of the BoTorch optimization routine
         try:
             points, _ = optimize_acqf_mixed(
-                acq_function=self._acquisition_function,
+                acq_function=self._botorch_acqf,
                 bounds=torch.from_numpy(searchspace.param_bounds_comp),
                 q=batch_size,
                 num_restarts=5,  # TODO make choice for num_restarts

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -40,12 +40,12 @@ def get_base_structure_hook(
     base: type[_T],
     overrides: Optional[dict] = None,
 ) -> Callable[[Union[dict, str], type[_T]], _T]:
-    """Return a hook for structuring a dictionary into an appropriate subclass.
+    """Return a hook for structuring a specified subclass.
 
     Provides the inverse operation to ``unstructure_base``.
 
     Args:
-        base: The corresponding class
+        base: The corresponding class.
         overrides: An optional dictionary of cattrs-overrides for certain attributes.
 
     Returns:
@@ -56,6 +56,9 @@ def get_base_structure_hook(
 
     def structure_base(val: Union[dict, str], _: type[_T]) -> _T:
         _type = val if isinstance(val, str) else val.pop("type")
+
+        # Try to find a match with a class name (or name abbreviation, if available)
+        # in the class hierarchy
         cls = next(
             (
                 cl
@@ -69,10 +72,11 @@ def get_base_structure_hook(
             ),
             None,
         )
+
         if cls is None:
             raise ValueError(
-                f"'{_type}' is neither a know subclass or subclass-abbreviation of "
-                f"{base.__name__}."
+                f"'{_type}' is neither a known subclass or subclass-abbreviation of "
+                f"'{base.__name__}'."
             )
 
         fn = make_dict_structure_fn(

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -82,7 +82,7 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 # For details on recommender objects, we refer to [`recommenders`](./../Basics/recommenders.md).
 
 seq_greedy_EI_recommender = TwoPhaseMetaRecommender(
-    recommender=SequentialGreedyRecommender(acquisition_function_cls="qEI"),
+    recommender=SequentialGreedyRecommender(acqf="qEI"),
 )
 random_recommender = TwoPhaseMetaRecommender(recommender=RandomRecommender())
 

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -82,7 +82,7 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 # For details on recommender objects, we refer to [`recommenders`](./../Basics/recommenders.md).
 
 seq_greedy_EI_recommender = TwoPhaseMetaRecommender(
-    recommender=SequentialGreedyRecommender(acqf="qEI"),
+    recommender=SequentialGreedyRecommender(acquisition_function="qEI"),
 )
 random_recommender = TwoPhaseMetaRecommender(recommender=RandomRecommender())
 

--- a/examples/Basics/recommenders.py
+++ b/examples/Basics/recommenders.py
@@ -114,7 +114,7 @@ recommender = TwoPhaseMetaRecommender(
     initial_recommender=INITIAL_RECOMMENDER,
     recommender=SequentialGreedyRecommender(
         surrogate_model=SURROGATE_MODEL,
-        acquisition_function_cls=ACQ_FUNCTION,
+        acqf=ACQ_FUNCTION,
         allow_repeated_recommendations=ALLOW_REPEATED_RECOMMENDATIONS,
         allow_recommending_already_measured=ALLOW_RECOMMENDING_ALREADY_MEASURED,
     ),

--- a/examples/Basics/recommenders.py
+++ b/examples/Basics/recommenders.py
@@ -114,7 +114,7 @@ recommender = TwoPhaseMetaRecommender(
     initial_recommender=INITIAL_RECOMMENDER,
     recommender=SequentialGreedyRecommender(
         surrogate_model=SURROGATE_MODEL,
-        acqf=ACQ_FUNCTION,
+        acquisition_function=ACQ_FUNCTION,
         allow_repeated_recommendations=ALLOW_REPEATED_RECOMMENDATIONS,
         allow_recommending_already_measured=ALLOW_RECOMMENDING_ALREADY_MEASURED,
     ),

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -78,7 +78,7 @@ CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acquisition_function_cls": "qEI",
+            "acqf": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         },

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -78,7 +78,7 @@ CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acqf": "qEI",
+            "acquisition_function": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         },

--- a/examples/Serialization/validate_config.py
+++ b/examples/Serialization/validate_config.py
@@ -77,7 +77,7 @@ CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acquisition_function_cls": "qEI",
+            "acqf": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         },
@@ -148,7 +148,7 @@ INVALID_CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acquisition_function_cls": "qEI",
+            "acqf": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         }

--- a/examples/Serialization/validate_config.py
+++ b/examples/Serialization/validate_config.py
@@ -77,7 +77,7 @@ CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acqf": "qEI",
+            "acquisition_function": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         },
@@ -148,7 +148,7 @@ INVALID_CONFIG = str(
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
-            "acqf": "qEI",
+            "acquisition_function": "qEI",
             "allow_repeated_recommendations": false,
             "allow_recommending_already_measured": false
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -593,7 +593,7 @@ def fixture_default_streaming_sequential_meta_recommender():
     )
 
 
-@pytest.fixture(name="acquisition_function_cls")
+@pytest.fixture(name="acqf")
 def fixture_default_acquisition_function():
     """The default acquisition function to be used if not specified differently."""
     return "qEI"
@@ -614,13 +614,13 @@ def fixture_initial_recommender():
 
 
 @pytest.fixture(name="recommender")
-def fixture_recommender(initial_recommender, surrogate_model, acquisition_function_cls):
+def fixture_recommender(initial_recommender, surrogate_model, acqf):
     """The default recommender to be used if not specified differently."""
     return TwoPhaseMetaRecommender(
         initial_recommender=initial_recommender,
         recommender=SequentialGreedyRecommender(
             surrogate_model=surrogate_model,
-            acquisition_function_cls=acquisition_function_cls,
+            acqf=acqf,
         ),
     )
 
@@ -698,7 +698,7 @@ def fixture_default_config():
             },
             "recommender": {
                 "type": "SequentialGreedyRecommender",
-                "acquisition_function_cls": "qEI",
+                "acqf": "qEI",
                 "allow_repeated_recommendations": false,
                 "allow_recommending_already_measured": false
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 import torch
 
+from baybe.acquisition import qExpectedImprovement
 from baybe.campaign import Campaign
 from baybe.constraints import (
     ContinuousLinearEqualityConstraint,
@@ -596,7 +597,7 @@ def fixture_default_streaming_sequential_meta_recommender():
 @pytest.fixture(name="acqf")
 def fixture_default_acquisition_function():
     """The default acquisition function to be used if not specified differently."""
-    return "qEI"
+    return qExpectedImprovement()
 
 
 @pytest.fixture(name="surrogate_model")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -621,7 +621,7 @@ def fixture_recommender(initial_recommender, surrogate_model, acqf):
         initial_recommender=initial_recommender,
         recommender=SequentialGreedyRecommender(
             surrogate_model=surrogate_model,
-            acqf=acqf,
+            acquisition_function=acqf,
         ),
     )
 
@@ -699,7 +699,7 @@ def fixture_default_config():
             },
             "recommender": {
                 "type": "SequentialGreedyRecommender",
-                "acqf": "qEI",
+                "acquisition_function": "qEI",
                 "allow_repeated_recommendations": false,
                 "allow_recommending_already_measured": false
             },

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -1,0 +1,42 @@
+"""Hypothesis strategies for acquisition functions."""
+
+import hypothesis.strategies as st
+
+from baybe.acquisition import (
+    ExpectedImprovement,
+    ProbabilityOfImprovement,
+    UpperConfidenceBound,
+    qExpectedImprovement,
+    qProbabilityOfImprovement,
+    qUpperConfidenceBound,
+)
+from baybe.acquisition.base import AcquisitionFunction
+from baybe.utils.basic import get_subclasses
+
+acqf_long_names = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
+acqf_abbreviations = [
+    cl._abbreviation
+    for cl in get_subclasses(AcquisitionFunction)
+    if hasattr(cl, "_abbreviation")
+]
+
+acqf_objects = st.one_of(
+    st.sampled_from(
+        [
+            ExpectedImprovement(),
+            ProbabilityOfImprovement(),
+            qExpectedImprovement(),
+            qProbabilityOfImprovement(),
+        ]
+    ),
+    st.builds(
+        UpperConfidenceBound, beta=st.floats(min_value=0.0, allow_infinity=False)
+    ),
+    st.builds(
+        qUpperConfidenceBound, beta=st.floats(min_value=0.0, allow_infinity=False)
+    ),
+)
+
+random_acqfs = st.one_of(
+    st.sampled_from(acqf_long_names), st.sampled_from(acqf_long_names), acqf_objects
+)

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -10,17 +10,8 @@ from baybe.acquisition import (
     qProbabilityOfImprovement,
     qUpperConfidenceBound,
 )
-from baybe.acquisition.base import AcquisitionFunction
-from baybe.utils.basic import get_subclasses
 
-acqf_long_names = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
-acqf_abbreviations = [
-    cl._abbreviation
-    for cl in get_subclasses(AcquisitionFunction)
-    if hasattr(cl, "_abbreviation")
-]
-
-acqf_objects = st.one_of(
+random_acqfs = st.one_of(
     st.sampled_from(
         [
             ExpectedImprovement(),
@@ -35,8 +26,4 @@ acqf_objects = st.one_of(
     st.builds(
         qUpperConfidenceBound, beta=st.floats(min_value=0.0, allow_infinity=False)
     ),
-)
-
-random_acqfs = st.one_of(
-    st.sampled_from(acqf_long_names), st.sampled_from(acqf_long_names), acqf_objects
 )

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -12,14 +12,10 @@ from baybe.acquisition import (
 )
 
 acquisition_functions = st.one_of(
-    st.sampled_from(
-        [
-            ExpectedImprovement(),
-            ProbabilityOfImprovement(),
-            qExpectedImprovement(),
-            qProbabilityOfImprovement(),
-        ]
-    ),
+    st.builds(ExpectedImprovement),
+    st.builds(ProbabilityOfImprovement),
+    st.builds(qExpectedImprovement),
+    st.builds(qProbabilityOfImprovement),
     st.builds(
         UpperConfidenceBound, beta=st.floats(min_value=0.0, allow_infinity=False)
     ),

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -11,7 +11,7 @@ from baybe.acquisition import (
     qUpperConfidenceBound,
 )
 
-random_acqfs = st.one_of(
+acquisition_functions = st.one_of(
     st.sampled_from(
         [
             ExpectedImprovement(),

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -3,7 +3,7 @@
 import pytest
 
 from baybe.acquisition.base import AcquisitionFunction
-from baybe.recommenders.pure.bayesian import SequentialGreedyRecommender
+from baybe.recommenders import SequentialGreedyRecommender
 from baybe.utils.basic import get_subclasses
 
 abbreviation_list = [
@@ -15,13 +15,13 @@ abbreviation_list = [
 fullname_list = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
 
 
-@pytest.mark.parametrize("acqf", abbreviation_list)
-def test_string_abbreviation(acqf):
-    """Tests the creation from abbreviation strings."""
-    SequentialGreedyRecommender(acqf=acqf)
+@pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
+def test_creation_from_string(acqf):
+    """Tests the creation from strings."""
+    AcquisitionFunction.from_dict({"type": acqf})
 
 
-@pytest.mark.parametrize("acqf", fullname_list)
-def test_string_fullname(acqf):
-    """Tests the creation from fullname strings."""
+@pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
+def test_string_usage_in_recommender(acqf):
+    """Tests the recommender initialization with acqfs as string."""
     SequentialGreedyRecommender(acqf=acqf)

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -1,0 +1,27 @@
+"""Test alternative ways of creation not considered in the strategies."""
+
+import pytest
+
+from baybe.acquisition.base import AcquisitionFunction
+from baybe.recommenders.pure.bayesian import SequentialGreedyRecommender
+from baybe.utils.basic import get_subclasses
+
+abbreviation_list = [
+    cl._abbreviation
+    for cl in get_subclasses(AcquisitionFunction)
+    if hasattr(cl, "_abbreviation")
+]
+
+fullname_list = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
+
+
+@pytest.mark.parametrize("acqf", abbreviation_list)
+def test_string_abbreviation(acqf):
+    """Tests the creation from abbreviation strings."""
+    SequentialGreedyRecommender(acqf=acqf)
+
+
+@pytest.mark.parametrize("acqf", fullname_list)
+def test_string_fullname(acqf):
+    """Tests the creation from fullname strings."""
+    SequentialGreedyRecommender(acqf=acqf)

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -24,4 +24,4 @@ def test_creation_from_string(acqf):
 @pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
 def test_string_usage_in_recommender(acqf):
     """Tests the recommender initialization with acqfs as string."""
-    SequentialGreedyRecommender(acqf=acqf)
+    SequentialGreedyRecommender(acquisition_function=acqf)

--- a/tests/serialization/test_acquisition_serialization.py
+++ b/tests/serialization/test_acquisition_serialization.py
@@ -1,0 +1,14 @@
+"""Test serialization of acquisition functions."""
+
+from hypothesis import given
+
+from baybe.acquisition.base import AcquisitionFunction
+from tests.hypothesis_strategies.acquisition import random_acqfs
+
+
+@given(random_acqfs)
+def test_acqf_roundtrip(acqf):
+    """A serialization roundtrip yields an equivalent object."""
+    string = acqf.to_json()
+    acqf2 = AcquisitionFunction.from_json(string)
+    assert acqf == acqf2, (acqf, acqf2)

--- a/tests/serialization/test_acquisition_serialization.py
+++ b/tests/serialization/test_acquisition_serialization.py
@@ -3,10 +3,10 @@
 from hypothesis import given
 
 from baybe.acquisition.base import AcquisitionFunction
-from tests.hypothesis_strategies.acquisition import random_acqfs
+from tests.hypothesis_strategies.acquisition import acquisition_functions
 
 
-@given(random_acqfs)
+@given(acquisition_functions)
 def test_acqf_roundtrip(acqf):
     """A serialization roundtrip yields an equivalent object."""
     string = acqf.to_json()

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,22 +1,13 @@
 """Acquisition function tests."""
 
-import pytest
-from pytest import param
+from hypothesis import given
 
-from baybe.acquisition.base import AcquisitionFunction
 from baybe.recommenders import SequentialGreedyRecommender
-from baybe.utils.basic import get_subclasses
 
-acqfs = [  # by object
-    param(cl(), id=f"{cl.__name__}_obj") for cl in get_subclasses(AcquisitionFunction)
-]
-acqfs += [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]  # by long name
-acqfs += [  # by abbreviation
-    cl._abbreviation for cl in get_subclasses(AcquisitionFunction)
-]
+from .hypothesis_strategies.acquisition import random_acqfs
 
 
-@pytest.mark.parametrize("acqf", acqfs)
-def test_deprecated_acqfs2(acqf):
-    """Using the deprecated strategy keyword raises an error."""
+@given(random_acqfs)
+def test_acqfs(acqf):
+    """Test all acquisition functions with sequential greedy recommender."""
     SequentialGreedyRecommender(acqf=acqf)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -19,4 +19,4 @@ acqfs += [  # by abbreviation
 @pytest.mark.parametrize("acqf", acqfs)
 def test_deprecated_acqfs2(acqf):
     """Using the deprecated strategy keyword raises an error."""
-    SequentialGreedyRecommender(acquisition_function_cls=acqf)
+    SequentialGreedyRecommender(acqf=acqf)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,22 @@
+"""Acquisition function tests."""
+
+import pytest
+from pytest import param
+
+from baybe.acquisition.base import AcquisitionFunction
+from baybe.recommenders import SequentialGreedyRecommender
+from baybe.utils.basic import get_subclasses
+
+acqfs = [  # by object
+    param(cl(), id=f"{cl.__name__}_obj") for cl in get_subclasses(AcquisitionFunction)
+]
+acqfs += [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]  # by long name
+acqfs += [  # by abbreviation
+    cl._abbreviation for cl in get_subclasses(AcquisitionFunction)
+]
+
+
+@pytest.mark.parametrize("acqf", acqfs)
+def test_deprecated_acqfs2(acqf):
+    """Using the deprecated strategy keyword raises an error."""
+    SequentialGreedyRecommender(acquisition_function_cls=acqf)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -10,4 +10,4 @@ from .hypothesis_strategies.acquisition import acquisition_functions
 @given(acquisition_functions)
 def test_acqfs(acqf):
     """Test all acquisition functions with sequential greedy recommender."""
-    SequentialGreedyRecommender(acqf=acqf)
+    SequentialGreedyRecommender(acquisition_function=acqf)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -4,10 +4,10 @@ from hypothesis import given
 
 from baybe.recommenders import SequentialGreedyRecommender
 
-from .hypothesis_strategies.acquisition import random_acqfs
+from .hypothesis_strategies.acquisition import acquisition_functions
 
 
-@given(random_acqfs)
+@given(acquisition_functions)
 def test_acqfs(acqf):
     """Test all acquisition functions with sequential greedy recommender."""
     SequentialGreedyRecommender(acqf=acqf)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -200,7 +200,7 @@ def test_deprecated_objective_config_deserialization():
 def test_deprecated_acqfs(acqf):
     """Using the deprecated acqf raises a warning."""
     with pytest.warns(DeprecationWarning):
-        SequentialGreedyRecommender(acqf=acqf)
+        SequentialGreedyRecommender(acquisition_function=acqf)
 
     with pytest.warns(DeprecationWarning):
         AcquisitionFunction.from_dict({"type": acqf})

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from baybe import BayBE, Campaign
+from baybe.acquisition.base import AcquisitionFunction
 from baybe.exceptions import DeprecationError
 from baybe.objective import Objective as OldObjective
 from baybe.objectives.base import Objective as NewObjective
@@ -200,6 +201,9 @@ def test_deprecated_acqfs(acqf):
     """Using the deprecated acqf raises a warning."""
     with pytest.warns(DeprecationWarning):
         SequentialGreedyRecommender(acqf=acqf)
+
+    with pytest.warns(DeprecationWarning):
+        AcquisitionFunction.from_dict({"type": acqf})
 
 
 def test_deprecated_acqf_keyword(acqf):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -200,3 +200,9 @@ def test_deprecated_acqfs(acqf):
     """Using the deprecated acqf raises a warning."""
     with pytest.warns(DeprecationWarning):
         SequentialGreedyRecommender(acqf=acqf)
+
+
+def test_deprecated_acqf_keyword(acqf):
+    """Using the deprecated keyword raises an error."""
+    with pytest.raises(DeprecationError):
+        SequentialGreedyRecommender(acquisition_function_cls="qEI")

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -11,6 +11,7 @@ from baybe.objective import Objective as OldObjective
 from baybe.objectives.base import Objective as NewObjective
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
+from baybe.recommenders.pure.bayesian import SequentialGreedyRecommender
 from baybe.recommenders.pure.nonpredictive.sampling import (
     FPSRecommender,
     RandomRecommender,
@@ -192,3 +193,10 @@ def test_deprecated_objective_config_deserialization():
     )
     actual = NewObjective.from_json(deprecated_objective_config)
     assert expected == actual, (expected, actual)
+
+
+@pytest.mark.parametrize("acqf", ("VarUCB", "qVarUCB"))
+def test_deprecated_acqfs(acqf):
+    """Using the deprecated acqf raises a warning."""
+    with pytest.warns(DeprecationWarning):
+        SequentialGreedyRecommender(acquisition_function_cls=acqf)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -199,4 +199,4 @@ def test_deprecated_objective_config_deserialization():
 def test_deprecated_acqfs(acqf):
     """Using the deprecated acqf raises a warning."""
     with pytest.warns(DeprecationWarning):
-        SequentialGreedyRecommender(acquisition_function_cls=acqf)
+        SequentialGreedyRecommender(acqf=acqf)

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -24,7 +24,7 @@ from .conftest import run_iterations
 # Settings of the individual components to be tested
 ########################################################################################
 valid_acquisition_functions = get_args(
-    get_type_hints(BayesianRecommender.__init__)["acquisition_function_cls"]
+    get_type_hints(BayesianRecommender.__init__)["acqf"]
 )
 valid_surrogate_models = [cls() for cls in get_available_surrogates()]
 valid_initial_recommenders = [cls() for cls in get_subclasses(NonPredictiveRecommender)]
@@ -118,7 +118,7 @@ test_targets = [
 #   recommender that can handle non-MC acquisition functions. Once the
 #   MarginalRecommender (or similar) is re-added, the acqf-tests can be reactivated.
 # @pytest.mark.slow
-# @pytest.mark.parametrize("acquisition_function_cls", valid_acquisition_functions)
+# @pytest.mark.parametrize("acqf", valid_acquisition_functions)
 # def test_iter_acquisition_function(campaign, n_iterations, batch_size):
 #     run_iterations(campaign, n_iterations, batch_size)
 

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -24,7 +24,7 @@ from .conftest import run_iterations
 # Settings of the individual components to be tested
 ########################################################################################
 valid_acquisition_functions = get_args(
-    get_type_hints(BayesianRecommender.__init__)["acqf"]
+    get_type_hints(BayesianRecommender.__init__)["acquisition_function"]
 )
 valid_surrogate_models = [cls() for cls in get_available_surrogates()]
 valid_initial_recommenders = [cls() for cls in get_subclasses(NonPredictiveRecommender)]

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -1,7 +1,6 @@
 # TODO: This file needs to be refactored.
 """Tests various configurations for a small number of iterations."""
 
-from typing import get_args, get_type_hints
 
 import pytest
 
@@ -23,9 +22,6 @@ from .conftest import run_iterations
 ########################################################################################
 # Settings of the individual components to be tested
 ########################################################################################
-valid_acquisition_functions = get_args(
-    get_type_hints(BayesianRecommender.__init__)["acquisition_function"]
-)
 valid_surrogate_models = [cls() for cls in get_available_surrogates()]
 valid_initial_recommenders = [cls() for cls in get_subclasses(NonPredictiveRecommender)]
 # TODO the TwoPhaseMetaRecommender below can be removed if the SeqGreedy recommender


### PR DESCRIPTION
Included:
- Major changes to the base_unstructuring hook. Whenever a string is provided it will try to find and create a class entry that corresponds to that string either with full name or abbreviation. This only happens for classes that have the `_abbreviation` member, others are unchanged
- Transferred the existing ACQFs, they can be initialized from long-object name, form short object-name, from long-string or from short-string (called abbreviation)
- Deprecated `VarUCB` and `qVarUCB`
- Deprecated `acquisition_function_cls` of ByaesianRecommender and renamed it to `acqf`
- Added hypothesis tests for the existing acquisition functions + one basic test initializing the seqgreedy recommender with these trategies
- renamed internal member `_acquisition_function` in bayesian reocmmenders to `_botorch_acqf`

Upcoming
- Generalize and potentially replace the `deborchize` interface and make is such that needed parameters are automatically passed to the botorch instance rather than hardcoded (`f_best`)
- Add newer acquisition functions like log, noisy, NIPV, possibly using the botorch factory utility