### PR TITLE
Fix telemetry execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structuring concrete subclasses no longer requires providing an explicit `type` field
 - `_target(s)` attributes of `Objectives` are now de-/serialized without leading
   underscore to support user-friendly serialization strings
+- Telemetry does not execute any code if it was disabled
 
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with

--- a/baybe/telemetry.py
+++ b/baybe/telemetry.py
@@ -106,19 +106,6 @@ DEFAULT_TELEMETRY_ENDPOINT = (
 DEFAULT_TELEMETRY_VPN_CHECK = "true"
 DEFAULT_TELEMETRY_VPN_CHECK_TIMEOUT = "0.5"
 
-try:
-    DEFAULT_TELEMETRY_USERNAME = (
-        hashlib.sha256(getpass.getuser().upper().encode()).hexdigest().upper()[:10]
-    )  # this hash is irreversible and cannot identify the user or their machine
-except ModuleNotFoundError:
-    # getpass.getuser() does not work on Windows if all the environment variables
-    # it checks are empty. Since then there is no way of inferring the username, we
-    # use UNKNOWN as fallback.
-    DEFAULT_TELEMETRY_USERNAME = "UNKNOWN"
-
-DEFAULT_TELEMETRY_HOSTNAME = (
-    hashlib.sha256(socket.gethostname().encode()).hexdigest().upper()[:10]
-)  # this hash is irreversible and cannot identify the user or their machine
 
 # Telemetry labels for metrics
 TELEM_LABELS = {
@@ -165,6 +152,21 @@ def is_enabled() -> bool:
 
 # Attempt telemetry initialization
 if is_enabled():
+    # Assign default user and machine name
+    try:
+        DEFAULT_TELEMETRY_USERNAME = (
+            hashlib.sha256(getpass.getuser().upper().encode()).hexdigest().upper()[:10]
+        )  # this hash is irreversible and cannot identify the user or their machine
+    except ModuleNotFoundError:
+        # getpass.getuser() does not work on Windows if all the environment variables
+        # it checks are empty. Since then there is no way of inferring the username, we
+        # use UNKNOWN as fallback.
+        DEFAULT_TELEMETRY_USERNAME = "UNKNOWN"
+
+    DEFAULT_TELEMETRY_HOSTNAME = (
+        hashlib.sha256(socket.gethostname().encode()).hexdigest().upper()[:10]
+    )  # this hash is irreversible and cannot identify the user or their machine
+
     _endpoint_url = os.environ.get(
         VARNAME_TELEMETRY_ENDPOINT, DEFAULT_TELEMETRY_ENDPOINT
     )
@@ -231,6 +233,9 @@ if is_enabled():
                 UserWarning,
             )
         os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
+else:
+    DEFAULT_TELEMETRY_USERNAME = "UNKNOWN"
+    DEFAULT_TELEMETRY_HOSTNAME = "UNKNOWN"
 
 
 def get_user_details() -> dict[str, str]:

--- a/tests/simulate_telemetry.py
+++ b/tests/simulate_telemetry.py
@@ -78,7 +78,6 @@ config = {
         ),
         initial_recommender=RandomRecommender(),
     ),
-    "numerical_measurements_must_be_within_tolerance": True,
 }
 
 # Actual User


### PR DESCRIPTION
This fixes #233 in that iT moves some code parts that have been executed even if telemetry was disabled (and thus could fail).

It doesn't touch the suggested replacement of `requests` because a confirmation with the UPTIMIZE Sagemaker kernels would be required, which in itself requires an update of the Sagemaker<->baybe connection due to the Python 3.8 deprecation