### PR TITLE
Polars pipeline for discrete sum, product and exclusion constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `SubspaceContinuous.samples_full_factorial` has been replaced with
   `SubspaceContinuous.sample_from_full_factorial`
 
-
+## [0.9.1] - 2024-06-04
 ### Changed
 - Discrete searchspace memory estimate is now natively represented in bytes 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ _ `_optional` subpackage for managing optional dependencies
 - Abstract `ContinuousNonlinearConstraint` class
 - `ContinuousCardinalityConstraint` class and corresponding uniform sampling mechanism
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
-- Discrete search space Cartesian product is created lazily via Polars
 - Polars expression for `DiscreteSumConstraint`, `DiscreteProductConstraint` and `DiscreteExcludeConstraint`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ _ `_optional` subpackage for managing optional dependencies
 - Abstract `ContinuousNonlinearConstraint` class
 - `ContinuousCardinalityConstraint` class and corresponding uniform sampling mechanism
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
+- Discrete search space Cartesian product is created lazily via Polars
+- Polars expression for `DiscreteSumConstraint`, `DiscreteProductConstraint` and `DiscreteExcludeConstraint`
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -46,7 +48,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `SubspaceContinuous.samples_full_factorial` has been replaced with
   `SubspaceContinuous.sample_from_full_factorial`
 
-## [0.9.1] - 2024-06-04
+
 ### Changed
 - Discrete searchspace memory estimate is now natively represented in bytes 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ _ `_optional` subpackage for managing optional dependencies
 - Abstract `ContinuousNonlinearConstraint` class
 - `ContinuousCardinalityConstraint` class and corresponding uniform sampling mechanism
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
-- Polars expression for `DiscreteSumConstraint`, `DiscreteProductConstraint` and `DiscreteExcludeConstraint`
+- Polars expressions for `DiscreteSumConstraint`, `DiscreteProductConstraint` and 
+  `DiscreteExcludeConstraint`
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -109,7 +109,7 @@ class DiscreteConstraint(Constraint, ABC):
         """Translate the constraint to Polars expression for filtering.
 
         Returns:
-            The Polars expression to pass to ``polars.LazyFrame.filter``.
+            The Polars expressions to pass to :meth:`polars.LazyFrame.filter`.
 
         Raises:
             NotImplementedError: If the constraint class does not have a Polars

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -116,8 +116,7 @@ class DiscreteConstraint(Constraint, ABC):
                 implementation.
         """
         raise NotImplementedError(
-            f"The {self.__class__.__name__} constraint does not have a Polars "
-            f"implementation."
+            f"'{self.__class__.__name__}' does not have a Polars implementation."
         )
 
 

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -109,7 +109,7 @@ class DiscreteConstraint(Constraint, ABC):
         """Translate the constraint to Polars expression for filtering.
 
         Returns:
-            The Polars Expr object to pass as an argument to filter().
+            The Polars expression to pass to ``polars.LazyFrame.filter``.
 
         Raises:
             NotImplementedError: If the constraint class does not have a Polars

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -21,6 +21,7 @@ from baybe.serialization import (
 from baybe.utils.numerical import DTypeFloatNumpy
 
 if TYPE_CHECKING:
+    import polars as pl
     from torch import Tensor
 
 
@@ -103,6 +104,21 @@ class DiscreteConstraint(Constraint, ABC):
         Returns:
             The dataframe indices of rows where the constraint is violated.
         """
+
+    def to_polars(self) -> pl.Expr:
+        """Translate the constraint to Polars expression for filtering.
+
+        Returns:
+            The Polars Expr object to pass as an argument to filter().
+
+        Raises:
+            NotImplementedError: If the constraint class does not have a Polars
+                implementation.
+        """
+        raise NotImplementedError(
+            f"The {self.__class__.__name__} constraint does not have a Polars "
+            f"implementation."
+        )
 
 
 @define

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -106,7 +106,7 @@ class Condition(ABC, SerialMixin):
         """
 
     @abstractmethod
-    def to_polars(self, expr: pl.Expr) -> pl.Expr:
+    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:
         """Apply the condition to a Polars expression.
 
         Args:
@@ -177,7 +177,7 @@ class ThresholdCondition(Condition):
         func = self._make_operator_function()
         return data.apply(func)
 
-    def to_polars(self, expr: pl.Expr) -> pl.Expr:  # noqa: D102
+    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
         # See base class.
         op = self._make_operator_function()
         return op(expr)
@@ -210,7 +210,7 @@ class SubSelectionCondition(Condition):
         # See base class.
         return data.isin(self.selection)
 
-    def to_polars(self, expr: pl.Expr) -> pl.Expr:  # noqa: D102
+    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
         # See base class.
         return expr.is_in(self.selection)
 

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -49,7 +49,7 @@ def _is_close(x: ArrayLike, y: ArrayLike, rtol: float, atol: float) -> np.ndarra
     """Return a boolean array indicating where ``x`` and ``y`` are close.
 
     The equivalent to ``numpy.isclose``.
-    Using ``numpy.isclose`` alongside Polars dataframes results in this error:
+    Using ``numpy.isclose`` with Polars dataframes results in this error:
     ``TypeError: ufunc 'isfinite' not supported for the input types``.
 
     Args:

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -48,7 +48,7 @@ def _is_not_close(x: ArrayLike, y: ArrayLike, rtol: float, atol: float) -> np.nd
 def _is_close(x: ArrayLike, y: ArrayLike, rtol: float, atol: float) -> np.ndarray:
     """Return a boolean array indicating where ``x`` and ``y`` are close.
 
-    The equivalent to ``numpy.isclose``.
+    The equivalent to :func:``numpy.isclose``.
     Using ``numpy.isclose`` with Polars dataframes results in this error:
     ``TypeError: ufunc 'isfinite' not supported for the input types``.
 

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -106,11 +106,11 @@ class Condition(ABC, SerialMixin):
         """
 
     @abstractmethod
-    def to_polars(self, input: pl.Expr) -> pl.Expr:
+    def to_polars(self, expr: pl.Expr) -> pl.Expr:
         """Apply the condition to a Polars expression.
 
         Args:
-            input: Input expression, for instance column selection etc.
+            expr: Input expression, for instance column selection etc.
 
         Returns:
             A expression that can be passed to filter rows that satisfy condition.
@@ -177,10 +177,10 @@ class ThresholdCondition(Condition):
         func = self.generate_operator_function()
         return data.apply(func)
 
-    def to_polars(self, input: pl.Expr) -> pl.Expr:
-        """Apply the condition to a Polars expression."""
+    def to_polars(self, expr: pl.Expr) -> pl.Expr:  # noqa: D102
+        # See base class.
         op = self.generate_operator_function()
-        return op(input)
+        return op(expr)
 
 
 @define
@@ -210,9 +210,9 @@ class SubSelectionCondition(Condition):
         # See base class.
         return data.isin(self.selection)
 
-    def to_polars(self, input: pl.Expr) -> pl.Expr:
-        """Apply the condition to a Polars expression."""
-        return input.is_in(self.selection)
+    def to_polars(self, expr: pl.Expr) -> pl.Expr:  # noqa: D102
+        # See base class.
+        return expr.is_in(self.selection)
 
 
 # Register (un-)structure hooks

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -51,20 +51,20 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         Returns:
             The Polars Expr object to pass as an argument to filter().
         """
-        satisfied: list[pl.Expr] = []
+        satisfied = []
         for k, cond in enumerate(self.conditions):
             # SubSelectionCondition requires parameter to generate an expression
             if isinstance(cond, SubSelectionCondition):
                 satisfied.append(cond.to_polars(self.parameters[k]))
             else:  # Assuming we have only two classes for condition
                 op = cond.to_polars(param=None)
-                satisfied.append(op(pl.col(self.parameters[k])))
+                satisfied.append(op(pl.col(self.parameters[k])))  # type: ignore[operator]
 
         # to prevent errors when we have empty condition list
         expr = reduce(_valid_logic_combiners[self.combiner], satisfied)
         # Negate the expression, because Polars' filter keeps the rows
         # the expression satisfies
-        expr = expr.not_()
+        expr = expr.not_()  # type: ignore[union-attr]
 
         return expr
 
@@ -94,7 +94,7 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
         """
         op = self.condition.to_polars()
-        return op(pl.sum_horizontal(self.parameters))
+        return op(pl.sum_horizontal(self.parameters))  # type: ignore[operator]
 
 
 @define

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -50,11 +50,11 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         for k, cond in enumerate(self.conditions):
             satisfied.append(cond.to_polars(pl.col(self.parameters[k])))
 
-        # to prevent errors when we have empty condition list
         expr = pl.reduce(_valid_logic_combiners[self.combiner], satisfied)
+
         # Negate the expression, because Polars' filter keeps the rows
         # the expression satisfies
-        expr = expr.not_()  # type: ignore[union-attr]
+        expr = expr.not_()
 
         return expr
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -44,12 +44,8 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
         return data.index[res]
 
-    def to_polars(self) -> pl.Expr:
-        """Translate the constraint to Polars expression for filtering.
-
-        Returns:
-            The Polars Expr object to pass as an argument to filter().
-        """
+    def to_polars(self) -> pl.Expr:  # noqa: D102
+        # See base class.
         satisfied = []
         for k, cond in enumerate(self.conditions):
             satisfied.append(cond.to_polars(pl.col(self.parameters[k])))
@@ -80,13 +76,8 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
         return data.index[mask_bad]
 
-    def to_polars(self) -> pl.Expr:
-        """Translate the constraint to Polars expression for filtering.
-
-        Returns:
-            The Polars Expr object to pass as an argument to filter().
-
-        """
+    def to_polars(self) -> pl.Expr:  # noqa: D102
+        # See base class.
         return self.condition.to_polars(pl.sum_horizontal(self.parameters))
 
 
@@ -107,13 +98,8 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
         return data.index[mask_bad]
 
-    def to_polars(self) -> pl.Expr:
-        """Translate the constraint to Polars expression for filtering.
-
-        Returns:
-            The Polars Expr object to pass as an argument to filter().
-
-        """
+    def to_polars(self) -> pl.Expr:  # noqa: D102
+        # See base class.
         op = _threshold_operators[self.condition.operator]
 
         # Get the product of columns

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -115,10 +115,9 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
         """
         op = _threshold_operators[self.condition.operator]
-        # Identify columns present in both self.parameters and df.columns
 
-        # Get the product of columns using reduce function and with an alias "prod"
-        expr = pl.reduce(lambda acc, x: acc * x, pl.col(self.parameters)).alias("prod")
+        # Get the product of columns
+        expr = pl.reduce(lambda acc, x: acc * x, pl.col(self.parameters))
 
         # Apply the threshold operator on expr and the condition threshold
         return op(expr, self.condition.threshold)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -681,7 +681,7 @@ def _apply_polars_constraint_filter(
         constraints: List of discrete constraints.
 
     Returns:
-        A Pandas Dataframe
+        A Polars LazyFrame with undesired rows removed.
 
     """
     # Limit constraints to Polars ones

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -676,6 +676,9 @@ def _apply_polars_constraint_filter(
 ) -> pl.LazyFrame:
     """Remove discrete search space entries inplace based on constraints.
 
+    Note:
+        This will silently skip constraints that have no Polars implementation.
+
     Args:
         ldf: The data in experimental representation to be modified inplace.
         constraints: Collection of discrete constraints.
@@ -684,11 +687,12 @@ def _apply_polars_constraint_filter(
         A Polars LazyFrame with undesired rows removed.
 
     """
-    # Limit constraints to Polars ones
     for c in constraints:
-        if hasattr(c, "to_polars"):
+        try:
             pl_expr = c.to_polars()
             ldf = ldf.filter(pl_expr)
+        except NotImplementedError:
+            pass
 
     return ldf
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -684,7 +684,7 @@ def _apply_polars_constraint_filter(
         constraints: Collection of discrete constraints.
 
     Returns:
-        A Polars LazyFrame with undesired rows removed.
+        A ``polars.LazyFrame`` with undesired rows removed.
 
     """
     for c in constraints:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -685,10 +685,10 @@ def _apply_polars_constraint_filter(
 
     """
     # Limit constraints to Polars ones
-    constraints = [c for c in constraints if hasattr(c, "to_polars")]
     for c in constraints:
-        pl_expr = c.to_polars()  # type: ignore[attr-defined]
-        ldf = ldf.filter(pl_expr)
+        if hasattr(c, "to_polars"):
+            pl_expr = c.to_polars()
+            ldf = ldf.filter(pl_expr)
 
     return ldf
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
+import polars as pl
 from attr import define, field
 from cattrs import IterableValidationError
 
@@ -668,6 +669,28 @@ class SubspaceDiscrete(SerialMixin):
             pass
 
         return comp_rep
+
+
+def _apply_polars_constraint_filter(
+    ldf: pl.LazyFrame, constraints: Collection[DiscreteConstraint]
+) -> pl.LazyFrame:
+    """Remove discrete search space entries inplace based on constraints.
+
+    Args:
+        ldf: The data in experimental representation to be modified inplace.
+        constraints: List of discrete constraints.
+
+    Returns:
+        A Pandas Dataframe
+
+    """
+    # Limit constraints to Polars ones
+    constraints = [c for c in constraints if hasattr(c, "to_polars")]
+    for c in constraints:
+        pl_expr = c.to_polars()  # type: ignore[attr-defined]
+        ldf = ldf.filter(pl_expr)
+
+    return ldf
 
 
 def _apply_constraint_filter(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -684,7 +684,7 @@ def _apply_polars_constraint_filter(
         constraints: Collection of discrete constraints.
 
     Returns:
-        A ``polars.LazyFrame`` with undesired rows removed.
+        A Polars lazyframe with undesired rows removed.
 
     """
     for c in constraints:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -678,7 +678,7 @@ def _apply_polars_constraint_filter(
 
     Args:
         ldf: The data in experimental representation to be modified inplace.
-        constraints: List of discrete constraints.
+        constraints: Collection of discrete constraints.
 
     Returns:
         A Polars LazyFrame with undesired rows removed.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -235,6 +235,7 @@ modindex_common_prefix = ["baybe."]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
+    "polars": ("https://docs.pola.rs/api/python/stable/", None),
     "sklearn": ("http://scikit-learn.org/stable", None),
     "sklearn_extra": ("https://scikit-learn-extra.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/mypy.ini
+++ b/mypy.ini
@@ -65,3 +65,6 @@ ignore_missing_imports = True
 
 [mypy-xyzpy]
 ignore_missing_imports = True
+
+[mypy-polars]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "ngboost>=0.3.12,<1",
     "numpy>=1.24.1,<2",
     "pandas>=1.4.2",
+    "polars>=0.19.19",
     "protobuf<=3.20.3,<4",
     "scikit-learn>=1.1.1,<2",
     "scikit-learn-extra>=0.3.0,<1",

--- a/tests/test_constraints_discrete.py
+++ b/tests/test_constraints_discrete.py
@@ -1,7 +1,10 @@
 """Test for imposing discrete constraints."""
 import math
 
+import polars as pl
 import pytest
+
+from baybe.searchspace.discrete import _apply_polars_constraint_filter
 
 
 @pytest.mark.parametrize(
@@ -237,4 +240,109 @@ def test_custom(campaign):
         & campaign.searchspace.discrete.exp_rep["Temperature"].apply(lambda x: x < 150)
         & campaign.searchspace.discrete.exp_rep["Solvent_1"].eq("C3")
     ).sum()
+    assert num_entries == 0
+
+
+def _lazyframe_from_product(parameters):
+    """Create a Polars Lazyframe from the product of given parameters and return it."""
+    param_frames = [pl.LazyFrame({p.name: p.values}) for p in parameters]
+
+    # Handling edge cases
+    if len(param_frames) == 1:
+        return param_frames[0]
+
+    # Cross-join parameters
+    res = param_frames[0]
+    for frame in param_frames[1:]:
+        res = res.join(frame, how="cross", force_parallel=True)
+
+    return res
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
+def test_polars_prodsum1(parameters, constraints):
+    """Tests Polars' implementation of sum constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with 1,2-sum above 150
+    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
+    ldf = ldf.filter(pl.col("sum") > 150)
+    num_entries = len(ldf.collect())
+
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
+def test_polars_prodsum2(parameters, constraints):
+    """Tests Polars' implementation of product constrain."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with product under 30
+    df = ldf.filter(
+        pl.reduce(lambda acc, x: acc * x, pl.col(["Fraction_1", "Fraction_2"])).alias(
+            "prod"
+        )
+        < 30
+    ).collect()
+
+    num_entries = len(df)
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
+def test_polars_prodsum3(parameters, constraints):
+    """Tests Polars' implementation of exact sum constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with sum unequal to 100
+    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
+    df = ldf.select(abs(pl.col("sum") - 100)).filter(pl.col("sum") > 0.01).collect()
+
+    num_entries = len(df)
+
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize(
+    "parameter_names",
+    [["Solvent_1", "SomeSetting", "Temperature", "Pressure"]],
+)
+@pytest.mark.parametrize(
+    "constraint_names", [["Constraint_4", "Constraint_5", "Constraint_6"]]
+)
+def test_polars_exclusion(mock_substances, parameters, constraints):
+    """Tests Polar's implementation of exclusion constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    print(ldf.explain())
+    # Number of entries with either first/second substance and a temperature above 151
+
+    df = ldf.filter(
+        (pl.col("Temperature") > 151)
+        & (pl.col("Solvent_1").is_in(list(mock_substances)[:2]))
+    ).collect()
+    num_entries = len(df)
+    assert num_entries == 0
+
+    # Number of entries with either last / second last substance and a pressure above 5
+    df = ldf.filter(
+        (pl.col("Pressure") > 5)
+        & (pl.col("Solvent_1").is_in(list(mock_substances)[-2:]))
+    ).collect()
+    num_entries = len(df)
+    assert num_entries == 0
+
+    # Number of entries with pressure below 3 and temperature above 120
+    df = ldf.filter((pl.col("Pressure") < 3) & (pl.col("Temperature") > 120)).collect()
+    num_entries = len(df)
     assert num_entries == 0

--- a/tests/test_constraints_discrete.py
+++ b/tests/test_constraints_discrete.py
@@ -1,10 +1,7 @@
 """Test for imposing discrete constraints."""
 import math
 
-import polars as pl
 import pytest
-
-from baybe.searchspace.discrete import _apply_polars_constraint_filter
 
 
 @pytest.mark.parametrize(
@@ -240,109 +237,4 @@ def test_custom(campaign):
         & campaign.searchspace.discrete.exp_rep["Temperature"].apply(lambda x: x < 150)
         & campaign.searchspace.discrete.exp_rep["Solvent_1"].eq("C3")
     ).sum()
-    assert num_entries == 0
-
-
-def _lazyframe_from_product(parameters):
-    """Create a Polars Lazyframe from the product of given parameters and return it."""
-    param_frames = [pl.LazyFrame({p.name: p.values}) for p in parameters]
-
-    # Handling edge cases
-    if len(param_frames) == 1:
-        return param_frames[0]
-
-    # Cross-join parameters
-    res = param_frames[0]
-    for frame in param_frames[1:]:
-        res = res.join(frame, how="cross", force_parallel=True)
-
-    return res
-
-
-@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
-@pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
-def test_polars_prodsum1(parameters, constraints):
-    """Tests Polars' implementation of sum constraint."""
-    ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
-
-    # Number of entries with 1,2-sum above 150
-    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
-    ldf = ldf.filter(pl.col("sum") > 150)
-    num_entries = len(ldf.collect())
-
-    assert num_entries == 0
-
-
-@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
-@pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
-def test_polars_prodsum2(parameters, constraints):
-    """Tests Polars' implementation of product constrain."""
-    ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
-
-    # Number of entries with product under 30
-    df = ldf.filter(
-        pl.reduce(lambda acc, x: acc * x, pl.col(["Fraction_1", "Fraction_2"])).alias(
-            "prod"
-        )
-        < 30
-    ).collect()
-
-    num_entries = len(df)
-    assert num_entries == 0
-
-
-@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
-@pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
-def test_polars_prodsum3(parameters, constraints):
-    """Tests Polars' implementation of exact sum constraint."""
-    ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
-
-    # Number of entries with sum unequal to 100
-    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
-    df = ldf.select(abs(pl.col("sum") - 100)).filter(pl.col("sum") > 0.01).collect()
-
-    num_entries = len(df)
-
-    assert num_entries == 0
-
-
-@pytest.mark.parametrize(
-    "parameter_names",
-    [["Solvent_1", "SomeSetting", "Temperature", "Pressure"]],
-)
-@pytest.mark.parametrize(
-    "constraint_names", [["Constraint_4", "Constraint_5", "Constraint_6"]]
-)
-def test_polars_exclusion(mock_substances, parameters, constraints):
-    """Tests Polar's implementation of exclusion constraint."""
-    ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
-    print(ldf.explain())
-    # Number of entries with either first/second substance and a temperature above 151
-
-    df = ldf.filter(
-        (pl.col("Temperature") > 151)
-        & (pl.col("Solvent_1").is_in(list(mock_substances)[:2]))
-    ).collect()
-    num_entries = len(df)
-    assert num_entries == 0
-
-    # Number of entries with either last / second last substance and a pressure above 5
-    df = ldf.filter(
-        (pl.col("Pressure") > 5)
-        & (pl.col("Solvent_1").is_in(list(mock_substances)[-2:]))
-    ).collect()
-    num_entries = len(df)
-    assert num_entries == 0
-
-    # Number of entries with pressure below 3 and temperature above 120
-    df = ldf.filter((pl.col("Pressure") < 3) & (pl.col("Temperature") > 120)).collect()
-    num_entries = len(df)
     assert num_entries == 0

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -1,4 +1,4 @@
-"""Test Polars' implementations of constraints."""
+"""Test Polars implementations of constraints."""
 
 import polars as pl
 import pytest
@@ -25,7 +25,7 @@ def _lazyframe_from_product(parameters):
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
 def test_polars_prodsum1(parameters, constraints):
-    """Tests Polars' implementation of sum constraint."""
+    """Tests Polars implementation of sum constraint."""
     ldf = _lazyframe_from_product(parameters)
 
     ldf = _apply_polars_constraint_filter(ldf, constraints)
@@ -61,7 +61,7 @@ def test_polars_prodsum2(parameters, constraints):
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
 def test_polars_prodsum3(parameters, constraints):
-    """Tests Polars' implementation of exact sum constraint."""
+    """Tests Polars implementation of exact sum constraint."""
     ldf = _lazyframe_from_product(parameters)
 
     ldf = _apply_polars_constraint_filter(ldf, constraints)
@@ -83,7 +83,7 @@ def test_polars_prodsum3(parameters, constraints):
     "constraint_names", [["Constraint_4", "Constraint_5", "Constraint_6"]]
 )
 def test_polars_exclusion(mock_substances, parameters, constraints):
-    """Tests Polar's implementation of exclusion constraint."""
+    """Tests Polars implementation of exclusion constraint."""
     ldf = _lazyframe_from_product(parameters)
 
     ldf = _apply_polars_constraint_filter(ldf, constraints)

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -7,7 +7,7 @@ from baybe.searchspace.discrete import _apply_polars_constraint_filter
 
 
 def _lazyframe_from_product(parameters):
-    """Create a Polars Lazyframe from the product of given parameters and return it."""
+    """Create a Polars lazyframe from the product of given parameters and return it."""
     param_frames = [pl.LazyFrame({p.name: p.values}) for p in parameters]
 
     # Handling edge cases
@@ -41,7 +41,7 @@ def test_polars_prodsum1(parameters, constraints):
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
 def test_polars_prodsum2(parameters, constraints):
-    """Tests Polars' implementation of product constrain."""
+    """Tests Polars implementation of product constrain."""
     ldf = _lazyframe_from_product(parameters)
 
     ldf = _apply_polars_constraint_filter(ldf, constraints)

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -1,0 +1,111 @@
+"""Test Polars' implementations of constraints."""
+
+import polars as pl
+import pytest
+
+from baybe.searchspace.discrete import _apply_polars_constraint_filter
+
+
+def _lazyframe_from_product(parameters):
+    """Create a Polars Lazyframe from the product of given parameters and return it."""
+    param_frames = [pl.LazyFrame({p.name: p.values}) for p in parameters]
+
+    # Handling edge cases
+    if len(param_frames) == 1:
+        return param_frames[0]
+
+    # Cross-join parameters
+    res = param_frames[0]
+    for frame in param_frames[1:]:
+        res = res.join(frame, how="cross", force_parallel=True)
+
+    return res
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
+def test_polars_prodsum1(parameters, constraints):
+    """Tests Polars' implementation of sum constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with 1,2-sum above 150
+    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
+    ldf = ldf.filter(pl.col("sum") > 150)
+    num_entries = len(ldf.collect())
+
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
+def test_polars_prodsum2(parameters, constraints):
+    """Tests Polars' implementation of product constrain."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with product under 30
+    df = ldf.filter(
+        pl.reduce(lambda acc, x: acc * x, pl.col(["Fraction_1", "Fraction_2"])).alias(
+            "prod"
+        )
+        < 30
+    ).collect()
+
+    num_entries = len(df)
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
+@pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
+def test_polars_prodsum3(parameters, constraints):
+    """Tests Polars' implementation of exact sum constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with sum unequal to 100
+    ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
+    df = ldf.select(abs(pl.col("sum") - 100)).filter(pl.col("sum") > 0.01).collect()
+
+    num_entries = len(df)
+
+    assert num_entries == 0
+
+
+@pytest.mark.parametrize(
+    "parameter_names",
+    [["Solvent_1", "SomeSetting", "Temperature", "Pressure"]],
+)
+@pytest.mark.parametrize(
+    "constraint_names", [["Constraint_4", "Constraint_5", "Constraint_6"]]
+)
+def test_polars_exclusion(mock_substances, parameters, constraints):
+    """Tests Polar's implementation of exclusion constraint."""
+    ldf = _lazyframe_from_product(parameters)
+
+    ldf = _apply_polars_constraint_filter(ldf, constraints)
+
+    # Number of entries with either first/second substance and a temperature above 151
+
+    df = ldf.filter(
+        (pl.col("Temperature") > 151)
+        & (pl.col("Solvent_1").is_in(list(mock_substances)[:2]))
+    ).collect()
+    num_entries = len(df)
+    assert num_entries == 0
+
+    # Number of entries with either last / second last substance and a pressure above 5
+    df = ldf.filter(
+        (pl.col("Pressure") > 5)
+        & (pl.col("Solvent_1").is_in(list(mock_substances)[-2:]))
+    ).collect()
+    num_entries = len(df)
+    assert num_entries == 0
+
+    # Number of entries with pressure below 3 and temperature above 120
+    df = ldf.filter((pl.col("Pressure") < 3) & (pl.col("Temperature") > 120)).collect()
+    num_entries = len(df)
+    assert num_entries == 0


### PR DESCRIPTION
**Update:  Added Polars support for `DiscreteExclusionConstraint`**
As the title says.

Tiny modifications are on the way, like removing the list of `polars_friendly_constraints`.