### PR TITLE
Telemetry changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Acquisition functions are now their own objects
 - `acquisition_function_cls` constructor parameter renamed to `acquisition_function`
 - User guide now explains the new objective classes
+- Telemetry deactivation warning is only shown to developers
 
 ### Removed
 - `model_params` attribute from `Surrogate` base class, `GaussianProcessSurrogate` and

--- a/README.md
+++ b/README.md
@@ -292,6 +292,18 @@ The available groups are:
 - `test`: Required for running the tests.
 - `dev`: All of the above plus `tox` and `pip-audit`. For code contributors.
 
+## Telemetry
+BayBE collects anonymous usage statistics **only** for employees of Merck KGaA, 
+Darmstadt, Germany and/or its affiliates. The recording of metrics is turned off for
+all other users and is impossible due to a VPN block. In any case, the usage statistics
+do **not** involve logging of recorded measurements, targets/parameters or their names
+or any project information that would allow for reconstruction of details. The user and
+host machine names are irreversibly anonymized.
+- You can verify the above statements by studying the open-source code in the
+  `telemetry` module.
+- You can always deactivate all telemetry by setting the environment variable 
+  `BAYBE_TELEMETRY_ENABLED` to `false` or `off`. For details please consult
+  [this page](https://emdgroup.github.io/baybe/_autosummary/baybe.telemetry.html).
 
 ## Authors
 

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -221,12 +221,15 @@ if is_enabled():
         # any telemetry timeouts or interference for the user in case of unexpected
         # errors. Possible ones are for instance ``socket.gaierror`` in case the user
         # has no internet connection.
-        warnings.warn(
-            f"WARNING: BayBE Telemetry endpoint {_endpoint_url} cannot be reached. "
-            "Disabling telemetry. The exception encountered was: "
-            f"{type(ex).__name__}, {ex}",
-            UserWarning,
-        )
+        if os.environ.get(VARNAME_TELEMETRY_USERNAME, "").startswith("DEV_"):
+            # This warning is only printed for developers to make them aware of
+            # potential issues
+            warnings.warn(
+                f"WARNING: BayBE Telemetry endpoint {_endpoint_url} cannot be reached. "
+                "Disabling telemetry. The exception encountered was: "
+                f"{type(ex).__name__}, {ex}",
+                UserWarning,
+            )
         os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 
 


### PR DESCRIPTION
- the warning in case telemetry is disabled due to lack of connectivity is only shown to developers. This means most users outside of Merck will not be spammed with this warning anymore as telemetry will always be disabled for them
- Reintroduces telemetry mentioning in the README