### PR TITLE
Fix surrogate slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Non-GP surrogates not working with `deepcopy` and the simulation module due to slotted
+  base class
+
 ## [0.9.0] - 2024-05-21
 ### Added
 - Class hierarchy for objectives

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -43,7 +43,7 @@ bytes to string and back, since the specification is a bijection between
 """
 
 
-@define
+@define(slots=False)
 class Surrogate(ABC, SerialMixin):
     """Abstract base class for all surrogate models."""
 


### PR DESCRIPTION
Non GP surrogate models could experience problems with `deepcopy` and the simulation module because they were non-slotted but the base class was slotted. This removes the base class slots.