### PR TITLE
Change location of folder for documentation building

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,8 +30,6 @@ jobs:
           tox -e docs-py39
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
-        with:
-          path: 'build/docs'
 
   deploy:
     needs: build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,8 @@ jobs:
           tox -e docs-py39
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs/build'
 
   deploy:
     needs: build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
 import shutil
-import sys
 
 # We need to "trick" sphinx due to it thinking that decorated classes are just aliases
 # We thus need to import and later define some specific names
@@ -253,10 +252,6 @@ intersphinx_mapping = {
 # --- Options for autodoc typehints and autodoc -------------------------------
 # https://pypi.org/project/sphinx-autodoc-typehints/
 
-# For some reason, sphinx does not like it if we use the -D option to just tell it
-# that we want to include private members. We thus manually verify whether the option
-# was set.
-private_members = "True" in sys.argv[sys.argv.index("-D") + 1]
 
 # Represent typehints whenever possible.
 autodoc_typehints = "both"
@@ -270,8 +265,6 @@ autodoc_preserve_defaults = False
 autodoc_default_options = {
     # Order by type (function, attribute...), required for proper inheritance
     "member-order": "groupwise",
-    # Include private members if this was requested
-    "private-members": private_members,
 }
 # Only show parameters that are documented.
 autodoc_typehints_description_target = "documented_params"

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -80,8 +80,6 @@ link_call = [
     "linkcheck",
     "docs",
     build_dir,
-    "-D",
-    f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
 ]
 # The actual call that will be made to build the documentation
 building_call = [
@@ -90,8 +88,6 @@ building_call = [
     "html",
     "docs",
     build_dir,
-    "-D",
-    f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
     "-n",  # Being nitpicky
     "-W",  # Fail when encountering an error or a warning
 ]

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -12,15 +12,6 @@ from baybe.telemetry import VARNAME_TELEMETRY_ENABLED
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "-t",
-    "--target_dir",
-    help="Destination directory in which the build will be saved (relative).\
-    Note that building the documentation actually happens within the doc folder.\
-    After building the documentation, it will be copied to this folder.\
-    Default is a subfolder 'docs' placed in `build`.",
-    default="./build/docs",
-)
-parser.add_argument(
     "-p",
     "--include_private",
     help="Include private methods in the documentation. Default is false.",
@@ -48,7 +39,6 @@ parser.add_argument(
 
 # Parse input arguments
 args = parser.parse_args()
-DESTINATION_DIR = args.target_dir
 INCLUDE_PRIVATE = args.include_private
 IGNORE_EXAMPLES = args.ignore_examples
 INCLUDE_WARNINGS = args.include_warnings
@@ -64,10 +54,9 @@ os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 build_dir = pathlib.Path("docs/build")
 sdk_dir = pathlib.Path("docs/sdk")
 autosummary_dir = pathlib.Path("docs/_autosummary")
-destination_dir = pathlib.Path(DESTINATION_DIR)
 
 # Collect all of the directories and delete them if they still exist.
-directories = [sdk_dir, autosummary_dir, build_dir, destination_dir]
+directories = [sdk_dir, autosummary_dir, build_dir]
 
 for directory in directories:
     if directory.is_dir():
@@ -129,9 +118,6 @@ adjust_pictures(
 for directory in [sdk_dir, autosummary_dir]:
     if directory.is_dir():
         shutil.rmtree(directory)
-
-documentation = pathlib.Path(build_dir)
-shutil.move(documentation, destination_dir)
 
 # Delete the created markdown files of the examples.
 example_directory = pathlib.Path("docs/examples")


### PR DESCRIPTION
This is the first PR in an upcoming series of documentation PRs. It changes two things:
1. Remove the option to build private modules
2. Change the folder in which the documentation is built to `docs/build` instead of `build/docs`.
The reasons for these changes are as follows:
1. This option was never used or tested anyway and created boilerplate code.
2. This enables to quickly re-build the documentation locally: When the documentation is available locally, then running `sphinx-build -b html docs docs/build -n -W` re-builds the documentation but *only checks for actual changes*.  Without the `-n` and `-W` options, it will also be a bit more forgiving with regards to failing which might be nice for quick testing how stuff is looking.

To make sure that this works, I have built the documentation based on this branch in my personal fork, which you can access [here](https://avhopp.github.io/baybe_dev/).