### PR TITLE
Avoid altering RNG states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_target(s)` attributes of `Objectives` are now de-/serialized without leading
   underscore to support user-friendly serialization strings
 - Telemetry does not execute any code if it was disabled
+- Running simulations no longer alters the states of the global random number generators
 
 ### Deprecations
 - The former `baybe.objective.Objective` class has been replaced with

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -15,9 +15,9 @@ from baybe.campaign import Campaign
 from baybe.exceptions import NotEnoughPointsLeftError, NothingToSimulateError
 from baybe.simulation.lookup import _look_up_target_values
 from baybe.targets.enum import TargetMode
-from baybe.utils.basic import temporary_seed
 from baybe.utils.dataframe import add_parameter_noise
 from baybe.utils.numerical import closer_element, closest_element
+from baybe.utils.random import temporary_seed
 
 
 def simulate_experiment(  # noqa: DOC502

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -20,7 +20,7 @@ from baybe.utils.numerical import closer_element, closest_element
 from baybe.utils.random import temporary_seed
 
 
-def simulate_experiment(  # noqa: DOC502
+def simulate_experiment(
     campaign: Campaign,
     lookup: Optional[Union[pd.DataFrame, Callable]] = None,
     /,

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from contextlib import nullcontext
 from copy import deepcopy
 from functools import partial
 from typing import Callable, Literal, Optional, Union
@@ -18,8 +19,6 @@ from baybe.utils.basic import temporary_seed
 from baybe.utils.dataframe import add_parameter_noise
 from baybe.utils.numerical import closer_element, closest_element
 
-_DEFAULT_SEED = 1337
-
 
 def simulate_experiment(  # noqa: DOC502
     campaign: Campaign,
@@ -29,7 +28,7 @@ def simulate_experiment(  # noqa: DOC502
     batch_size: int = 1,
     n_doe_iterations: Optional[int] = None,
     initial_data: Optional[pd.DataFrame] = None,
-    random_seed: int = _DEFAULT_SEED,
+    random_seed: Optional[int] = None,
     impute_mode: Literal[
         "error", "worst", "best", "mean", "random", "ignore"
     ] = "error",
@@ -57,7 +56,7 @@ def simulate_experiment(  # noqa: DOC502
             testable configurations left.
         initial_data: The initial measurement data to be ingested before starting the
             loop.
-        random_seed: The random seed used for the simulation.
+        random_seed: An optional random seed to be used for the simulation.
         impute_mode: Specifies how a missing lookup will be handled.
             There are six different options available.
 
@@ -97,7 +96,8 @@ def simulate_experiment(  # noqa: DOC502
     # TODO: Due to the "..." operator, sphinx does not render this properly. Might
     #   want to investigate in the future.
 
-    with temporary_seed(random_seed):
+    context = temporary_seed(random_seed) if random_seed is not None else nullcontext()
+    with context:
         return _simulate_experiment_given_seed(
             campaign,
             lookup,

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -22,7 +22,9 @@ except ImportError as ex:
 
 from baybe.campaign import Campaign
 from baybe.exceptions import NothingToSimulateError
-from baybe.simulation.core import _DEFAULT_SEED, simulate_experiment
+from baybe.simulation.core import simulate_experiment
+
+_DEFAULT_SEED = 1337
 
 
 def simulate_scenarios(

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -1,13 +1,9 @@
 """Collection of small basic utilities."""
 
-import contextlib
-import random
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass
 from inspect import signature
 from typing import Any, Callable, TypeVar
-
-import numpy as np
 
 from baybe.exceptions import UnidentifiedSubclassError
 
@@ -84,47 +80,6 @@ def get_baseclasses(
                 classes.extend(get_baseclasses(baseclass, abstract=abstract))
 
     return classes
-
-
-def set_random_seed(seed: int):
-    """Set the global random seed.
-
-    Args:
-        seed: The chosen global random seed.
-    """
-    import torch
-
-    torch.manual_seed(seed)
-    random.seed(seed)
-    np.random.seed(seed)
-
-
-@contextlib.contextmanager
-def temporary_seed(seed: int):  # noqa: DOC402, DOC404
-    """Context manager for setting a temporary random seed.
-
-    Args:
-        seed: The chosen random seed.
-    """
-    import torch
-
-    # Collect the current RNG states
-    state_builtin = random.getstate()
-    state_np = np.random.get_state()
-    state_torch = torch.get_rng_state()
-
-    # Set the requested seed
-    set_random_seed(seed)
-
-    # Run the context-specific code
-    try:
-        yield
-
-    # Restore the original RNG states
-    finally:
-        random.setstate(state_builtin)
-        np.random.set_state(state_np)
-        torch.set_rng_state(state_torch)
 
 
 def hilberts_factory(factory: Callable[..., _T]) -> Iterable[_T]:

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -1,5 +1,6 @@
 """Collection of small basic utilities."""
 
+import contextlib
 import random
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass
@@ -96,6 +97,34 @@ def set_random_seed(seed: int):
     torch.manual_seed(seed)
     random.seed(seed)
     np.random.seed(seed)
+
+
+@contextlib.contextmanager
+def temporary_seed(seed: int):  # noqa: DOC402, DOC404
+    """Context manager for setting a temporary random seed.
+
+    Args:
+        seed: The chosen random seed.
+    """
+    import torch
+
+    # Collect the current RNG states
+    state_builtin = random.getstate()
+    state_np = np.random.get_state()
+    state_torch = torch.get_rng_state()
+
+    # Set the requested seed
+    set_random_seed(seed)
+
+    # Run the context-specific code
+    try:
+        yield
+
+    # Restore the original RNG states
+    finally:
+        random.setstate(state_builtin)
+        np.random.set_state(state_np)
+        torch.set_rng_state(state_torch)
 
 
 def hilberts_factory(factory: Callable[..., _T]) -> Iterable[_T]:

--- a/baybe/utils/random.py
+++ b/baybe/utils/random.py
@@ -1,0 +1,47 @@
+"""Utilities targeting random number generation."""
+
+import contextlib
+import random
+
+import numpy as np
+
+
+def set_random_seed(seed: int):
+    """Set the global random seed.
+
+    Args:
+        seed: The chosen global random seed.
+    """
+    import torch
+
+    torch.manual_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+
+
+@contextlib.contextmanager
+def temporary_seed(seed: int):  # noqa: DOC402, DOC404
+    """Context manager for setting a temporary random seed.
+
+    Args:
+        seed: The chosen random seed.
+    """
+    import torch
+
+    # Collect the current RNG states
+    state_builtin = random.getstate()
+    state_np = np.random.get_state()
+    state_torch = torch.get_rng_state()
+
+    # Set the requested seed
+    set_random_seed(seed)
+
+    # Run the context-specific code
+    try:
+        yield
+
+    # Restore the original RNG states
+    finally:
+        random.setstate(state_builtin)
+        np.random.set_state(state_np)
+        torch.set_rng_state(state_torch)


### PR DESCRIPTION
This PR fixes #218 by adding a context manager that allows running simulations without altering the state of the global random number generators.