### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.12, except the fulltest which is also run in 3.9
+# - This runs everything in Python 3.12, except the fulltest which is also run in 3.10
 # - Only coretest and fulltest environments are cached due to space limit
 
 name: Continuous Integration
@@ -124,7 +124,7 @@ jobs:
     needs: [typecheck, audit]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'} ]
+        py-version: [ {semantic: '3.10', tox: 'py310'} ]
     name: Core Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -146,7 +146,7 @@ jobs:
     needs: [typecheck, audit]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'}, {semantic: '3.12', tox: 'py312'} ]
+        py-version: [ {semantic: '3.10', tox: 'py310'}, {semantic: '3.12', tox: 'py312'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-python@v5
-        with: {python-version: "3.9"}
+        with: {python-version: "3.10"}
       - name: Install tox
         run: pip install tox-uv
       - name: Build Docs ${{ inputs.force == true && '(Force)' || '' }}
-        run: tox -e docs-py39 ${{ inputs.force == true && '-- -f -r' || '-- -r' }}
+        run: tox -e docs-py310 ${{ inputs.force == true && '-- -f -r' || '-- -r' }}
       - name: Upload docs artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -1,6 +1,6 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.9, 3.10, 3.11 and 3.12
+# - This runs everything in Python 3.10, 3.11 and 3.12
 # - No environments are cached due to space limit
 
 name: Regular Checks
@@ -40,18 +40,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: {python-version: "3.9"}
+        with: {python-version: "3.10"}
       - name: Build Docs
         run: |
           pip install tox-uv
-          tox -e docs-py39 -- -r
+          tox -e docs-py310 -- -r
 
   lint:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'},
-                      {semantic: '3.10', tox: 'py310'},
+        py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
                       {semantic: '3.12', tox: 'py312'} ]
     name: Lint ${{ matrix.py-version.semantic }}
@@ -72,8 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'},
-                      {semantic: '3.10', tox: 'py310'},
+        py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
                       {semantic: '3.12', tox: 'py312'} ]
     name: Type Check ${{ matrix.py-version.semantic }}
@@ -94,8 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'},
-                      {semantic: '3.10', tox: 'py310'},
+        py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
                       {semantic: '3.12', tox: 'py312'} ]
     name: Audit ${{ matrix.py-version.semantic }}
@@ -116,8 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'},
-                      {semantic: '3.10', tox: 'py310'},
+        py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
                       {semantic: '3.12', tox: 'py312'} ]
     name: Core Tests ${{ matrix.py-version.semantic }}
@@ -142,8 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py-version: [ {semantic: '3.9', tox: 'py39'},
-                      {semantic: '3.10', tox: 'py310'},
+        py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
                       {semantic: '3.12', tox: 'py312'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Datatype inconsistencies for various parameters' `values` and `comp_df` and 
   `SubSelectionCondition`'s `selection` related to floating point precision
 
+### Removed
+- Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 
+  and guidelines from [Scientific Python](https://scientific-python.org/specs/spec-0000/)
+
 ## [0.9.0] - 2024-05-21
 ### Added
 - Class hierarchy for objectives

--- a/baybe/utils/interval.py
+++ b/baybe/utils/interval.py
@@ -1,6 +1,5 @@
 """Utilities for handling intervals."""
 
-import sys
 import warnings
 from collections.abc import Iterable
 from functools import singledispatchmethod
@@ -8,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from attrs import define, field
-from packaging import version
 
 from baybe.serialization import SerialMixin, converter
 from baybe.utils.numerical import DTypeFloatNumpy
@@ -18,19 +16,6 @@ if TYPE_CHECKING:
 
 # TODO[typing]: Add return type hints to classmethod constructors once ForwardRefs
 #   are supported: https://bugs.python.org/issue41987
-
-# TODO: Remove when upgrading python version
-if version.parse(sys.version.split()[0]) < version.parse("3.9.8"):
-    # Monkeypatching necessary due to functools bug fixed in 3.9.8
-    #   https://stackoverflow.com/questions/62696796/singledispatchmethod-and-
-    #       class-method-decorators-in-python-3-8
-    #   https://bugs.python.org/issue39679
-    def _register(self, cls, method=None):
-        if hasattr(cls, "__func__"):
-            setattr(cls, "__annotations__", cls.__func__.__annotations__)
-        return self.dispatcher.register(cls, func=method)
-
-    singledispatchmethod.register = _register  # type: ignore[method-assign]
 
 
 class InfiniteIntervalError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,13 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "Apache-2.0" }
-requires-python =">=3.9,<3.13"
+requires-python =">=3.10,<3.13"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/README.md
+++ b/tests/README.md
@@ -58,15 +58,15 @@ possibility to test different python variants as well.
 
 ### Environments
 In `tox.ini`, we have configured several environments for running different actions 
-(`fulltest`, `coretest`, `lint`, `audit`) against different versions of python (e.g. `py39`, `py310`, .
+(`fulltest`, `coretest`, `lint`, `audit`) against different versions of python (e.g. `py310`, `py311`, .
 ..). 
 You can specify both in `tox` to call a certain combination. 
 
 For instance 
 ```bash
-tox -e fulltest-py39
+tox -e fulltest-py310
 ``` 
-will run pytest on baybe with all optional features in python 3.9, while 
+will run pytest on baybe with all optional features in python 3.10, while 
 ```bash
 tox -e coretest-py312
 ```
@@ -84,13 +84,13 @@ tox -l
 ### Shortcuts
 In case you want to run several combinations, you can specify them like
 ```bash
-tox -e audit-py39,audit-py311
+tox -e audit-py310,audit-py311
 ```
 
 If you omit the python version from the environment, `tox` will use the version 
 from the command-executing environment:
 ```bash
-tox -e coretest  # runs like '-e coretest-py39' if called from a python 3.9 environment
+tox -e coretest  # runs like '-e coretest-py310' if called from a python 3.10 environment
 ```
 
 If you simply want to run all combinations, you can use

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 min_version = 4.9
-env_list = {fulltest,coretest,lint,mypy,audit}-py{39,310,311,312}
+env_list = {fulltest,coretest,lint,mypy,audit}-py{310,311,312}
 isolated_build = True
 
-[testenv:fulltest,fulltest-py{39,310,311,312}]
+[testenv:fulltest,fulltest-py{310,311,312}]
 description = Run PyTest with all extra functionality
 extras = test,chem,examples,simulation,onnx
 passenv =
@@ -17,7 +17,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:coretest,coretest-py{39,310,311,312}]
+[testenv:coretest,coretest-py{310,311,312}]
 description = Run PyTest with core functionality
 extras = test
 passenv =
@@ -31,7 +31,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:lint,lint-py{39,310,311,312}]
+[testenv:lint,lint-py{310,311,312}]
 description = Run linters and format checkers
 extras = lint,examples
 skip_install = True
@@ -40,7 +40,7 @@ commands =
     python --version
     pre-commit run --all-files {posargs:--show-diff-on-failure}
 
-[testenv:mypy,mypy-py{39,310,311,312}]
+[testenv:mypy,mypy-py{310,311,312}]
 description = Run mypy
 extras = mypy
 setenv =
@@ -49,7 +49,7 @@ commands =
     python --version
     mypy
 
-[testenv:audit,audit-py{39,310,311,312}]
+[testenv:audit,audit-py{310,311,312}]
 description = Run pip-audit
 extras = dev # audit entire environment
 setenv =
@@ -59,7 +59,7 @@ commands =
     python --version
     pip-audit {env:EXCLUDES:}
 
-[testenv:docs,docs-py{39,310,311,312}]
+[testenv:docs,docs-py{310,311,312}]
 description = Build documentation, including the examples, and check links
 extras = docs
 setenv =


### PR DESCRIPTION
This PR drops Python 3.9 support because Botorch, being one of our main dependencies, follows the "Scientific Python" guidelines and thus no longer supports it:
https://scientific-python.org/specs/spec-0000/