### PR TITLE
Refactor surrogates and decorators

### DIFF
--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -51,8 +51,8 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
 
     # Object variables
     model_params: dict = field(factory=dict)
-    """The parameters for the used model. This is initialized with reasonable default
-    values for the derived child classes."""
+    """Optional model parameter that will be passed to the surrogate constructor.
+    This is initialized with reasonable default values for the derived child classes."""
 
     def _make_selection_default(
         self,

--- a/baybe/surrogates/__init__.py
+++ b/baybe/surrogates/__init__.py
@@ -1,6 +1,5 @@
 """BayBE surrogates."""
 
-from baybe.surrogates.base import get_available_surrogates
 from baybe.surrogates.custom import _ONNX_INSTALLED, register_custom_architecture
 from baybe.surrogates.gaussian_process import GaussianProcessSurrogate
 from baybe.surrogates.linear import BayesianLinearSurrogate
@@ -9,7 +8,6 @@ from baybe.surrogates.ngboost import NGBoostSurrogate
 from baybe.surrogates.random_forest import RandomForestSurrogate
 
 __all__ = [
-    "get_available_surrogates",
     "register_custom_architecture",
     "BayesianLinearSurrogate",
     "GaussianProcessSurrogate",

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -16,8 +16,12 @@ from cattrs.dispatch import (
 )
 
 from baybe.searchspace import SearchSpace
-from baybe.serialization import SerialMixin, converter, unstructure_base
-from baybe.serialization.core import get_base_structure_hook
+from baybe.serialization.core import (
+    converter,
+    get_base_structure_hook,
+    unstructure_base,
+)
+from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.utils import _prepare_inputs, _prepare_targets
 
 if TYPE_CHECKING:

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -12,7 +12,6 @@ from attrs import define
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin, converter, unstructure_base
 from baybe.surrogates.utils import _prepare_inputs, _prepare_targets
-from baybe.utils.basic import get_subclasses
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -218,32 +217,6 @@ def _structure_surrogate(val, _):
         val["onnx_str"] = onnx_str.encode(_ONNX_ENCODING)
 
     return converter.structure_attrs_fromdict(val, cls)
-
-
-def get_available_surrogates() -> list[type[Surrogate]]:
-    """List all available surrogate models.
-
-    Returns:
-        A list of available surrogate classes.
-    """
-    # List available names
-    available_names = {
-        cl.__name__
-        for cl in get_subclasses(Surrogate)
-        if cl.__name__ not in _WRAPPER_MODELS
-    }
-
-    # Convert them to classes
-    available_classes = [
-        getattr(sys.modules[__package__], mdl_name, None)
-        for mdl_name in available_names
-    ]
-
-    # TODO: The initialization of the classes is currently necessary for the renaming
-    #  to take place (see [15436] and NOTE in `structure_surrogate`).
-    [cl() for cl in available_classes if cl is not None]
-
-    return [cl for cl in available_classes if cl is not None]
 
 
 # Register (un-)structure hooks

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -132,7 +132,7 @@ class Surrogate(ABC, SerialMixin):
         train_x = _prepare_inputs(train_x)
         train_y = _prepare_targets(train_y)
 
-        return self._fit(searchspace, train_x, train_y)
+        self._fit(searchspace, train_x, train_y)
 
     @abstractmethod
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -18,12 +18,6 @@ if TYPE_CHECKING:
 
 # Define constants
 _MIN_VARIANCE = 1e-6
-_WRAPPER_MODELS = (
-    "SplitModel",
-    "ScaledModel",
-    "CustomArchitectureSurrogate",
-    "CustomONNXSurrogate",
-)
 
 _ONNX_ENCODING = "latin-1"
 """Constant signifying the encoding for onnx byte strings in pretrained models.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from attrs import define
+from attrs import define, field
 
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin, converter, unstructure_base
@@ -42,6 +42,9 @@ class Surrogate(ABC, SerialMixin):
     supports_transfer_learning: ClassVar[bool]
     """Class variable encoding whether or not the surrogate supports transfer
     learning."""
+
+    _model: Any = field(init=False, default=None)
+    """The actual model."""
 
     def posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """Evaluate the surrogate model at the given candidate points.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -55,10 +55,16 @@ class Surrogate(ABC, SerialMixin):
                 denotes the "q-batch" shape, and ``d`` is the input dimension. For
                 more details about batch shapes, see: https://botorch.org/docs/batching
 
+        Raises:
+            RuntimeError: When attempting to use the model before it has been fitted.
+
         Returns:
             The posterior means and posterior covariance matrices of the t-batched
             candidate points.
         """
+        if self._model is None:
+            raise RuntimeError("The surrogate model has not been fitted yet.")
+
         import torch
 
         # Prepare the input

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -67,16 +67,10 @@ class Surrogate(ABC, SerialMixin):
                 denotes the "q-batch" shape, and ``d`` is the input dimension. For
                 more details about batch shapes, see: https://botorch.org/docs/batching
 
-        Raises:
-            RuntimeError: When attempting to use the model before it has been fitted.
-
         Returns:
             The posterior means and posterior covariance matrices of the t-batched
             candidate points.
         """
-        if self._model is None:
-            raise RuntimeError("The surrogate model has not been fitted yet.")
-
         import torch
 
         # Prepare the input

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -163,8 +163,8 @@ def _encode_onnx_str(raw_structure_hook):
     """Encode ONNX string for deserialization purposes."""
 
     def wrapper(dict_, _):
-        if "onnx_str" in dict_:
-            dict_["onnx_str"] = dict_["onnx_str"].encode(_ONNX_ENCODING)
+        if (onnx_str := dict_.get("onnx_str")) and isinstance(onnx_str, str):
+            dict_["onnx_str"] = onnx_str.encode(_ONNX_ENCODING)
         obj = raw_structure_hook(dict_, _)
 
         return obj

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
-from attrs import define, field
+from attrs import define
 from cattrs import override
 from cattrs.dispatch import (
     StructuredValue,
@@ -50,13 +50,6 @@ class Surrogate(ABC, SerialMixin):
     supports_transfer_learning: ClassVar[bool]
     """Class variable encoding whether or not the surrogate supports transfer
     learning."""
-
-    # NOTE: This attribute holds a subclass-specific object whose type and use
-    #   also depends on the particular surrogate at hand. Currently, the contained model
-    #   is assumed non-persistent and thus not considered for serialization and object
-    #   comparison via the equality operator.
-    _model: Any = field(init=False, default=None, eq=False)
-    """The actual model."""
 
     def posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """Evaluate the surrogate model at the given candidate points.

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -69,15 +69,15 @@ def register_custom_architecture(
             supports_transfer_learning: ClassVar[bool] = False
 
             def __init__(self, *args, **kwargs):
-                self.model = model_cls(*args, **kwargs)
+                self._model = model_cls(*args, **kwargs)
 
             def _fit(
                 self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
             ) -> None:
-                return self.model._fit(searchspace, train_x, train_y)
+                return self._model._fit(searchspace, train_x, train_y)
 
             def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
-                return self.model._posterior(candidates)
+                return self._model._posterior(candidates)
 
             def __get_attribute__(self, attr):
                 """Access the attributes of the class instance if available.
@@ -94,7 +94,7 @@ def register_custom_architecture(
                     return val
 
                 # If the attribute is not overwritten, use that of the internal model
-                return self.model.__getattribute__(attr)
+                return self._model.__getattribute__(attr)
 
         # Catch constant targets if needed
         cls = (
@@ -141,7 +141,7 @@ if _ONNX_INSTALLED:
         """The ONNX byte str representing the model."""
 
         _model: ort.InferenceSession = field(init=False, eq=False)
-        """The internal model."""
+        """The actual model."""
 
         @_model.default
         def default_model(self) -> ort.InferenceSession:

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -140,10 +140,14 @@ if _ONNX_INSTALLED:
         onnx_str: bytes = field(validator=validators.instance_of(bytes))
         """The ONNX byte str representing the model."""
 
-        def __attrs_post_init__(self) -> None:
+        _model: ort.InferenceSession = field(init=False, eq=False)
+        """The actual model."""
+
+        @_model.default
+        def default_model(self) -> ort.InferenceSession:
             """Instantiate the ONNX inference session."""
             try:
-                self._model = ort.InferenceSession(self.onnx_str)
+                return ort.InferenceSession(self.onnx_str)
             except Exception as exc:
                 raise ValueError("Invalid ONNX string") from exc
 

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -140,14 +140,10 @@ if _ONNX_INSTALLED:
         onnx_str: bytes = field(validator=validators.instance_of(bytes))
         """The ONNX byte str representing the model."""
 
-        _model: ort.InferenceSession = field(init=False, eq=False)
-        """The actual model."""
-
-        @_model.default
-        def default_model(self) -> ort.InferenceSession:
+        def __attrs_post_init__(self) -> None:
             """Instantiate the ONNX inference session."""
             try:
-                return ort.InferenceSession(self.onnx_str)
+                self._model = ort.InferenceSession(self.onnx_str)
             except Exception as exc:
                 raise ValueError("Invalid ONNX string") from exc
 

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -31,11 +31,6 @@ class GaussianProcessSurrogate(Surrogate):
     kernel: Optional[Kernel] = field(default=None)
     """The kernel used by the Gaussian Process."""
 
-    # TODO: type should be Optional[botorch.models.SingleTaskGP] but is currently
-    #   omitted due to: https://github.com/python-attrs/cattrs/issues/531
-    _model = field(init=False, default=None)
-    """The actual model."""
-
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         posterior = self._model.posterior(candidates)

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -31,6 +31,11 @@ class GaussianProcessSurrogate(Surrogate):
     kernel: Optional[Kernel] = field(default=None)
     """The kernel used by the Gaussian Process."""
 
+    # TODO: type should be Optional[botorch.models.SingleTaskGP] but is currently
+    #   omitted due to: https://github.com/python-attrs/cattrs/issues/531
+    _model = field(init=False, default=None)
+    """The actual model."""
+
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
         posterior = self._model.posterior(candidates)

--- a/baybe/surrogates/gaussian_process.py
+++ b/baybe/surrogates/gaussian_process.py
@@ -33,7 +33,7 @@ class GaussianProcessSurrogate(Surrogate):
 
     # TODO: type should be Optional[botorch.models.SingleTaskGP] but is currently
     #   omitted due to: https://github.com/python-attrs/cattrs/issues/531
-    _model = field(init=False, default=None)
+    _model = field(init=False, default=None, eq=False)
     """The actual model."""
 
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -43,7 +43,7 @@ class BayesianLinearSurrogate(Surrogate):
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 
-    _model: Optional[ARDRegression] = field(init=False, default=None)
+    _model: Optional[ARDRegression] = field(init=False, default=None, eq=False)
     """The actual model."""
 
     @batchify

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -41,7 +41,7 @@ class BayesianLinearSurrogate(Surrogate):
         converter=dict,
         validator=get_model_params_validator(ARDRegression.__init__),
     )
-    # See base class.
+    """Optional model parameter that will be passed to the surrogate constructor."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from attr import define, field
 from sklearn.linear_model import ARDRegression
@@ -42,6 +42,9 @@ class BayesianLinearSurrogate(Surrogate):
         validator=get_model_params_validator(ARDRegression.__init__),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
+
+    _model: Optional[ARDRegression] = field(init=False, default=None)
+    """The actual model."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import define, field
 from sklearn.linear_model import ARDRegression
@@ -42,9 +42,6 @@ class BayesianLinearSurrogate(Surrogate):
         validator=get_model_params_validator(ARDRegression.__init__),
     )
     # See base class.
-
-    _model: Optional[ARDRegression] = field(init=False, default=None)
-    """The actual model."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -15,7 +15,7 @@ from sklearn.linear_model import ARDRegression
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
-from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
+from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
 if TYPE_CHECKING:
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 
 @catch_constant_targets
-@scale_model
-@define
+@autoscale
+@define(slots=False)
 class BayesianLinearSurrogate(Surrogate):
     """A Bayesian linear regression surrogate model."""
 

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -30,8 +30,10 @@ class MeanPredictionSurrogate(Surrogate):
     # See base class.
 
     # Object variables
-    target_value: Optional[float] = field(init=False, default=None)
-    """The value of the posterior mean."""
+    _model: Optional[float] = field(init=False, default=None)
+    """The actual model.
+
+    Here, the "model" is just a numerical value, namely the constant posterior mean."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
@@ -40,10 +42,10 @@ class MeanPredictionSurrogate(Surrogate):
         import torch
 
         # TODO: use target value bounds for covariance scaling when explicitly provided
-        mean = self.target_value * torch.ones([len(candidates)])
+        mean = self._model * torch.ones([len(candidates)])
         var = torch.ones(len(candidates))
         return mean, var
 
     def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
         # See base class.
-        self.target_value = train_y.mean().item()
+        self._model = train_y.mean().item()

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar
 
-from attr import define, field
+from attr import define
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -28,12 +28,6 @@ class MeanPredictionSurrogate(Surrogate):
 
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
-
-    # Object variables
-    _model: Optional[float] = field(init=False, default=None)
-    """The actual model.
-
-    Here, the "model" is just a numerical value, namely the constant posterior mean."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -31,9 +31,7 @@ class MeanPredictionSurrogate(Surrogate):
 
     # Object variables
     _model: Optional[float] = field(init=False, default=None)
-    """The actual model.
-
-    Here, the "model" is just a numerical value, namely the constant posterior mean."""
+    """The estimated posterior mean value of the training targets."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Optional
 
-from attr import define
+from attr import define, field
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
@@ -28,6 +28,12 @@ class MeanPredictionSurrogate(Surrogate):
 
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
+
+    # Object variables
+    _model: Optional[float] = field(init=False, default=None)
+    """The actual model.
+
+    Here, the "model" is just a numerical value, namely the constant posterior mean."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -30,7 +30,7 @@ class MeanPredictionSurrogate(Surrogate):
     # See base class.
 
     # Object variables
-    _model: Optional[float] = field(init=False, default=None)
+    _model: Optional[float] = field(init=False, default=None, eq=False)
     """The estimated posterior mean value of the training targets."""
 
     @batchify

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -46,7 +46,7 @@ class NGBoostSurrogate(Surrogate):
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 
-    _model: Optional[NGBRegressor] = field(init=False, default=None)
+    _model: Optional[NGBRegressor] = field(init=False, default=None, eq=False)
     """The actual model."""
 
     def __attrs_post_init__(self):

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from attr import define, field
 from ngboost import NGBRegressor
@@ -45,6 +45,9 @@ class NGBoostSurrogate(Surrogate):
         validator=get_model_params_validator(NGBRegressor.__init__),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
+
+    _model: Optional[NGBRegressor] = field(init=False, default=None)
+    """The actual model."""
 
     def __attrs_post_init__(self):
         self.model_params = {**self._default_model_params, **self.model_params}

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import define, field
 from ngboost import NGBRegressor
@@ -45,9 +45,6 @@ class NGBoostSurrogate(Surrogate):
         validator=get_model_params_validator(NGBRegressor.__init__),
     )
     # See base class.
-
-    _model: Optional[NGBRegressor] = field(init=False, default=None)
-    """The actual model."""
 
     def __attrs_post_init__(self):
         self.model_params = {**self._default_model_params, **self.model_params}

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -15,7 +15,7 @@ from ngboost import NGBRegressor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
-from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
+from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
 if TYPE_CHECKING:
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 
 
 @catch_constant_targets
-@scale_model
-@define
+@autoscale
+@define(slots=False)
 class NGBoostSurrogate(Surrogate):
     """A natural-gradient-boosting surrogate model."""
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -44,7 +44,7 @@ class NGBoostSurrogate(Surrogate):
         converter=dict,
         validator=get_model_params_validator(NGBRegressor.__init__),
     )
-    # See base class.
+    """Optional model parameter that will be passed to the surrogate constructor."""
 
     def __attrs_post_init__(self):
         self.model_params = {**self._default_model_params, **self.model_params}

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -44,7 +44,7 @@ class RandomForestSurrogate(Surrogate):
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 
-    _model: Optional[RandomForestRegressor] = field(init=False, default=None)
+    _model: Optional[RandomForestRegressor] = field(init=False, default=None, eq=False)
     """The actual model."""
 
     @batchify

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -16,7 +16,7 @@ from sklearn.ensemble import RandomForestRegressor
 
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import Surrogate
-from baybe.surrogates.utils import batchify, catch_constant_targets, scale_model
+from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
 if TYPE_CHECKING:
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 
 
 @catch_constant_targets
-@scale_model
-@define
+@autoscale
+@define(slots=False)
 class RandomForestSurrogate(Surrogate):
     """A random forest surrogate model."""
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 from attr import define, field
@@ -43,9 +43,6 @@ class RandomForestSurrogate(Surrogate):
         validator=get_model_params_validator(RandomForestRegressor.__init__),
     )
     # See base class.
-
-    _model: Optional[RandomForestRegressor] = field(init=False, default=None)
-    """The actual model."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -42,7 +42,7 @@ class RandomForestSurrogate(Surrogate):
         converter=dict,
         validator=get_model_params_validator(RandomForestRegressor.__init__),
     )
-    # See base class.
+    """Optional model parameter that will be passed to the surrogate constructor."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -8,7 +8,7 @@ available in the future. Thus, please have a look in the source code directly.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import numpy as np
 from attr import define, field
@@ -43,6 +43,9 @@ class RandomForestSurrogate(Surrogate):
         validator=get_model_params_validator(RandomForestRegressor.__init__),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
+
+    _model: Optional[RandomForestRegressor] = field(init=False, default=None)
+    """The actual model."""
 
     @batchify
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -225,7 +225,9 @@ def batchify(
     """
 
     @wraps(posterior)
-    def sequential_posterior(model: Surrogate, candidates: Tensor) -> [Tensor, Tensor]:
+    def sequential_posterior(
+        model: Surrogate, candidates: Tensor
+    ) -> tuple[Tensor, Tensor]:
         """Replace the posterior function by one that processes batches sequentially.
 
         Args:

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -99,10 +99,10 @@ def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
         if train_y.numel() == 1 or train_y.std() < std_threshold:
             self._model = MeanPredictionSurrogate()
             self._model._fit(searchspace, train_x, train_y)
-            return
 
         # Regular operation
-        _fit_original(self, searchspace, train_x, train_y)
+        else:
+            _fit_original(self, searchspace, train_x, train_y)
 
     # Replace the methods
     cls._posterior = _posterior_new

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,10 +8,6 @@ import os
 import shutil
 import sys
 
-# We need to "trick" sphinx due to it thinking that decorated classes are just aliases
-# We thus need to import and later define some specific names
-from baybe.surrogates import get_available_surrogates
-
 # -- Path setup --------------------------------------------------------------
 
 __location__ = os.path.dirname(__file__)
@@ -284,10 +280,8 @@ typehints_use_signature = True
 
 
 # This function enables us to hook into the internal sphinx processes
-# These allow us to change docstrings (resp. how they are processed) which is currently
-# necessary for properly rendering the surrogates
+# These allow us to change docstrings (resp. how they are processed)
 def setup(app):  # noqa: D103
-    get_available_surrogates()
     app.connect("autodoc-process-docstring", autodoc_process_docstring)
 
 

--- a/docs/userguide/surrogates.md
+++ b/docs/userguide/surrogates.md
@@ -7,10 +7,10 @@ Surrogate models are used to model and estimate the unknown objective function o
 BayBE provides a comprehensive selection of surrogate models, empowering you to choose the most suitable option for your specific needs. The following surrogate models are available within BayBE:
 
 * [`GaussianProcessSurrogate`](baybe.surrogates.gaussian_process.GaussianProcessSurrogate)
-* `BayesianLinearSurrogate`
+* [`BayesianLinearSurrogate`](baybe.surrogates.linear.BayesianLinearSurrogate)
 * [`MeanPredictionSurrogate`](baybe.surrogates.naive.MeanPredictionSurrogate)
-* `NGBoostSurrogate`
-* `RandomForestSurrogate`
+* [`NGBoostSurrogate`](baybe.surrogates.ngboost.NGBoostSurrogate)
+* [`RandomForestSurrogate`](baybe.surrogates.random_forest.RandomForestSurrogate)
 
 
 ## Using custom models

--- a/examples/Basics/recommenders.py
+++ b/examples/Basics/recommenders.py
@@ -25,13 +25,10 @@ from baybe.recommenders import (
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
-from baybe.surrogates import (
-    BayesianLinearSurrogate,
-    GaussianProcessSurrogate,
-    NGBoostSurrogate,
-    RandomForestSurrogate,
-)
+from baybe.surrogates import GaussianProcessSurrogate
+from baybe.surrogates.base import Surrogate
 from baybe.targets import NumericalTarget
+from baybe.utils.basic import get_subclasses
 from baybe.utils.dataframe import add_fake_results
 
 ### Available recommenders suitable for initial recommendation
@@ -55,15 +52,8 @@ INITIAL_RECOMMENDER = RandomRecommender()
 # This model uses available data to model the objective function as well as the uncertainty.
 # The surrogate model is then used by the acquisition function to make recommendations.
 
-# The following are some available basic surrogates
-# Use `baybe.surrogates.get_available_surrogates()` for a complete list.
-
-available_surrogate_models = [
-    GaussianProcessSurrogate(),
-    RandomForestSurrogate(),
-    NGBoostSurrogate(),
-    BayesianLinearSurrogate(),
-]
+# The following are the available basic surrogates
+print(get_subclasses(Surrogate))
 
 # Per default a Gaussian Process is used
 # You can change the used kernel by using the optional `kernel` keyword.

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -18,7 +18,8 @@ import streamlit as st
 from baybe.acquisition import qExpectedImprovement
 from baybe.parameters import NumericalDiscreteParameter
 from baybe.searchspace import SearchSpace
-from baybe.surrogates import get_available_surrogates
+from baybe.surrogates.base import Surrogate
+from baybe.utils.basic import get_subclasses
 
 # define constants
 N_PARAMETER_VALUES = 1000
@@ -74,7 +75,9 @@ def main():
 
     # collect all available surrogate models
     surrogate_model_classes = {
-        surr.__name__: surr for surr in get_available_surrogates()
+        surr.__name__: surr
+        for surr in get_subclasses(Surrogate)
+        if surr.__name__ != "CustomONNXSurrogate"
     }
 
     # simulation parameters

--- a/tests/serialization/test_surrogate_serialization.py
+++ b/tests/serialization/test_surrogate_serialization.py
@@ -2,10 +2,16 @@
 
 import pytest
 
-from baybe.surrogates.base import Surrogate, get_available_surrogates
+from baybe.surrogates.base import Surrogate
+from baybe.utils.basic import get_subclasses
+
+# TODO: Add serialization test for ONNX surrogate
+surrogates = [
+    cls() for cls in get_subclasses(Surrogate) if cls.__name__ != "CustomONNXSurrogate"
+]
 
 
-@pytest.mark.parametrize("surrogate", [cls() for cls in get_available_surrogates()])
+@pytest.mark.parametrize("surrogate", surrogates)
 def test_surrogate_serialization(surrogate):
     string = surrogate.to_json()
     surrogate2 = Surrogate.from_json(string)

--- a/tests/serialization/test_surrogate_serialization.py
+++ b/tests/serialization/test_surrogate_serialization.py
@@ -5,14 +5,15 @@ import pytest
 from baybe.surrogates.base import Surrogate
 from baybe.utils.basic import get_subclasses
 
-# TODO: Add serialization test for ONNX surrogate
-surrogates = [
-    cls() for cls in get_subclasses(Surrogate) if cls.__name__ != "CustomONNXSurrogate"
-]
 
+@pytest.mark.parametrize("surrogate_cls", get_subclasses(Surrogate))
+def test_surrogate_serialization(surrogate_cls, onnx_surrogate):
+    """A serialization roundtrip yields an equivalent object."""
+    if surrogate_cls.__name__ == "CustomONNXSurrogate":
+        surrogate = onnx_surrogate
+    else:
+        surrogate = surrogate_cls()
 
-@pytest.mark.parametrize("surrogate", surrogates)
-def test_surrogate_serialization(surrogate):
     string = surrogate.to_json()
     surrogate2 = Surrogate.from_json(string)
-    assert surrogate == surrogate2
+    assert surrogate == surrogate2, (surrogate, surrogate2)

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -15,7 +15,7 @@ from baybe.recommenders.pure.bayesian.sequential_greedy import (
 )
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType
-from baybe.surrogates import get_available_surrogates
+from baybe.surrogates.base import Surrogate
 from baybe.utils.basic import get_subclasses
 
 from .conftest import run_iterations
@@ -23,7 +23,9 @@ from .conftest import run_iterations
 ########################################################################################
 # Settings of the individual components to be tested
 ########################################################################################
-valid_surrogate_models = [cls() for cls in get_available_surrogates()]
+valid_surrogate_models = [
+    cls() for cls in get_subclasses(Surrogate) if cls.__name__ != "CustomONNXSurrogate"
+]
 valid_initial_recommenders = [cls() for cls in get_subclasses(NonPredictiveRecommender)]
 # TODO the TwoPhaseMetaRecommender below can be removed if the SeqGreedy recommender
 #  allows no training data


### PR DESCRIPTION
This PR refactors our surrogate package, which significantly removes boilerplate/workaround code and solves several longstanding issues:
* The `catch_constant_targets` and `scale_model` decorators have been drastically reduced/improved. Most importantly, they no longer cause problems in the subclass hierarchy, which allows us to remove many ugly workarounds with serialization hooks, the docs, typing, ... 
  **Note:** Potentially the `scale_model` decorator might vanish entirely when refactoring scaling, but this already serves as a preparation as the decorator can now be cleanly removed without other side-effects.
* The corresponding code and doc workarounds have been fixed
* ~~The `_model` attribute has been pulled up the base class and is now correctly handled in serialization and equality checks.~~