### PR TITLE
Add more kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mypy` for search space and objectives
 - Class hierarchy for objectives
 - Deserialization is now also possible from optional class name abbreviations
-- `Kernel`, `MaternKernel`, `AdditiveKernel`, `ProductKernel` and `ScaleKernel` 
-  classes for specifying kernels
+- `AdditiveKernel`, `LinearKernel`, `MaternKernel`, `PeriodicKernel`, 
+  `PiecewisePolynomialKernel`, `PolynomialKernel`, `ProductKernel`, `RBFKernel`, 
+  `RFFKernel`, `RQKernel`, `ScaleKernel` classes for specifying kernels
+- `GammaPrior`, `HalfCauchyPrior`, `NormalPrior`, `HalfNormalPrior`, `LogNormalPrior`
+  and `SmoothedBoxPrior` classes for specifying priors 
 - `KernelFactory` protocol enabling context-dependent construction of kernels
 - Preset mechanism for `GaussianProcessSurrogate`
 - `hypothesis` strategies and roundtrip test for kernels, constraints, objectives,
@@ -18,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New acquisition functions: `qSR`, `qNEI`, `LogEI`, `qLogEI`, `qLogNEI`
 - Serialization user guide
 - Basic deserialization tests using different class type specifiers
-- `GammaPrior`, `HalfCauchyPrior`, `NormalPrior`, `HalfNormalPrior`, `LogNormalPrior`
-  and `SmoothedBoxPrior` can now be chosen as lengthscale prior
 - Environment variables user guide
 - Utility for estimating memory requirements of discrete product search space
 

--- a/baybe/kernels/__init__.py
+++ b/baybe/kernels/__init__.py
@@ -5,7 +5,6 @@ arguments see https://docs.gpytorch.ai/en/stable/kernels.html.
 """
 
 from baybe.kernels.basic import (
-    CosineKernel,
     LinearKernel,
     MaternKernel,
     PeriodicKernel,
@@ -19,7 +18,6 @@ from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 
 __all__ = [
     "AdditiveKernel",
-    "CosineKernel",
     "LinearKernel",
     "MaternKernel",
     "PeriodicKernel",

--- a/baybe/kernels/__init__.py
+++ b/baybe/kernels/__init__.py
@@ -1,11 +1,29 @@
 """Kernels for Gaussian process surrogate models."""
 
-from baybe.kernels.basic import MaternKernel
+from baybe.kernels.basic import (
+    CosineKernel,
+    LinearKernel,
+    MaternKernel,
+    PeriodicKernel,
+    PiecewisePolynomialKernel,
+    PolynomialKernel,
+    RBFKernel,
+    RFFKernel,
+    RQKernel,
+)
 from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 
 __all__ = [
     "AdditiveKernel",
+    "CosineKernel",
+    "LinearKernel",
     "MaternKernel",
+    "PeriodicKernel",
+    "PiecewisePolynomialKernel",
+    "PolynomialKernel",
     "ProductKernel",
+    "RBFKernel",
+    "RFFKernel",
+    "RQKernel",
     "ScaleKernel",
 ]

--- a/baybe/kernels/__init__.py
+++ b/baybe/kernels/__init__.py
@@ -1,4 +1,8 @@
-"""Kernels for Gaussian process surrogate models."""
+"""Kernels for Gaussian process surrogate models.
+
+The kernel classes mimic classes from GPyTorch. For details on specification and
+arguments see https://docs.gpytorch.ai/en/stable/kernels.html.
+"""
 
 from baybe.kernels.basic import (
     CosineKernel,

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -14,34 +14,6 @@ from baybe.utils.validation import finite_float
 
 
 @define(frozen=True)
-class CosineKernel(Kernel):
-    """A cosine kernel."""
-
-    period_length_prior: Optional[Prior] = field(
-        default=None, validator=optional_v(instance_of(Prior))
-    )
-    """An optional prior on the kernel period length."""
-
-    period_length_initial_value: Optional[float] = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
-    )
-    """An optional initial value for the kernel period length."""
-
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
-        import torch
-
-        from baybe.utils.torch import DTypeFloatTorch
-
-        gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
-        if (initial_value := self.period_length_initial_value) is not None:
-            gpytorch_kernel.period_length = torch.tensor(
-                initial_value, dtype=DTypeFloatTorch
-            )
-        return gpytorch_kernel
-
-
-@define(frozen=True)
 class LinearKernel(Kernel):
     """A linear kernel."""
 

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -20,12 +20,12 @@ class CosineKernel(Kernel):
     period_length_prior: Optional[Prior] = field(
         default=None, validator=optional_v(instance_of(Prior))
     )
-    """An optional prior on the kernel periodic length."""
+    """An optional prior on the kernel period length."""
 
     period_length_initial_value: Optional[float] = field(
         default=None, converter=optional_c(float), validator=optional_v(finite_float)
     )
-    """An optional initial value for the kernel periodic length."""
+    """An optional initial value for the kernel period length."""
 
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         # See base class.
@@ -48,12 +48,12 @@ class LinearKernel(Kernel):
     variance_prior: Optional[Prior] = field(
         default=None, validator=optional_v(instance_of(Prior))
     )
-    """An optional prior on the variance parameter."""
+    """An optional prior on the kernel variance parameter."""
 
     variance_initial_value: Optional[float] = field(
         default=None, converter=optional_c(float), validator=optional_v(finite_float)
     )
-    """An optional initial value for the variance parameter."""
+    """An optional initial value for the kernel variance parameter."""
 
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         # See base class.
@@ -109,12 +109,12 @@ class PeriodicKernel(Kernel):
     period_length_prior: Optional[Prior] = field(
         default=None, validator=optional_v(instance_of(Prior))
     )
-    """An optional prior on the kernel periodic length."""
+    """An optional prior on the kernel period length."""
 
     period_length_initial_value: Optional[float] = field(
         default=None, converter=optional_c(float), validator=optional_v(finite_float)
     )
-    """An optional initial value for the kernel periodic length."""
+    """An optional initial value for the kernel period length."""
 
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         # See base class.
@@ -174,7 +174,6 @@ class PolynomialKernel(Kernel):
         from baybe.utils.torch import DTypeFloatTorch
 
         gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
-
         if (initial_value := self.offset_initial_value) is not None:
             gpytorch_kernel.offset = torch.tensor(initial_value, dtype=DTypeFloatTorch)
         return gpytorch_kernel

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from attrs import define, field
 from attrs.converters import optional as optional_c
-from attrs.validators import gt, in_, instance_of
+from attrs.validators import ge, in_, instance_of
 from attrs.validators import optional as optional_v
 
 from baybe.kernels.base import Kernel
@@ -136,7 +136,7 @@ class PeriodicKernel(Kernel):
 class PiecewisePolynomialKernel(Kernel):
     """A piecewise polynomial kernel."""
 
-    q: float = field(converter=int, validator=in_([0, 1, 2, 3]), default=2)
+    q: int = field(validator=in_([0, 1, 2, 3]), default=2)
     """A smoothness parameter."""
 
     lengthscale_prior: Optional[Prior] = field(
@@ -154,7 +154,7 @@ class PiecewisePolynomialKernel(Kernel):
 class PolynomialKernel(Kernel):
     """A polynomial kernel."""
 
-    power: int = field(converter=int)
+    power: int = field(validator=[instance_of(int), ge(0)])
     """The power of the polynomial term."""
 
     offset_prior: Optional[Prior] = field(
@@ -198,7 +198,7 @@ class RBFKernel(Kernel):
 class RFFKernel(Kernel):
     """A random Fourier features (RFF) kernel."""
 
-    num_samples: int = field(converter=int, validator=gt(0))
+    num_samples: int = field(validator=[instance_of(int), ge(1)])
     """The number of frequencies to draw."""
 
     lengthscale_prior: Optional[Prior] = field(

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -4,13 +4,69 @@ from typing import Optional
 
 from attrs import define, field
 from attrs.converters import optional as optional_c
-from attrs.validators import in_, instance_of
+from attrs.validators import gt, in_, instance_of
 from attrs.validators import optional as optional_v
 
 from baybe.kernels.base import Kernel
 from baybe.priors.base import Prior
 from baybe.utils.conversion import fraction_to_float
 from baybe.utils.validation import finite_float
+
+
+@define(frozen=True)
+class CosineKernel(Kernel):
+    """A cosine kernel."""
+
+    period_length_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel periodic length."""
+
+    period_length_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel periodic length."""
+
+    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+        # See base class.
+        import torch
+
+        from baybe.utils.torch import DTypeFloatTorch
+
+        gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
+        if (initial_value := self.period_length_initial_value) is not None:
+            gpytorch_kernel.period_length = torch.tensor(
+                initial_value, dtype=DTypeFloatTorch
+            )
+        return gpytorch_kernel
+
+
+@define(frozen=True)
+class LinearKernel(Kernel):
+    """A linear kernel."""
+
+    variance_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the variance parameter."""
+
+    variance_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the variance parameter."""
+
+    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+        # See base class.
+        import torch
+
+        from baybe.utils.torch import DTypeFloatTorch
+
+        gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
+        if (initial_value := self.variance_initial_value) is not None:
+            gpytorch_kernel.variance = torch.tensor(
+                initial_value, dtype=DTypeFloatTorch
+            )
+        return gpytorch_kernel
 
 
 @define(frozen=True)
@@ -24,6 +80,142 @@ class MaternKernel(Kernel):
 
     Only takes the values 0.5, 1.5 or 2.5. Larger values yield smoother interpolations.
     """
+
+    lengthscale_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel lengthscale."""
+
+    lengthscale_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel lengthscale."""
+
+
+@define(frozen=True)
+class PeriodicKernel(Kernel):
+    """A periodic kernel."""
+
+    lengthscale_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel lengthscale."""
+
+    lengthscale_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel lengthscale."""
+
+    period_length_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel periodic length."""
+
+    period_length_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel periodic length."""
+
+    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+        # See base class.
+        import torch
+
+        from baybe.utils.torch import DTypeFloatTorch
+
+        gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
+        # lengthscale is handled by the base class
+
+        if (initial_value := self.period_length_initial_value) is not None:
+            gpytorch_kernel.period_length = torch.tensor(
+                initial_value, dtype=DTypeFloatTorch
+            )
+        return gpytorch_kernel
+
+
+@define(frozen=True)
+class PiecewisePolynomialKernel(Kernel):
+    """A piecewise polynomial kernel."""
+
+    q: float = field(converter=int, validator=in_([0, 1, 2, 3]), default=2)
+    """A smoothness parameter."""
+
+    lengthscale_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel lengthscale."""
+
+    lengthscale_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel lengthscale."""
+
+
+@define(frozen=True)
+class PolynomialKernel(Kernel):
+    """A polynomial kernel."""
+
+    power: int = field(converter=int)
+    """The power of the polynomial term."""
+
+    offset_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel offset."""
+
+    offset_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel offset."""
+
+    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+        # See base class.
+        import torch
+
+        from baybe.utils.torch import DTypeFloatTorch
+
+        gpytorch_kernel = super().to_gpytorch(*args, **kwargs)
+
+        if (initial_value := self.offset_initial_value) is not None:
+            gpytorch_kernel.offset = torch.tensor(initial_value, dtype=DTypeFloatTorch)
+        return gpytorch_kernel
+
+
+@define(frozen=True)
+class RBFKernel(Kernel):
+    """A radial basis function (RBF) kernel."""
+
+    lengthscale_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel lengthscale."""
+
+    lengthscale_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel lengthscale."""
+
+
+@define(frozen=True)
+class RFFKernel(Kernel):
+    """A random Fourier features (RFF) kernel."""
+
+    num_samples: int = field(converter=int, validator=gt(0))
+    """The number of frequencies to draw."""
+
+    lengthscale_prior: Optional[Prior] = field(
+        default=None, validator=optional_v(instance_of(Prior))
+    )
+    """An optional prior on the kernel lengthscale."""
+
+    lengthscale_initial_value: Optional[float] = field(
+        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+    )
+    """An optional initial value for the kernel lengthscale."""
+
+
+@define(frozen=True)
+class RQKernel(Kernel):
+    """A rational quadratic (RQ) kernel."""
 
     lengthscale_prior: Optional[Prior] = field(
         default=None, validator=optional_v(instance_of(Prior))

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -1,5 +1,5 @@
 """Composite kernels (that is, kernels composed of other kernels)."""
-
+from functools import reduce
 from operator import add, mul
 from typing import Optional
 
@@ -56,7 +56,7 @@ class AdditiveKernel(Kernel):
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         # See base class.
 
-        return add(*(k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
+        return reduce(add, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
 
 @define(frozen=True)
@@ -71,4 +71,4 @@ class ProductKernel(Kernel):
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         # See base class.
 
-        return mul(*(k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
+        return reduce(mul, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))

--- a/baybe/priors/__init__.py
+++ b/baybe/priors/__init__.py
@@ -1,4 +1,8 @@
-"""Prior distributions."""
+"""Prior distributions.
+
+The prior classes mimic classes from GPyTorch. For details on specification and
+arguments see https://docs.gpytorch.ai/en/stable/priors.html.
+"""
 
 from baybe.priors.basic import (
     GammaPrior,

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -4,7 +4,17 @@ from enum import Enum
 
 import hypothesis.strategies as st
 
-from baybe.kernels.basic import MaternKernel
+from baybe.kernels.basic import (
+    CosineKernel,
+    LinearKernel,
+    MaternKernel,
+    PeriodicKernel,
+    PiecewisePolynomialKernel,
+    PolynomialKernel,
+    RBFKernel,
+    RFFKernel,
+    RQKernel,
+)
 from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 
 from ..hypothesis_strategies.basic import finite_floats
@@ -19,6 +29,20 @@ class KernelType(Enum):
     PRODUCT = "PRODUCT"
 
 
+cosine_kernels = st.builds(
+    CosineKernel,
+    period_length_prior=st.one_of(st.none(), priors),
+    period_length_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates Cosine kernels."""
+
+linear_kernels = st.builds(
+    LinearKernel,
+    variance_prior=st.one_of(st.none(), priors),
+    variance_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates linear kernels."""
+
 matern_kernels = st.builds(
     MaternKernel,
     nu=st.sampled_from((0.5, 1.5, 2.5)),
@@ -27,8 +51,66 @@ matern_kernels = st.builds(
 )
 """A strategy that generates Matern kernels."""
 
+periodic_kernels = st.builds(
+    PeriodicKernel,
+    lengthscale_prior=st.one_of(st.none(), priors),
+    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    period_length_prior=st.one_of(st.none(), priors),
+    period_length_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates periodic kernels."""
 
-base_kernels = st.one_of([matern_kernels])
+piecewise_polynomial_kernels = st.builds(
+    PiecewisePolynomialKernel,
+    q=st.integers(min_value=0, max_value=3),
+    lengthscale_prior=st.one_of(st.none(), priors),
+    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates piecewise polynomial kernels."""
+
+polynomial_kernels = st.builds(
+    PolynomialKernel,
+    power=st.integers(),
+    offset_prior=st.one_of(st.none(), priors),
+    offset_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates polynomial kernels."""
+
+rbf_kernels = st.builds(
+    RBFKernel,
+    lengthscale_prior=st.one_of(st.none(), priors),
+    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates radial basis function (RBF) kernels."""
+
+rff_kernels = st.builds(
+    RFFKernel,
+    num_samples=st.integers(min_value=1),
+    lengthscale_prior=st.one_of(st.none(), priors),
+    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates radial basis function (RBF) kernels."""
+
+rq_kernels = st.builds(
+    RQKernel,
+    lengthscale_prior=st.one_of(st.none(), priors),
+    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+)
+"""A strategy that generates rational quadratic (RQ) kernels."""
+
+base_kernels = st.one_of(
+    [
+        matern_kernels,  # on top because it is the default for many use cases
+        linear_kernels,
+        rbf_kernels,
+        rq_kernels,
+        cosine_kernels,
+        rff_kernels,
+        piecewise_polynomial_kernels,
+        polynomial_kernels,
+        periodic_kernels,
+    ]
+)
 """A strategy that generates base kernels to be used within more complex kernels."""
 
 

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -5,7 +5,6 @@ from enum import Enum
 import hypothesis.strategies as st
 
 from baybe.kernels.basic import (
-    CosineKernel,
     LinearKernel,
     MaternKernel,
     PeriodicKernel,
@@ -28,13 +27,6 @@ class KernelType(Enum):
     ADDITIVE = "ADDITIVE"
     PRODUCT = "PRODUCT"
 
-
-cosine_kernels = st.builds(
-    CosineKernel,
-    period_length_prior=st.one_of(st.none(), priors),
-    period_length_initial_value=st.one_of(st.none(), finite_floats()),
-)
-"""A strategy that generates cosine kernels."""
 
 linear_kernels = st.builds(
     LinearKernel,
@@ -104,7 +96,6 @@ base_kernels = st.one_of(
         linear_kernels,
         rbf_kernels,
         rq_kernels,
-        cosine_kernels,
         rff_kernels,
         piecewise_polynomial_kernels,
         polynomial_kernels,

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -34,7 +34,7 @@ cosine_kernels = st.builds(
     period_length_prior=st.one_of(st.none(), priors),
     period_length_initial_value=st.one_of(st.none(), finite_floats()),
 )
-"""A strategy that generates Cosine kernels."""
+"""A strategy that generates cosine kernels."""
 
 linear_kernels = st.builds(
     LinearKernel,
@@ -89,7 +89,7 @@ rff_kernels = st.builds(
     lengthscale_prior=st.one_of(st.none(), priors),
     lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
 )
-"""A strategy that generates radial basis function (RBF) kernels."""
+"""A strategy that generates random Fourier features (RFF) kernels."""
 
 rq_kernels = st.builds(
     RQKernel,

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -70,7 +70,7 @@ piecewise_polynomial_kernels = st.builds(
 
 polynomial_kernels = st.builds(
     PolynomialKernel,
-    power=st.integers(),
+    power=st.integers(min_value=0),
     offset_prior=st.one_of(st.none(), priors),
     offset_initial_value=st.one_of(st.none(), finite_floats()),
 )

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -205,15 +205,6 @@ def test_iter_nonmc_acquisition_function(campaign, n_iterations, batch_size):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "lengthscale_prior", valid_priors, ids=[c.__class__ for c in valid_priors]
-)
-@pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
-def test_iter_prior(campaign, n_iterations, batch_size):
-    run_iterations(campaign, n_iterations, batch_size)
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize(
     "kernel", valid_kernels, ids=[c.__class__ for c in valid_kernels]
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -167,6 +167,14 @@ valid_composite_kernels = [
     AdditiveKernel([PolynomialKernel(1), PolynomialKernel(2), PolynomialKernel(3)]),
     AdditiveKernel([RBFKernel(), RQKernel(), PolynomialKernel(1)]),
     ProductKernel([MaternKernel(1.5), MaternKernel(2.5)]),
+    ProductKernel([RBFKernel(), RQKernel(), PolynomialKernel(1)]),
+    ProductKernel([PolynomialKernel(1), PolynomialKernel(2), PolynomialKernel(3)]),
+    AdditiveKernel(
+        [
+            ProductKernel([MaternKernel(1.5), MaternKernel(2.5)]),
+            AdditiveKernel([MaternKernel(1.5), MaternKernel(2.5)]),
+        ]
+    ),
 ]
 
 valid_kernels = valid_base_kernels + valid_scale_kernels + valid_composite_kernels


### PR DESCRIPTION
This PR is adding more kernel choices. There are some notable points to consider below:

**Bugfix arithmetic Kernels**
These used to apply operators like `mul(*a_list)` but since the operators are defined as 2-input only this failed for a 3-composite kernel test I added. It was fixed via rephrasing it to `reduce(mul, a_list)`

**Removed Prior Iteration Tests**
These have become obsolete as the kernels are tested with many priors. I've also reduced the prior used with the scale kernel in iteration tests to one choice, otherwise the list of kernels just got too large.

**RQKernel alpha**
Even though this kernel has an attribute called `alpha` (also visible in the equation [here](https://docs.gpytorch.ai/en/stable/kernels.html#rqkernel)) it does not seem to accept priors for it. Hence, I have ignored `alpha`, both regarding prior and initial value in our corresponding kernel

**CosineKernel**
I was not able to find prior settings that work with this kernel in the iteration tests. The error I get seem purely computational (a la could not fit any reasonable model etc). I have thus not included it in this PR