### PR TITLE
Memory estimation utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GammaPrior`, `HalfCauchyPrior`, `NormalPrior`, `HalfNormalPrior`, `LogNormalPrior`
   and `SmoothedBoxPrior` can now be chosen as lengthscale prior
 - Environment variables user guide
+- Utility for estimated search space memory consumption based on parameter lists
 
 ### Changed
 - Reorganized acquisition.py into `acquisition` subpackage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GammaPrior`, `HalfCauchyPrior`, `NormalPrior`, `HalfNormalPrior`, `LogNormalPrior`
   and `SmoothedBoxPrior` can now be chosen as lengthscale prior
 - Environment variables user guide
-- Utility for estimated search space memory consumption based on parameter lists
+- Utility for estimating memory requirements of discrete product search space
 
 ### Changed
 - Reorganized acquisition.py into `acquisition` subpackage

--- a/baybe/constraints/validation.py
+++ b/baybe/constraints/validation.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 
 from baybe.constraints.base import Constraint
 from baybe.constraints.discrete import DiscreteDependenciesConstraint
-from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parameter
+from baybe.parameters.base import Parameter
 
 
 def validate_constraints(  # noqa: DOC101, DOC103
@@ -26,12 +26,8 @@ def validate_constraints(  # noqa: DOC101, DOC103
         )
 
     param_names_all = [p.name for p in parameters]
-    param_names_discrete = [
-        p.name for p in parameters if isinstance(p, DiscreteParameter)
-    ]
-    param_names_continuous = [
-        p.name for p in parameters if isinstance(p, ContinuousParameter)
-    ]
+    param_names_discrete = [p.name for p in parameters if p.is_discrete]
+    param_names_continuous = [p.name for p in parameters if p.is_continuous]
     for constraint in constraints:
         if not all(p in param_names_all for p in constraint.parameters):
             raise ValueError(

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -55,6 +55,16 @@ class Parameter(ABC, SerialMixin):
     def __str__(self) -> str:
         return str(self.summary())
 
+    @property
+    def is_continuous(self) -> bool:
+        """Boolean indicating if this is a continuous parameter."""
+        return isinstance(self, ContinuousParameter)
+
+    @property
+    def is_discrete(self) -> bool:
+        """Boolean indicating if this is a discrete parameter."""
+        return isinstance(self, DiscreteParameter)
+
 
 @define(frozen=True, slots=False)
 class DiscreteParameter(Parameter, ABC):

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -298,7 +298,7 @@ class SearchSpace(SerialMixin):
             The estimated memory size.
         """
         discrete_parameters = [p for p in parameters if p.is_discrete]
-        return SubspaceDiscrete.estimate_product_space_size(discrete_parameters)
+        return SubspaceDiscrete.estimate_product_space_size(discrete_parameters)  # type: ignore[arg-type]
 
     def transform(
         self,

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -15,12 +15,12 @@ from baybe.constraints import (
     ContinuousLinearInequalityConstraint,
     validate_constraints,
 )
-from baybe.constraints.base import Constraint, DiscreteConstraint
+from baybe.constraints.base import Constraint
 from baybe.parameters import (
     SubstanceEncoding,
     TaskParameter,
 )
-from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parameter
+from baybe.parameters.base import Parameter
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
     SubspaceDiscrete,
@@ -136,18 +136,18 @@ class SearchSpace(SerialMixin):
             constraints = []
 
         discrete: SubspaceDiscrete = SubspaceDiscrete.from_product(
-            parameters=[p for p in parameters if isinstance(p, DiscreteParameter)],
-            constraints=[c for c in constraints if isinstance(c, DiscreteConstraint)],
+            parameters=[p for p in parameters if p.is_discrete],  # type:ignore[misc]
+            constraints=[c for c in constraints if c.is_discrete],  # type:ignore[misc]
             empty_encoding=empty_encoding,
         )
         continuous: SubspaceContinuous = SubspaceContinuous(
-            parameters=[p for p in parameters if isinstance(p, ContinuousParameter)],
-            constraints_lin_eq=[
+            parameters=[p for p in parameters if p.is_continuous],  # type:ignore[misc]
+            constraints_lin_eq=[  # type:ignore[misc]
                 c
                 for c in constraints
                 if isinstance(c, ContinuousLinearEqualityConstraint)
             ],
-            constraints_lin_ineq=[
+            constraints_lin_ineq=[  # type:ignore[misc]
                 c
                 for c in constraints
                 if isinstance(c, ContinuousLinearInequalityConstraint)
@@ -187,15 +187,17 @@ class SearchSpace(SerialMixin):
                 "parameter names."
             )
 
-        disc_params = [p for p in parameters if isinstance(p, DiscreteParameter)]
-        cont_params = [p for p in parameters if isinstance(p, ContinuousParameter)]
+        disc_params = [p for p in parameters if p.is_discrete]
+        cont_params = [p for p in parameters if p.is_continuous]
 
         return SearchSpace(
             discrete=SubspaceDiscrete.from_dataframe(
-                df[[p.name for p in disc_params]], disc_params
+                df[[p.name for p in disc_params]],
+                disc_params,  # type:ignore[arg-type]
             ),
             continuous=SubspaceContinuous.from_dataframe(
-                df[[p.name for p in cont_params]], cont_params
+                df[[p.name for p in cont_params]],
+                cont_params,  # type:ignore[arg-type]
             ),
         )
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from enum import Enum
 from typing import Optional, cast
 
@@ -23,6 +23,7 @@ from baybe.parameters import (
 from baybe.parameters.base import Parameter
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
+    MemorySize,
     SubspaceDiscrete,
     validate_simplex_subspace_from_config,
 )
@@ -282,6 +283,22 @@ class SearchSpace(SerialMixin):
         # When there are no task parameters, we effectively have a single task
         except StopIteration:
             return 1
+
+    @staticmethod
+    def estimate_product_space_size(parameters: Iterable[Parameter]) -> MemorySize:
+        """Estimate an upper bound for the memory size of a product space.
+
+        Continuous parameters are ignored because creating a continuous subspace has
+        no considerable memory footprint.
+
+        Args:
+            parameters: The parameters spanning the product space.
+
+        Returns:
+            The estimated memory size.
+        """
+        discrete_parameters = [p for p in parameters if p.is_discrete]
+        return SubspaceDiscrete.estimate_product_space_size(discrete_parameters)
 
     def transform(
         self,

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -337,7 +337,7 @@ class SubspaceDiscrete(SerialMixin):
                 f"All parameters passed via 'simplex_parameters' "
                 f"must be of type '{NumericalDiscreteParameter.__name__}'."
             )
-        if not all(isinstance(p, DiscreteParameter) for p in product_parameters):
+        if not all(p.is_discrete for p in product_parameters):
             raise ValueError(
                 f"All parameters passed via 'product_parameters' "
                 f"must be of subclasses of '{DiscreteParameter.__name__}'."
@@ -618,12 +618,12 @@ def parameter_cartesian_prod_to_df(
     Returns:
         A dataframe containing all possible discrete parameter value combinations.
     """
-    discrete_parameters = [p for p in parameters if isinstance(p, DiscreteParameter)]
+    discrete_parameters = [p for p in parameters if p.is_discrete]
     if not discrete_parameters:
         return pd.DataFrame()
 
     index = pd.MultiIndex.from_product(
-        [p.values for p in discrete_parameters],
+        [p.values for p in discrete_parameters],  # type:ignore[attr-defined]
         names=[p.name for p in discrete_parameters],
     )
     ret = pd.DataFrame(index=index).reset_index()

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -521,7 +521,7 @@ class SubspaceDiscrete(SerialMixin):
 
     @staticmethod
     def estimate_product_space_size(
-        parameters: Iterable[DiscreteParameter]
+        parameters: Sequence[DiscreteParameter]
     ) -> MemorySize:
         """Estimate an upper bound for the memory size of a product space.
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -557,10 +557,10 @@ class SubspaceDiscrete(SerialMixin):
         exp_rep_size, exp_rep_unit = bytes_to_human_readable(exp_rep_bytes)
 
         return MemorySize(
-            exp_rep_memory=exp_rep_size,
+            exp_rep_memory=np.round(exp_rep_size, 2),
             exp_rep_unit=exp_rep_unit,
             exp_rep_shape=(n_rows, n_cols_exp),
-            comp_rep_memory=comp_rep_size,
+            comp_rep_memory=np.round(comp_rep_size, 2),
             comp_rep_unit=comp_rep_unit,
             comp_rep_shape=(n_rows, n_cols_comp),
         )

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -35,21 +35,27 @@ from baybe.utils.numerical import DTypeFloatNumpy
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
 
 
-# @dataclass(kw_only=True)
-# class MemorySize:
-#     # A dictionary with the searchspace estimation results and units:
-#     # - `Comp_Rep_Size`: Size of the computational representation.
-#     # - `Comp_Rep_Unit`: The unit of Comp_Rep_Size.
-#     # - `Comp_Rep_Shape`: Tuple expressing the shape as (n_rows, n_cols).
-#     # - `Exp_Rep_Size`: Size of the experimental representation.
-#     # - `Exp_Rep_Unit`: The unit of Exp_Rep_Size.
-#     # - `Exp_Rep_Shape`: Tuple expressing the shape as (n_rows, n_cols).
-#     comp_rep_size: float
-#     comp_rep_unit: str
-#     comp_rep_shape: tuple[int, int]
-#     exp_rep_size: float
-#     exp_rep_unit: str
-#     exp_rep_shape: tuple[int, int]
+@define(kw_only=True)
+class MemorySize:
+    """Estimated memory size of a :class:`SubspaceDiscrete`."""
+
+    exp_rep_memory: float
+    """The memory size of the experimental representation dataframe."""
+
+    exp_rep_unit: str
+    """The unit ``exp_rep_size``."""
+
+    exp_rep_shape: tuple[int, int]
+    """The shape of the experimental representation dataframe."""
+
+    comp_rep_memory: float
+    """The memory size of the computational representation dataframe."""
+
+    comp_rep_unit: str
+    """The unit ``comp_rep_size``."""
+
+    comp_rep_shape: tuple[int, int]
+    """The shape of the computational representation dataframe."""
 
 
 @define
@@ -514,7 +520,9 @@ class SubspaceDiscrete(SerialMixin):
         return bounds
 
     @staticmethod
-    def estimate_product_space_size(parameters: Iterable[DiscreteParameter]) -> dict:
+    def estimate_product_space_size(
+        parameters: Iterable[DiscreteParameter]
+    ) -> MemorySize:
         """Estimate an upper bound for the memory size of a product space.
 
         Args:
@@ -548,14 +556,14 @@ class SubspaceDiscrete(SerialMixin):
         )
         exp_rep_size, exp_rep_unit = bytes_to_human_readable(exp_rep_bytes)
 
-        return {
-            "Comp_Rep_Size": comp_rep_size,
-            "Comp_Rep_Unit": comp_rep_unit,
-            "Comp_Rep_Shape": (n_rows, n_cols_comp),
-            "Exp_Rep_Size": exp_rep_size,
-            "Exp_Rep_Unit": exp_rep_unit,
-            "Exp_Rep_Shape": (n_rows, n_cols_exp),
-        }
+        return MemorySize(
+            exp_rep_memory=exp_rep_size,
+            exp_rep_unit=exp_rep_unit,
+            exp_rep_shape=(n_rows, n_cols_exp),
+            comp_rep_memory=comp_rep_size,
+            comp_rep_unit=comp_rep_unit,
+            comp_rep_shape=(n_rows, n_cols_comp),
+        )
 
     def mark_as_measured(
         self,

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -15,7 +15,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.targets.enum import TargetMode
 from baybe.utils.numerical import DTypeFloatNumpy
 
@@ -250,7 +249,7 @@ def add_parameter_noise(
             data[param.name] += np.random.uniform(-noise_level, noise_level, len(data))
 
         # Respect continuous intervals
-        if isinstance(param, ContinuousParameter):
+        if param.is_continuous:
             data[param.name] = data[param.name].clip(
                 param.bounds.lower, param.bounds.upper
             )
@@ -406,11 +405,7 @@ def fuzzy_row_match(
 
         # Differentiate category-like and discrete numerical parameters
         cat_cols = [p.name for p in parameters if not p.is_numeric]
-        num_cols = [
-            p.name
-            for p in parameters
-            if (p.is_numeric and isinstance(p, DiscreteParameter))
-        ]
+        num_cols = [p.name for p in parameters if (p.is_numeric and p.is_discrete)]
 
         # Discrete parameters must match exactly
         match = left_df[cat_cols].eq(row[cat_cols]).all(axis=1, skipna=False)

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -7,20 +7,20 @@ from baybe.parameters.base import DiscreteParameter, Parameter
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-def bytes_to_human_readable(num: float) -> tuple[str, str]:
+def bytes_to_human_readable(num: float) -> tuple[float, str]:
     """Turn float number representing memory byte size into a human-readable format.
 
     Args:
         num: The number representing a memory size in bytes.
 
     Returns:
-        Tuple with the converted number string and its determined human-readable unit.
+        Tuple with the converted number and its determined human-readable unit.
     """
     for unit in ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
         if abs(num) < 1024.0:
-            return f"{num:3.1f}", unit
+            return num, unit
         num /= 1024.0
-    return f"{num:.1f}", "YB"
+    return num, "YB"
 
 
 def estimate_searchspace_size(parameters: list[Parameter]) -> dict:

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -1,4 +1,6 @@
 """Utilities for memory usage."""
+
+from collections.abc import Iterable
 from typing import cast
 
 import numpy as np
@@ -24,7 +26,7 @@ def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
     return num, "YB"
 
 
-def estimate_searchspace_size(parameters: list[Parameter]) -> dict:
+def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
     """Estimate upper bound for the search space size in memory.
 
     For now, constraints are not considered.

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -1,13 +1,5 @@
 """Utilities for memory usage."""
 
-from collections.abc import Iterable
-
-import numpy as np
-import pandas as pd
-
-from baybe.parameters.base import DiscreteParameter
-from baybe.utils.numerical import DTypeFloatNumpy
-
 
 def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
     """Turn a float number representing a memory byte size into a human-readable format.
@@ -23,57 +15,3 @@ def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
             return num, unit
         num /= 1024.0
     return num, "YB"
-
-
-def estimate_discrete_subspace_size(parameters: Iterable[DiscreteParameter]) -> dict:
-    """Estimate an upper bound for the search space memory size (ignoring constraints).
-
-    Args:
-        parameters: The parameters spanning the search space.
-
-    Returns:
-        A dictionary with the searchspace estimation results and units:
-            - `Comp_Rep_Size`: Size of the computational representation.
-            - `Comp_Rep_Unit`: The unit of Comp_Rep_Size.
-            - `Comp_Rep_Shape`: Tuple expressing the shape as (n_rows, n_cols).
-            - `Exp_Rep_Size`: Size of the experimental representation.
-            - `Exp_Rep_Unit`: The unit of Exp_Rep_Size.
-            - `Exp_Rep_Shape`: Tuple expressing the shape as (n_rows, n_cols).
-    """
-    # Comp rep space is estimated as the size of float times the number of matrix
-    # elements in the comp rep. The latter is the total number of value combinations
-    # times the total number of columns.
-    n_combinations = 1
-    n_comp_columns = 0
-    for param in parameters:
-        n_combinations *= param.comp_df.shape[0]
-        n_comp_columns += param.comp_df.shape[1]
-
-    comp_rep_size, comp_rep_unit = bytes_to_human_readable(
-        np.array([0.0], dtype=DTypeFloatNumpy).itemsize
-        * n_combinations
-        * n_comp_columns
-    )
-
-    # Exp rep space is estimated as the size of the exp rep dataframe times the number
-    # of times it will appear in the entire search space. The latter is the total number
-    # of value combination divided by the number of values for the respective parameter.
-    # Contributions of all parameters are summed up.
-    exp_rep_bytes = 0
-    for param in parameters:
-        exp_rep_bytes += (
-            pd.DataFrame(param.values).memory_usage(index=False, deep=True).sum()
-            * n_combinations
-            / param.comp_df.shape[0]
-        )
-
-    exp_rep_size, exp_rep_unit = bytes_to_human_readable(exp_rep_bytes)
-
-    return {
-        "Comp_Rep_Size": comp_rep_size,
-        "Comp_Rep_Unit": comp_rep_unit,
-        "Comp_Rep_Shape": (n_combinations, n_comp_columns),
-        "Exp_Rep_Size": exp_rep_size,
-        "Exp_Rep_Unit": exp_rep_unit,
-        "Exp_Rep_Shape": (n_combinations, len(parameters)),
-    }

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -11,13 +11,13 @@ from baybe.utils.numerical import DTypeFloatNumpy
 
 
 def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
-    """Turn float number representing memory byte size into a human-readable format.
+    """Turn a float number representing a memory byte size into a human-readable format.
 
     Args:
         num: The number representing a memory size in bytes.
 
     Returns:
-        Tuple with the converted number and its determined human-readable unit.
+        A tuple with the converted number and its determined human-readable unit.
     """
     for unit in ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
         if abs(num) < 1024.0:
@@ -27,15 +27,13 @@ def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
 
 
 def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
-    """Estimate upper bound for the search space size in memory.
-
-    For now, constraints are not considered.
+    """Estimate an upper bound for the search space memory size (ignoring constraints).
 
     Args:
-        parameters: List of parameters.
+        parameters: The parameters spanning the search space.
 
     Returns:
-        Dictionary with the searchspace estimation results and units:
+        A dictionary with the searchspace estimation results and units:
             - `Comp_Rep_Size`: Size of the computational representation.
             - `Comp_Rep_Unit`: The unit of Comp_Rep_Size.
             - `Comp_Rep_Shape`: Tuple expressing the shape as (n_rows, n_cols).
@@ -45,7 +43,7 @@ def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
     """
     # Comp rep space is estimated as the size of float times the number of matrix
     # elements in the comp rep. The latter is the total number of value combinations
-    # times the number of total columns.
+    # times the total number of columns.
     n_combinations = 1
     n_comp_columns = 0
     for param in [p for p in parameters if p.is_discrete]:
@@ -59,12 +57,12 @@ def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
         * n_comp_columns
     )
 
-    # The exp rep is estimated as the size of the exp rep dataframe times the number of
-    # times it will appear in the entire search space. The latter is the total number
+    # Exp rep space is estimated as the size of the exp rep dataframe times the number
+    # of times it will appear in the entire search space. The latter is the total number
     # of value combination divided by the number of values for the respective parameter.
     # Contributions of all parameters are summed up.
     exp_rep_bytes = 0
-    for k, param in enumerate([p for p in parameters if p.is_discrete]):
+    for _, param in enumerate([p for p in parameters if p.is_discrete]):
         param = cast(DiscreteParameter, param)
         exp_rep_bytes += (
             pd.DataFrame(param.values).memory_usage(index=False, deep=True).sum()

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -26,7 +26,7 @@ def bytes_to_human_readable(num: float) -> tuple[str, str]:
 def estimate_searchspace_size(parameters: list[Parameter]) -> dict:
     """Estimate upper bound for the search space size in memory.
 
-    For now, constraints are not considered. Since the size of
+    For now, constraints are not considered.
 
     Args:
         parameters: List of parameters.

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -8,7 +8,7 @@ from baybe.parameters.base import DiscreteParameter, Parameter
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-def bytes_to_human_readable(num: float) -> tuple[float, str]:
+def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
     """Turn float number representing memory byte size into a human-readable format.
 
     Args:

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -1,12 +1,11 @@
 """Utilities for memory usage."""
 
 from collections.abc import Iterable
-from typing import cast
 
 import numpy as np
 import pandas as pd
 
-from baybe.parameters.base import DiscreteParameter, Parameter
+from baybe.parameters.base import DiscreteParameter
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
@@ -26,7 +25,7 @@ def bytes_to_human_readable(num: float, /) -> tuple[float, str]:
     return num, "YB"
 
 
-def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
+def estimate_discrete_subspace_size(parameters: Iterable[DiscreteParameter]) -> dict:
     """Estimate an upper bound for the search space memory size (ignoring constraints).
 
     Args:
@@ -46,8 +45,7 @@ def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
     # times the total number of columns.
     n_combinations = 1
     n_comp_columns = 0
-    for param in [p for p in parameters if p.is_discrete]:
-        param = cast(DiscreteParameter, param)
+    for param in parameters:
         n_combinations *= param.comp_df.shape[0]
         n_comp_columns += param.comp_df.shape[1]
 
@@ -62,8 +60,7 @@ def estimate_searchspace_size(parameters: Iterable[Parameter]) -> dict:
     # of value combination divided by the number of values for the respective parameter.
     # Contributions of all parameters are summed up.
     exp_rep_bytes = 0
-    for _, param in enumerate([p for p in parameters if p.is_discrete]):
-        param = cast(DiscreteParameter, param)
+    for param in parameters:
         exp_rep_bytes += (
             pd.DataFrame(param.values).memory_usage(index=False, deep=True).sum()
             * n_combinations

--- a/baybe/utils/memory.py
+++ b/baybe/utils/memory.py
@@ -1,0 +1,62 @@
+"""Utilities for memory usage."""
+from typing import cast
+
+from baybe.parameters.base import DiscreteParameter, Parameter
+from baybe.utils.numerical import DTypeFloatNumpy
+
+
+def bytes_to_human_readable(num: float) -> tuple[str, str]:
+    """Turn float number representing memory byte size into a human-readable format.
+
+    Args:
+        num: The number representing a memory size in bytes.
+
+    Returns:
+        Tuple with the converted number string and its determined human-readable unit.
+    """
+    for unit in ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB"]:
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}", unit
+        num /= 1024.0
+    return f"{num:.1f}", "YB"
+
+
+def estimate_searchspace_size(parameters: list[Parameter]) -> dict:
+    """Estimate upper bound for the search space size in memory.
+
+    For now, constraints are not considered. Since the size of
+
+    Args:
+        parameters: List of parameters.
+
+    Returns:
+        Dictionary with the results for exp_rep and comp_rep and unit indicator.
+    """
+    values = 1
+    columns = 0
+    for param in [p for p in parameters if p.is_discrete]:
+        param = cast(DiscreteParameter, param)
+        values *= param.comp_df.shape[0]
+        columns += param.comp_df.shape[1]
+
+    exp_rep_bytes = 0
+    for k, param in enumerate([p for p in parameters if p.is_discrete]):
+        param = cast(DiscreteParameter, param)
+        exp_rep_bytes += (
+            param.comp_df.memory_usage(index=True if k == 0 else False, deep=True).sum()
+            * values
+            / param.comp_df.shape[0]
+        )
+
+    comp_rep_size, comp_rep_unit = bytes_to_human_readable(
+        DTypeFloatNumpy(0).itemsize * values * columns
+    )
+
+    exp_rep_size, exp_rep_unit = bytes_to_human_readable(exp_rep_bytes)
+
+    return {
+        "Comp_Rep_Size": comp_rep_size,
+        "Comp_Rep_Unit": comp_rep_unit,
+        "Exp_Rep_Size": exp_rep_size,
+        "Exp_Rep_Unit": exp_rep_unit,
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from pytest import param
 
+from baybe.searchspace.core import SearchSpace
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import closest_element
 
@@ -30,15 +31,15 @@ def test_closest_element(as_ndarray, array):
     assert actual == _CLOSEST, (actual, _CLOSEST)
 
 
-def test_searchspace_memory_estimate(searchspace):
+def test_searchspace_memory_estimate(searchspace: SearchSpace):
     """The memory estimate doesn't differ by more than 5% from the actual memory."""
     estimate = searchspace.discrete.estimate_product_space_size(
         searchspace.discrete.parameters
     )
-    estimate_exp = estimate["Exp_Rep_Size"]
-    estimate_comp = estimate["Comp_Rep_Size"]
-    estimate_exp_unit = estimate["Exp_Rep_Unit"]
-    estimate_comp_unit = estimate["Comp_Rep_Unit"]
+    estimate_exp = estimate.exp_rep_memory
+    estimate_comp = estimate.comp_rep_memory
+    estimate_exp_unit = estimate.exp_rep_unit
+    estimate_comp_unit = estimate.comp_rep_unit
 
     actual_exp, actual_exp_unit = bytes_to_human_readable(
         searchspace.discrete.exp_rep.memory_usage(deep=True, index=False).sum()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,9 +33,7 @@ def test_closest_element(as_ndarray, array):
 
 def test_searchspace_memory_estimate(searchspace: SearchSpace):
     """The memory estimate doesn't differ by more than 5% from the actual memory."""
-    estimate = searchspace.discrete.estimate_product_space_size(
-        searchspace.discrete.parameters
-    )
+    estimate = searchspace.estimate_product_space_size(searchspace.parameters)
     estimate_exp = estimate.exp_rep_memory
     estimate_comp = estimate.comp_rep_memory
     estimate_exp_unit = estimate.exp_rep_unit

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest import param
 
-from baybe.utils.memory import bytes_to_human_readable, estimate_searchspace_size
+from baybe.utils.memory import bytes_to_human_readable, estimate_discrete_subspace_size
 from baybe.utils.numerical import closest_element
 
 _TARGET = 1337
@@ -32,7 +32,7 @@ def test_closest_element(as_ndarray, array):
 
 def test_searchspace_memory_estimate(searchspace):
     """The memory estimate doesn't differ by more than 5% from the actual memory."""
-    estimate = estimate_searchspace_size(searchspace.parameters)
+    estimate = estimate_discrete_subspace_size(searchspace.discrete.parameters)
     estimate_exp = estimate["Exp_Rep_Size"]
     estimate_comp = estimate["Comp_Rep_Size"]
     estimate_exp_unit = estimate["Exp_Rep_Unit"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from pytest import param
 
+from baybe.utils.memory import bytes_to_human_readable, estimate_searchspace_size
 from baybe.utils.numerical import closest_element
 
 _TARGET = 1337
@@ -27,3 +28,30 @@ def test_closest_element(as_ndarray, array):
         array = np.asarray(array)
     actual = closest_element(array, _TARGET)
     assert actual == _CLOSEST, (actual, _CLOSEST)
+
+
+def test_searchspace_memory_estimate(searchspace):
+    """The memory estimate doesn't differ by more than 5% from the actual memory."""
+    estimate = estimate_searchspace_size(searchspace.parameters)
+    estimate_exp = estimate["Exp_Rep_Size"]
+    estimate_comp = estimate["Comp_Rep_Size"]
+    estimate_exp_unit = estimate["Exp_Rep_Unit"]
+    estimate_comp_unit = estimate["Comp_Rep_Unit"]
+
+    actual_exp, actual_exp_unit = bytes_to_human_readable(
+        searchspace.discrete.exp_rep.memory_usage(deep=True, index=False).sum()
+    )
+    actual_comp, actual_comp_unit = bytes_to_human_readable(
+        searchspace.discrete.comp_rep.memory_usage(deep=True, index=False).sum()
+    )
+
+    assert estimate_exp_unit == actual_exp_unit, "Exp units differ!"
+    assert estimate_comp_unit == actual_comp_unit, "Comp units differ!"
+    assert 0.95 <= float(estimate_exp) / float(actual_exp) <= 1.05, (
+        estimate_exp,
+        actual_exp,
+    )
+    assert 0.95 <= float(estimate_comp) / float(actual_comp) <= 1.05, (
+        estimate_comp,
+        actual_comp,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,13 +45,13 @@ def test_searchspace_memory_estimate(searchspace):
         searchspace.discrete.comp_rep.memory_usage(deep=True, index=False).sum()
     )
 
-    assert estimate_exp_unit == actual_exp_unit, "Exp units differ!"
-    assert estimate_comp_unit == actual_comp_unit, "Comp units differ!"
-    assert 0.95 <= float(estimate_exp) / float(actual_exp) <= 1.05, (
-        estimate_exp,
-        actual_exp,
-    )
-    assert 0.95 <= float(estimate_comp) / float(actual_comp) <= 1.05, (
-        estimate_comp,
-        actual_comp,
-    )
+    # These tests could fail in the unlikely case where the size is close to a
+    # transition from one unit to the other
+    assert (
+        estimate_exp_unit == actual_exp_unit
+    ), f"Exp units differ: {estimate_exp_unit}, {actual_exp_unit}"
+    assert (
+        estimate_comp_unit == actual_comp_unit
+    ), f"Comp units differ: {estimate_comp_unit}, {actual_comp_unit}"
+    assert 0.95 <= estimate_exp / actual_exp <= 1.05, (estimate_exp, actual_exp)
+    assert 0.95 <= estimate_comp / actual_comp <= 1.05, (estimate_comp, actual_comp)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pytest import param
 
-from baybe.utils.memory import bytes_to_human_readable, estimate_discrete_subspace_size
+from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import closest_element
 
 _TARGET = 1337
@@ -32,7 +32,9 @@ def test_closest_element(as_ndarray, array):
 
 def test_searchspace_memory_estimate(searchspace):
     """The memory estimate doesn't differ by more than 5% from the actual memory."""
-    estimate = estimate_discrete_subspace_size(searchspace.discrete.parameters)
+    estimate = searchspace.discrete.estimate_product_space_size(
+        searchspace.discrete.parameters
+    )
     estimate_exp = estimate["Exp_Rep_Size"]
     estimate_comp = estimate["Comp_Rep_Size"]
     estimate_exp_unit = estimate["Exp_Rep_Unit"]


### PR DESCRIPTION
Closes #223 

Added
- utility to convert a float number indicating the byte size of an object into a human readable format with unit
- utility to estimate upper bound for discrete `exp_rep` and `comp_rep` of the searchspace based on a list of parameters
- `is_discrete` and `is_continuous` properties for the Parameter base class indicating whether they are conti or discrete (similar to already existing props for constraints)

Test
- used the searchspace from full_lookup in three size variants (by adding values to the temperature parameter)
<img width="816" alt="image" src="https://github.com/emdgroup/baybe/assets/17951239/7d3164d5-d1df-4180-bc38-26ba5024aaa2">
