### PR TITLE
Enable uninstalling `requests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User guide now explains the new objective classes
 - Telemetry deactivation warning is only shown to developers
 - `torch`, `gpytorch` and `botorch` are lazy-loaded for improved startup time
+- Failed `requests` package import now disables telemetry instead of causing an
+  exception. This enables using baybe after uninstalling all internet packages.
 
 ### Removed
 - `model_params` attribute from `Surrogate` base class, `GaussianProcessSurrogate` and

--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ host machine names are irreversibly anonymized.
 - You can always deactivate all telemetry by setting the environment variable 
   `BAYBE_TELEMETRY_ENABLED` to `false` or `off`. For details please consult
   [this page](https://emdgroup.github.io/baybe/_autosummary/baybe.telemetry.html).
+- If you want to be absolutely sure, you can uninstall internet related packages such
+  as `requests` or `opentelemetry*` from the environment. Due to the inability of
+  specifying opt-out dependencies, these are installed by default, but the package
+  works without them.
 
 ## Authors
 

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -84,7 +84,6 @@ from typing import Union
 from urllib.parse import urlparse
 
 import pandas as pd
-import requests
 
 from baybe.parameters.base import Parameter
 from baybe.utils.boolean import strtobool
@@ -134,6 +133,7 @@ TELEM_LABELS = {
 
 # Attempt telemetry import
 try:
+    import requests
     from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
         OTLPMetricExporter,
     )


### PR DESCRIPTION
I was surprised to learn BayBE includes telemetry so deep in the project. It's uncomfortable importing a package that talks to the internet.

Since

> "BayBE collects anonymous usage statistics **only** for employees of Merck KGaA, Darmstadt, Germany and/or its affiliates. The recording of metrics is turned off for all other users and impossible due to a VPN block."

these dependencies seem useless for most users?

In this PR, I moved `requests` to the `# Attempt telemetry import` section so it's no longer needed to run anything in this project.

Because of https://github.com/emdgroup/baybe/pull/181, the telemetry is no longer optional to install when using pyproject.toml? I just installed the dependencies manually. It'd be nice to have this be optional so users don't get surprised by an automatic requests installed. Does poetry not do that?

---

Also, is there a reason this is not mentioned in the README? It used to be, but was removed: https://github.com/emdgroup/baybe/pull/3. Why?