### PR TITLE
Multiversion documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,4 +68,8 @@ jobs:
             git_hash=$(git rev-parse --short "$GITHUB_SHA")
             git add -f $FOLDER
             git commit --allow-empty -m "Sphinx documentation for ${git_hash}"
+            echo "Redirecting stable to newly released version" 
+            ln -sf $FOLDER stable
+            git add stable
+            git commit -m "redirect stable to new version $FOLDER"
             git push origin gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
     steps:
@@ -37,22 +37,35 @@ jobs:
         run: pip install tox-uv
       - name: Build Docs ${{ inputs.force == true && '(Force)' || '' }}
         run: tox -e docs-py39 ${{ inputs.force == true && '-- -f' || '' }}
-      - name: Upload docs artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: 'docs/build'
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+      - name: Prepare gh-pages branch with HTML output from Sphinx
+        run: |
+            git fetch origin gh-pages:gh-pages
+            git checkout gh-pages
+            if ${{ github.event_name == 'workflow_dispatch'}}; then
+              echo "Triggered by workflow_dispatch"
+              FOLDER='latest'
+            else
+              echo "Triggered by release"
+              FOLDER=${{github.event.release.tag_name}}
+            fi
+            echo "$FOLDER"
+            if [-d $FOLDER]; then
+              rm -rf ./$FOLDER
+            fi
+            mkdir ./$FOLDER
+            cp -rv docs/build/* ./$FOLDER
+      - name: Update gh-pages branch
+        run: |
+            if ${{ github.event_name == 'workflow_dispatch'}}; then
+              echo "Triggered by workflow_dispatch"
+              FOLDER='latest'
+            else
+              echo "Triggered by release"
+              FOLDER=${{github.event.release.tag_name}}
+            fi
+            git config --local user.email "sphinx-upload[bot]@users.noreply.github.com"
+            git config --local user.name "sphinx-upload[bot]"
+            git_hash=$(git rev-parse --short "$GITHUB_SHA")
+            git add -f $FOLDER
+            git commit --allow-empty -m "Sphinx documentation for ${git_hash}"
+            git push origin gh-pages


### PR DESCRIPTION
This PR draft changes the doc building workflow for enabling mult version documentation. It is based on [this blog entry](https://blog.esciencecenter.nl/versioned-documentation-using-only-github-actions-and-github-pages-1825296e31aa), but skipping the step about building old versions (although we might want to include this).

Some comments:
- This was tested on my fork, and you can see some of the results like a more populated `gh-pages`. See the links in our internal chat (which I do not put here since this would make the description very crowded).
- Two major things are still missing: (i) With the current workflow, you can access existing versions of the documentation, but only if you have the explicit link. That is, there is no "version selector" or something similar in the .md/.html files. (ii) Old versions of the documentation do not have a banner mentioning that this is the outdated version.
- It will still be necessary to change some of the settings on the repo, most importantly that deployment will be done from a branch, see [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).