### PR TITLE
Enable single point precision via env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User guide now explains the new objective classes
 - Telemetry deactivation warning is only shown to developers
 - `torch`, `gpytorch` and `botorch` are lazy-loaded for improved startup time
+- Environment variables `BAYBE_NUMPY_USE_SINGLE_PRECISION` and
+  `BAYBE_TORCH_USE_SINGLE_PRECISION` to enforce single point precision usage
 
 ### Removed
 - `model_params` attribute from `Surrogate` base class, `GaussianProcessSurrogate` and

--- a/baybe/utils/numerical.py
+++ b/baybe/utils/numerical.py
@@ -1,11 +1,21 @@
 """Utilities for numeric operations."""
 
+import os
 from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt
 
-DTypeFloatNumpy = np.float64
+from baybe.utils.boolean import strtobool
+
+VARNAME_NUMPY_USE_SINGLE_PRECISION = "BAYBE_NUMPY_USE_SINGLE_PRECISION"
+"""Environment variable name for enforcing single precision in numpy."""
+
+DTypeFloatNumpy = (
+    np.float32
+    if strtobool(os.environ.get(VARNAME_NUMPY_USE_SINGLE_PRECISION, "False"))
+    else np.float64
+)
 """Floating point data type used for numpy arrays."""
 
 DTypeFloatONNX = np.float32

--- a/baybe/utils/torch.py
+++ b/baybe/utils/torch.py
@@ -1,6 +1,18 @@
 """Torch utilities shipped as separate module for lazy-loading."""
 
+
+import os
+
 import torch
 
-DTypeFloatTorch = torch.float64
+from baybe.utils.boolean import strtobool
+
+VARNAME_TORCH_USE_SINGLE_PRECISION = "BAYBE_TORCH_USE_SINGLE_PRECISION"
+"""Environment variable name for enforcing single precision in torch."""
+
+DTypeFloatTorch = (
+    torch.float32
+    if strtobool(os.environ.get(VARNAME_TORCH_USE_SINGLE_PRECISION, "False"))
+    else torch.float64
+)
 """Floating point data type used for torch tensors."""


### PR DESCRIPTION
Added
- env var for torch
- env var for numpy
- these are booleans that enforce usage of single precision if True, False by default

Notes:
- Did some very light testing via fulltest and setting the tox env vars to use single precision there
- some tests expectedly fail due to numerical instability -> no action required
- some tests fail because hypothesis generate incompatible floats --> likely fixed by using `st.floats(...,width=32)` if single precision is desired --> not done under the assumption we dont want tests enabled for single precision, would require flexible checking everywhere
- some tests fail as constraints complain about combining Single and Double precision --> likely because `rhs` and `coefficients` are defined as python floats, hence 64 bit. This means using double precision with env vars also implies providing explicit 32bit floats in such fields (like `coefficients` or `rhs`), otherwise it wont work. This is not something I'd fix but perhaps mention in the userguide