### PR TITLE
Increate hypothesis deadline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,13 @@ try:
 except ImportError:
     _STREAMLIT_INSTALLED = False
 
-# All fixture functions have prefix 'fixture_' and explicitly declared name so they
+# Hypothesis settings
+from hypothesis import settings
+
+settings.register_profile("ci", deadline=2000)
+settings.load_profile("ci")
+
+# All fixture functions have prefix 'fixture_' and explicitly declared name, so they
 # can be reused by other fixtures, see
 # https://docs.pytest.org/en/stable/reference/reference.html#pytest-fixture
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ except ImportError:
 # Hypothesis settings
 from hypothesis import settings
 
-settings.register_profile("ci", deadline=2000)
+settings.register_profile("ci", deadline=2000, max_examples=200)
 settings.load_profile("ci")
 
 # All fixture functions have prefix 'fixture_' and explicitly declared name, so they

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from hypothesis import settings
 
 from baybe.acquisition import qExpectedImprovement
 from baybe.campaign import Campaign
@@ -82,8 +83,6 @@ except ImportError:
     _STREAMLIT_INSTALLED = False
 
 # Hypothesis settings
-from hypothesis import settings
-
 settings.register_profile("ci", deadline=2000, max_examples=200)
 settings.load_profile("ci")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ from baybe.telemetry import (
     VARNAME_TELEMETRY_USERNAME,
 )
 from baybe.utils.basic import hilberts_factory
+from baybe.utils.boolean import strtobool
 from baybe.utils.dataframe import add_fake_results, add_parameter_noise
 
 try:
@@ -84,7 +85,8 @@ except ImportError:
 
 # Hypothesis settings
 settings.register_profile("ci", deadline=2000, max_examples=200)
-settings.load_profile("ci")
+if strtobool(os.getenv("CI", "false")):
+    settings.load_profile("ci")
 
 # All fixture functions have prefix 'fixture_' and explicitly declared name, so they
 # can be reused by other fixtures, see

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-from hypothesis import settings
+from hypothesis import settings as hypothesis_settings
 
 from baybe.acquisition import qExpectedImprovement
 from baybe.campaign import Campaign
@@ -84,9 +84,9 @@ except ImportError:
     _STREAMLIT_INSTALLED = False
 
 # Hypothesis settings
-settings.register_profile("ci", deadline=2000, max_examples=200)
+hypothesis_settings.register_profile("ci", deadline=500, max_examples=100)
 if strtobool(os.getenv("CI", "false")):
-    settings.load_profile("ci")
+    hypothesis_settings.load_profile("ci")
 
 # All fixture functions have prefix 'fixture_' and explicitly declared name, so they
 # can be reused by other fixtures, see


### PR DESCRIPTION
About 30-50% of pipelines fail because there is a hypothesis timeout. This PR introduces a CI profile that
- increases the hypothesis deadline form 200ms to 500ms
- doubles the amount of max examples (default of 100 seemed a bit small)