### PR TITLE
Serialization user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and acquisition functions
 - New acquisition functions: `qSR`, `qNEI`, `LogEI`, `qLogEI`, `qLogNEI`
 - `GammaPrior` can now be chosen as lengthscale prior
+- Serialization user guide
+- Basic deserialization tests using different class type specifiers
 
 ### Changed
 - Reorganized acquisition.py into `acquisition` subpackage
@@ -35,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter configurations
 - Simulation no longer fails for targets in `MATCH` mode
 - `closest_element` now works for array-like input of all kinds
+- Structuring concrete subclasses no longer requires providing an explicit `type` field
+- `_target(s)` attributes of `Objectives` are now de-/serialized without leading
+  underscore to support user-friendly serialization strings
 
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -14,7 +14,7 @@ from baybe.acquisition.base import AcquisitionFunction
 class PosteriorMean(AcquisitionFunction):
     """Posterior mean."""
 
-    _abbreviation: ClassVar[str] = "PM"
+    abbreviation: ClassVar[str] = "PM"
 
 
 ########################################################################################
@@ -23,7 +23,7 @@ class PosteriorMean(AcquisitionFunction):
 class qSimpleRegret(AcquisitionFunction):
     """Monte Carlo based simple regret."""
 
-    _abbreviation: ClassVar[str] = "qSR"
+    abbreviation: ClassVar[str] = "qSR"
 
 
 ########################################################################################
@@ -32,35 +32,35 @@ class qSimpleRegret(AcquisitionFunction):
 class ExpectedImprovement(AcquisitionFunction):
     """Analytical expected improvement."""
 
-    _abbreviation: ClassVar[str] = "EI"
+    abbreviation: ClassVar[str] = "EI"
 
 
 @define(frozen=True)
 class qExpectedImprovement(AcquisitionFunction):
     """Monte Carlo based expected improvement."""
 
-    _abbreviation: ClassVar[str] = "qEI"
+    abbreviation: ClassVar[str] = "qEI"
 
 
 @define(frozen=True)
 class LogExpectedImprovement(AcquisitionFunction):
     """Logarithmic analytical expected improvement."""
 
-    _abbreviation: ClassVar[str] = "LogEI"
+    abbreviation: ClassVar[str] = "LogEI"
 
 
 @define(frozen=True)
 class qLogExpectedImprovement(AcquisitionFunction):
     """Logarithmic Monte Carlo based expected improvement."""
 
-    _abbreviation: ClassVar[str] = "qLogEI"
+    abbreviation: ClassVar[str] = "qLogEI"
 
 
 @define(frozen=True)
 class qNoisyExpectedImprovement(AcquisitionFunction):
     """Monte Carlo based noisy expected improvement."""
 
-    _abbreviation: ClassVar[str] = "qNEI"
+    abbreviation: ClassVar[str] = "qNEI"
 
     prune_baseline: bool = field(default=True, validator=instance_of(bool))
     """Auto-prune candidates that are unlikely to be the best."""
@@ -70,7 +70,7 @@ class qNoisyExpectedImprovement(AcquisitionFunction):
 class qLogNoisyExpectedImprovement(AcquisitionFunction):
     """Logarithmic Monte Carlo based noisy expected improvement."""
 
-    _abbreviation: ClassVar[str] = "qLogNEI"
+    abbreviation: ClassVar[str] = "qLogNEI"
 
     prune_baseline: bool = field(default=True, validator=instance_of(bool))
     """Auto-prune candidates that are unlikely to be the best."""
@@ -82,14 +82,14 @@ class qLogNoisyExpectedImprovement(AcquisitionFunction):
 class ProbabilityOfImprovement(AcquisitionFunction):
     """Analytical probability of improvement."""
 
-    _abbreviation: ClassVar[str] = "PI"
+    abbreviation: ClassVar[str] = "PI"
 
 
 @define(frozen=True)
 class qProbabilityOfImprovement(AcquisitionFunction):
     """Monte Carlo based probability of improvement."""
 
-    _abbreviation: ClassVar[str] = "qPI"
+    abbreviation: ClassVar[str] = "qPI"
 
 
 ########################################################################################
@@ -98,7 +98,7 @@ class qProbabilityOfImprovement(AcquisitionFunction):
 class UpperConfidenceBound(AcquisitionFunction):
     """Analytical upper confidence bound."""
 
-    _abbreviation: ClassVar[str] = "UCB"
+    abbreviation: ClassVar[str] = "UCB"
 
     beta: float = field(converter=float, validator=ge(0.0), default=0.2)
     """Trade-off parameter for mean and variance.
@@ -113,7 +113,7 @@ class UpperConfidenceBound(AcquisitionFunction):
 class qUpperConfidenceBound(AcquisitionFunction):
     """Monte Carlo based upper confidence bound."""
 
-    _abbreviation: ClassVar[str] = "qUCB"
+    abbreviation: ClassVar[str] = "qUCB"
 
     beta: float = field(converter=float, validator=ge(0.0), default=0.2)
     """Trade-off parameter for mean and variance.

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -83,7 +83,7 @@ def _add_deprecation_hook(hook):
             ) in UCB_DEPRECATIONS:
                 warnings.warn(
                     f"The use of `{entry}` is deprecated and will be disabled in a "
-                    f"future version. The get the same outcome, use the new "
+                    f"future version. To get the same outcome, use the new "
                     f"`{UCB_DEPRECATIONS[entry]}` class instead with a beta of 100.0.",
                     DeprecationWarning,
                 )

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -25,13 +25,13 @@ from baybe.utils.dataframe import to_tensor
 class AcquisitionFunction(ABC, SerialMixin):
     """Abstract base class for all acquisition functions."""
 
-    _abbreviation: ClassVar[str]
+    abbreviation: ClassVar[str]
     """An alternative name for type resolution."""
 
     @classproperty
     def is_mc(cls) -> bool:
         """Flag indicating whether this is a Monte-Carlo acquisition function."""
-        return cls._abbreviation.startswith("q")
+        return cls.abbreviation.startswith("q")
 
     def to_botorch(
         self,

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -46,3 +46,7 @@ class OptionalImportError(Exception):
 
 class DeprecationError(Exception):
     """Signals the use of a deprecated mechanism to the user, interrupting execution."""
+
+
+class UnidentifiedSubclassError(Exception):
+    """A specified subclass cannot be found in the given class hierarchy."""

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -5,6 +5,7 @@ from typing import Union
 
 import pandas as pd
 from attrs import define
+from cattrs import override
 
 from baybe.objectives.deprecation import structure_objective
 from baybe.serialization.core import (
@@ -47,4 +48,13 @@ def to_objective(x: Union[Target, Objective], /) -> Objective:
 
 # Register de-/serialization hooks
 converter.register_structure_hook(Objective, structure_objective)
-converter.register_unstructure_hook(Objective, unstructure_base)
+converter.register_unstructure_hook(
+    Objective,
+    lambda x: unstructure_base(
+        x,
+        overrides=dict(
+            _target=override(rename="target"),
+            _targets=override(rename="targets"),
+        ),
+    ),
+)

--- a/baybe/objectives/deprecation.py
+++ b/baybe/objectives/deprecation.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from baybe.objectives.base import Objective
 
 
-def structure_objective(val: dict, cls) -> Objective:
+def structure_objective(val: dict, cls: type) -> Objective:
     """A structure hook that automatically determines an objective fallback type."""  # noqa: D401 (imperative mood)
     from baybe.objective import Objective as OldObjective
     from baybe.objectives.base import Objective

--- a/baybe/objectives/deprecation.py
+++ b/baybe/objectives/deprecation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Union
 
+from cattrs import override
 from cattrs.gen import make_dict_structure_fn
 
 from baybe.serialization import converter
@@ -35,7 +36,13 @@ def structure_objective(val: dict, _) -> Objective:
             cls = next(cl for cl in get_subclasses(Objective) if cl.__name__ == _type)
         except StopIteration as ex:
             raise ValueError(f"Unknown subclass '{_type}'.") from ex
-        fun = make_dict_structure_fn(cls, converter, _cattrs_forbid_extra_keys=True)  # type: ignore
+        fun = make_dict_structure_fn(
+            cls,
+            converter,
+            _cattrs_forbid_extra_keys=True,
+            _target=override(rename="target"),
+            _targets=override(rename="targets"),
+        )  # type: ignore
         return fun(val, cls)
 
     # If no type is provided, determine the type by the number of targets given

--- a/baybe/objectives/deprecation.py
+++ b/baybe/objectives/deprecation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from cattrs import override
 from cattrs.gen import make_dict_structure_fn
@@ -23,10 +23,6 @@ def structure_objective(val: dict, cls) -> Objective:
     from baybe.objectives.base import Objective
     from baybe.objectives.desirability import DesirabilityObjective
     from baybe.objectives.single import SingleTargetObjective
-
-    cls: Union[
-        type[Objective], type[SingleTargetObjective], type[DesirabilityObjective]
-    ]
 
     val = val.copy()
 

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -8,6 +8,7 @@ import cattrs
 import pandas as pd
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn
 
+from baybe.utils.basic import find_subclass, refers_to
 from baybe.utils.boolean import is_abstract
 
 _T = TypeVar("_T")
@@ -54,49 +55,29 @@ def get_base_structure_hook(
         The hook.
     """
     # TODO: use include_subclasses (https://github.com/python-attrs/cattrs/issues/434)
-    from baybe.utils.basic import get_subclasses
 
     def structure_base(val: Union[dict, str], cls: type[_T]) -> _T:
-        # If the given class can be instantiated, simply use it ...
+        # If the given class can be instantiated, only ensure there is no conflict with
+        # a potentially specified type field
         if not is_abstract(cls):
-            # ... but ensure there is no conflict with a potentially set manual type
-            if ((type_ := val.pop("type", None)) is not None) and (
-                cls.__name__ != type_
-            ):
+            if (type_ := val.pop("type", None)) and not refers_to(cls, type_):
                 raise ValueError(
-                    f"The given target class is '{cls.__name__}', which does not "
-                    f"match with the specified type '{type_}'."
+                    f"The class '{cls.__name__}' specified for deserialization "
+                    f"does not match with the given type information '{type_}'."
                 )
+            concrete_cls = cls
 
+        # Otherwise, extract the type information from the given input and find
+        # the corresponding class in the hierarchy
         else:
             type_ = val if isinstance(val, str) else val.pop("type")
+            concrete_cls = find_subclass(base, type_)
 
-            # Try to find a match with a class name (or name abbreviation, if available)
-            # in the class hierarchy
-            cls = next(
-                (
-                    cl
-                    for cl in get_subclasses(base)
-                    if type_
-                    in (
-                        (cl.__name__, cl.abbreviation)
-                        if hasattr(cl, "abbreviation")
-                        else (cl.__name__,)
-                    )
-                ),
-                None,
-            )
-
-            if cls is None:
-                raise ValueError(
-                    f"'{type_}' is neither a known subclass or subclass-abbreviation "
-                    f"of '{base.__name__}'."
-                )
-
+        # Create the structuring function for the class and call it
         fn = make_dict_structure_fn(
-            cls, converter, **(overrides or {}), _cattrs_forbid_extra_keys=True
+            concrete_cls, converter, **(overrides or {}), _cattrs_forbid_extra_keys=True
         )
-        return fn({} if isinstance(val, str) else val, cls)
+        return fn({} if isinstance(val, str) else val, concrete_cls)
 
     return structure_base
 

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -79,8 +79,8 @@ def get_base_structure_hook(
                     for cl in get_subclasses(base)
                     if type_
                     in (
-                        (cl.__name__, cl._abbreviation)
-                        if hasattr(cl, "_abbreviation")
+                        (cl.__name__, cl.abbreviation)
+                        if hasattr(cl, "abbreviation")
                         else (cl.__name__,)
                     )
                 ),

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -159,8 +159,6 @@ def refers_to(cls: type, name_or_abbr: str, /) -> bool:
 
 def find_subclass(base: type, name_or_abbr: str, /):
     """Retrieve a specific subclass of a base class via its name or abbreviation."""
-    from baybe.utils.basic import get_subclasses
-
     try:
         return next(cl for cl in get_subclasses(base) if refers_to(cl, name_or_abbr))
     except StopIteration:

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -8,6 +8,8 @@ from typing import Any, Callable, TypeVar
 
 import numpy as np
 
+from baybe.exceptions import UnidentifiedSubclassError
+
 _C = TypeVar("_C", bound=type)
 _T = TypeVar("_T")
 _U = TypeVar("_U")
@@ -144,3 +146,25 @@ class classproperty:
 
     def __get__(self, _, cl: type):
         return self.fn(cl)
+
+
+def refers_to(cls: type, name_or_abbr: str, /) -> bool:
+    """Check if the given name or abbreviation refers to the specified class."""
+    return name_or_abbr in (
+        (cls.__name__, cls.abbreviation)
+        if hasattr(cls, "abbreviation")
+        else (cls.__name__,)
+    )
+
+
+def find_subclass(base: type, name_or_abbr: str, /):
+    """Retrieve a specific subclass of a base class via its name or abbreviation."""
+    from baybe.utils.basic import get_subclasses
+
+    try:
+        return next(cl for cl in get_subclasses(base) if refers_to(cl, name_or_abbr))
+    except StopIteration:
+        raise UnidentifiedSubclassError(
+            f"The class name or abbreviation '{name_or_abbr}' does not refer to any "
+            f"of the subclasses of '{base.__name__}'."
+        )

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -162,31 +162,32 @@ This requirement can be disabled using the method's
 
 ## Serialization
 
-Like most of the objects managed by BayBE, `Campaign` objects can be serialized and
-deserialized using the [`to_json`](baybe.serialization.mixin.SerialMixin.to_json) and
-[`from_json`](baybe.serialization.mixin.SerialMixin.from_json) methods, which 
-allow to convert between Python objects their corresponding representation in JSON 
-format. 
-These representations are fully equivalent, meaning that serializing and subsequently 
-deserializing a campaign yields an exact copy of the object:
-
+Like other BayBE objects, [`Campaigns`](baybe.campaign.Campaign) can be de-/serialized 
+using their [`from_json`](baybe.serialization.mixin.SerialMixin.from_json)/
+[`to_json`](baybe.serialization.mixin.SerialMixin.to_json) methods, which 
+allow to convert between Python objects and their corresponding representation in JSON 
+format:
 ~~~python
 campaign_json = campaign.to_json()
-recreated_campaign = Campaign.from_json(campaign_json)
-assert campaign == recreated_campaign
+reconstructed = Campaign.from_json(campaign_json)
+assert campaign == reconstructed
 ~~~
 
-This provides an easy way to persist the current state of your campaign for long 
-term storage and continue the experimentation at a later point in time.
-For more information on serialization, we
-refer to the corresponding [examples](./../../examples/Serialization/Serialization).
+General information on this topic can be found in our 
+[serialization user guide](/userguide/serialization).
+For campaigns, however, this possibility is particularly noteworthy as it enables
+one of the most common workflows in this context –
+persisting the current state of a campaign for long-term storage and continuing the
+experimentation at a later point in time:
 
-```{admonition} Dataframe serialization
-:class: note
-Note that `DataFrame` objects associated with the `Campaign` object are converted to 
-a binary format during serialization, which has the consequence that their JSON 
-representation is not human-readable.
-```
+1. Get your campaign object
+    * When initiating the workflow, create a new campaign object
+    * When coming from the last step below, **deserialize** the existing campaign object
+2. Add the latest measurement results
+3. Get a recommendation
+4. **Serialize** the campaign and store it somewhere
+5. Run your (potentially lengthy) real-world experiments
+6. Repeat
 
 ## Further information
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -311,10 +311,10 @@ an object's attributes in their "canonical" form, which is often not the preferr
 approach.
 
 For instance, a search space is composed of two sub-components, a
-{class}`discrete subspace <baybe.searchspace.discrete.SubspaceDiscrete>`
-and a {class}`continuous subspace <baybe.searchspace.continuous.SubspaceContinuous>`,
+[discrete subspace](baybe.searchspace.discrete.SubspaceDiscrete)
+and a [continuous subspace](baybe.searchspace.continuous.SubspaceContinuous),
 which are accordingly expected by the 
-{meth}`SearchSpace constructor <baybe.searchspace.core.SearchSpace.__init__>`.
+[`SearchSpace` constructor](baybe.searchspace.core.SearchSpace.__init__).
 However, instead of providing the two components directly, most users would more
 naturally invoke one of the alternative `classmethods` available, such as
 {meth}`SearchSpace.from_product <baybe.searchspace.core.SearchSpace.from_product>` or 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -205,6 +205,7 @@ mirroring the flexibility of specifying subtypes to your configuration file:
 
 ```python
 from baybe.parameters.base import Parameter
+from baybe.parameters import CategoricalParameter, TaskParameter
 
 categorial_parameter = CategoricalParameter(name="setting", values=["low", "high"])
 categorical_parameter_str = """

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -23,7 +23,7 @@ i.e., reassembling the corresponding Python object from its serialized format.
 
 (JSON_SERIALIZATION)=
 ## JSON de-/serialization
-All BayBE objects can be conveniently serialized into an equivalent JSON 
+Most BayBE objects can be conveniently serialized into an equivalent JSON 
 representation by calling their
 {meth}`to_json <baybe.serialization.mixin.SerialMixin.to_json>` method.
 The obtained JSON string can then be deserialized via the 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -112,12 +112,17 @@ assert from_json == via_init
 ### Using default values
 Just like default values can be omitted when working in Python ...
 ```python
+from baybe.parameters import CategoricalParameter
+
 p1 = CategoricalParameter(name="setting", values=["low", "high"])
 p2 = CategoricalParameter(name="setting", values=["low", "high"], encoding="OHE")
+
 assert p1 == p2
 ```
 ... they can be omitted from the corresponding serialization string.
 ```python
+from baybe.parameters import CategoricalParameter
+
 p1_str = """
 {
     "name": "setting",
@@ -131,6 +136,7 @@ p2_str = """
     "encoding": "OHE"
 }
 """
+
 assert CategoricalParameter.from_json(p1_str) == CategoricalParameter.from_json(p2_str)
 ```
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -244,7 +244,7 @@ at a later stage.
 ```
 
 ### Using abbreviations
-Classes that have an `_abbreviation` class variable defined can be conveniently
+Classes that have an `abbreviation` class variable defined can be conveniently
 deserialization using the corresponding abbreviation string:
 ```python
 from baybe.acquisition.base import AcquisitionFunction

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -15,9 +15,9 @@ Some of these workflows are demonstrated in the sections below.
 * With **serialization**, we refer to the process of breaking down structured objects
 (such as [Campaigns](baybe.campaign.Campaign)) into their fundamental building blocks
 and subsequently converting these blocks into a format usable outside the Python
-ecosystem.
+ecosystem (called a "serialization string").
 * With **deserialization**, we accordingly refer to the inverse operation,
-i.e., reassembling the corresponding Python object from its serialized format. 
+i.e., reassembling the corresponding Python object from its serialization string. 
 * With **roundtrip**, we refer to the successive execution of both steps.
 ```
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -60,7 +60,7 @@ than the serialization step.
 ## Deserialization from configuration strings
 The workflow described [above](#JSON_SERIALIZATION) most naturally applies to
 situations where we start inside the Python ecosystem and want to make an object
-"leave" the running session. 
+leave the running session. 
 However, in many cases, we would like to kickstart the process from the other end and
 rather specify a BayBE object **outside** Python for use in a later computation.
 Common examples are when we wish to interact with an API or simply want to persist 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -192,8 +192,11 @@ parameter_str = """
 """
 ```
 Unless you are aware of the specific purpose for which the string was created,
-calling one of the classes' `__init__` methods directly is impossible because you 
+calling one of the classes' constructors directly is impossible because you 
 simply do not know which one to chose.
+A similar situation arises with [nested objects](#NESTED_OBJECTS) because resorting to
+an explicit constructor call of a hand-selected subclass is only possible at the
+highest level of the hierarchy, whereas the inner object types would remain unspecified.
 
 The problem can be easily circumvented using an explicit subclass resolution 
 mechanism, i.e., by tagging the respective subclass in an additional `type` field that
@@ -246,6 +249,7 @@ acqf2 = AcquisitionFunction.from_json('{"type": "UCB"}')
 assert acqf1 == acqf2
 ```
 
+(NESTED_OBJECTS)=
 ### Nesting objects
 BayBE objects typically appear as part of a larger object hierarchy.
 For instance, a

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -100,26 +100,21 @@ assert from_json == via_init
 ```
 
 ### Using default values
-Just like default values can be omitted when working in Python ...
+Just like default values can be omitted when working in Python,
+they can be omitted from the corresponding serialization string:
 ```python
 from baybe.parameters import CategoricalParameter
 
 p1 = CategoricalParameter(name="setting", values=["low", "high"])
 p2 = CategoricalParameter(name="setting", values=["low", "high"], encoding="OHE")
 
-assert p1 == p2
-```
-... they can be omitted from the corresponding serialization string.
-```python
-from baybe.parameters import CategoricalParameter
-
-p1_str = """
+p1_json = """
 {
     "name": "setting",
     "values": ["low", "high"]
 }
 """
-p2_str = """
+p2_json = """
 {
     "name": "setting",
     "values": ["low", "high"],
@@ -127,7 +122,10 @@ p2_str = """
 }
 """
 
-assert CategoricalParameter.from_json(p1_str) == CategoricalParameter.from_json(p2_str)
+p1_from_json = CategoricalParameter.from_json(p1_json)
+p2_from_json = CategoricalParameter.from_json(p2_json)
+
+assert p1 == p1_from_json == p2 == p2_from_json 
 ```
 
 ### Automatic field conversion

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -87,13 +87,13 @@ We specify these accordingly as separate fields in the JSON string:
 ```python
 from baybe.parameters import CategoricalParameter
 
-parameter_str = """
+parameter_json = """
 {
     "name": "Setting",
     "values": ["low", "high"]
 }
 """
-via_json = CategoricalParameter.from_json(parameter_str)
+via_json = CategoricalParameter.from_json(parameter_json)
 via_init = CategoricalParameter(name="Setting", values=["low", "high"])
 
 assert via_json == via_init
@@ -178,7 +178,7 @@ both
 {meth}`CategoricalParameter <baybe.parameters.categorical.CategoricalParameter.__init__>` and 
 {meth}`TaskParameter <baybe.parameters.categorical.TaskParameter.__init__>`:
 ```python
-parameter_str = """
+parameter_json = """
 {
     "name": "Setting",
     "values": ["low", "high"]
@@ -204,7 +204,7 @@ from baybe.parameters.base import Parameter
 from baybe.parameters import CategoricalParameter, TaskParameter
 
 categorical_parameter = CategoricalParameter(name="Setting", values=["low", "high"])
-categorical_parameter_str = """
+categorical_parameter_json = """
 {
     "type": "CategoricalParameter",
     "name": "Setting",
@@ -212,11 +212,11 @@ categorical_parameter_str = """
 }
 """
 # NOTE: we can use `Parameter.from_json` instead of `CategoricalParameter.from_json`:
-categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_str)
+categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_json)
 assert categorical_parameter == categorical_parameter_reconstructed
 
 task_parameter = TaskParameter(name="Setting", values=["low", "high"])
-task_parameter_str = """
+task_parameter_json = """
 {
     "type": "TaskParameter",
     "name": "Setting",
@@ -224,7 +224,7 @@ task_parameter_str = """
 }
 """
 # NOTE: we can use `Parameter.from_json` instead of `TaskParameter.from_json`:
-task_parameter_reconstructed = Parameter.from_json(task_parameter_str)
+task_parameter_reconstructed = Parameter.from_json(task_parameter_json)
 assert task_parameter == task_parameter_reconstructed
 ```
 
@@ -269,7 +269,7 @@ objective = DesirabilityObjective(
     scalarizer="MEAN",
 )
 
-objective_str = """
+objective_json = """
 {   
     "targets": [
         {
@@ -290,7 +290,7 @@ objective_str = """
 }
 """
 
-assert objective == DesirabilityObjective.from_json(objective_str)
+assert objective == DesirabilityObjective.from_json(objective_json)
 ```
 
 (ALTERNATIVE_CONSTRUCTORS)=
@@ -326,7 +326,7 @@ searchspace = SearchSpace.from_product(
     ]
 )
 
-searchspace_str = """
+searchspace_json = """
 {
     "constructor": "from_product",
     "parameters": [
@@ -344,7 +344,7 @@ searchspace_str = """
 }
 """
 
-assert searchspace == SearchSpace.from_json(searchspace_str)
+assert searchspace == SearchSpace.from_json(searchspace_json)
 ```
 
 ### Dataframe deserialization
@@ -377,7 +377,7 @@ subspace = SubspaceDiscrete.from_dataframe(
     )
 )
 
-subspace_string = """
+subspace_json = """
 {
     "constructor": "from_dataframe",
     "df": {
@@ -387,7 +387,7 @@ subspace_string = """
     }
 }
 """
-reconstructed = SubspaceDiscrete.from_json(subspace_string)
+reconstructed = SubspaceDiscrete.from_json(subspace_json)
 
 assert subspace == reconstructed
 ```

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -66,7 +66,7 @@ rather specify a BayBE object **outside** Python for use in a later computation.
 Common examples are when we wish to interact with an API or simply want to persist 
 a certain BayBE component in the form of a "configuration" file.
 
-The following sections given an overview of the flexibilities that are offered for this
+The following sections give an overview of the flexibilities that are offered for this
 task. Of course, the underlying concepts can be mixed and matched arbitrarily.
 
 ### Basic string assembly
@@ -304,7 +304,7 @@ and a [continuous subspace](baybe.searchspace.continuous.SubspaceContinuous),
 which are accordingly expected by the 
 [`SearchSpace`](baybe.searchspace.core.SearchSpace.__init__) constructor.
 However, instead of providing the two components directly, most users would more
-naturally invoke one of the alternative `classmethods` available, such as
+naturally invoke one of the alternative class methods available, such as
 {meth}`SearchSpace.from_product <baybe.searchspace.core.SearchSpace.from_product>` or 
 {meth}`SearchSpace.from_dataframe <baybe.searchspace.core.SearchSpace.from_dataframe>`.
 
@@ -361,7 +361,7 @@ While you can manually work around this additional conversion step using our
 a more elegant solution becomes apparent when noticing that invoking alternative 
 constructors also works for non-BayBE objects.
 In particular, this means you can resort to any dataframe constructor of your choice
-(such as [DataFrame.from_records](pandas.DataFrame.from_records))
+(such as {meth}`DataFrame.from_records <pandas.DataFrame.from_records>`)
 when defining your configuration, instead of having to work with compressed formats:
 
 ```python

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -8,19 +8,20 @@ This enables a variety of advanced workflows, such as:
 * Interaction with APIs and databases
 * Writing "configuration" files
 
-Some of the common workflows are demonstrated below.
+Some of these workflows are demonstrated in the sections below.
 
 ```{admonition} Terminology
 :class: important
 * With **serialization**, we refer to the process of breaking down structured objects
-(such as [Campaigns](baybe.campaign.Campaign)) into their most basic building blocks and
-subsequently converting these blocks into a format usable outside the Python ecosystem.
+(such as [Campaigns](baybe.campaign.Campaign)) into their fundamental building blocks
+and subsequently converting these blocks into a format usable outside the Python
+ecosystem.
 * With **deserialization**, we accordingly refer to the inverse operation,
-i.e. reassembling the corresponding Python object from its serialized format. 
+i.e., reassembling the corresponding Python object from its serialized format. 
 * With **roundtrip**, we refer to the successive execution of both steps.
 ```
 
-
+(JSON_SERIALIZATION)=
 ## JSON de-/serialization
 All BayBE objects can be conveniently serialized into an equivalent JSON 
 representation by calling their
@@ -33,10 +34,12 @@ of the corresponding class, which yields an "equivalent copy" of the original ob
 :class: important
 Roundtrip serialization is configured such that the obtained copy of an object
 is semantically equivalent to its original version and thus behaves identically.
-Note, however, that some objects contain ephemeral content (i.e. internal objects such
-as temporary data or cached computation results) that may be lost during the roundtrip.
+Note, however, that some objects contain ephemeral content (i.e., internal objects such
+as temporary data or cached computation results) that may be lost during a 
+serialization roundtrip.
 Because this content will be automatically recreated on the fly when needed,
-it is ignored for equality comparison with `==`.
+it is ignored for comparison with the `==` operator, enabling a semantically correct
+equality check.
 ```
 
 For example:
@@ -50,7 +53,288 @@ assert parameter == reconstructed
 ```
 
 This form of roundtrip serialization can be used, for instance, to persist objects
-for long-term storage, but also provides an easy way to "move" existing objects between
-Python sessions by executing the deserializing step in a different context
+for long-term storage, but it also provides an easy way to "move" existing objects
+between Python sessions by executing the deserializing step in a different context
 than the serialization step.
+
+## Deserialization from configuration strings
+The workflow described [above](#JSON_SERIALIZATION) most naturally applies to
+situations where we start inside the Python ecosystem and want to make an object
+"leave" the running session. 
+However, in many cases, we would like to kickstart the process from the other end and
+rather specify a BayBe object **outside** Python for use in a later computation.
+Common examples are when we wish to interact with an API or simply want to persist 
+a certain BayBE component in the form of a "configuration" file.
+
+The following sections given an overview of the flexibilities that are offered for this
+task. Of course, the underlying concepts can be mixed and matched arbitrarily.
+
+### Basic string assembly
+Writing a configuration for a certain BayBE object in form of a serialization string is
+easy:
+1. Select your desired object class
+2. Identify the arguments expected by one of its constructors (see also [here](#ALTERNATIVE_CONSTRUCTORS))
+3. Pack them into a JSON string that mirrors the constructor signature
+
+Let's have a more detailed look, for instance, at the serialization string from
+the [above example](#JSON_SERIALIZATION), this time assuming we wanted to assemble
+the string manually.
+For this purpose, we have a peek at the signature of the `__init__` method of
+{meth}`CategoricalParameter <baybe.parameters.categorical.CategoricalParameter.__init__>`
+and notice that it has two required arguments, `name` and `values`.
+We specify these accordingly as separate fields in the JSON string:
+
+```python
+from baybe.parameters import CategoricalParameter
+
+parameter_str = """
+{
+    "name": "setting",
+    "values": ["low", "high"]
+}
+"""
+from_json = CategoricalParameter.from_json(parameter_str)
+via_init = CategoricalParameter(name="setting", values=["low", "high"])
+
+assert from_json == via_init
+```
+
+### Using default values
+Just like default values can be omitted when working in Python ...
+```python
+p1 = CategoricalParameter(name="setting", values=["low", "high"])
+p2 = CategoricalParameter(name="setting", values=["low", "high"], encoding="OHE")
+assert p1 == p2
+```
+... they can be omitted from the corresponding serialization string.
+```python
+p1_str = """
+{
+    "type": "CategoricalParameter",
+    "name": "setting",
+    "values": ["low", "high"]
+}
+"""
+p2_str = """
+{
+    "type": "CategoricalParameter",
+    "name": "setting",
+    "values": ["low", "high"],
+    "encoding": "OHE"
+}
+"""
+assert CategoricalParameter.from_json(p1_str) == CategoricalParameter.from_json(p2_str)
+```
+
+### Automatic field conversion
+You may have noticed that BayBE classes apply converters to their inputs so that
+simpler attribute representations can be passed.
+Of course, these shortcuts can be analogously used inside a configuration string.
+
+While the above holds generally true for all classes that have converters in place,
+providing a few specific example may help to convey the concept:
+
+* Since {class}`Intervals <baybe.utils.interval.Interval>` can be created _implicitly_,
+    it is enough the specify their bound values directly:
+    ```python
+    from baybe.targets import NumericalTarget
+    from baybe.utils.interval import Interval
+
+    t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
+    t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
+    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
+
+    assert t1 == t2 == t3
+    ```
+
+* Conversion to enums happens automatically whenever needed;
+    therefore, providing a raw string instead is sufficient:
+    ```python
+    from baybe.targets import NumericalTarget, TargetMode
+
+    t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
+    t2 = NumericalTarget(name="t", mode="MAX")
+    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
+
+    assert t1 == t2 == t3
+    ```
+
+### Tagged subclasses
+Due to the leading design philosophy behind BayBE to provide its users easy access
+to a broad range of tools, you typically have the choice between several modelling 
+alternatives when building your objects.
+For example, when describing the degrees of freedom of your experimental campaign,
+you can chose from several different [parameter types](/userguide/parameters).
+
+While this is offers great flexibility, it comes with a challenge for deserialization
+because you cannot know a priori which concrete object subclass is contained 
+in an incoming serialization string on the receiving end.
+Instead, you oftentimes need to be able to process the incoming string dynamically.
+
+For example, consider the following string, which perfectly mirrors the signatures of 
+both
+{meth}`CategoricalParameter <baybe.parameters.categorical.CategoricalParameter.__init__>` and 
+{meth}`TaskParameter <baybe.parameters.categorical.TaskParameter.__init__>`:
+```python
+parameter_str = """
+{
+    "name": "setting",
+    "values": ["low", "high"]
+}
+"""
+```
+Unless you are aware of the specific purpose for which the string was created,
+calling one of the classes' `__init__` methods directly is impossible because you 
+simply do not know which one to chose.
+
+The problem can be easily circumvented using an explicit subclass resolution 
+mechanism, i.e., by tagging the respective subclass in an additional `type` field that
+holds the class' name.
+This allows to deserialize the object from the corresponding base class instead,
+mirroring the flexibility of specifying subtypes to your configuration file:
+
+```python
+from baybe.parameters.base import Parameter
+
+categorial_parameter = CategoricalParameter(name="setting", values=["low", "high"])
+categorical_parameter_str = """
+{
+    "type": "CategoricalParameter",
+    "name": "setting",
+    "values": ["low", "high"]
+}
+"""
+categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_str)
+assert categorial_parameter == categorical_parameter_reconstructed
+
+task_parameter = TaskParameter(name="setting", values=["low", "high"])
+task_parameter_str = """
+{
+    "type": "TaskParameter",
+    "name": "setting",
+    "values": ["low", "high"]
+}
+"""
+task_parameter_reconstructed = Parameter.from_json(task_parameter_str)
+assert task_parameter == task_parameter_reconstructed
+```
+
+```{note} 
+When serializing an object that belongs to a class hierarchy, BayBE automatically
+injects the `type` field into the serialization string to enable frictionless deserialization
+at a later stage.
+```
+
+### Using abbreviations
+Classes that have an `_abbreviation` class variable defined can be conveniently
+deserialization using the corresponding abbreviation string:
+```python
+from baybe.acquisition.base import AcquisitionFunction
+
+acqf1 = AcquisitionFunction.from_json('{"type": "UpperConfidenceBound"}')
+acqf2 = AcquisitionFunction.from_json('{"type": "UCB"}')
+
+assert acqf1 == acqf2
+```
+
+### Nesting objects
+BayBE objects typically appear as part of a larger object hierarchy.
+For instance, a
+{class}`SearchSpace <baybe.searchspace.core.SearchSpace>` can hold one or several
+{class}`Parameters <baybe.parameters.base.Parameter>`, just like an
+{class}`Objective <baybe.objectives.base.Objective>` can hold one ore several 
+{class}`Targets <baybe.targets.base.Target>`.
+This hierarchical structure can be directly replicated in the serialization string:
+
+```python
+from baybe.objectives import DesirabilityObjective
+from baybe.targets import NumericalTarget
+
+objective = DesirabilityObjective(
+    targets=[
+        NumericalTarget(name="t1", mode="MAX", bounds=(-1, 1)),
+        NumericalTarget(name="t2", mode="MIN", bounds=(0, 1)),
+    ],
+    weights=[0.1, 0.9],
+    scalarizer="MEAN",
+)
+
+objective_str = """
+{   
+    "type": "DesirabilityObjective", 
+    "targets": [
+        {
+            "type": "NumericalTarget",
+            "name": "t1",
+            "mode": "MAX",
+            "bounds": [-1.0, 1.0]
+        }, 
+        {
+            "type": "NumericalTarget",
+            "name": "t2",
+            "mode": "MIN",
+            "bounds": [0.0, 1.0]
+        }
+    ],
+    "weights": [0.1, 0.9],
+    "scalarizer": "MEAN"
+}
+"""
+
+assert objective == DesirabilityObjective.from_json(objective_str)
+```
+
+(ALTERNATIVE_CONSTRUCTORS)=
+### Invoking alternative constructors
+Many BayBE classes offer additional routes of construction next to the default
+mechanism via the class' `__init__` method.
+This offers convenient ways of object initialization alternative to specifying
+an object's attributes in their "canonical" form, which is often not the preferred
+approach.
+
+For instance, a search space is composed of two sub-components, a
+{class}`discrete subspace <baybe.searchspace.discrete.SubspaceDiscrete>`
+and a {class}`continuous subspace <baybe.searchspace.continuous.SubspaceContinuous>`,
+which are accordingly expected by the 
+{meth}`SearchSpace constructor <baybe.searchspace.core.SearchSpace.__init__>`.
+However, instead of providing the two components directly, most users would more
+naturally invoke one of the alternative `classmethods` available, such as
+{meth}`SearchSpace.from_product <baybe.searchspace.core.SearchSpace.from_product>` or 
+{meth}`SearchSpace.from_dataframe <baybe.searchspace.core.SearchSpace.from_dataframe>`.
+
+Using a serialization string, the same alternative routes can be triggered via the
+optional `constructor` field that allows specifying the initializer to be used for the
+object creation step:
+
+```python
+from baybe.searchspace import SearchSpace
+from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
+
+searchspace = SearchSpace.from_product(
+    parameters=[
+        CategoricalParameter(name="Category", values=["low", "high"]),
+        NumericalDiscreteParameter(name="Number", values=[1, 2, 3]),
+    ]
+)
+
+searchspace_str = """
+{
+    "constructor": "from_product",
+    "parameters": [
+        {
+            "type": "CategoricalParameter",
+            "name": "Category",
+            "values": ["low", "high"]
+        },
+        {
+            "type": "NumericalDiscreteParameter",
+            "name": "Number",
+            "values": [1, 2, 3]
+        }
+    ]
+}
+"""
+
+assert searchspace == SearchSpace.from_json(searchspace_str)
+```
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -358,8 +358,8 @@ with configuration strings.
 While you can manually work around this additional conversion step using our
 {func}`serialize_dataframe <baybe.serialization.utils.serialize_dataframe>` and
 {func}`deserialize_dataframe <baybe.serialization.utils.deserialize_dataframe>` helpers,
-a more elegant solution becomes apparent when noticing that invoking alternative 
-constructors also works for non-BayBE objects.
+a more elegant solution becomes apparent when noticing that [invoking alternative 
+constructors](#ALTERNATIVE_CONSTRUCTORS) also works for non-BayBE objects.
 In particular, this means you can resort to any dataframe constructor of your choice
 (such as {meth}`DataFrame.from_records <pandas.DataFrame.from_records>`)
 when defining your configuration, instead of having to work with compressed formats:

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -93,10 +93,10 @@ parameter_str = """
     "values": ["low", "high"]
 }
 """
-from_json = CategoricalParameter.from_json(parameter_str)
+via_json = CategoricalParameter.from_json(parameter_str)
 via_init = CategoricalParameter(name="Setting", values=["low", "high"])
 
-assert from_json == via_init
+assert via_json == via_init
 ```
 
 ### Using default values
@@ -122,10 +122,10 @@ p2_json = """
 }
 """
 
-p1_from_json = CategoricalParameter.from_json(p1_json)
-p2_from_json = CategoricalParameter.from_json(p2_json)
+p1_via_json = CategoricalParameter.from_json(p1_json)
+p2_via_json = CategoricalParameter.from_json(p2_json)
 
-assert p1 == p1_from_json == p2 == p2_from_json 
+assert p1 == p1_via_json == p2 == p2_via_json 
 ```
 
 ### Automatic field conversion

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -302,7 +302,7 @@ For instance, a search space is composed of two sub-components, a
 [discrete subspace](baybe.searchspace.discrete.SubspaceDiscrete)
 and a [continuous subspace](baybe.searchspace.continuous.SubspaceContinuous),
 which are accordingly expected by the 
-[`SearchSpace` constructor](baybe.searchspace.core.SearchSpace.__init__).
+[`SearchSpace`](baybe.searchspace.core.SearchSpace.__init__) constructor.
 However, instead of providing the two components directly, most users would more
 naturally invoke one of the alternative `classmethods` available, such as
 {meth}`SearchSpace.from_product <baybe.searchspace.core.SearchSpace.from_product>` or 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -57,16 +57,6 @@ for long-term storage, but it also provides an easy way to "move" existing objec
 between Python sessions by executing the deserializing step in a different context
 than the serialization step.
 
-(DATAFRAME_BINARIZATION)=
-```{admonition} Dataframe serialization
-:class: attention
-Note that [`DataFrames`](pandas.DataFrame) are automatically converted to a 
-binary format before serialization to ensure type safety, which has the consequence
-that their JSON representation is not human-readable. 
-Information on how to bypass this conversion when using configuration strings can
-be found [below](DATAFRAME_DESERIALIZATION).
-```
-
 ## Deserialization from configuration strings
 The workflow described [above](#JSON_SERIALIZATION) most naturally applies to
 situations where we start inside the Python ecosystem and want to make an object
@@ -356,14 +346,25 @@ searchspace_str = """
 assert searchspace == SearchSpace.from_json(searchspace_str)
 ```
 
-(DATAFRAME_DESERIALIZATION)=
-#### Dataframe deserialization
-Note that invoking alternative construction routes also works for non-BayBE objects
-like [DataFrames](pandas.DataFrame).
-This is elegant because it allows us to resort to arbitrary constructors
+### Dataframe deserialization
+
+When serializing BayBE objects, contained [`DataFrames`](pandas.DataFrame) are 
+automatically converted to a binary format in order to
+1. ensure that the involved data types are exactly restored after completing the roundtrip and
+2. decrease the size of the serialization string through compression.
+
+From the user's perspective, this has the disadvantage that the resulting JSON
+representation is not human-readable, which can be a challenge when working
+with configuration strings.
+
+While you can manually work around this additional conversion step using our
+{func}`serialize_dataframe <baybe.serialization.utils.serialize_dataframe>` and
+{func}`deserialize_dataframe <baybe.serialization.utils.deserialize_dataframe>` helpers,
+a more elegant solution becomes apparent when noticing that invoking alternative 
+constructors also works for non-BayBE objects.
+In particular, this means you can resort to any dataframe constructor of your choice
 (such as [DataFrame.from_records](pandas.DataFrame.from_records))
-instead of having to work with 
-[human-unreadable representations](#DATAFRAME_BINARIZATION) in configuration strings: 
+when defining your configuration, instead of having to work with compressed formats:
 
 ```python
 import pandas as pd

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -46,7 +46,7 @@ For example:
 ```python
 from baybe.parameters import CategoricalParameter
 
-parameter = CategoricalParameter(name="setting", values=["low", "high"])
+parameter = CategoricalParameter(name="Setting", values=["low", "high"])
 json_string = parameter.to_json()
 reconstructed = CategoricalParameter.from_json(json_string)
 assert parameter == reconstructed
@@ -89,12 +89,12 @@ from baybe.parameters import CategoricalParameter
 
 parameter_str = """
 {
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"]
 }
 """
 from_json = CategoricalParameter.from_json(parameter_str)
-via_init = CategoricalParameter(name="setting", values=["low", "high"])
+via_init = CategoricalParameter(name="Setting", values=["low", "high"])
 
 assert from_json == via_init
 ```
@@ -105,18 +105,18 @@ they can be omitted from the corresponding serialization string:
 ```python
 from baybe.parameters import CategoricalParameter
 
-p1 = CategoricalParameter(name="setting", values=["low", "high"])
-p2 = CategoricalParameter(name="setting", values=["low", "high"], encoding="OHE")
+p1 = CategoricalParameter(name="Setting", values=["low", "high"])
+p2 = CategoricalParameter(name="Setting", values=["low", "high"], encoding="OHE")
 
 p1_json = """
 {
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"]
 }
 """
 p2_json = """
 {
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"],
     "encoding": "OHE"
 }
@@ -142,9 +142,9 @@ providing a few specific example may help to convey the concept:
     from baybe.targets import NumericalTarget
     from baybe.utils.interval import Interval
 
-    t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
-    t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
-    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
+    t1 = NumericalTarget(name="T", mode="MAX", bounds=Interval(0, 1))
+    t2 = NumericalTarget(name="T", mode="MAX", bounds=(0, 1))
+    t3 = NumericalTarget.from_json('{"name": "T", "mode": "MAX", "bounds": [0, 1]}')
 
     assert t1 == t2 == t3
     ```
@@ -154,9 +154,9 @@ providing a few specific example may help to convey the concept:
     ```python
     from baybe.targets import NumericalTarget, TargetMode
 
-    t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
-    t2 = NumericalTarget(name="t", mode="MAX")
-    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
+    t1 = NumericalTarget(name="T", mode=TargetMode.MAX)
+    t2 = NumericalTarget(name="T", mode="MAX")
+    t3 = NumericalTarget.from_json('{"name": "T", "mode": "MAX"}')
 
     assert t1 == t2 == t3
     ```
@@ -180,7 +180,7 @@ both
 ```python
 parameter_str = """
 {
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"]
 }
 """
@@ -202,22 +202,22 @@ mirroring the flexibility of specifying subtypes to your configuration file:
 from baybe.parameters.base import Parameter
 from baybe.parameters import CategoricalParameter, TaskParameter
 
-categorial_parameter = CategoricalParameter(name="setting", values=["low", "high"])
+categorial_parameter = CategoricalParameter(name="Setting", values=["low", "high"])
 categorical_parameter_str = """
 {
     "type": "CategoricalParameter",
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"]
 }
 """
 categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_str)
 assert categorial_parameter == categorical_parameter_reconstructed
 
-task_parameter = TaskParameter(name="setting", values=["low", "high"])
+task_parameter = TaskParameter(name="Setting", values=["low", "high"])
 task_parameter_str = """
 {
     "type": "TaskParameter",
-    "name": "setting",
+    "name": "Setting",
     "values": ["low", "high"]
 }
 """
@@ -259,8 +259,8 @@ from baybe.targets import NumericalTarget
 
 objective = DesirabilityObjective(
     targets=[
-        NumericalTarget(name="t1", mode="MAX", bounds=(-1, 1)),
-        NumericalTarget(name="t2", mode="MIN", bounds=(0, 1)),
+        NumericalTarget(name="T1", mode="MAX", bounds=(-1, 1)),
+        NumericalTarget(name="T2", mode="MIN", bounds=(0, 1)),
     ],
     weights=[0.1, 0.9],
     scalarizer="MEAN",
@@ -271,13 +271,13 @@ objective_str = """
     "targets": [
         {
             "type": "NumericalTarget",
-            "name": "t1",
+            "name": "T1",
             "mode": "MAX",
             "bounds": [-1.0, 1.0]
         }, 
         {
             "type": "NumericalTarget",
-            "name": "t2",
+            "name": "T2",
             "mode": "MIN",
             "bounds": [0.0, 1.0]
         }
@@ -370,7 +370,7 @@ from baybe.searchspace.discrete import SubspaceDiscrete
 
 subspace = SubspaceDiscrete.from_dataframe(
     pd.DataFrame.from_records(
-        data=[[1, "a"], [2, "b"], [3, "c"]], columns=["numerical", "categorical"]
+        data=[[1, "a"], [2, "b"], [3, "c"]], columns=["Number", "Category"]
     )
 )
 
@@ -380,7 +380,7 @@ subspace_string = """
     "df": {
         "constructor": "from_records",
         "data": [[1, "a"], [2, "b"], [3, "c"]],
-        "columns": ["numerical", "categorical"]
+        "columns": ["Number", "Category"]
     }
 }
 """

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -161,7 +161,7 @@ providing a few specific example may help to convey the concept:
     assert t1 == t2 == t3
     ```
 
-### The `type` field
+### The type field
 Due to the leading design philosophy behind BayBE to provide its users easy access
 to a broad range of tools, you typically have the choice between several modelling 
 alternatives when building your objects.

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -161,7 +161,7 @@ providing a few specific example may help to convey the concept:
     assert t1 == t2 == t3
     ```
 
-### Tagged subclasses
+### The `type` field
 Due to the leading design philosophy behind BayBE to provide its users easy access
 to a broad range of tools, you typically have the choice between several modelling 
 alternatives when building your objects.

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -202,7 +202,7 @@ mirroring the flexibility of specifying subtypes to your configuration file:
 from baybe.parameters.base import Parameter
 from baybe.parameters import CategoricalParameter, TaskParameter
 
-categorial_parameter = CategoricalParameter(name="Setting", values=["low", "high"])
+categorical_parameter = CategoricalParameter(name="Setting", values=["low", "high"])
 categorical_parameter_str = """
 {
     "type": "CategoricalParameter",
@@ -211,7 +211,7 @@ categorical_parameter_str = """
 }
 """
 categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_str)
-assert categorial_parameter == categorical_parameter_reconstructed
+assert categorical_parameter == categorical_parameter_reconstructed
 
 task_parameter = TaskParameter(name="Setting", values=["low", "high"])
 task_parameter_str = """
@@ -233,7 +233,7 @@ at a later stage.
 
 ### Using abbreviations
 Classes that have an `abbreviation` class variable defined can be conveniently
-deserialization using the corresponding abbreviation string:
+deserialized using the corresponding abbreviation string:
 ```python
 from baybe.acquisition.base import AcquisitionFunction
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -180,7 +180,7 @@ alternatives when building your objects.
 For example, when describing the degrees of freedom of your experimental campaign,
 you can chose from several different [parameter types](/userguide/parameters).
 
-While this is offers great flexibility, it comes with a challenge for deserialization
+While this offers great flexibility, it comes with a challenge for deserialization
 because you cannot know a priori which concrete object subclass is contained 
 in an incoming serialization string on the receiving end.
 Instead, you oftentimes need to be able to process the incoming string dynamically.

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -146,28 +146,28 @@ providing a few specific example may help to convey the concept:
 
 * Since {class}`Intervals <baybe.utils.interval.Interval>` can be created _implicitly_,
     it is enough the specify their bound values directly:
-    ```python
-    from baybe.targets import NumericalTarget
-    from baybe.utils.interval import Interval
+```python
+from baybe.targets import NumericalTarget
+from baybe.utils.interval import Interval
 
-    t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
-    t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
-    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
+t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
+t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
+t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
 
-    assert t1 == t2 == t3
-    ```
+assert t1 == t2 == t3
+```
 
 * Conversion to enums happens automatically whenever needed;
     therefore, providing a raw string instead is sufficient:
-    ```python
-    from baybe.targets import NumericalTarget, TargetMode
+```python
+from baybe.targets import NumericalTarget, TargetMode
 
-    t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
-    t2 = NumericalTarget(name="t", mode="MAX")
-    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
+t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
+t2 = NumericalTarget(name="t", mode="MAX")
+t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
 
-    assert t1 == t2 == t3
-    ```
+assert t1 == t2 == t3
+```
 
 ### Tagged subclasses
 Due to the leading design philosophy behind BayBE to provide its users easy access

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -150,28 +150,28 @@ providing a few specific example may help to convey the concept:
 
 * Since {class}`Intervals <baybe.utils.interval.Interval>` can be created _implicitly_,
     it is enough the specify their bound values directly:
-```python
-from baybe.targets import NumericalTarget
-from baybe.utils.interval import Interval
+    ```python
+    from baybe.targets import NumericalTarget
+    from baybe.utils.interval import Interval
 
-t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
-t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
-t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
+    t1 = NumericalTarget(name="t", mode="MAX", bounds=Interval(0, 1))
+    t2 = NumericalTarget(name="t", mode="MAX", bounds=(0, 1))
+    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX", "bounds": [0, 1]}')
 
-assert t1 == t2 == t3
-```
+    assert t1 == t2 == t3
+    ```
 
 * Conversion to enums happens automatically whenever needed;
     therefore, providing a raw string instead is sufficient:
-```python
-from baybe.targets import NumericalTarget, TargetMode
+    ```python
+    from baybe.targets import NumericalTarget, TargetMode
 
-t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
-t2 = NumericalTarget(name="t", mode="MAX")
-t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
+    t1 = NumericalTarget(name="t", mode=TargetMode.MAX)
+    t2 = NumericalTarget(name="t", mode="MAX")
+    t3 = NumericalTarget.from_json('{"name": "t", "mode": "MAX"}')
 
-assert t1 == t2 == t3
-```
+    assert t1 == t2 == t3
+    ```
 
 ### Tagged subclasses
 Due to the leading design philosophy behind BayBE to provide its users easy access

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -120,14 +120,12 @@ assert p1 == p2
 ```python
 p1_str = """
 {
-    "type": "CategoricalParameter",
     "name": "setting",
     "values": ["low", "high"]
 }
 """
 p2_str = """
 {
-    "type": "CategoricalParameter",
     "name": "setting",
     "values": ["low", "high"],
     "encoding": "OHE"
@@ -272,7 +270,6 @@ objective = DesirabilityObjective(
 
 objective_str = """
 {   
-    "type": "DesirabilityObjective", 
     "targets": [
         {
             "type": "NumericalTarget",

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -1,0 +1,56 @@
+# Serialization
+
+BayBE is shipped with a sophisticated serialization engine that allows to unstructure
+its objects into basic types and seamlessly reassemble them afterward.
+This enables a variety of advanced workflows, such as:
+* Persisting objects for later use
+* Transmission and processing outside the Python ecosystem
+* Interaction with APIs and databases
+* Writing "configuration" files
+
+Some of the common workflows are demonstrated below.
+
+```{admonition} Terminology
+:class: important
+* With **serialization**, we refer to the process of breaking down structured objects
+(such as [Campaigns](baybe.campaign.Campaign)) into their most basic building blocks and
+subsequently converting these blocks into a format usable outside the Python ecosystem.
+* With **deserialization**, we accordingly refer to the inverse operation,
+i.e. reassembling the corresponding Python object from its serialized format. 
+* With **roundtrip**, we refer to the successive execution of both steps.
+```
+
+
+## JSON de-/serialization
+All BayBE objects can be conveniently serialized into an equivalent JSON 
+representation by calling their
+{meth}`to_json <baybe.serialization.mixin.SerialMixin.to_json>` method.
+The obtained JSON string can then be deserialized via the 
+{meth}`from_json <baybe.serialization.mixin.SerialMixin.from_json>` method
+of the corresponding class, which yields an "equivalent copy" of the original object.
+
+```{admonition} Equivalent copies
+:class: important
+Roundtrip serialization is configured such that the obtained copy of an object
+is semantically equivalent to its original version and thus behaves identically.
+Note, however, that some objects contain ephemeral content (i.e. internal objects such
+as temporary data or cached computation results) that may be lost during the roundtrip.
+Because this content will be automatically recreated on the fly when needed,
+it is ignored for equality comparison with `==`.
+```
+
+For example:
+```python
+from baybe.parameters import CategoricalParameter
+
+parameter = CategoricalParameter(name="setting", values=["low", "high"])
+json_string = parameter.to_json()
+reconstructed = CategoricalParameter.from_json(json_string)
+assert parameter == reconstructed
+```
+
+This form of roundtrip serialization can be used, for instance, to persist objects
+for long-term storage, but also provides an easy way to "move" existing objects between
+Python sessions by executing the deserializing step in a different context
+than the serialization step.
+

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -72,7 +72,7 @@ The workflow described [above](#JSON_SERIALIZATION) most naturally applies to
 situations where we start inside the Python ecosystem and want to make an object
 "leave" the running session. 
 However, in many cases, we would like to kickstart the process from the other end and
-rather specify a BayBe object **outside** Python for use in a later computation.
+rather specify a BayBE object **outside** Python for use in a later computation.
 Common examples are when we wish to interact with an API or simply want to persist 
 a certain BayBE component in the form of a "configuration" file.
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -34,8 +34,8 @@ of the corresponding class, which yields an "equivalent copy" of the original ob
 :class: important
 Roundtrip serialization is configured such that the obtained copy of an object
 is semantically equivalent to its original version and thus behaves identically.
-Note, however, that some objects contain ephemeral content (i.e., internal objects such
-as temporary data or cached computation results) that may be lost during a 
+Note, however, that some objects contain non-persistent content (i.e., internal objects
+such as temporary data or cached computation results) that may be lost during a 
 serialization roundtrip.
 Because this content will be automatically recreated on the fly when needed,
 it is ignored for comparison with the `==` operator, enabling a semantically correct

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -195,7 +195,8 @@ highest level of the hierarchy, whereas the inner object types would remain unsp
 The problem can be easily circumvented using an explicit subclass resolution 
 mechanism, i.e., by tagging the respective subclass in an additional `type` field that
 holds the class' name.
-This allows to deserialize the object from the corresponding base class instead,
+This allows to deserialize the object from the corresponding base class instead 
+(i.e., {class}`Parameter <baybe.parameters.base.Parameter>` class in the example below),
 mirroring the flexibility of specifying subtypes to your configuration file:
 
 ```python
@@ -210,6 +211,7 @@ categorical_parameter_str = """
     "values": ["low", "high"]
 }
 """
+# NOTE: we can use `Parameter.from_json` instead of `CategoricalParameter.from_json`:
 categorical_parameter_reconstructed = Parameter.from_json(categorical_parameter_str)
 assert categorical_parameter == categorical_parameter_reconstructed
 
@@ -221,6 +223,7 @@ task_parameter_str = """
     "values": ["low", "high"]
 }
 """
+# NOTE: we can use `Parameter.from_json` instead of `TaskParameter.from_json`:
 task_parameter_reconstructed = Parameter.from_json(task_parameter_str)
 assert task_parameter == task_parameter_reconstructed
 ```

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -57,6 +57,16 @@ for long-term storage, but it also provides an easy way to "move" existing objec
 between Python sessions by executing the deserializing step in a different context
 than the serialization step.
 
+(DATAFRAME_BINARIZATION)=
+```{admonition} Dataframe serialization
+:class: attention
+Note that [`DataFrames`](pandas.DataFrame) are automatically converted to a 
+binary format before serialization to ensure type safety, which has the consequence
+that their JSON representation is not human-readable. 
+Information on how to bypass this conversion when using configuration strings can
+be found [below](DATAFRAME_DESERIALIZATION).
+```
+
 ## Deserialization from configuration strings
 The workflow described [above](#JSON_SERIALIZATION) most naturally applies to
 situations where we start inside the Python ecosystem and want to make an object
@@ -338,3 +348,36 @@ searchspace_str = """
 assert searchspace == SearchSpace.from_json(searchspace_str)
 ```
 
+(DATAFRAME_DESERIALIZATION)=
+#### Dataframe deserialization
+Note that invoking alternative construction routes also works for non-BayBE objects
+like [DataFrames](pandas.DataFrame).
+This is elegant because it allows us to resort to arbitrary constructors
+(such as [DataFrame.from_records](pandas.DataFrame.from_records))
+instead of having to work with 
+[human-unreadable representations](#DATAFRAME_BINARIZATION) in configuration strings: 
+
+```python
+import pandas as pd
+from baybe.searchspace.discrete import SubspaceDiscrete
+
+subspace = SubspaceDiscrete.from_dataframe(
+    pd.DataFrame.from_records(
+        data=[[1, "a"], [2, "b"], [3, "c"]], columns=["numerical", "categorical"]
+    )
+)
+
+subspace_string = """
+{
+    "constructor": "from_dataframe",
+    "df": {
+        "constructor": "from_records",
+        "data": [[1, "a"], [2, "b"], [3, "c"]],
+        "columns": ["numerical", "categorical"]
+    }
+}
+"""
+reconstructed = SubspaceDiscrete.from_json(subspace_string)
+
+assert subspace == reconstructed
+```

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -129,8 +129,8 @@ assert p1 == p1_from_json == p2 == p2_from_json
 ```
 
 ### Automatic field conversion
-You may have noticed that BayBE classes apply converters to their inputs so that
-simpler attribute representations can be passed.
+BayBE classes apply converters to their inputs so that simpler attribute
+representations can be passed.
 Of course, these shortcuts can be analogously used inside a configuration string.
 
 While the above holds generally true for all classes that have converters in place,

--- a/docs/userguide/userguide.md
+++ b/docs/userguide/userguide.md
@@ -7,6 +7,7 @@ Objective <objective>
 Parameters <parameters>
 Recommenders <recommenders>
 Search Spaces <searchspace>
+Serialization <serialization>
 Simulation <simulation>
 Surrogates <surrogates>
 Targets <targets>

--- a/tests/docs/utils.py
+++ b/tests/docs/utils.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from textwrap import dedent
 from typing import Union
 
 
@@ -11,10 +12,10 @@ def extract_code_blocks(
     """Extract all python code blocks from the specified file."""
     contents = Path(path).read_text()
     pattern = (
-        r"(?:```|~~~)python\s+(.*?)\s+(?:```|~~~)"
+        r"\s*(?:```|~~~)python\n*(.*?)\n*\s*(?:```|~~~)"
         if include_tilde
-        else r"```python\s+(.*?)\s+```"
+        else r"\s*```python\n*(.*?)\n*\s*```"
     )
-    code_blocks = re.findall(pattern, contents, flags=re.DOTALL)
+    code_blocks = [dedent(c) for c in re.findall(pattern, contents, flags=re.DOTALL)]
 
     return code_blocks

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -7,9 +7,9 @@ from baybe.recommenders import SequentialGreedyRecommender
 from baybe.utils.basic import get_subclasses
 
 abbreviation_list = [
-    cl._abbreviation
+    cl.abbreviation
     for cl in get_subclasses(AcquisitionFunction)
-    if hasattr(cl, "_abbreviation")
+    if hasattr(cl, "abbreviation")
 ]
 
 fullname_list = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]

--- a/tests/serialization/test_deserialization.py
+++ b/tests/serialization/test_deserialization.py
@@ -1,4 +1,11 @@
-"""Deserialization tests."""
+"""Deserialization tests.
+
+The purpose of these tests is to ensure that deserialization works for all possible ways
+in which type information can be provided.
+
+NOTE: The tests are based on `AcquisitionFunction` simply because the class provides the
+    `abbreviation` variable that is necessary for the tests.
+"""
 
 import pytest
 from pytest import param

--- a/tests/serialization/test_deserialization.py
+++ b/tests/serialization/test_deserialization.py
@@ -1,0 +1,71 @@
+"""Deserialization tests."""
+
+import pytest
+from pytest import param
+
+from baybe.acquisition.acqfs import UpperConfidenceBound
+from baybe.acquisition.base import AcquisitionFunction
+
+
+@pytest.mark.parametrize(
+    ("cls", "dct"),
+    [
+        param(
+            AcquisitionFunction,
+            {"type": "UpperConfidenceBound", "beta": 1337},
+            id="base-full",
+        ),
+        param(
+            AcquisitionFunction,
+            {"type": "UCB", "beta": 1337},
+            id="base-abbreviation",
+        ),
+        param(
+            UpperConfidenceBound,
+            {"type": "UpperConfidenceBound", "beta": 1337},
+            id="subclass-full",
+        ),
+        param(
+            UpperConfidenceBound,
+            {"type": "UCB", "beta": 1337},
+            id="subclass-abbreviation",
+        ),
+        param(
+            UpperConfidenceBound,
+            {"beta": 1337},
+            id="subclass-without",
+        ),
+    ],
+)
+def test_valid_deserialization(cls, dct):
+    """Serialization is possible from concrete class and from base class.
+
+    Concrete class works with: full type name, type abbreviation, and without type.
+    Base class works with: full type name and type abbreviation.
+    """
+    UpperConfidenceBound(beta=1337) == cls.from_dict(dct)
+
+
+@pytest.mark.parametrize(
+    ("cls", "dct", "err", "msg"),
+    [
+        param(
+            AcquisitionFunction,
+            {"beta": 1337},
+            KeyError,
+            "type",
+            id="missing-type",
+        ),
+        param(
+            UpperConfidenceBound,
+            {"type": "wrong", "beta": 1337},
+            ValueError,
+            "'UpperConfidenceBound' .* does not match .* 'wrong'",
+            id="inconsistent-type",
+        ),
+    ],
+)
+def test_invalid_deserialization(cls, dct, err, msg):
+    """Incorrect type information throws the correct error."""
+    with pytest.raises(err, match=msg):
+        cls.from_dict(dct)

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -124,7 +124,7 @@ test_targets = [
 @pytest.mark.parametrize(
     "acqf",
     valid_mc_acquisition_functions,
-    ids=[a._abbreviation for a in valid_mc_acquisition_functions],
+    ids=[a.abbreviation for a in valid_mc_acquisition_functions],
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_iter_mc_acquisition_function(campaign, n_iterations, batch_size, acqf):
@@ -135,7 +135,7 @@ def test_iter_mc_acquisition_function(campaign, n_iterations, batch_size, acqf):
 @pytest.mark.parametrize(
     "acqf",
     valid_nonmc_acquisition_functions,
-    ids=[a._abbreviation for a in valid_nonmc_acquisition_functions],
+    ids=[a.abbreviation for a in valid_nonmc_acquisition_functions],
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 @pytest.mark.parametrize("batch_size", [1], ids=["b1"])


### PR DESCRIPTION
This PR finally adds a serialization user guide and fixes a few little issues in the serialization logic:
* Structuring concrete subclasses no longer requires providing an explicit `type` field
* The `_target(s)` attributes of objectives in are unstructured without the underscore
  (this is currently done via a workaround by overriding the hook of the base class)