### PR TITLE
Simplification of doc building script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'build/docs'
+          path: 'docs/build'
 
   deploy:
     needs: build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
 import shutil
-import sys
 
 # -- Path setup --------------------------------------------------------------
 
@@ -250,11 +249,6 @@ intersphinx_mapping = {
 # --- Options for autodoc typehints and autodoc -------------------------------
 # https://pypi.org/project/sphinx-autodoc-typehints/
 
-# For some reason, sphinx does not like it if we use the -D option to just tell it
-# that we want to include private members. We thus manually verify whether the option
-# was set.
-private_members = "True" in sys.argv[sys.argv.index("-D") + 1]
-
 # Represent typehints whenever possible.
 autodoc_typehints = "both"
 # Separate class names and init functions.
@@ -267,8 +261,6 @@ autodoc_preserve_defaults = False
 autodoc_default_options = {
     # Order by type (function, attribute...), required for proper inheritance
     "member-order": "groupwise",
-    # Include private members if this was requested
-    "private-members": private_members,
 }
 # Only show parameters that are documented.
 autodoc_typehints_description_target = "documented_params"

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -43,7 +43,7 @@ if not INCLUDE_WARNINGS:
 
 # Disable telemtetry
 os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
-# Directories where Sphinx will always put the build, sdk and autosummary data
+# Directory where Sphinx builds the documentation
 build_dir = pathlib.Path("docs/build")
 
 # The call for checking external links.
@@ -52,7 +52,7 @@ link_call = [
     "-b",
     "linkcheck",
     "docs",
-    "docs/build",
+    build_dir,
 ]
 # The actual call that will be made to build the documentation
 building_call = [
@@ -60,7 +60,7 @@ building_call = [
     "-b",
     "html",
     "docs",
-    "docs/build",
+    build_dir,
     "-n",  # Being nitpicky
     "-W",  # Fail when encountering an error or a warning
 ]

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -45,15 +45,6 @@ if not INCLUDE_WARNINGS:
 os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 # Directories where Sphinx will always put the build, sdk and autosummary data
 build_dir = pathlib.Path("docs/build")
-sdk_dir = pathlib.Path("docs/sdk")
-autosummary_dir = pathlib.Path("docs/_autosummary")
-
-# Collect all of the directories and delete them if they still exist.
-directories = [sdk_dir, autosummary_dir, build_dir]
-
-for directory in directories:
-    if directory.is_dir():
-        shutil.rmtree(directory)
 
 # The call for checking external links.
 link_call = [
@@ -105,12 +96,6 @@ adjust_pictures(
     light_version="full_lookup_light",
     dark_version="full_lookup_dark",
 )
-
-
-# Clean the other files
-for directory in [sdk_dir, autosummary_dir]:
-    if directory.is_dir():
-        shutil.rmtree(directory)
 
 
 # Delete the created markdown files of the examples.

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -12,12 +12,6 @@ from baybe.telemetry import VARNAME_TELEMETRY_ENABLED
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "-p",
-    "--include_private",
-    help="Include private methods in the documentation. Default is false.",
-    action="store_true",
-)
-parser.add_argument(
     "-e",
     "--ignore_examples",
     help="Ignore the examples and do not include them into the documentation.",
@@ -39,7 +33,6 @@ parser.add_argument(
 
 # Parse input arguments
 args = parser.parse_args()
-INCLUDE_PRIVATE = args.include_private
 IGNORE_EXAMPLES = args.ignore_examples
 INCLUDE_WARNINGS = args.include_warnings
 FORCE = args.force
@@ -69,8 +62,6 @@ link_call = [
     "linkcheck",
     "docs",
     "docs/build",
-    "-D",
-    f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
 ]
 # The actual call that will be made to build the documentation
 building_call = [
@@ -79,8 +70,6 @@ building_call = [
     "html",
     "docs",
     "docs/build",
-    "-D",
-    f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
     "-n",  # Being nitpicky
     "-W",  # Fail when encountering an error or a warning
 ]

--- a/docs/scripts/convert_code_to_documentation.py
+++ b/docs/scripts/convert_code_to_documentation.py
@@ -12,15 +12,6 @@ from baybe.telemetry import VARNAME_TELEMETRY_ENABLED
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    "-t",
-    "--target_dir",
-    help="Destination directory in which the build will be saved (relative).\
-    Note that building the documentation actually happens within the doc folder.\
-    After building the documentation, it will be copied to this folder.\
-    Default is a subfolder 'docs' placed in `build`.",
-    default="./build/docs",
-)
-parser.add_argument(
     "-p",
     "--include_private",
     help="Include private methods in the documentation. Default is false.",
@@ -48,7 +39,6 @@ parser.add_argument(
 
 # Parse input arguments
 args = parser.parse_args()
-DESTINATION_DIR = args.target_dir
 INCLUDE_PRIVATE = args.include_private
 IGNORE_EXAMPLES = args.ignore_examples
 INCLUDE_WARNINGS = args.include_warnings
@@ -64,10 +54,9 @@ os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 build_dir = pathlib.Path("docs/build")
 sdk_dir = pathlib.Path("docs/sdk")
 autosummary_dir = pathlib.Path("docs/_autosummary")
-destination_dir = pathlib.Path(DESTINATION_DIR)
 
 # Collect all of the directories and delete them if they still exist.
-directories = [sdk_dir, autosummary_dir, build_dir, destination_dir]
+directories = [sdk_dir, autosummary_dir, build_dir]
 
 for directory in directories:
     if directory.is_dir():
@@ -79,7 +68,7 @@ link_call = [
     "-b",
     "linkcheck",
     "docs",
-    build_dir,
+    "docs/build",
     "-D",
     f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
 ]
@@ -89,7 +78,7 @@ building_call = [
     "-b",
     "html",
     "docs",
-    build_dir,
+    "docs/build",
     "-D",
     f"autodoc_default_options.private_members={INCLUDE_PRIVATE}",
     "-n",  # Being nitpicky
@@ -134,8 +123,6 @@ for directory in [sdk_dir, autosummary_dir]:
     if directory.is_dir():
         shutil.rmtree(directory)
 
-documentation = pathlib.Path(build_dir)
-shutil.move(documentation, destination_dir)
 
 # Delete the created markdown files of the examples.
 example_directory = pathlib.Path("docs/examples")


### PR DESCRIPTION
This PR simplifies our current doc building script. The only goal of this PR is to get rid of code that is actually not necessary and that makes the script unnecessarily complex.

More precisely, this PR does the following:
- Change the default location of the documentation: This is done as it potentially allows easier local building and testing in the future.
- Remove the option to include private members in the documentation: This was not used at all but was responsible for quite some amount of code
- Do not delete the directories created by Sphinx: Sphinx creates several directories while building the documentation. These were deleted previously, which this PR now changes.

Note that there is exactly one commit per change, trying to make this as easy to review as possible. Also, you can verify on my fork (https://avhopp.github.io/baybe_dev/) that the documentation is also still built properly.