### PR TITLE
Deprecate SequentialGreedyRecommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 
   and guidelines from [Scientific Python](https://scientific-python.org/specs/spec-0000/)
 
+### Fixed
+- `sequential` flag of `SequentialGreedyRecommender` is now set to `True`
+
 ### Breaking Changes
 - Providing an explicit `batch_size` is now mandatory when asking for recommendations
 - `RecommenderProtocol.recommend` now accepts an optional `Objective` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `Surrogate` base class now exposes a `to_botorch` method
+- `SubspaceDiscrete.to_searchspace` and `SubspaceContinuous.to_searchspace`
+  convenience constructor
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ of the user guide.
 
 ```python
 from baybe.recommenders import (
-    SequentialGreedyRecommender,
+    BotorchRecommender,
     FPSRecommender,
     TwoPhaseMetaRecommender,
 )
 
 recommender = TwoPhaseMetaRecommender(
     initial_recommender=FPSRecommender(),  # farthest point sampling
-    recommender=SequentialGreedyRecommender(),  # Bayesian model-based optimization
+    recommender=BotorchRecommender(),  # Bayesian model-based optimization
 )
 ```
 

--- a/baybe/recommenders/__init__.py
+++ b/baybe/recommenders/__init__.py
@@ -6,6 +6,7 @@ from baybe.recommenders.meta.sequential import (
     TwoPhaseMetaRecommender,
 )
 from baybe.recommenders.naive import NaiveHybridSpaceRecommender
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.bayesian.sequential_greedy import (
     SequentialGreedyRecommender,
 )
@@ -20,6 +21,7 @@ from baybe.recommenders.pure.nonpredictive.sampling import (
 )
 
 __all__ = [
+    "BotorchRecommender",
     "FPSRecommender",
     "GaussianMixtureClusteringRecommender",
     "KMeansClusteringRecommender",

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -14,9 +14,7 @@ from baybe.exceptions import NoRecommendersLeftError
 from baybe.objectives.base import Objective
 from baybe.recommenders.meta.base import MetaRecommender
 from baybe.recommenders.pure.base import PureRecommender
-from baybe.recommenders.pure.bayesian.sequential_greedy import (
-    SequentialGreedyRecommender,
-)
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.nonpredictive.sampling import RandomRecommender
 from baybe.searchspace import SearchSpace
 from baybe.serialization import (
@@ -44,7 +42,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
     initial_recommender: PureRecommender = field(factory=RandomRecommender)
     """The initial recommender used by the meta recommender."""
 
-    recommender: PureRecommender = field(factory=SequentialGreedyRecommender)
+    recommender: PureRecommender = field(factory=BotorchRecommender)
     """The recommender used by the meta recommender after the switch."""
 
     switch_after: int = field(default=1)

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -40,11 +40,11 @@ class NaiveHybridSpaceRecommender(PureRecommender):
     # problem that might come up when implementing new subclasses of PureRecommender
     disc_recommender: PureRecommender = field(factory=BotorchRecommender)
     """The recommender used for the discrete subspace. Default:
-    :class:`baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender`"""
+    :class:`baybe.recommenders.pure.bayesian.botorch.BotorchRecommender`"""
 
     cont_recommender: BayesianRecommender = field(factory=BotorchRecommender)
     """The recommender used for the continuous subspace. Default:
-    :class:`baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender`"""
+    :class:`baybe.recommenders.pure.bayesian.botorch.BotorchRecommender`"""
 
     def __attrs_post_init__(self):
         """Validate if flags are synchronized and overrides them otherwise."""

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -9,9 +9,7 @@ from attrs import define, evolve, field, fields
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
-from baybe.recommenders.pure.bayesian.sequential_greedy import (
-    SequentialGreedyRecommender,
-)
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
 from baybe.utils.dataframe import to_tensor
@@ -40,11 +38,11 @@ class NaiveHybridSpaceRecommender(PureRecommender):
     # works for now. Still, we manually check whether the disc_recommender belongs to
     # one of these two subclasses such that we might be able to easily spot a potential
     # problem that might come up when implementing new subclasses of PureRecommender
-    disc_recommender: PureRecommender = field(factory=SequentialGreedyRecommender)
+    disc_recommender: PureRecommender = field(factory=BotorchRecommender)
     """The recommender used for the discrete subspace. Default:
     :class:`baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender`"""
 
-    cont_recommender: BayesianRecommender = field(factory=SequentialGreedyRecommender)
+    cont_recommender: BayesianRecommender = field(factory=BotorchRecommender)
     """The recommender used for the continuous subspace. Default:
     :class:`baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender`"""
 

--- a/baybe/recommenders/pure/__init__.py
+++ b/baybe/recommenders/pure/__init__.py
@@ -4,7 +4,10 @@ Pure recommenders implement selection algorithms and can be queried for providin
 recommendations. They can be part of meta recommenders.
 """
 
-from baybe.recommenders.pure.bayesian import SequentialGreedyRecommender
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
+from baybe.recommenders.pure.bayesian.sequential_greedy import (
+    SequentialGreedyRecommender,
+)
 from baybe.recommenders.pure.nonpredictive import (
     FPSRecommender,
     GaussianMixtureClusteringRecommender,
@@ -14,10 +17,11 @@ from baybe.recommenders.pure.nonpredictive import (
 )
 
 __all__ = [
-    "SequentialGreedyRecommender",
-    "RandomRecommender",
+    "BotorchRecommender",
     "FPSRecommender",
-    "PAMClusteringRecommender",
-    "KMeansClusteringRecommender",
     "GaussianMixtureClusteringRecommender",
+    "KMeansClusteringRecommender",
+    "PAMClusteringRecommender",
+    "RandomRecommender",
+    "SequentialGreedyRecommender",
 ]

--- a/baybe/recommenders/pure/bayesian/__init__.py
+++ b/baybe/recommenders/pure/bayesian/__init__.py
@@ -1,9 +1,11 @@
 """Bayesian recommenders."""
 
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.bayesian.sequential_greedy import (
     SequentialGreedyRecommender,
 )
 
 __all__ = [
+    "BotorchRecommender",
     "SequentialGreedyRecommender",
 ]

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -35,7 +35,7 @@ class BayesianRecommender(PureRecommender, ABC):
     _botorch_acqf = field(default=None, init=False)
     """The current acquisition function."""
 
-    acquisition_function_cls: bool = field(default=None, kw_only=True)
+    acquisition_function_cls: str | None = field(default=None, kw_only=True)
     "Deprecated! Raises an error when used."
 
     @acquisition_function_cls.validator

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -28,14 +28,14 @@ class BayesianRecommender(PureRecommender, ABC):
     """The used surrogate model."""
 
     acquisition_function: AcquisitionFunction = field(
-        converter=convert_acqf, factory=qExpectedImprovement, kw_only=True
+        converter=convert_acqf, factory=qExpectedImprovement
     )
     """The used acquisition function class."""
 
     _botorch_acqf = field(default=None, init=False)
     """The current acquisition function."""
 
-    acquisition_function_cls: bool = field(default=None)
+    acquisition_function_cls: bool = field(default=None, kw_only=True)
     "Deprecated! Raises an error when used."
 
     @acquisition_function_cls.validator

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -1,6 +1,5 @@
 """Botorch recommender."""
 
-import warnings
 from typing import Any, ClassVar
 
 import pandas as pd
@@ -38,11 +37,10 @@ class BotorchRecommender(BayesianRecommender):
     # See base class.
 
     # Object variables
-    sequential: bool | None = field(default=None)
-    """Flag defining whether to apply sequential greedy or batch optimization.
-    Only relevant for continuous search spaces, where it defaults to ``False``.
-    In discrete/hybrid spaces, sequential greedy optimization is applied automatically,
-    meaning that the flag is ignored.
+    sequential_continuous: bool = field(default=False)
+    """Flag defining whether to apply sequential greedy or batch optimization in
+    **continuous** search spaces. (In discrete/hybrid spaces, sequential greedy
+    optimization is applied automatically.)
     """
 
     hybrid_sampler: str = field(
@@ -92,15 +90,6 @@ class BotorchRecommender(BayesianRecommender):
             The dataframe indices of the recommended points in the provided
             computational representation.
         """
-        if self.sequential is False:  # <-- explicit check against ``False`` required!
-            warnings.warn(
-                f"The 'sequential' flag has been set to `False`, but sequential "
-                f"greedy optimization automatically applied to search spaces "
-                f"of type '{subspace_discrete.to_searchspace().type}', hence the "
-                f"flag is ignored. To disable this warning, either use "
-                f"`sequential=True` or do not set any value."
-            )
-
         # For batch size > 1, this optimizer needs a MC acquisition function
         if batch_size > 1 and not self.acquisition_function.is_mc:
             raise NoMCAcquisitionFunctionError(
@@ -176,7 +165,7 @@ class BotorchRecommender(BayesianRecommender):
                 for c in subspace_continuous.constraints_lin_ineq
             ]
             or None,  # TODO: https://github.com/pytorch/botorch/issues/2042
-            sequential=self.sequential or False,
+            sequential=self.sequential_continuous,
         )
 
         # Return optimized points as dataframe
@@ -211,15 +200,6 @@ class BotorchRecommender(BayesianRecommender):
         Returns:
             The recommended points.
         """
-        if self.sequential is False:  # <-- explicit check against ``False`` required!
-            warnings.warn(
-                f"The 'sequential' flag has been set to `False`, but sequential "
-                f"greedy optimization automatically applied to search spaces "
-                f"of type '{searchspace.type}', hence the "
-                f"flag is ignored. To disable this warning, either use "
-                f"`sequential=True` or do not set any value."
-            )
-
         # For batch size > 1, this optimizer needs a MC acquisition function
         if batch_size > 1 and not self.acquisition_function.is_mc:
             raise NoMCAcquisitionFunctionError(

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -37,6 +37,10 @@ class BotorchRecommender(BayesianRecommender):
     # See base class.
 
     # Object variables
+    sequential: bool = field(default=False)
+    """Flag defining whether to apply sequential greedy or batch optimization.
+    Only relevant for continuous search spaces."""
+
     hybrid_sampler: str = field(
         validator=validators.in_(["None", "Farthest", "Random"]), default="None"
     )
@@ -159,6 +163,7 @@ class BotorchRecommender(BayesianRecommender):
                 for c in subspace_continuous.constraints_lin_ineq
             ]
             or None,  # TODO: https://github.com/pytorch/botorch/issues/2042
+            sequential=self.sequential,
         )
 
         # Return optimized points as dataframe

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -1,4 +1,4 @@
-"""Sequential greedy recommender."""
+"""Botorch recommender."""
 
 from typing import Any, ClassVar
 
@@ -19,16 +19,17 @@ from baybe.utils.sampling_algorithms import farthest_point_sampling
 
 @define
 class BotorchRecommender(BayesianRecommender):
-    """Pure recommender using sequential greedy optimization.
+    """A pure recommender utilizing Botorch's optimization machinery.
 
-    This recommender implements the BoTorch functions ``optimize_acqf_discrete``,
-    ``optimize_acqf`` and ``optimize_acqf_mixed`` for the optimization of discrete,
-    continuous and hybrid search spaces. In particular, it can be applied in all
-    kinds of search spaces.
-    It is important to note that this algorithm performs a brute-force optimization in
-    hybrid search spaces which can be computationally expensive. Thus, the behavior of
-    the algorithm in hybrid search spaces can be controlled by two additional
-    parameters.
+    This recommender makes use of Botorch's ``optimize_acqf_discrete``,
+    ``optimize_acqf`` and ``optimize_acqf_mixed`` functions to optimize discrete,
+    continuous and hybrid search spaces, respectively. Accordingly, it can be applied to
+    all kinds of search spaces.
+
+    Note:
+        In hybrid search spaces, the used algorithm performs a brute-force optimization
+        that can be computationally expensive. Thus, the behavior of the algorithm in
+        hybrid search spaces can be controlled via two additional parameters.
     """
 
     # Class variables

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -18,7 +18,7 @@ from baybe.utils.sampling_algorithms import farthest_point_sampling
 
 
 @define
-class SequentialGreedyRecommender(BayesianRecommender):
+class BotorchRecommender(BayesianRecommender):
     """Pure recommender using sequential greedy optimization.
 
     This recommender implements the BoTorch functions ``optimize_acqf_discrete``,

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -17,7 +17,7 @@ from baybe.utils.dataframe import to_tensor
 from baybe.utils.sampling_algorithms import farthest_point_sampling
 
 
-@define
+@define(kw_only=True)
 class BotorchRecommender(BayesianRecommender):
     """A pure recommender utilizing Botorch's optimization machinery.
 

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -2,19 +2,15 @@
 
 import warnings
 
-from attrs import define
-
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 
 
-@define
-class SequentialGreedyRecommender(BotorchRecommender):
+def SequentialGreedyRecommender(*args, **kwargs) -> BotorchRecommender:
     """A :class:`baybe.recommenders.pure.bayesian.botorch.BotorchRecommender` alias for backward compatibility."""  # noqa: D401, E501
-
-    def __attrs_pre_init__(self):
-        warnings.warn(
-            f"The class `SequentialGreedyRecommender` has been deprecated and will be "
-            f"removed in a future version. Please use `{BotorchRecommender.__name__}` "
-            f"for a one-to-one replacement.",
-            DeprecationWarning,
-        )
+    warnings.warn(
+        f"The class `SequentialGreedyRecommender` has been deprecated and will be "
+        f"removed in a future version. "
+        f"Please use `{BotorchRecommender.__name__}(sequential=True)` instead.",
+        DeprecationWarning,
+    )
+    return BotorchRecommender(*args, **kwargs, sequential=True)

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -10,7 +10,8 @@ def SequentialGreedyRecommender(*args, **kwargs) -> BotorchRecommender:
     warnings.warn(
         f"The class `SequentialGreedyRecommender` has been deprecated and will be "
         f"removed in a future version. "
-        f"Please use `{BotorchRecommender.__name__}(sequential=True)` instead.",
+        f"Please use `{BotorchRecommender.__name__}(sequential_continuous=True)` "
+        f"instead.",
         DeprecationWarning,
     )
-    return BotorchRecommender(*args, **kwargs, sequential=True)
+    return BotorchRecommender(*args, **kwargs, sequential_continuous=True)

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -1,0 +1,16 @@
+"""Temporary namespace for backward compatibility."""
+
+import warnings
+
+from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
+
+
+def SequentialGreedyRecommender(*args, **kwargs):
+    """A :class:`baybe.recommenders.pure.bayesian.botorch.BotorchRecommender` alias for backward compatibility."""  # noqa: D401, E501
+    warnings.warn(
+        f"The class `SequentialGreedyRecommender` has been deprecated and will be "
+        f"removed in a future version. Please use `{BotorchRecommender.__name__}` for "
+        f"a one-to-one replacement.",
+        DeprecationWarning,
+    )
+    return BotorchRecommender(*args, **kwargs)

--- a/baybe/recommenders/pure/bayesian/sequential_greedy.py
+++ b/baybe/recommenders/pure/bayesian/sequential_greedy.py
@@ -2,15 +2,19 @@
 
 import warnings
 
+from attrs import define
+
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 
 
-def SequentialGreedyRecommender(*args, **kwargs):
+@define
+class SequentialGreedyRecommender(BotorchRecommender):
     """A :class:`baybe.recommenders.pure.bayesian.botorch.BotorchRecommender` alias for backward compatibility."""  # noqa: D401, E501
-    warnings.warn(
-        f"The class `SequentialGreedyRecommender` has been deprecated and will be "
-        f"removed in a future version. Please use `{BotorchRecommender.__name__}` for "
-        f"a one-to-one replacement.",
-        DeprecationWarning,
-    )
-    return BotorchRecommender(*args, **kwargs)
+
+    def __attrs_pre_init__(self):
+        warnings.warn(
+            f"The class `SequentialGreedyRecommender` has been deprecated and will be "
+            f"removed in a future version. Please use `{BotorchRecommender.__name__}` "
+            f"for a one-to-one replacement.",
+            DeprecationWarning,
+        )

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -21,6 +21,9 @@ from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.basic import to_tuple
 from baybe.utils.dataframe import pretty_print_df
 from baybe.utils.numerical import DTypeFloatNumpy
+
+if TYPE_CHECKING:
+    from baybe.searchspace.core import SearchSpace
 
 
 @define
@@ -73,6 +76,12 @@ class SubspaceContinuous(SerialMixin):
             \r{pretty_print_df(lin_ineq_constr_df)}"""
 
         return continuous_str.replace("\n", "\n ").replace("\r", "\r ")
+
+    def to_searchspace(self) -> SearchSpace:
+        """Turn the subspace into a search space with no discrete part."""
+        from baybe.searchspace.core import SearchSpace
+
+        return SearchSpace(continuous=self)
 
     @classmethod
     def empty(cls) -> SubspaceContinuous:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Sequence
 from math import prod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -31,6 +31,9 @@ from baybe.utils.dataframe import (
 )
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import DTypeFloatNumpy
+
+if TYPE_CHECKING:
+    from baybe.searchspace.core import SearchSpace
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
 
@@ -213,6 +216,12 @@ class SubspaceDiscrete(SerialMixin):
             return
         off_task_idxs = ~self._on_task_configurations()
         self.metadata.loc[off_task_idxs.values, "dont_recommend"] = True  # type: ignore
+
+    def to_searchspace(self) -> SearchSpace:
+        """Turn the subspace into a search space with no continuous part."""
+        from baybe.searchspace.core import SearchSpace
+
+        return SearchSpace(discrete=self)
 
     def _on_task_configurations(self) -> pd.Series:
         """Retrieve the parameter configurations for the active tasks."""

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("baybe.deprecation", "baybe.strategies.deprecation", "baybe.objectives.deprecation") %}
+{% if not item in ("baybe.deprecation", "baybe.strategies.deprecation", "baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy") %}
    {{ item }}
 {%- endif %}
 {%- endfor %}

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -97,7 +97,7 @@ used is strongly discouraged.
 **Note:** While the above distinction is true in the general case, it may not be 
 relevant for all configured settings, for instance, when the used recommender 
 is not capable of joint optimization. Currently, the 
-[SequentialGreedyRecommender](baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender)
+[BotorchRecommender](baybe.recommenders.pure.bayesian.botorch.BotorchRecommender)
 is the only recommender available that performs joint optimization.
 ```
 

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -30,7 +30,7 @@ The Bayesian recommenders in BayBE are built on the foundation of the
 class, offering an array of possibilities with internal surrogate models and support
 for various acquisition functions.
 
-* The **[`SequentialGreedyRecommender`](baybe.recommenders.pure.bayesian.sequential_greedy.SequentialGreedyRecommender)**
+* The **[`BotorchRecommender`](baybe.recommenders.pure.bayesian.botorch.BotorchRecommender)**
   is a powerful recommender that performs sequential Greedy optimization. It can be
   applied for discrete, continuous and hybrid search spaces. It is an implementation of
   the BoTorch optimization functions for discrete, continuous and mixed spaces.
@@ -89,13 +89,13 @@ logics. BayBE offers three distinct kinds of meta recommenders.
   to a Bayesian recommender as soon as measurements have been ingested:
 ```python
 from baybe.recommenders import (
+    BotorchRecommender,
     TwoPhaseMetaRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
 )
 
 recommender = TwoPhaseMetaRecommender(
-    initial_recommender=RandomRecommender(), recommender=SequentialGreedyRecommender()
+    initial_recommender=RandomRecommender(), recommender=BotorchRecommender()
 )
 ```
 

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -32,16 +32,16 @@ for various acquisition functions.
 
 * The **[`BotorchRecommender`](baybe.recommenders.pure.bayesian.botorch.BotorchRecommender)**
   is a powerful recommender based on BoTorch's optimization engine that can be applied
-  to all kinds of search spaces. In continuous spaces, its `sequential` flag allows to
-  chose between greedy sequential optimization and batch optimization as the underlying
-  point generation mode. In discrete/hybrid spaces, sequential greedy selection is the
-  only available mode and is thus activated automatically. Note that the recommender
-  performs a brute-force search when applied to hybrid search spaces, as it optimizes
-  the continuous part of the space while exhaustively searching choices in the discrete
-  subspace. You can customize this behavior to only sample a certain percentage of the
-  discrete subspace via the `sample_percentage` attribute and to choose different
-  sampling algorithms via the `hybrid_sampler` attribute. An example on using this
-  recommender in a hybrid space can be found
+  to all kinds of search spaces. In continuous spaces, its `sequential_continuous` flag
+  allows to chose between greedy sequential optimization and batch optimization as the
+  underlying point generation mode. In discrete/hybrid spaces, sequential greedy
+  selection is the only available mode and is thus activated automatically. Note that
+  the recommender performs a brute-force search when applied to hybrid search spaces, as
+  it optimizes the continuous part of the space while exhaustively searching choices in
+  the discrete subspace. You can customize this behavior to only sample a certain
+  percentage of the discrete subspace via the `sample_percentage` attribute and to
+  choose different sampling algorithms via the `hybrid_sampler` attribute. An example on
+  using this recommender in a hybrid space can be found
   [here](./../../examples/Backtesting/hybrid).
 
 * The **[`NaiveHybridSpaceRecommender`](baybe.recommenders.naive.NaiveHybridSpaceRecommender)**

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -35,13 +35,15 @@ for various acquisition functions.
   to all kinds of search spaces. In continuous spaces, its `sequential_continuous` flag
   allows to chose between greedy sequential optimization and batch optimization as the
   underlying point generation mode. In discrete/hybrid spaces, sequential greedy
-  selection is the only available mode and is thus activated automatically. Note that
-  the recommender performs a brute-force search when applied to hybrid search spaces, as
-  it optimizes the continuous part of the space while exhaustively searching choices in
-  the discrete subspace. You can customize this behavior to only sample a certain
-  percentage of the discrete subspace via the `sample_percentage` attribute and to
-  choose different sampling algorithms via the `hybrid_sampler` attribute. An example on
-  using this recommender in a hybrid space can be found
+  selection is the only available mode and is thus activated automatically.
+  
+  Note that the recommender performs a brute-force search when applied to hybrid search
+  spaces, as it optimizes the continuous part of the space while exhaustively searching
+  choices in the discrete subspace. You can customize this behavior to only sample a
+  certain percentage of the discrete subspace via the `sample_percentage` attribute and
+  to choose different sampling algorithms via the `hybrid_sampler` attribute.
+  
+  An example on using this recommender in a hybrid space can be found
   [here](./../../examples/Backtesting/hybrid).
 
 * The **[`NaiveHybridSpaceRecommender`](baybe.recommenders.naive.NaiveHybridSpaceRecommender)**

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -31,8 +31,11 @@ class, offering an array of possibilities with internal surrogate models and sup
 for various acquisition functions.
 
 * The **[`BotorchRecommender`](baybe.recommenders.pure.bayesian.botorch.BotorchRecommender)**
-  is a powerful recommender based on BoTorch's optimization engine, which can be applied
-  to all kinds of search spaces. However, it is important to note that the recommender
+  is a powerful recommender based on BoTorch's optimization engine that can be applied
+  to all kinds of search spaces. In continuous spaces, its `sequential` flag allows to
+  chose between greedy sequential optimization and batch optimization as the underlying
+  point generation mode. In discrete/hybrid spaces, sequential greedy selection is the
+  only available mode and is thus activated automatically. Note that the recommender
   performs a brute-force search when applied to hybrid search spaces, as it optimizes
   the continuous part of the space while exhaustively searching choices in the discrete
   subspace. You can customize this behavior to only sample a certain percentage of the

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -31,16 +31,15 @@ class, offering an array of possibilities with internal surrogate models and sup
 for various acquisition functions.
 
 * The **[`BotorchRecommender`](baybe.recommenders.pure.bayesian.botorch.BotorchRecommender)**
-  is a powerful recommender that performs sequential Greedy optimization. It can be
-  applied for discrete, continuous and hybrid search spaces. It is an implementation of
-  the BoTorch optimization functions for discrete, continuous and mixed spaces.
-  It is important to note that this recommender performs a brute-force search when
-  applied in hybrid search spaces, as it optimizes the continuous part of the space
-  while exhaustively searching choices in the discrete subspace. You can customize
-  this behavior to only sample a certain percentage of the discrete subspace via the
-  `sample_percentage` attribute and to choose different sampling algorithms via the
-  `hybrid_sampler` attribute. An example on using this recommender in a hybrid space
-  can be found [here](./../../examples/Backtesting/hybrid).
+  is a powerful recommender based on BoTorch's optimization engine, which can be applied
+  to all kinds of search spaces. However, it is important to note that the recommender
+  performs a brute-force search when applied to hybrid search spaces, as it optimizes
+  the continuous part of the space while exhaustively searching choices in the discrete
+  subspace. You can customize this behavior to only sample a certain percentage of the
+  discrete subspace via the `sample_percentage` attribute and to choose different
+  sampling algorithms via the `hybrid_sampler` attribute. An example on using this
+  recommender in a hybrid space can be found
+  [here](./../../examples/Backtesting/hybrid).
 
 * The **[`NaiveHybridSpaceRecommender`](baybe.recommenders.naive.NaiveHybridSpaceRecommender)**
   can be applied to all search spaces, but is intended to be used in hybrid spaces.

--- a/examples/Backtesting/custom_analytical.py
+++ b/examples/Backtesting/custom_analytical.py
@@ -22,8 +22,8 @@ from baybe import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter
 from baybe.recommenders import (
+    BotorchRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -82,7 +82,7 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 # For details on recommender objects, we refer to [`recommenders`](./../Basics/recommenders.md).
 
 seq_greedy_EI_recommender = TwoPhaseMetaRecommender(
-    recommender=SequentialGreedyRecommender(acquisition_function="qEI"),
+    recommender=BotorchRecommender(acquisition_function="qEI"),
 )
 random_recommender = TwoPhaseMetaRecommender(recommender=RandomRecommender())
 

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -19,9 +19,9 @@ from baybe import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalContinuousParameter, NumericalDiscreteParameter
 from baybe.recommenders import (
+    BotorchRecommender,
     NaiveHybridSpaceRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -123,9 +123,7 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 # We thus recommend to keep this parameter rather low.
 
 seq_greedy_recommender = TwoPhaseMetaRecommender(
-    recommender=SequentialGreedyRecommender(
-        hybrid_sampler="Farthest", sampling_percentage=0.3
-    ),
+    recommender=BotorchRecommender(hybrid_sampler="Farthest", sampling_percentage=0.3),
 )
 naive_hybrid_recommender = TwoPhaseMetaRecommender(
     recommender=NaiveHybridSpaceRecommender()

--- a/examples/Backtesting/hybrid.py
+++ b/examples/Backtesting/hybrid.py
@@ -112,9 +112,9 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 ### Constructing campaigns for the simulation loop
 
 # This example compares three different available hybrid recommenders:
-# The `SequentialGreedyRecommender`, the `NaiveHybridSpaceRecommender` and the `RandomRecommender`.
+# The `BotorchRecommender`, the `NaiveHybridSpaceRecommender` and the `RandomRecommender`.
 # For each of them, we initialize one recommender object.
-# Note that it is possible to further specify the behavior of the `SequentialGreedyRecommender`.
+# Note that it is possible to further specify the behavior of the `BotorchRecommender`.
 # Using the two keywords `hybrid_sampler` and `sampling_percentage`, one can control
 # - how much of the discrete subspace should be explored
 # - how these points should be sampled.

--- a/examples/Basics/recommenders.py
+++ b/examples/Basics/recommenders.py
@@ -20,8 +20,8 @@ from baybe import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter, SubstanceParameter
 from baybe.recommenders import (
+    BotorchRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -103,7 +103,7 @@ ALLOW_RECOMMENDING_ALREADY_MEASURED = True
 
 recommender = TwoPhaseMetaRecommender(
     initial_recommender=INITIAL_RECOMMENDER,
-    recommender=SequentialGreedyRecommender(
+    recommender=BotorchRecommender(
         surrogate_model=SURROGATE_MODEL,
         acquisition_function=ACQ_FUNCTION,
         allow_repeated_recommendations=ALLOW_REPEATED_RECOMMENDATIONS,

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -28,8 +28,8 @@ from baybe.parameters import (
     SubstanceParameter,
 )
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -134,9 +134,7 @@ campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=SingleTargetObjective(target=NumericalTarget(name="Yield", mode="MAX")),
     recommender=TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(
-            surrogate_model=StackingRegressorSurrogate()
-        ),
+        recommender=BotorchRecommender(surrogate_model=StackingRegressorSurrogate()),
         initial_recommender=FPSRecommender(),
     ),
 )

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -21,8 +21,8 @@ from baybe.parameters import (
     SubstanceParameter,
 )
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -190,9 +190,7 @@ campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=SingleTargetObjective(target=NumericalTarget(name="Yield", mode="MAX")),
     recommender=TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(
-            surrogate_model=NeuralNetDropoutSurrogate()
-        ),
+        recommender=BotorchRecommender(surrogate_model=NeuralNetDropoutSurrogate()),
         initial_recommender=FPSRecommender(),
     ),
 )

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -19,8 +19,8 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -102,7 +102,7 @@ campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=SingleTargetObjective(target=NumericalTarget(name="Yield", mode="MAX")),
     recommender=TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(surrogate_model=surrogate_model),
+        recommender=BotorchRecommender(surrogate_model=surrogate_model),
         initial_recommender=FPSRecommender(),
     ),
 )

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -19,8 +19,8 @@ from baybe.parameters import (
     SubstanceParameter,
 )
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -84,7 +84,7 @@ campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=SingleTargetObjective(target=NumericalTarget(name="Yield", mode="MAX")),
     recommender=TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(surrogate_model=surrogate_model),
+        recommender=BotorchRecommender(surrogate_model=surrogate_model),
         initial_recommender=FPSRecommender(),
     ),
 )

--- a/examples/Searchspaces/hybrid_space.py
+++ b/examples/Searchspaces/hybrid_space.py
@@ -107,7 +107,7 @@ objective = SingleTargetObjective(target=NumericalTarget(name="Target", mode="MI
 # Here, we explicitly create a recommender object to use the `NaiveHybridSpaceRecommender`.
 # The keywords `disc_recommender` and `cont_recommender` can be used to select different
 # recommenders for the corresponding subspaces.
-# We use the default choices, which is the `SequentialGreedyRecommender`.
+# We use the default choices, which is the `BotorchRecommender`.
 
 hybrid_recommender = TwoPhaseMetaRecommender(recommender=NaiveHybridSpaceRecommender())
 

--- a/examples/Serialization/basic_serialization.py
+++ b/examples/Serialization/basic_serialization.py
@@ -17,8 +17,8 @@ from baybe.parameters import (
     NumericalDiscreteParameter,
 )
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -49,7 +49,7 @@ campaign = Campaign(
     searchspace=SearchSpace.from_product(parameters=parameters, constraints=None),
     objective=SingleTargetObjective(target=NumericalTarget(name="Yield", mode="MAX")),
     recommender=TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(),
+        recommender=BotorchRecommender(),
         initial_recommender=FPSRecommender(),
     ),
 )

--- a/examples/Serialization/create_from_config.py
+++ b/examples/Serialization/create_from_config.py
@@ -74,7 +74,7 @@ CONFIG = str(
             "type": "FPSRecommender"
         },
         "recommender": {
-            "type": "SequentialGreedyRecommender",
+            "type": "BotorchRecommender",
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },

--- a/examples/Serialization/validate_config.py
+++ b/examples/Serialization/validate_config.py
@@ -73,7 +73,7 @@ CONFIG = str(
             "type": "FPSRecommender"
         },
         "recommender": {
-            "type": "SequentialGreedyRecommender",
+            "type": "BotorchRecommender",
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },
@@ -144,7 +144,7 @@ INVALID_CONFIG = str(
             "type": "FPSRecommender"
         },
         "recommender": {
-            "type": "SequentialGreedyRecommender",
+            "type": "BotorchRecommender",
             "surrogate_model": {
                 "type": "GaussianProcessSurrogate"
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,8 @@ from baybe.recommenders.meta.sequential import (
     TwoPhaseMetaRecommender,
 )
 from baybe.recommenders.pure.base import PureRecommender
-from baybe.recommenders.pure.bayesian.sequential_greedy import (
-    SequentialGreedyRecommender,
+from baybe.recommenders.pure.bayesian.botorch import (
+    BotorchRecommender,
 )
 from baybe.recommenders.pure.nonpredictive.sampling import RandomRecommender
 from baybe.searchspace import SearchSpace
@@ -588,7 +588,7 @@ def fixture_default_twophase_meta_recommender(recommender, initial_recommender):
 def fixture_default_sequential_meta_recommender():
     """The default ```SequentialMetaRecommender```."""
     return SequentialMetaRecommender(
-        recommenders=[RandomRecommender(), SequentialGreedyRecommender()],
+        recommenders=[RandomRecommender(), BotorchRecommender()],
         mode="reuse_last",
     )
 
@@ -597,9 +597,7 @@ def fixture_default_sequential_meta_recommender():
 def fixture_default_streaming_sequential_meta_recommender():
     """The default ```StreamingSequentialMetaRecommender```."""
     return StreamingSequentialMetaRecommender(
-        recommenders=chain(
-            (RandomRecommender(),), hilberts_factory(SequentialGreedyRecommender)
-        )
+        recommenders=chain((RandomRecommender(),), hilberts_factory(BotorchRecommender))
     )
 
 
@@ -640,7 +638,7 @@ def fixture_recommender(initial_recommender, surrogate_model, acqf):
     """The default recommender to be used if not specified differently."""
     return TwoPhaseMetaRecommender(
         initial_recommender=initial_recommender,
-        recommender=SequentialGreedyRecommender(
+        recommender=BotorchRecommender(
             surrogate_model=surrogate_model,
             acquisition_function=acqf,
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -717,7 +717,7 @@ def fixture_default_config():
                 "type": "RandomRecommender"
             },
             "recommender": {
-                "type": "SequentialGreedyRecommender",
+                "type": "BotorchRecommender",
                 "acquisition_function": "qEI",
                 "allow_repeated_recommendations": false,
                 "allow_recommending_already_measured": false

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -3,7 +3,7 @@
 import pytest
 
 from baybe.acquisition.base import AcquisitionFunction
-from baybe.recommenders import SequentialGreedyRecommender
+from baybe.recommenders import BotorchRecommender
 from baybe.utils.basic import get_subclasses
 
 abbreviation_list = [
@@ -24,4 +24,4 @@ def test_creation_from_string(acqf):
 @pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
 def test_string_usage_in_recommender(acqf):
     """Tests the recommender initialization with acqfs as string."""
-    SequentialGreedyRecommender(acquisition_function=acqf)
+    BotorchRecommender(acquisition_function=acqf)

--- a/tests/serialization/test_naive_hybrid_serialization.py
+++ b/tests/serialization/test_naive_hybrid_serialization.py
@@ -6,8 +6,8 @@ from baybe.campaign import Campaign
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.recommenders.naive import NaiveHybridSpaceRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
-from baybe.recommenders.pure.bayesian.sequential_greedy import (
-    SequentialGreedyRecommender,
+from baybe.recommenders.pure.bayesian.botorch import (
+    BotorchRecommender,
 )
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType
@@ -30,7 +30,7 @@ valid_discrete_bayesian_recommenders = [
 valid_naive_hybrid_recommenders = [
     TwoPhaseMetaRecommender(
         recommender=NaiveHybridSpaceRecommender(
-            disc_recommender=disc, cont_recommender=SequentialGreedyRecommender()
+            disc_recommender=disc, cont_recommender=BotorchRecommender()
         )
     )
     for disc in [

--- a/tests/simulate_telemetry.py
+++ b/tests/simulate_telemetry.py
@@ -10,8 +10,8 @@ from baybe.campaign import Campaign
 from baybe.objective import Objective
 from baybe.parameters import NumericalDiscreteParameter, SubstanceParameter
 from baybe.recommenders import (
+    BotorchRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
     TwoPhaseMetaRecommender,
 )
 from baybe.searchspace import SearchSpace
@@ -72,7 +72,7 @@ config = {
         mode="SINGLE", targets=[NumericalTarget(name="Yield", mode="MAX")]
     ),
     "recommender": TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(
+        recommender=BotorchRecommender(
             allow_repeated_recommendations=False,
             allow_recommending_already_measured=False,
         ),

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -2,7 +2,7 @@
 
 from hypothesis import given
 
-from baybe.recommenders import SequentialGreedyRecommender
+from baybe.recommenders import BotorchRecommender
 
 from .hypothesis_strategies.acquisition import acquisition_functions
 
@@ -10,4 +10,4 @@ from .hypothesis_strategies.acquisition import acquisition_functions
 @given(acquisition_functions)
 def test_acqfs(acqf):
     """Test all acquisition functions with sequential greedy recommender."""
-    SequentialGreedyRecommender(acquisition_function=acqf)
+    BotorchRecommender(acquisition_function=acqf)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -12,7 +12,10 @@ from baybe.objective import Objective as OldObjective
 from baybe.objectives.base import Objective as NewObjective
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
-from baybe.recommenders.pure.bayesian import SequentialGreedyRecommender
+from baybe.recommenders.pure.bayesian import (
+    BotorchRecommender,
+    SequentialGreedyRecommender,
+)
 from baybe.recommenders.pure.nonpredictive.sampling import (
     FPSRecommender,
     RandomRecommender,
@@ -178,7 +181,7 @@ def test_deprecated_objective_config_deserialization():
 def test_deprecated_acqfs(acqf):
     """Using the deprecated acqf raises a warning."""
     with pytest.warns(DeprecationWarning):
-        SequentialGreedyRecommender(acquisition_function=acqf)
+        BotorchRecommender(acquisition_function=acqf)
 
     with pytest.warns(DeprecationWarning):
         AcquisitionFunction.from_dict({"type": acqf})
@@ -187,7 +190,7 @@ def test_deprecated_acqfs(acqf):
 def test_deprecated_acqf_keyword(acqf):
     """Using the deprecated keyword raises an error."""
     with pytest.raises(DeprecationError):
-        SequentialGreedyRecommender(acquisition_function_cls="qEI")
+        BotorchRecommender(acquisition_function_cls="qEI")
 
 
 def test_deprecated_sequentialgreedyrecommender_class():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -188,3 +188,9 @@ def test_deprecated_acqf_keyword(acqf):
     """Using the deprecated keyword raises an error."""
     with pytest.raises(DeprecationError):
         SequentialGreedyRecommender(acquisition_function_cls="qEI")
+
+
+def test_deprecated_sequentialgreedyrecommender_class():
+    """Using the deprecated `SequentialGreedyRecommender` class raises a warning."""
+    with pytest.warns(DeprecationWarning):
+        SequentialGreedyRecommender()

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -29,8 +29,8 @@ from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.recommenders.naive import NaiveHybridSpaceRecommender
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
-from baybe.recommenders.pure.bayesian.sequential_greedy import (
-    SequentialGreedyRecommender,
+from baybe.recommenders.pure.bayesian.botorch import (
+    BotorchRecommender,
 )
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType
@@ -94,9 +94,7 @@ sampling_strategies = [
 #  allows no training data
 valid_hybrid_sequential_greedy_recommenders = [
     TwoPhaseMetaRecommender(
-        recommender=SequentialGreedyRecommender(
-            hybrid_sampler=sampler, sampling_percentage=per
-        )
+        recommender=BotorchRecommender(hybrid_sampler=sampler, sampling_percentage=per)
     )
     for sampler, per in sampling_strategies
 ]
@@ -118,7 +116,7 @@ valid_discrete_bayesian_recommenders = [
 valid_naive_hybrid_recommenders = [
     TwoPhaseMetaRecommender(
         recommender=NaiveHybridSpaceRecommender(
-            disc_recommender=disc, cont_recommender=SequentialGreedyRecommender()
+            disc_recommender=disc, cont_recommender=BotorchRecommender()
         )
     )
     for disc in [

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -80,7 +80,7 @@ valid_hybrid_recommenders = [
     for cls in get_subclasses(PureRecommender)
     if cls.compatibility == SearchSpaceType.HYBRID
 ]
-# List of SequentialGreedy recommenders with different sampling strategies.
+# List of BotorchRecommenders with different sampling strategies.
 sampling_strategies = [
     # Valid combinations
     ("None", 0.0),

--- a/tests/test_meta_recommenders.py
+++ b/tests/test_meta_recommenders.py
@@ -4,16 +4,16 @@ import pytest
 
 from baybe.exceptions import NoRecommendersLeftError
 from baybe.recommenders import (
+    BotorchRecommender,
     FPSRecommender,
     RandomRecommender,
-    SequentialGreedyRecommender,
     SequentialMetaRecommender,
     StreamingSequentialMetaRecommender,
     TwoPhaseMetaRecommender,
 )
 from tests.conftest import select_recommender
 
-RECOMMENDERS = [RandomRecommender(), FPSRecommender(), SequentialGreedyRecommender()]
+RECOMMENDERS = [RandomRecommender(), FPSRecommender(), BotorchRecommender()]
 
 
 def test_twophase_meta_recommender():


### PR DESCRIPTION
This PR deprecates the `SequentialGreedyRecommender` class and replaces it with the new `BotorchRecommender` class, which now let's the user control the `sequential` flag being passed to the underlying optimization routine.