### PR TITLE
Refactor recommender signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Passing an `Objective` to `Campaign` is now optional
+
+### Breaking Changes
+- Providing an explicit `batch_size` is now mandatory when asking for recommendations
+
 ## [0.9.1] - 2024-06-04
 ### Changed
 - Discrete searchspace memory estimate is now natively represented in bytes 
@@ -51,6 +58,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a warning instead of passing through the uncaught exception
 - Environment variables `BAYBE_NUMPY_USE_SINGLE_PRECISION` and
   `BAYBE_TORCH_USE_SINGLE_PRECISION` to enforce single point precision usage
+
+### Breaking Changes
+- `RecommenderProtocol.recommend` now accepts an optional `Objective` 
+- `RecommenderProtocol.recommend` now expects training data to be provided as a single
+  dataframe in experimental representation instead of two separate dataframes in
+  computational representation
 
 ### Removed
 - `model_params` attribute from `Surrogate` base class, `GaussianProcessSurrogate` and

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -298,10 +298,10 @@ class Campaign(SerialMixin):
 
         # Get the recommended search space entries
         rec = self.recommender.recommend(
-            self.searchspace,
             batch_size,
-            self._measurements_parameters_comp,
-            self._measurements_targets_comp,
+            self.searchspace,
+            self.objective,
+            self._measurements_exp,
         )
 
         # Cache the recommendations

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -133,20 +133,6 @@ class Campaign(SerialMixin):
         """The targets of the underlying objective."""
         return self.objective.targets if self.objective is not None else ()
 
-    @property
-    def _measurements_parameters_comp(self) -> pd.DataFrame:
-        """The computational representation of the measured parameters."""
-        if len(self._measurements_exp) < 1:
-            return pd.DataFrame()
-        return self.searchspace.transform(self._measurements_exp)
-
-    @property
-    def _measurements_targets_comp(self) -> pd.DataFrame:
-        """The computational representation of the measured targets."""
-        if len(self._measurements_exp) < 1:
-            return pd.DataFrame()
-        return self.objective.transform(self._measurements_exp)
-
     @classmethod
     def from_config(cls, config_json: str) -> Campaign:
         """Create a campaign from a configuration JSON.

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from typing import Optional
 
 import cattrs
 import numpy as np
 import pandas as pd
 from attrs import define, field
+from attrs.converters import optional
 
 from baybe.exceptions import DeprecationError
 from baybe.objectives.base import Objective, to_objective
@@ -47,7 +49,9 @@ class Campaign(SerialMixin):
     searchspace: SearchSpace = field()
     """The search space in which the experiments are conducted."""
 
-    objective: Objective = field(converter=to_objective)
+    objective: Optional[Objective] = field(
+        default=None, converter=optional(to_objective)
+    )
     """The optimization objective.
     When passing a single :class:`baybe.targets.base.Target`, it gets automatically
     wrapped into a :class:`baybe.objectives.single.SingleTargetObjective`."""
@@ -127,7 +131,7 @@ class Campaign(SerialMixin):
     @property
     def targets(self) -> tuple[Target, ...]:
         """The targets of the underlying objective."""
-        return self.objective.targets
+        return self.objective.targets if self.objective is not None else ()
 
     @property
     def _measurements_parameters_comp(self) -> pd.DataFrame:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -258,7 +258,7 @@ class Campaign(SerialMixin):
 
     def recommend(
         self,
-        batch_size: int = 5,
+        batch_size: int,
         batch_quantity: int = None,  # type: ignore[assignment]
     ) -> pd.DataFrame:
         """Provide the recommendations for the next batch of experiments.

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -18,7 +18,7 @@ class RecommenderProtocol(Protocol):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective],
         measurements: Optional[pd.DataFrame],
     ) -> pd.DataFrame:
         """Recommend a batch of points from the given search space.
@@ -26,7 +26,7 @@ class RecommenderProtocol(Protocol):
         Args:
             batch_size: The number of points to be recommended.
             searchspace: The search space from which to recommend the points.
-            objective: The objective to be optimized.
+            objective: An optional objective to be optimized.
             measurements: Optional experimentation data that can be used for model
                 training. The data is to be provided in "experimental representation":
                 It needs to contain one column for each parameter spanning the search

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -5,6 +5,7 @@ from typing import Optional, Protocol
 import cattrs
 import pandas as pd
 
+from baybe.objectives.base import Objective
 from baybe.recommenders.deprecation import structure_recommender_protocol
 from baybe.searchspace import SearchSpace
 from baybe.serialization import converter, unstructure_base
@@ -15,21 +16,29 @@ class RecommenderProtocol(Protocol):
 
     def recommend(
         self,
-        searchspace: SearchSpace,
         batch_size: int,
-        train_x: Optional[pd.DataFrame],
-        train_y: Optional[pd.DataFrame],
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame],
     ) -> pd.DataFrame:
         """Recommend a batch of points from the given search space.
 
         Args:
-            searchspace: The search space from which to recommend the points.
             batch_size: The number of points to be recommended.
-            train_x: Optional training inputs for training a model.
-            train_y: Optional training labels for training a model.
+            searchspace: The search space from which to recommend the points.
+            objective: The objective to be optimized.
+            measurements: Optional experimentation data that can be used for model
+                training. The data is to be provided in "experimental representation":
+                It needs to contain one column for each parameter spanning the search
+                space (column name matching the parameter name) and one column for each
+                target tracked by the objective (column name matching the target name).
+                Each row corresponds to one conducted experiment, where the parameter
+                columns define the experimental setting and the target columns report
+                the measured outcomes.
 
         Returns:
-            A dataframe containing the recommendations as individual rows.
+            A dataframe containing the recommendations in experimental representation
+            as individual rows.
         """
         ...
 

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -81,9 +81,9 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
     ) -> pd.DataFrame:
         """See :func:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
         recommender = self.select_recommender(
-            searchspace, objective, batch_size, measurements
+            batch_size, searchspace, objective, measurements
         )
-        return recommender.recommend(searchspace, objective, batch_size, measurements)
+        return recommender.recommend(batch_size, searchspace, objective, measurements)
 
 
 # Register (un-)structure hooks

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -8,6 +8,7 @@ import pandas as pd
 from attrs import define, field
 
 from baybe.exceptions import DeprecationError
+from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
 from baybe.recommenders.deprecation import structure_recommender_protocol
 from baybe.recommenders.pure.base import PureRecommender
@@ -50,20 +51,22 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
     @abstractmethod
     def select_recommender(
         self,
+        batch_size: int,
         searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         """Select a pure recommender for the given experimentation context.
 
         Args:
-            searchspace:
-                See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
             batch_size:
                 See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
-            train_x: See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
-            train_y: See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
+            searchspace:
+                See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
+            objective:
+                See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
+            measurements:
+                See :func:`baybe.recommenders.meta.base.MetaRecommender.recommend`.
 
         Returns:
             The selected recommender.
@@ -71,14 +74,16 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
 
     def recommend(
         self,
+        batch_size: int,
         searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         """See :func:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
-        recommender = self.select_recommender(searchspace, batch_size, train_x, train_y)
-        return recommender.recommend(searchspace, batch_size, train_x, train_y)
+        recommender = self.select_recommender(
+            searchspace, objective, batch_size, measurements
+        )
+        return recommender.recommend(searchspace, objective, batch_size, measurements)
 
 
 # Register (un-)structure hooks

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -53,7 +53,7 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         """Select a pure recommender for the given experimentation context.
@@ -76,7 +76,7 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         """See :func:`baybe.recommenders.base.RecommenderProtocol.recommend`."""

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -81,9 +81,17 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
     ) -> pd.DataFrame:
         """See :func:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
         recommender = self.select_recommender(
-            batch_size, searchspace, objective, measurements
+            batch_size=batch_size,
+            searchspace=searchspace,
+            objective=objective,
+            measurements=measurements,
         )
-        return recommender.recommend(batch_size, searchspace, objective, measurements)
+        return recommender.recommend(
+            batch_size=batch_size,
+            searchspace=searchspace,
+            objective=objective,
+            measurements=measurements,
+        )
 
 
 # Register (un-)structure hooks

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -54,7 +54,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
-        searchspace: SearchSpace,
+        searchspace: Optional[SearchSpace] = None,
         objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
@@ -125,7 +125,7 @@ class SequentialMetaRecommender(MetaRecommender):
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
-        searchspace: SearchSpace,
+        searchspace: Optional[SearchSpace] = None,
         objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
@@ -207,7 +207,7 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
-        searchspace: SearchSpace,
+        searchspace: Optional[SearchSpace] = None,
         objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -55,7 +55,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         # See base class.
@@ -126,7 +126,7 @@ class SequentialMetaRecommender(MetaRecommender):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         # See base class.
@@ -208,7 +208,7 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         # See base class.

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -16,19 +16,12 @@ from baybe.recommenders.pure.base import PureRecommender
 from baybe.recommenders.pure.bayesian.sequential_greedy import (
     SequentialGreedyRecommender,
 )
-from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.recommenders.pure.nonpredictive.sampling import RandomRecommender
 from baybe.searchspace import SearchSpace
 from baybe.serialization import (
     block_deserialization_hook,
     block_serialization_hook,
     converter,
-)
-
-# TODO: Make bayesian recommenders handle empty training data
-_unsupported_recommender_error = ValueError(
-    f"For cases where no training is available, the selected recommender "
-    f"must be a subclass of '{NonPredictiveRecommender.__name__}'."
 )
 
 
@@ -65,12 +58,6 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         train_y: Optional[pd.DataFrame] = None,
     ) -> PureRecommender:
         # See base class.
-
-        # TODO: enable bayesian recommenders for empty training data
-        if (train_x is None or len(train_x) == 0) and not isinstance(
-            self.initial_recommender, NonPredictiveRecommender
-        ):
-            raise _unsupported_recommender_error
 
         return (
             self.recommender
@@ -171,12 +158,6 @@ class SequentialMetaRecommender(MetaRecommender):
         # Remember the training dataset size for the next call
         self._n_last_measurements = len(train_x)
 
-        # TODO: enable bayesian recommenders for empty training data
-        if (train_x is None or len(train_x) == 0) and not isinstance(
-            recommender, NonPredictiveRecommender
-        ):
-            raise _unsupported_recommender_error
-
         return recommender
 
 
@@ -252,12 +233,6 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
 
         # Remember the training dataset size for the next call
         self._n_last_measurements = len(train_x)
-
-        # TODO: enable bayesian recommenders for empty training data
-        if (train_x is None or len(train_x) == 0) and not isinstance(
-            self._last_recommender, NonPredictiveRecommender
-        ):
-            raise _unsupported_recommender_error
 
         return self._last_recommender  # type: ignore[return-value]
 

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -27,6 +27,8 @@ class NaiveHybridSpaceRecommender(PureRecommender):
     a non-hybrid space, it uses the corresponding recommender.
     """
 
+    # TODO: Cleanly implement naive recommender using fixed parameter class
+
     # Class variables
     compatibility: ClassVar[SearchSpaceType] = SearchSpaceType.HYBRID
     # See base class.

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -80,7 +80,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Optional
 import pandas as pd
 from attrs import define, evolve, field, fields
 
+from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.bayesian.sequential_greedy import (
@@ -77,10 +78,10 @@ class NaiveHybridSpaceRecommender(PureRecommender):
 
     def recommend(  # noqa: D102
         self,
+        batch_size: int,
         searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
 
@@ -103,10 +104,10 @@ class NaiveHybridSpaceRecommender(PureRecommender):
             degenerate_recommender = self.cont_recommender
         if degenerate_recommender is not None:
             return degenerate_recommender.recommend(
-                searchspace=searchspace,
                 batch_size=batch_size,
-                train_x=train_x,
-                train_y=train_y,
+                searchspace=searchspace,
+                objective=objective,
+                measurements=measurements,
             )
 
         # We are in a hybrid setting now
@@ -129,7 +130,9 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
-            self.disc_recommender._setup_botorch_acqf(searchspace, train_x, train_y)
+            self.disc_recommender._setup_botorch_acqf(
+                searchspace, objective, measurements
+            )
 
             # Construct the partial acquisition function that attaches cont_part
             # whenever evaluating the acquisition function
@@ -154,7 +157,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         disc_part_tensor = to_tensor(disc_part).unsqueeze(-2)
 
         # Setup a fresh acquisition function for the continuous recommender
-        self.cont_recommender._setup_botorch_acqf(searchspace, train_x, train_y)
+        self.cont_recommender._setup_botorch_acqf(searchspace, objective, measurements)
 
         # Construct the continuous space as a standalone space
         cont_acqf_part = PartialAcquisitionFunction(

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -7,6 +7,7 @@ import pandas as pd
 from attrs import define, field
 
 from baybe.exceptions import NotEnoughPointsLeftError
+from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
 from baybe.searchspace import SearchSpace
 from baybe.searchspace.continuous import SubspaceContinuous
@@ -33,10 +34,10 @@ class PureRecommender(ABC, RecommenderProtocol):
 
     def recommend(  # noqa: D102
         self,
+        batch_size: int,
         searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class
         if searchspace.type is SearchSpaceType.CONTINUOUS:

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -36,7 +36,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -83,7 +83,7 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Optional[Objective],
+        objective: Optional[Objective] = None,
         measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -52,21 +52,9 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: Optional[pd.DataFrame] = None,
+        measurements: pd.DataFrame,
     ) -> None:
-        """Create the acquisition function for the current training data.
-
-        The acquisition function is stored in the private attribute
-        ``_acquisition_function``.
-
-        Args:
-            searchspace:
-                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
-            objective:
-                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
-            measurements:
-                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
-        """  # noqa: E501
+        """Create the acquisition function for the current training data."""  # noqa: E501
         # TODO: Transition point from dataframe to tensor needs to be refactored.
         #   Currently, surrogate models operate with tensors, while acquisition
         #   functions with dataframes.

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -91,4 +91,9 @@ class BayesianRecommender(PureRecommender, ABC):
 
         self._setup_botorch_acqf(searchspace, objective, measurements)
 
-        return super().recommend(batch_size, searchspace, objective, measurements)
+        return super().recommend(
+            batch_size=batch_size,
+            searchspace=searchspace,
+            objective=objective,
+            measurements=measurements,
+        )

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -80,7 +80,7 @@ class BayesianRecommender(PureRecommender, ABC):
                 f"that an objective is specified."
             )
 
-        if measurements is None:
+        if (measurements is None) or (len(measurements) == 0):
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
                 f"empty training data."

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -97,4 +97,4 @@ class BayesianRecommender(PureRecommender, ABC):
 
         self._setup_botorch_acqf(searchspace, objective, measurements)
 
-        return super().recommend(searchspace, objective, batch_size, measurements)
+        return super().recommend(batch_size, searchspace, objective, measurements)

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -60,11 +60,9 @@ class BayesianRecommender(PureRecommender, ABC):
         #   functions with dataframes.
         train_x = searchspace.transform(measurements)
         train_y = objective.transform(measurements)
-        surrogate_model = self.surrogate_model._fit(
-            searchspace, *to_tensor(train_x, train_y)
-        )
+        self.surrogate_model._fit(searchspace, *to_tensor(train_x, train_y))
         self._botorch_acqf = self.acquisition_function.to_botorch(
-            surrogate_model, train_x, train_y
+            self.surrogate_model, train_x, train_y
         )
 
     def recommend(  # noqa: D102

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -83,13 +83,21 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         batch_size: int,
         searchspace: SearchSpace,
-        objective: Objective,
+        objective: Optional[Objective],
         measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
+
+        if objective is None:
+            raise NotImplementedError(
+                f"Recommenders of type '{BayesianRecommender.__name__}' require "
+                f"that an objective is specified."
+            )
+
         if measurements is None:
             raise NotImplementedError(
-                "Bayesian recommenders do not support empty training data yet."
+                f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
+                f"empty training data."
             )
 
         if _ONNX_INSTALLED and isinstance(self.surrogate_model, CustomONNXSurrogate):

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -10,6 +10,7 @@ from baybe.acquisition.acqfs import qExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.acquisition.utils import convert_acqf
 from baybe.exceptions import DeprecationError
+from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import _ONNX_INSTALLED, GaussianProcessSurrogate
@@ -50,71 +51,50 @@ class BayesianRecommender(PureRecommender, ABC):
     def _setup_botorch_acqf(
         self,
         searchspace: SearchSpace,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> None:
-        """Create the current acquisition function from provided training data.
+        """Create the acquisition function for the current training data.
 
         The acquisition function is stored in the private attribute
         ``_acquisition_function``.
 
         Args:
-            searchspace: The search space in which the experiments are to be conducted.
-            train_x: The features of the conducted experiments.
-            train_y: The corresponding response values.
-
-        Raises:
-            NotImplementedError: If the setup is attempted from empty training data
-        """
-        if train_x is None or train_y is None:
-            raise NotImplementedError(
-                "Bayesian recommenders do not support empty training data yet."
-            )
-
-        surrogate_model = self._fit(searchspace, train_x, train_y)
+            searchspace:
+                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
+            objective:
+                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
+            measurements:
+                See :meth:`baybe.recommenders.pure.bayesian.BayesianRecommender.recommend`.
+        """  # noqa: E501
+        # TODO: Transition point from dataframe to tensor needs to be refactored.
+        #   Currently, surrogate models operate with tensors, while acquisition
+        #   functions with dataframes.
+        train_x = searchspace.transform(measurements)
+        train_y = objective.transform(measurements)
+        surrogate_model = self.surrogate_model._fit(
+            searchspace, *to_tensor(train_x, train_y)
+        )
         self._botorch_acqf = self.acquisition_function.to_botorch(
             surrogate_model, train_x, train_y
         )
 
-    def _fit(
-        self,
-        searchspace: SearchSpace,
-        train_x: pd.DataFrame,
-        train_y: pd.DataFrame,
-    ) -> Surrogate:
-        """Train a fresh surrogate model instance.
-
-        Args:
-            searchspace: The search space.
-            train_x: The features of the conducted experiments.
-            train_y: The corresponding response values.
-
-        Returns:
-            A surrogate model fitted to the provided data.
-
-        Raises:
-            ValueError: If the training inputs and targets do not have the same index.
-        """
-        # validate input
-        if not train_x.index.equals(train_y.index):
-            raise ValueError("Training inputs and targets must have the same index.")
-
-        self.surrogate_model.fit(searchspace, *to_tensor(train_x, train_y))
-
-        return self.surrogate_model
-
     def recommend(  # noqa: D102
         self,
+        batch_size: int,
         searchspace: SearchSpace,
-        batch_size: int = 1,
-        train_x: Optional[pd.DataFrame] = None,
-        train_y: Optional[pd.DataFrame] = None,
+        objective: Objective,
+        measurements: Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         # See base class.
+        if measurements is None:
+            raise NotImplementedError(
+                "Bayesian recommenders do not support empty training data yet."
+            )
 
         if _ONNX_INSTALLED and isinstance(self.surrogate_model, CustomONNXSurrogate):
             CustomONNXSurrogate.validate_compatibility(searchspace)
 
-        self._setup_botorch_acqf(searchspace, train_x, train_y)
+        self._setup_botorch_acqf(searchspace, objective, measurements)
 
-        return super().recommend(searchspace, batch_size, train_x, train_y)
+        return super().recommend(searchspace, objective, batch_size, measurements)

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -1,12 +1,42 @@
 """Base class for all nonpredictive recommenders."""
 
+import warnings
 from abc import ABC
+from typing import Optional
 
+import pandas as pd
 from attrs import define
 
+from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
+from baybe.searchspace.core import SearchSpace
 
 
 @define
 class NonPredictiveRecommender(PureRecommender, ABC):
     """Abstract base class for all nonpredictive recommenders."""
+
+    def recommend(  # noqa: D102
+        self,
+        batch_size: int,
+        searchspace: SearchSpace,
+        objective: Optional[Objective] = None,
+        measurements: Optional[pd.DataFrame] = None,
+    ) -> pd.DataFrame:
+        # See base class.
+
+        if (measurements is not None) and (len(measurements) != 0):
+            warnings.warn(
+                f"'{self.recommend.__name__}' was called with a non-empty "
+                f"set of measurements but '{self.__class__.__name__}' does not "
+                f"utilize any training data, meaning that the argument is ignored.",
+                UserWarning,
+            )
+        if objective is not None:
+            warnings.warn(
+                f"'{self.recommend.__name__}' was called with a an explicit objective "
+                f"but '{self.__class__.__name__}' does not "
+                f"consider any objectives, meaning that the argument is ignored.",
+                UserWarning,
+            )
+        return super().recommend(batch_size, searchspace, objective, measurements)

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -39,4 +39,9 @@ class NonPredictiveRecommender(PureRecommender, ABC):
                 f"consider any objectives, meaning that the argument is ignored.",
                 UserWarning,
             )
-        return super().recommend(batch_size, searchspace, objective, measurements)
+        return super().recommend(
+            batch_size=batch_size,
+            searchspace=searchspace,
+            objective=objective,
+            measurements=measurements,
+        )

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -97,6 +97,11 @@ def simulate_experiment(
     #   want to investigate in the future.
     # TODO: Use a `will_terminate` campaign property to decide if the campaign will
     #   run indefinitely or not, and allow omitting `n_doe_iterations` for the latter.
+    if campaign.objective is None:
+        raise ValueError(
+            "The given campaign has no objective defined, hence there are no targets "
+            "to be tracked."
+        )
 
     context = temporary_seed(random_seed) if random_seed is not None else nullcontext()
     with context:

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -8,6 +8,8 @@
 
 ### Necessary imports for this example
 
+import pandas as pd
+
 from baybe import Campaign
 from baybe.objectives import DesirabilityObjective
 from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
@@ -104,15 +106,16 @@ print(campaign)
 N_ITERATIONS = 3
 
 for kIter in range(N_ITERATIONS):
-    print(f"\n\n#### ITERATION {kIter+1} ####")
-
     rec = campaign.recommend(batch_size=3)
-    print("\nRecommended measurements:\n", rec)
-
     add_fake_results(rec, campaign)
-    print("\nRecommended measurements with fake measured results:\n", rec)
-
     campaign.add_measurements(rec)
+    desirability = campaign.objective.transform(campaign.measurements)
+
+    print(f"\n\n#### ITERATION {kIter+1} ####")
+    print("\nRecommended measurements with fake measured results:\n")
+    print(rec)
+    print("\nInternal measurement database with desirability values:\n")
+    print(pd.concat([campaign.measurements, desirability], axis=1))
 
 ### Addendum: Description of `transformation` functions
 

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -114,10 +114,6 @@ for kIter in range(N_ITERATIONS):
 
     campaign.add_measurements(rec)
 
-    print("\n\nInternal measurement dataframe computational representation Y:\n")
-    print(campaign._measurements_targets_comp)
-
-
 ### Addendum: Description of `transformation` functions
 
 # This function is used to transform target values to the interval `[0,1]` for `MAX`/`MIN` mode.

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ exclude = (?x)(
           | baybe/utils/dataframe.py
           | baybe/deprecation.py
           | baybe/exceptions.py
+    	  | baybe/recommenders/naive.py
           | baybe/scaler.py
           | baybe/simulation.py
           )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -865,9 +865,8 @@ def select_recommender(
 ) -> PureRecommender:
     """Select a recommender for a given training dataset size."""
     searchspace = Mock()
-    objective = Mock()
     df = Mock()
     df.__len__ = Mock(return_value=training_size)
     return meta_recommender.select_recommender(
-        batch_size=1, searchspace=searchspace, objective=objective, measurements=df
+        batch_size=1, searchspace=searchspace, measurements=df
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from itertools import chain
 from typing import Union
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -859,22 +860,14 @@ def run_iterations(
         campaign.add_measurements(rec)
 
 
-def get_dummy_training_data(length: int) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Create column-less input and target dataframes of specified length."""
-    df = pd.DataFrame(np.empty((length, 0)))
-    return df, df
-
-
-def get_dummy_searchspace() -> SearchSpace:
-    """Create a dummy searchspace whose actual content is irrelevant."""
-    parameters = [NumericalDiscreteParameter(name="test", values=(0, 1))]
-    return SearchSpace.from_product(parameters)
-
-
 def select_recommender(
     meta_recommender: MetaRecommender, training_size: int
 ) -> PureRecommender:
-    """Select a recommender for given training dataset size."""
-    searchspace = get_dummy_searchspace()
-    df_x, df_y = get_dummy_training_data(training_size)
-    return meta_recommender.select_recommender(searchspace, train_x=df_x, train_y=df_y)
+    """Select a recommender for a given training dataset size."""
+    searchspace = Mock()
+    objective = Mock()
+    df = Mock()
+    df.__len__ = Mock(return_value=training_size)
+    return meta_recommender.select_recommender(
+        batch_size=1, searchspace=searchspace, objective=objective, measurements=df
+    )

--- a/tests/serialization/test_campaign_serialization.py
+++ b/tests/serialization/test_campaign_serialization.py
@@ -15,7 +15,7 @@ def test_campaign_serialization(campaign):
     campaign2 = roundtrip(campaign)
     assert campaign == campaign2
 
-    campaign.recommend()
+    campaign.recommend(batch_size=1)
     campaign2 = roundtrip(campaign)
     assert campaign == campaign2
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -115,7 +115,7 @@ def test_deprecated_campaign_tolerance_flag(flag):
 def test_deprecated_batch_quantity_keyword(campaign):
     """Using the deprecated batch_quantity keyword raises an error."""
     with pytest.raises(DeprecationError):
-        campaign.recommend(batch_quantity=5)
+        campaign.recommend(batch_size=5, batch_quantity=5)
 
 
 @pytest.mark.parametrize("flag", (True, False))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,55 @@
+"""Integration tests."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pytest import param
+
+from baybe.parameters.numerical import NumericalDiscreteParameter
+from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
+from baybe.searchspace.core import SearchSpace
+from baybe.targets.numerical import NumericalTarget
+from baybe.utils.basic import get_subclasses
+
+nonpredictive_recommenders = [
+    param(cls(allow_recommending_already_measured=True), id=cls.__name__)
+    for cls in get_subclasses(NonPredictiveRecommender)
+]
+
+p1 = NumericalDiscreteParameter("p1", [1, 2])
+t1 = NumericalTarget("t1", "MAX")
+objective = t1.to_objective()
+measurements = pd.DataFrame(
+    {p1.name: p1.values, t1.name: np.random.random(len(p1.values))}
+)
+
+
+@pytest.fixture(name="searchspace")
+def fixture_searchspace():
+    return SearchSpace.from_product([p1])
+
+
+@pytest.mark.parametrize("recommender", nonpredictive_recommenders)
+def test_nonbayesian_recommender_with_measurements(recommender, searchspace):
+    """Calling a non-Bayesian recommender with training data raises a warning."""
+    with pytest.warns(
+        UserWarning,
+        match=(
+            f"'{recommender.__class__.__name__}' does not utilize any training data"
+        ),
+    ):
+        recommender.recommend(
+            batch_size=1, searchspace=searchspace, measurements=measurements
+        )
+
+
+@pytest.mark.parametrize("recommender", nonpredictive_recommenders)
+def test_nonbayesian_recommender_with_objective(recommender, searchspace):
+    """Calling a non-Bayesian recommender with an objective raises a warning."""
+    with pytest.warns(
+        UserWarning,
+        match=(f"'{recommender.__class__.__name__}' does not consider any objectives"),
+    ):
+        recommender.recommend(
+            batch_size=1, searchspace=searchspace, objective=objective
+        )


### PR DESCRIPTION
This PR implements a breaking change by refactoring the recommender signature such that:
* it accepts an optional `Objective`
* it expects training data as a single dataframe in experimental representation

Apart from fixing certain responsibilities (e.g. `Campaign` now only acts as a meta-data handler, just like it is supposed to) this enables/prepares several new features:
* Users can directly use `Recommender`s as entry point instead of being forced to go via `Campaign`
* Because recommenders now operate on experimental representations, they can offer the same interface back to users, e.g. when exposing model-internal things such as acquisition functions and surrogate models
* Additional pre-processing steps that require access to the experimental representation (such as data-augmentation) can now happen inside recommenders
