### PR TITLE
Hotfix for match mode simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `n_task_params` now evaluates to 1 if `task_idx == 0`
 - Simulation no longer fails in `ignore` mode when lookup dataframe contains duplicate
   parameter configurations
+- Simulation no longer fails for targets in `MATCH` mode
+- `closest_element` now works for array-like input of all kinds
 
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with

--- a/baybe/simulation.py
+++ b/baybe/simulation.py
@@ -549,7 +549,7 @@ def simulate_experiment(
             agg_fun = np.min
             cum_fun = np.minimum.accumulate
         elif target.mode is TargetMode.MATCH:
-            match_val = np.mean(target.bounds)
+            match_val = target.bounds.center
             agg_fun = partial(closest_element, target=match_val)
             cum_fun = lambda x: np.array(  # noqa: E731
                 np.frompyfunc(

--- a/baybe/utils/numerical.py
+++ b/baybe/utils/numerical.py
@@ -45,7 +45,7 @@ def closest_element(array: npt.ArrayLike, target: float) -> float:
         The closest element.
     """
     if np.ndim(array) == 0:
-        return float(array)
+        return np.asarray(array).item()
     array = np.ravel(array)
     return array[np.abs(array - target).argmin()]
 

--- a/baybe/utils/numerical.py
+++ b/baybe/utils/numerical.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 
 import numpy as np
+import numpy.typing as npt
 
 DTypeFloatNumpy = np.float64
 """Floating point data type used for numpy arrays."""
@@ -33,16 +34,19 @@ def geom_mean(arr: np.ndarray, weights: Sequence[float]) -> np.ndarray:
     return np.prod(np.power(arr, np.atleast_2d(weights) / np.sum(weights)), axis=1)
 
 
-def closest_element(array: np.ndarray, target: float) -> float:
+def closest_element(array: npt.ArrayLike, target: float) -> float:
     """Find the element of an array that is closest to a target value.
 
     Args:
-        array: The array in which the closest value should be found.
+        array: The array in which the closest value is to be found.
         target: The target value.
 
     Returns:
-        The closes element.
+        The closest element.
     """
+    if np.ndim(array) == 0:
+        return float(array)
+    array = np.ravel(array)
     return array[np.abs(array - target).argmin()]
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+"""Tests for utilities."""
+
+import numpy as np
+import pytest
+from pytest import param
+
+from baybe.utils.numerical import closest_element
+
+
+@pytest.mark.parametrize(
+    "as_ndarray", [param(False, id="list"), param(True, id="array")]
+)
+@pytest.mark.parametrize(
+    ("array", "target", "expected"),
+    [
+        param(0, 0.1, 0, id="0D"),
+        param([0, 1], 0.1, 0, id="1D"),
+        param([[2, 3], [0, 1]], 0.1, 0, id="2D"),
+    ],
+)
+def test_closest_element(as_ndarray, array, target, expected):
+    """The closest element can be found irrespective of the input type."""
+    if as_ndarray:
+        array = np.asarray(array)
+    actual = closest_element(array, target)
+    assert actual == expected, (actual, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,21 +6,24 @@ from pytest import param
 
 from baybe.utils.numerical import closest_element
 
+_TARGET = 1337
+_CLOSEST = _TARGET + 0.1
+
 
 @pytest.mark.parametrize(
     "as_ndarray", [param(False, id="list"), param(True, id="array")]
 )
 @pytest.mark.parametrize(
-    ("array", "target", "expected"),
+    "array",
     [
-        param(0, 0.1, 0, id="0D"),
-        param([0, 1], 0.1, 0, id="1D"),
-        param([[2, 3], [0, 1]], 0.1, 0, id="2D"),
+        param(_CLOSEST, id="0D"),
+        param([0, _CLOSEST], id="1D"),
+        param([[2, 3], [0, _CLOSEST]], id="2D"),
     ],
 )
-def test_closest_element(as_ndarray, array, target, expected):
+def test_closest_element(as_ndarray, array):
     """The closest element can be found irrespective of the input type."""
     if as_ndarray:
         array = np.asarray(array)
-    actual = closest_element(array, target)
-    assert actual == expected, (actual, expected)
+    actual = closest_element(array, _TARGET)
+    assert actual == _CLOSEST, (actual, _CLOSEST)


### PR DESCRIPTION
Fixes #207 by:
* Correctly accessing `Interval` attributes
* Making `closest_element` handle arbitrary array-like input