### PR TITLE
`torch` lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `hypothesis` strategies and roundtrip test for kernels, constraints and objectives
 
 ### Changed
-- `torch` numeric types are now loaded lazily
 - Reorganized acquisition.py into `acquisition` subpackage
-- `torch` is imported lazily in `surrogates`
 - Acquisition functions are now their own objects
 - `acquisition_function_cls` constructor parameter renamed to `acquisition_function`
 - User guide now explains the new objective classes
 - Telemetry deactivation warning is only shown to developers
+- `torch`, `gpytorch` and `botorch` are lazy-loaded for improved startup time
 
 ### Removed
 - `model_params` attribute from `Surrogate` base class, `GaussianProcessSurrogate` and

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -8,8 +8,6 @@ from baybe.acquisition.acqfs import (
     qProbabilityOfImprovement,
     qUpperConfidenceBound,
 )
-from baybe.acquisition.adapter import AdapterModel, debotorchize
-from baybe.acquisition.partial import PartialAcquisitionFunction
 
 EI = ExpectedImprovement
 PI = ProbabilityOfImprovement
@@ -35,9 +33,4 @@ __all__ = [
     "qEI",
     "qPI",
     "qUCB",
-    # ---------------------------
-    # Helpers
-    "debotorchize",
-    "AdapterModel",
-    "PartialAcquisitionFunction",
 ]

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -8,7 +8,6 @@ from typing import ClassVar, Union
 
 from attrs import define
 
-from baybe.acquisition.adapter import debotorchize
 from baybe.serialization.core import (
     converter,
     get_base_structure_hook,
@@ -28,6 +27,8 @@ class AcquisitionFunction(ABC, SerialMixin):
     def to_botorch(self, surrogate: Surrogate, best_f: float):
         """Create the botorch-ready representation of the function."""
         import botorch.acquisition as botorch_acquisition
+
+        from baybe.acquisition.adapter import debotorchize
 
         acqf_cls = getattr(botorch_acquisition, self.__class__.__name__)
 

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -1,11 +1,10 @@
 """Naive recommender for hybrid spaces."""
 
 import warnings
-from typing import ClassVar, Optional, cast
+from typing import TYPE_CHECKING, ClassVar, Optional, cast
 
 import pandas as pd
 from attrs import define, evolve, field, fields
-from torch import Tensor
 
 from baybe.acquisition import PartialAcquisitionFunction
 from baybe.recommenders.pure.base import PureRecommender
@@ -16,6 +15,9 @@ from baybe.recommenders.pure.bayesian.sequential_greedy import (
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
 from baybe.utils.dataframe import to_tensor
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @define

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -1,7 +1,7 @@
 """Naive recommender for hybrid spaces."""
 
 import warnings
-from typing import TYPE_CHECKING, ClassVar, Optional, cast
+from typing import ClassVar, Optional
 
 import pandas as pd
 from attrs import define, evolve, field, fields
@@ -14,9 +14,6 @@ from baybe.recommenders.pure.bayesian.sequential_greedy import (
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
 from baybe.utils.dataframe import to_tensor
-
-if TYPE_CHECKING:
-    from torch import Tensor
 
 
 @define
@@ -119,7 +116,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # will then be attached to every discrete point when the acquisition function
         # is evaluated.
         cont_part = searchspace.continuous.samples_random(1)
-        cont_part_tensor = cast(Tensor, to_tensor(cont_part)).unsqueeze(-2)
+        cont_part_tensor = to_tensor(cont_part).unsqueeze(-2)
 
         # Get discrete candidates. The metadata flags are ignored since the search space
         # is hybrid
@@ -154,7 +151,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # Get one random discrete point that will be attached when evaluating the
         # acquisition function in the discrete space.
         disc_part = searchspace.discrete.comp_rep.loc[disc_rec_idx].sample(1)
-        disc_part_tensor = cast(Tensor, to_tensor(disc_part)).unsqueeze(-2)
+        disc_part_tensor = to_tensor(disc_part).unsqueeze(-2)
 
         # Setup a fresh acquisition function for the continuous recommender
         self.cont_recommender._setup_botorch_acqf(searchspace, train_x, train_y)

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar, Optional, cast
 import pandas as pd
 from attrs import define, evolve, field, fields
 
-from baybe.acquisition import PartialAcquisitionFunction
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.bayesian.sequential_greedy import (
@@ -87,6 +86,8 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         train_y: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
+
+        from baybe.acquisition.partial import PartialAcquisitionFunction
 
         if (not isinstance(self.disc_recommender, BayesianRecommender)) and (
             not isinstance(self.disc_recommender, NonPredictiveRecommender)

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -4,7 +4,6 @@ from typing import Any, ClassVar
 
 import pandas as pd
 from attrs import define, field, validators
-from botorch.optim import optimize_acqf, optimize_acqf_discrete, optimize_acqf_mixed
 
 from baybe.exceptions import NoMCAcquisitionFunctionError
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
@@ -69,6 +68,8 @@ class SequentialGreedyRecommender(BayesianRecommender):
     ) -> pd.Index:
         # See base class.
 
+        from botorch.optim import optimize_acqf_discrete
+
         # determine the next set of points to be tested
         candidates_tensor = to_tensor(candidates_comp)
         try:
@@ -102,7 +103,9 @@ class SequentialGreedyRecommender(BayesianRecommender):
         batch_size: int,
     ) -> pd.DataFrame:
         # See base class.
+
         import torch
+        from botorch.optim import optimize_acqf
 
         try:
             points, _ = optimize_acqf(
@@ -161,6 +164,7 @@ class SequentialGreedyRecommender(BayesianRecommender):
                 is chosen.
         """
         import torch
+        from botorch.optim import optimize_acqf_mixed
 
         if len(candidates_comp) > 0:
             # Calculate the number of samples from the given percentage

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -27,7 +27,6 @@ from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets
 from baybe.surrogates.validation import validate_custom_architecture_cls
 from baybe.utils.numerical import DTypeFloatONNX
-from baybe.utils.torch import DTypeFloatTorch
 
 try:
     import onnxruntime as ort
@@ -155,6 +154,8 @@ if _ONNX_INSTALLED:
         @batchify
         def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
             import torch
+
+            from baybe.utils.torch import DTypeFloatTorch
 
             model_inputs = {
                 self.onnx_input_name: candidates.numpy().astype(DTypeFloatONNX)

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 from attr import define, field
-from botorch import fit_gpytorch_mll
-from botorch.models import SingleTaskGP
-from botorch.models.transforms import Normalize, Standardize
-from gpytorch import ExactMarginalLogLikelihood
-from gpytorch.kernels import IndexKernel, ScaleKernel
-from gpytorch.likelihoods import GaussianLikelihood
-from gpytorch.means import ConstantMean
-from gpytorch.priors import GammaPrior
 
 from baybe.kernels import MaternKernel
 from baybe.kernels.base import Kernel
@@ -20,6 +12,7 @@ from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 
 if TYPE_CHECKING:
+    from botorch.models import SingleTaskGP
     from torch import Tensor
 
 
@@ -49,7 +42,10 @@ class GaussianProcessSurrogate(Surrogate):
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
         # See base class.
 
+        import botorch
+        import gpytorch
         import torch
+        from gpytorch.priors import GammaPrior
 
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
@@ -63,10 +59,10 @@ class GaussianProcessSurrogate(Surrogate):
 
         # define the input and outcome transforms
         # TODO [Scaling]: scaling should be handled by search space object
-        input_transform = Normalize(
+        input_transform = botorch.models.transforms.Normalize(
             train_x.shape[1], bounds=bounds, indices=numeric_idxs
         )
-        outcome_transform = Standardize(train_y.shape[1])
+        outcome_transform = botorch.models.transforms.Standardize(train_y.shape[1])
 
         # ---------- GP prior selection ---------- #
         # TODO: temporary prior choices adapted from edbo, replace later on
@@ -105,7 +101,7 @@ class GaussianProcessSurrogate(Surrogate):
         batch_shape = train_x.shape[:-2]
 
         # create GP mean
-        mean_module = ConstantMean(batch_shape=batch_shape)
+        mean_module = gpytorch.means.ConstantMean(batch_shape=batch_shape)
 
         # define the covariance module for the numeric dimensions
         gpytorch_kernel = self.kernel.to_gpytorch(
@@ -114,7 +110,7 @@ class GaussianProcessSurrogate(Surrogate):
             batch_shape=batch_shape,
             lengthscale_prior=lengthscale_prior[0],
         )
-        base_covar_module = ScaleKernel(
+        base_covar_module = gpytorch.kernels.ScaleKernel(
             gpytorch_kernel,
             batch_shape=batch_shape,
             outputscale_prior=outputscale_prior[0],
@@ -130,7 +126,7 @@ class GaussianProcessSurrogate(Surrogate):
         if task_idx is None:
             covar_module = base_covar_module
         else:
-            task_covar_module = IndexKernel(
+            task_covar_module = gpytorch.kernels.IndexKernel(
                 num_tasks=searchspace.n_tasks,
                 active_dims=task_idx,
                 rank=searchspace.n_tasks,  # TODO: make controllable
@@ -138,14 +134,14 @@ class GaussianProcessSurrogate(Surrogate):
             covar_module = base_covar_module * task_covar_module
 
         # create GP likelihood
-        likelihood = GaussianLikelihood(
+        likelihood = gpytorch.likelihoods.GaussianLikelihood(
             noise_prior=noise_prior[0], batch_shape=batch_shape
         )
         if noise_prior[1] is not None:
             likelihood.noise = torch.tensor([noise_prior[1]])
 
         # construct and fit the Gaussian process
-        self._model = SingleTaskGP(
+        self._model = botorch.models.SingleTaskGP(
             train_x,
             train_y,
             input_transform=input_transform,
@@ -154,5 +150,5 @@ class GaussianProcessSurrogate(Surrogate):
             covar_module=covar_module,
             likelihood=likelihood,
         )
-        mll = ExactMarginalLogLikelihood(self._model.likelihood, self._model)
-        fit_gpytorch_mll(mll)
+        mll = gpytorch.ExactMarginalLogLikelihood(self._model.likelihood, self._model)
+        botorch.fit_gpytorch_mll(mll)

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar
 
 from attr import define, field
 
@@ -12,7 +12,6 @@ from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
 
 if TYPE_CHECKING:
-    from botorch.models import SingleTaskGP
     from torch import Tensor
 
 
@@ -31,7 +30,9 @@ class GaussianProcessSurrogate(Surrogate):
     kernel: Kernel = field(factory=MaternKernel)
     """The kernel used by the Gaussian Process."""
 
-    _model: Optional[SingleTaskGP] = field(init=False, default=None)
+    # TODO: type should be Optional[botorch.models.SingleTaskGP] but is currently
+    #   omitted due to: https://github.com/python-attrs/cattrs/issues/531
+    _model = field(init=False, default=None)
     """The actual model."""
 
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, ClassVar
 
-import torch
-from torch import Tensor
-
 from baybe.scaler import DefaultScaler
 from baybe.searchspace import SearchSpace
 
 if TYPE_CHECKING:
+    from torch import Tensor
+
     from baybe.surrogates.base import Surrogate
 
 _MIN_TARGET_STD = 1e-6
@@ -90,6 +89,8 @@ def catch_constant_targets(model_cls: type[Surrogate]):
 
         def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
             """Call the posterior function of the internal model instance."""
+            import torch
+
             mean, var = self.model._posterior(candidates)
 
             # If a joint posterior is expected but the model has been overridden by one
@@ -105,6 +106,8 @@ def catch_constant_targets(model_cls: type[Surrogate]):
             self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
         ) -> None:
             """Select a model based on the variance of the targets and fits it."""
+            import torch
+
             from baybe.surrogates.naive import MeanPredictionSurrogate
 
             # https://github.com/pytorch/pytorch/issues/29372
@@ -232,6 +235,8 @@ def batchify(
         Returns:
             The mean and the covariance.
         """
+        import torch
+
         # If no batch dimensions are given, call the model directly
         if candidates.ndim == 2:
             return posterior(model, candidates)

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
     Literal,
     Optional,
     Union,
+    overload,
 )
 
 import numpy as np
@@ -28,7 +29,17 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterable[Tensor]]:
+@overload
+def to_tensor(df: pd.DataFrame) -> Tensor:
+    ...
+
+
+@overload
+def to_tensor(*dfs: pd.DataFrame) -> Iterator[Tensor]:
+    ...
+
+
+def to_tensor(*dfs: pd.DataFrame) -> Union[Tensor, Iterator[Tensor]]:
     """Convert a given set of dataframes into tensors (dropping all indices).
 
     Args:

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -15,7 +15,7 @@ from botorch.optim import optimize_acqf_discrete
 from funcy import rpartial
 
 import streamlit as st
-from baybe.acquisition import debotorchize
+from baybe.acquisition.adapter import debotorchize
 from baybe.parameters import NumericalDiscreteParameter
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import get_available_surrogates

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -2,6 +2,8 @@
 
 import importlib
 import pkgutil
+import subprocess
+import sys
 
 import pytest
 
@@ -21,3 +23,27 @@ def find_modules() -> list[str]:
 def test_imports(module: str):
     """All modules can be imported without throwing errors."""
     importlib.import_module(module)
+
+
+WHITELIST = [
+    "baybe.acquisition.adapter",
+    "baybe.acquisition.partial",
+    "baybe.utils.botorch_wrapper",
+    "baybe.utils.torch",
+]
+"""List of modules that are allowed to import torch."""
+
+
+def test_torch_lazy_loading():
+    """Torch does not appear in the module list after loading BayBE modules."""
+    imps = "\n".join([f"import {i}" for i in find_modules() if i not in WHITELIST])
+    code = "\n".join(
+        [
+            "import sys",
+            f"{imps}",
+            "exit(int('torch' in sys.modules.keys()))",
+        ]
+    )
+    python_interpreter = sys.executable
+    result = subprocess.call([python_interpreter, "-c", code])
+    assert result == 0

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,8 +4,11 @@ import importlib
 import pkgutil
 import subprocess
 import sys
+from collections.abc import Sequence
 
 import pytest
+
+_EAGER_LOADING_EXIT_CODE = 42
 
 
 def find_modules() -> list[str]:
@@ -17,6 +20,27 @@ def find_modules() -> list[str]:
             path=package.__path__, prefix=package.__name__ + "."
         )
     ]
+
+
+def make_import_check(modules: Sequence[str], target: str) -> str:
+    """Create code that tests if importing the given modules also imports the target.
+
+    Args:
+        modules: The modules to be imported by the created code.
+        target: The target module whose presence is to be checked after the import.
+
+    Returns:
+        str: Code that signals the presence of the target via a non-zero exit code.
+    """
+    imports = "\n".join([f"import {module}" for module in modules])
+    return "\n".join(
+        [
+            "import sys",
+            f"{imports}",
+            f"hit = '{target}' in sys.modules.keys()",
+            f"exit({_EAGER_LOADING_EXIT_CODE} if hit else 0)",
+        ]
+    )
 
 
 @pytest.mark.parametrize("module", find_modules())
@@ -36,14 +60,8 @@ WHITELIST = [
 
 def test_torch_lazy_loading():
     """Torch does not appear in the module list after loading BayBE modules."""
-    imps = "\n".join([f"import {i}" for i in find_modules() if i not in WHITELIST])
-    code = "\n".join(
-        [
-            "import sys",
-            f"{imps}",
-            "exit(int('torch' in sys.modules.keys()))",
-        ]
-    )
+    modules = [i for i in find_modules() if i not in WHITELIST]
+    code = make_import_check(modules, "torch")
     python_interpreter = sys.executable
     result = subprocess.call([python_interpreter, "-c", code])
     assert result == 0

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,7 @@
 """Import tests."""
 
 import importlib
+import os
 import pkgutil
 import subprocess
 import sys
@@ -8,6 +9,11 @@ from collections.abc import Sequence
 
 import pytest
 from pytest import param
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("BAYBE_TEST_ENV") != "FULLTEST",
+    reason="Only possible in FULLTEST environment.",
+)
 
 _EAGER_LOADING_EXIT_CODE = 42
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,23 @@
+"""Import tests."""
+
+import importlib
+import pkgutil
+
+import pytest
+
+
+def find_modules() -> list[str]:
+    """Return all BayBE module names."""
+    package = importlib.import_module("baybe")
+    return [
+        name
+        for _, name, _ in pkgutil.walk_packages(
+            path=package.__path__, prefix=package.__name__ + "."
+        )
+    ]
+
+
+@pytest.mark.parametrize("module", find_modules())
+def test_imports(module: str):
+    """All modules can be imported without throwing errors."""
+    importlib.import_module(module)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,4 @@
-"""Import tests."""
+"""Tests for module imports."""
 
 import importlib
 import os

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -37,7 +37,7 @@ def make_import_check(modules: Sequence[str], target: str) -> str:
         target: The target module whose presence is to be checked after the import.
 
     Returns:
-        str: Code that signals the presence of the target via a non-zero exit code.
+        Code that signals the presence of the target via a non-zero exit code.
     """
     imports = "\n".join([f"import {module}" for module in modules])
     return "\n".join(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -73,3 +73,15 @@ def test_lazy_loading(target: str, whitelist: Sequence[str]):
     python_interpreter = sys.executable
     result = subprocess.call([python_interpreter, "-c", code])
     assert result == 0
+
+
+@pytest.mark.parametrize(
+    ("target", "module"),
+    [param(k, m, id=f"{k}-{m}") for k, v in WHITELISTS.items() for m in v],
+)
+def test_whitelist_modules_are_true_positives(target, module):
+    """The whitelisted modules actually import the target."""
+    code = make_import_check([module], target)
+    python_interpreter = sys.executable
+    result = subprocess.call([python_interpreter, "-c", code])
+    assert result == _EAGER_LOADING_EXIT_CODE

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ extras = test,chem,examples,simulation,onnx
 passenv = CI
 setenv =
     SMOKE_TEST = true
+    BAYBE_TEST_ENV = FULLTEST
 commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
@@ -19,6 +20,7 @@ extras = test
 passenv = CI
 setenv =
     SMOKE_TEST = true
+    BAYBE_TEST_ENV = CORETEST
 commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}


### PR DESCRIPTION
This PR finalizes the import refactoring such that `torch` (and the dependent packages `gpytorch`/`botorch`) are loaded lazily for improved package import speed.

Further, new import tests ensure that:
* all BayBE modules can be loaded without errors
* `torch` is not eagerly loaded (to prevent regressions)