### PR TITLE
Custom kernel priors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deserialization is now also possible from optional class name abbreviations
 - `Kernel` base class allowing to specify kernels
 - `MaternKernel` class can be chosen for GP surrogates
-- `hypothesis` strategies and roundtrip test for kernels, constraints, objectives and acquisition
-  functions
+- `hypothesis` strategies and roundtrip test for kernels, constraints, objectives, priors
+  and acquisition functions
 - New acquisition functions: `qSR`, `qNEI`, `LogEI`, `qLogEI`, `qLogNEI`
+- `GammaPrior` can now be chosen as lengthscale prior
 
 ### Changed
 - Reorganized acquisition.py into `acquisition` subpackage

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -1,9 +1,11 @@
 """Base classes for all kernels."""
 
 from abc import ABC
+from typing import Optional
 
-from attrs import define
+from attrs import define, field
 
+from baybe.kernels.priors.base import Prior
 from baybe.serialization.core import (
     converter,
     get_base_structure_hook,
@@ -17,12 +19,20 @@ from baybe.utils.basic import filter_attributes
 class Kernel(ABC, SerialMixin):
     """Abstract base class for all kernels."""
 
+    lengthscale_prior: Optional[Prior] = field(default=None, kw_only=True)
+    """An optional prior on the kernel lengthscale."""
+
     def to_gpytorch(self, *args, **kwargs):
         """Create the gpytorch representation of the kernel."""
         import gpytorch.kernels
 
         kernel_cls = getattr(gpytorch.kernels, self.__class__.__name__)
         fields_dict = filter_attributes(object=self, callable_=kernel_cls.__init__)
+
+        # If a lengthscale prior was chosen, we manually add it to the dictionary
+        if self.lengthscale_prior is not None:
+            fields_dict["lengthscale_prior"] = self.lengthscale_prior.to_gpytorch()
+
         # Update kwargs to contain class-specific attributes
         kwargs.update(fields_dict)
 

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -32,7 +32,7 @@ def _convert_fraction(value: Union[str, float, Fraction], /) -> float:
     return float(value)
 
 
-@define
+@define(frozen=True)
 class MaternKernel(Kernel):
     """A Matern kernel using a smoothness parameter."""
 

--- a/baybe/kernels/priors/__init__.py
+++ b/baybe/kernels/priors/__init__.py
@@ -1,0 +1,5 @@
+"""Available priors."""
+
+from baybe.kernels.priors.basic import GammaPrior
+
+__all__ = ["GammaPrior"]

--- a/baybe/kernels/priors/base.py
+++ b/baybe/kernels/priors/base.py
@@ -1,0 +1,35 @@
+"""Base class for all priors."""
+
+from abc import ABC
+
+from attrs import define
+
+from baybe.serialization.core import (
+    converter,
+    get_base_structure_hook,
+    unstructure_base,
+)
+from baybe.serialization.mixin import SerialMixin
+from baybe.utils.basic import filter_attributes
+
+
+@define(frozen=True)
+class Prior(ABC, SerialMixin):
+    """Abstract base class for all priors."""
+
+    def to_gpytorch(self, *args, **kwargs):
+        """Create the gpytorch representation of the prior."""
+        import gpytorch.priors
+
+        prior_cls = getattr(gpytorch.priors, self.__class__.__name__)
+        fields_dict = filter_attributes(object=self, callable_=prior_cls.__init__)
+
+        # Update kwargs to contain class-specific attributes
+        kwargs.update(fields_dict)
+
+        return prior_cls(*args, **kwargs)
+
+
+# Register de-/serialization hooks
+converter.register_structure_hook(Prior, get_base_structure_hook(Prior))
+converter.register_unstructure_hook(Prior, unstructure_base)

--- a/baybe/kernels/priors/basic.py
+++ b/baybe/kernels/priors/basic.py
@@ -1,0 +1,16 @@
+"""Priors that can be used for kernels."""
+from attrs import define, field
+from attrs.validators import gt
+
+from baybe.kernels.priors.base import Prior
+
+
+@define(frozen=True)
+class GammaPrior(Prior):
+    """A Gamma prior parameterized by concentration and rate."""
+
+    concentration: float = field(converter=float, validator=gt(0.0))
+    """The concentration."""
+
+    rate: float = field(converter=float, validator=gt(0.0))
+    """The rate."""

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -4,4 +4,11 @@ import hypothesis.strategies as st
 
 from baybe.kernels import MaternKernel
 
-matern_kernels = st.builds(MaternKernel, st.sampled_from((0.5, 1.5, 2.5)))
+from ..hypothesis_strategies.priors import priors
+
+matern_kernels = st.builds(
+    MaternKernel,
+    nu=st.sampled_from((0.5, 1.5, 2.5)),
+    lengthscale_prior=st.one_of(st.none(), priors),
+)
+"""A strategy that generates Matern kernels."""

--- a/tests/hypothesis_strategies/priors.py
+++ b/tests/hypothesis_strategies/priors.py
@@ -1,0 +1,19 @@
+"""Hypothesis strategies for priors."""
+
+import hypothesis.strategies as st
+
+from baybe.kernels.priors import GammaPrior
+
+gamma_priors = st.builds(
+    GammaPrior,
+    st.floats(min_value=0, exclude_min=True),
+    st.floats(min_value=0, exclude_min=True),
+)
+"""A strategy that generates Gamma priors."""
+
+priors = st.one_of(
+    [
+        gamma_priors,
+    ]
+)
+"""A strategy that generates priors."""

--- a/tests/serialization/test_prior_serialization.py
+++ b/tests/serialization/test_prior_serialization.py
@@ -1,0 +1,13 @@
+"""Test serialization of priors."""
+
+from hypothesis import given
+
+from baybe.kernels.priors.base import Prior
+from tests.hypothesis_strategies.priors import priors
+
+
+@given(priors)
+def test_prior_kernel_roundtrip(prior: Prior):
+    string = prior.to_json()
+    prior2 = Prior.from_json(string)
+    assert prior == prior2, (prior, prior2)


### PR DESCRIPTION
This PR introduces custom priors for kernels. It provides an ABC `Prior` as well as a `GammaPrior` class and corresponding tests.

Note that this PR does not yet introduce custom `ScaleKernels` and only adjusts the priors at the point where they are used for our custom `MaternKernels`. At other parts of the code, we technically still use the original `GPyTorch` priors, which is a bit hidden by the `.to_gyptorch()` call. This will all be fixed in upcoming PRs.

Further note that the kernel serialization currently fails. @AdrianSosic and I already briefly investigated the error and did not manage to track it down, and agreed to investigate this issue once the code is pushed (which is the case now)