### PR TITLE
Reorganize simulation lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `transform` methods of `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous`
   now take additional `allow_missing` and `allow_extra` keyword arguments
 - More details to the transfer learning user guide
+- Activated doctests
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -38,6 +39,7 @@ _ `_optional` subpackage for managing optional dependencies
 - Sampling methods in `qNIPV` and `BotorchRecommender` are now specified via 
   `DiscreteSamplingMethod` enum
 - `Interval` class now supports degenerate intervals containing only one element
+- `add_fake_results` now directly processes `Target` objects instead of a `Campaign`
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/baybe/simulation/_imputation.py
+++ b/baybe/simulation/_imputation.py
@@ -1,0 +1,87 @@
+"""Target value imputation functionality."""
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from baybe.targets import NumericalTarget
+from baybe.targets.enum import TargetMode
+
+
+def _impute_lookup(
+    row: pd.Series,
+    lookup: pd.DataFrame,
+    targets: list[NumericalTarget],
+    mode: Literal["error", "best", "worst", "mean", "random"] = "error",
+) -> np.ndarray:
+    """Perform data imputation for missing lookup values.
+
+    Depending on the chosen mode, this might raise errors instead.
+
+    Args:
+        row: The data that should be matched with the lookup dataframe.
+        lookup: The lookup dataframe.
+        targets: The campaign targets, providing the required mode information.
+        mode: The used impute mode.
+            See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
+
+    Returns:
+        The filled-in lookup results.
+
+    Raises:
+        IndexError: If the mode ``"error"`` is chosen and at least one of the targets
+            could not be found.
+    """
+    # TODO: this function needs another code cleanup and refactoring
+
+    target_names = [t.name for t in targets]
+    if mode == "mean":
+        match_vals = lookup.loc[:, target_names].mean(axis=0).values
+    elif mode == "worst":
+        worst_vals = []
+        for target in targets:
+            if target.mode is TargetMode.MAX:
+                worst_vals.append(lookup.loc[:, target.name].min().flatten()[0])
+            elif target.mode is TargetMode.MIN:
+                worst_vals.append(lookup.loc[:, target.name].max().flatten()[0])
+            if target.mode is TargetMode.MATCH:
+                worst_vals.append(
+                    lookup.loc[
+                        lookup.loc[
+                            (lookup[target.name] - target.bounds.center).abs().idxmax(),
+                        ],
+                        target.name,
+                    ].flatten()[0]
+                )
+        match_vals = np.array(worst_vals)
+    elif mode == "best":
+        best_vals = []
+        for target in targets:
+            if target.mode is TargetMode.MAX:
+                best_vals.append(lookup.loc[:, target.name].max().flatten()[0])
+            elif target.mode is TargetMode.MIN:
+                best_vals.append(lookup.loc[:, target.name].min().flatten()[0])
+            if target.mode is TargetMode.MATCH:
+                best_vals.append(
+                    lookup.loc[
+                        lookup.loc[
+                            (lookup[target.name] - target.bounds.center).abs().idxmin(),
+                        ],
+                        target.name,
+                    ].flatten()[0]
+                )
+        match_vals = np.array(best_vals)
+    elif mode == "random":
+        vals = []
+        randindex = np.random.choice(lookup.index)
+        for target in targets:
+            vals.append(lookup.loc[randindex, target.name].flatten()[0])
+        match_vals = np.array(vals)
+    else:
+        raise IndexError(
+            f"Cannot match the recommended row {row} to any of "
+            f"the rows in the lookup."
+        )
+
+    return match_vals

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -171,7 +171,7 @@ def simulate_experiment(
                 break
 
             n_experiments += len(measured)
-            look_up_targets(lookup, measured, campaign.targets, impute_mode)
+            look_up_targets(measured, campaign.targets, lookup, impute_mode)
 
             # Create the summary for the current iteration and store it
             result = pd.DataFrame(

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -180,7 +180,7 @@ def simulate_experiment(
                 break
 
             n_experiments += len(measured)
-            _look_up_target_values(measured, campaign, lookup, impute_mode)
+            _look_up_target_values(measured, campaign.targets, lookup, impute_mode)
 
             # Create the summary for the current iteration and store it
             result = pd.DataFrame(

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -180,7 +180,7 @@ def simulate_experiment(
                 break
 
             n_experiments += len(measured)
-            look_up_targets(measured, campaign.targets, lookup, impute_mode)
+            look_up_targets(lookup, measured, campaign.targets, impute_mode)
 
             # Create the summary for the current iteration and store it
             result = pd.DataFrame(

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 from baybe.campaign import Campaign
 from baybe.exceptions import NotEnoughPointsLeftError, NothingToSimulateError
-from baybe.simulation.lookup import _look_up_target_values
+from baybe.simulation.lookup import look_up_targets
 from baybe.targets.enum import TargetMode
 from baybe.utils.dataframe import add_parameter_noise
 from baybe.utils.numerical import DTypeFloatNumpy, closer_element, closest_element
@@ -180,7 +180,7 @@ def simulate_experiment(
                 break
 
             n_experiments += len(measured)
-            _look_up_target_values(measured, campaign.targets, lookup, impute_mode)
+            look_up_targets(measured, campaign.targets, lookup, impute_mode)
 
             # Create the summary for the current iteration and store it
             result = pd.DataFrame(

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -43,14 +43,9 @@ def simulate_experiment(
 
     Args:
         campaign: The DOE setting to be simulated.
-        lookup: The lookup used to close the loop, provided in the form of a dataframe
-            or callable that define the targets for the queried parameter settings:
-            First, a dataframe containing experimental settings and their target
-            results can be chosen.
-            Second, A callable, providing target values for the given parameter
-            settings. can be chosen. The callable is assumed to return either a float
-            or a tuple of floats and to accept an arbitrary number of floats as input.
-            Finally,``None`` can be chosen, producing fake results.
+        lookup: The lookup used to close the loop, providing target values for the
+            queried parameter settings.
+            For details, see :func:`baybe.simulation.lookup.look_up_targets`.
         batch_size: The number of recommendations to be queried per iteration.
         n_doe_iterations:  The number of iterations to run the design-of-experiments
             loop. If not specified, the simulation proceeds until there are no more
@@ -59,15 +54,11 @@ def simulate_experiment(
             loop.
         random_seed: An optional random seed to be used for the simulation.
         impute_mode: Specifies how a missing lookup will be handled.
-            There are six different options available.
+            For details, see :func:`baybe.simulation.lookup.look_up_targets`.
+            In addition to the choices listed there, the following option is available:
 
-            - ``"error"``: An error will be thrown.
-            - ``"worst"``: Imputation uses the worst available value for each target.
-            - ``"best"``: Imputation uses the best available value for each target.
-            - ``"mean"``: Imputation uses the mean value for each target.
-            - ``"random"``: A random row will be used as lookup.
-            - ``"ignore"``: The search space is stripped before recommendations are made
-              so that unmeasured experiments will not be recommended.
+            -   ``"ignore"``: The search space is stripped before recommendations are
+                made so that unmeasured experiments will not be recommended.
         noise_percent: If not ``None``, relative noise in percent of
             ``noise_percent`` will be applied to the parameter measurements.
 

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -1,6 +1,5 @@
 """Target lookup mechanisms."""
 
-
 from __future__ import annotations
 
 import logging
@@ -30,17 +29,45 @@ def look_up_targets(
         "error", "worst", "best", "mean", "random", "ignore"
     ] = "error",
 ) -> None:
-    """Fill the target values in the query dataframe using the lookup mechanism.
+    """Add/fill target values in a dataframe using a lookup mechanism.
 
-    Note that this does not create a new dataframe but modifies ``queries`` in-place.
+    Note:
+        This does not create a new dataframe but modifies ``queries`` in-place.
 
     Args:
-        lookup: The lookup mechanism.
-            See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
-        queries: A dataframe containing points to be queried.
-        targets: The targets whose values to look up.
-        impute_mode: The used impute mode.
-            See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
+        lookup: The lookup mechanism. Can be one of the following choices:
+
+            -   A dataframe mapping rows of ``queries`` to the corresponding target
+                values. That is, it must contain the same columns as ``queries`` plus
+                one additional column for each of the given target.
+            -   A callable, providing target values for each row of ``queries``.
+            -   ``None``. Produces fake values for all targets.
+        queries: The dataframe to be modified. Its content must be compatible with the
+            chosen lookup mechanism.
+        targets: The targets whose values are to be looked up.
+        impute_mode: Specifies how a missing lookup will be handled. Only relevant for
+            dataframe lookups. Can be one of the following choices:
+
+            - ``"error"``: An error will be thrown.
+            - ``"worst"``: Imputes the worst available value for each target.
+            - ``"best"``: Imputes the best available value for each target.
+            - ``"mean"``: Imputes the mean value for each target.
+            - ``"random"``: A random row will be used for the lookup.
+
+    Example:
+        >>> import pandas as pd
+        >>> from baybe.targets.numerical import NumericalTarget
+        >>> from baybe.simulation.lookup import look_up_targets
+        >>>
+        >>> targets = [NumericalTarget("target", "MAX")]
+        >>> df = pd.DataFrame({"x": [1, 2, 3]})
+        >>> lookup_df = pd.DataFrame({"x": [1, 2], "target": [10, 20]})
+        >>> look_up_targets(lookup_df, df, targets, impute_mode="mean")
+        >>> print(df)
+           x  target
+        0  1    10.0
+        1  2    20.0
+        2  3    15.0
     """
 
 

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -50,7 +50,7 @@ def look_up_targets(
             - ``"random"``: A random row will be used for the lookup.
 
     Raises:
-        ValueError: If an invalid lookup mechanism is provided.
+        ValueError: If an unsupported lookup mechanism is provided.
 
     Example:
         >>> import pandas as pd
@@ -74,7 +74,7 @@ def look_up_targets(
     elif isinstance(lookup, pd.DataFrame):
         _look_up_targets_from_dataframe(queries, targets, lookup, impute_mode)
     else:
-        raise ValueError("Invalid lookup mechanism.")
+        raise ValueError("Unsupported lookup mechanism.")
 
 
 def _look_up_targets_from_callable(

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-def _look_up_target_values(
+def look_up_targets(
     queries: pd.DataFrame,
     targets: Collection[Target],
     lookup: pd.DataFrame | Callable | None = None,

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -27,7 +27,7 @@ def look_up_targets(
     impute_mode: Literal[
         "error", "worst", "best", "mean", "random", "ignore"
     ] = "error",
-):
+) -> None:
     """Fill the target values in the query dataframe using the lookup mechanism.
 
     Note that this does not create a new dataframe but modifies ``queries`` in-place.
@@ -39,88 +39,97 @@ def look_up_targets(
             See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
         impute_mode: The used impute mode.
             See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
-
-    Raises:
-        AssertionError: If an analytical function is used and an incorrect number of
-            targets was specified.
     """
-    # TODO: This function needs another code cleanup and refactoring. In particular,
-    #   the different lookup modes should be implemented via multiple dispatch.
-
-    # Extract all target names
-    target_names = [t.name for t in targets]
-
     # If no lookup is provided, invent some fake results
     if lookup is None:
         add_fake_results(queries, targets)
 
     # Compute the target values via a callable
     elif isinstance(lookup, Callable):
-        # TODO: Currently, the alignment of return values to targets is based on the
-        #   column ordering, which is not robust. Instead, the callable should return
-        #   a dataframe with properly labeled columns.
-
-        # Since the return of a lookup function is a tuple, the following code stores
-        # tuples of floats in a single column with label 0:
-        measured_targets = queries.apply(lambda x: lookup(*x.values), axis=1).to_frame()
-        # We transform this column to a DataFrame in which there is an individual
-        # column for each of the targets....
-        split_target_columns = pd.DataFrame(
-            measured_targets[0].to_list(), index=measured_targets.index
-        )
-        # ... and assign this to measured_targets in order to have one column per target
-        measured_targets[split_target_columns.columns] = split_target_columns
-        if measured_targets.shape[1] != len(targets):
-            raise AssertionError(
-                "If you use an analytical function as lookup, make sure "
-                "the configuration has the right amount of targets "
-                "specified."
-            )
-        for k_target, target in enumerate(targets):
-            queries[target.name] = measured_targets.iloc[:, k_target]
+        _look_up_targets_from_callable(queries, targets, lookup)
 
     # Get results via dataframe lookup (works only for exact matches)
     # IMPROVE: Although it's not too important for a simulation, this
     #  could also be implemented for approximate matches
     elif isinstance(lookup, pd.DataFrame):
-        all_match_vals = []
-        for _, row in queries.iterrows():
-            # IMPROVE: to the entire matching at once via a merge
-            ind = lookup[
-                (lookup.loc[:, row.index] == row).all(axis=1, skipna=False)
-            ].index.values
+        _look_up_targets_from_dataframe(queries, targets, lookup, impute_mode)
 
-            if len(ind) > 1:
-                # More than two instances of this parameter combination
-                # have been measured
-                _logger.warning(
-                    "The lookup rows with indexes %s seem to be "
-                    "duplicates regarding parameter values. Choosing a "
-                    "random one.",
-                    ind,
+
+def _look_up_targets_from_callable(
+    queries: pd.DataFrame, targets: Collection[Target], lookup: Callable
+) -> None:
+    # TODO: Currently, the alignment of return values to targets is based on the
+    #   column ordering, which is not robust. Instead, the callable should return
+    #   a dataframe with properly labeled columns.
+
+    # Since the return of a lookup function is a tuple, the following code stores
+    # tuples of floats in a single column with label 0:
+    measured_targets = queries.apply(lambda x: lookup(*x.values), axis=1).to_frame()
+    # We transform this column to a DataFrame in which there is an individual
+    # column for each of the targets....
+    split_target_columns = pd.DataFrame(
+        measured_targets[0].to_list(), index=measured_targets.index
+    )
+    # ... and assign this to measured_targets in order to have one column per target
+    measured_targets[split_target_columns.columns] = split_target_columns
+    if measured_targets.shape[1] != len(targets):
+        raise AssertionError(
+            "If you use an analytical function as lookup, make sure "
+            "the configuration has the right amount of targets "
+            "specified."
+        )
+    for k_target, target in enumerate(targets):
+        queries[target.name] = measured_targets.iloc[:, k_target]
+
+
+def _look_up_targets_from_dataframe(
+    queries: pd.DataFrame,
+    targets: Collection[Target],
+    lookup: pd.DataFrame,
+    impute_mode: Literal[
+        "error", "worst", "best", "mean", "random", "ignore"
+    ] = "error",
+) -> None:
+    target_names = [t.name for t in targets]
+
+    all_match_vals = []
+    for _, row in queries.iterrows():
+        # IMPROVE: to the entire matching at once via a merge
+        ind = lookup[
+            (lookup.loc[:, row.index] == row).all(axis=1, skipna=False)
+        ].index.values
+
+        if len(ind) > 1:
+            # More than two instances of this parameter combination
+            # have been measured
+            _logger.warning(
+                "The lookup rows with indexes %s seem to be "
+                "duplicates regarding parameter values. Choosing a "
+                "random one.",
+                ind,
+            )
+            match_vals = lookup.loc[np.random.choice(ind), target_names].values
+
+        elif len(ind) < 1:
+            # Parameter combination cannot be looked up and needs to be
+            # imputed.
+            if impute_mode == "ignore":
+                raise AssertionError(
+                    "Something went wrong for impute_mode 'ignore'. "
+                    "It seems the search space was not correctly "
+                    "reduced before recommendations were generated."
                 )
-                match_vals = lookup.loc[np.random.choice(ind), target_names].values
+            match_vals = _impute_lookup(row, lookup, targets, impute_mode)
 
-            elif len(ind) < 1:
-                # Parameter combination cannot be looked up and needs to be
-                # imputed.
-                if impute_mode == "ignore":
-                    raise AssertionError(
-                        "Something went wrong for impute_mode 'ignore'. "
-                        "It seems the search space was not correctly "
-                        "reduced before recommendations were generated."
-                    )
-                match_vals = _impute_lookup(row, lookup, targets, impute_mode)
+        else:
+            # Exactly one match has been found
+            match_vals = lookup.loc[ind[0], target_names].values
 
-            else:
-                # Exactly one match has been found
-                match_vals = lookup.loc[ind[0], target_names].values
+        # Collect the matches
+        all_match_vals.append(match_vals)
 
-            # Collect the matches
-            all_match_vals.append(match_vals)
-
-        # Add the lookup values
-        queries.loc[:, target_names] = np.asarray(all_match_vals)
+    # Add the lookup values
+    queries.loc[:, target_names] = np.asarray(all_match_vals)
 
 
 def _impute_lookup(

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -5,17 +5,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Collection
 from functools import singledispatch
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
 
+from baybe.simulation._imputation import _impute_lookup
 from baybe.targets.base import Target
-from baybe.targets.enum import TargetMode
 from baybe.utils.dataframe import add_fake_results
-
-if TYPE_CHECKING:
-    from baybe.targets import NumericalTarget
 
 _logger = logging.getLogger(__name__)
 
@@ -163,81 +160,3 @@ def _look_up_targets_from_dataframe(
 
     # Add the lookup values
     queries.loc[:, target_names] = np.asarray(all_match_vals)
-
-
-def _impute_lookup(
-    row: pd.Series,
-    lookup: pd.DataFrame,
-    targets: list[NumericalTarget],
-    mode: Literal["error", "best", "worst", "mean", "random"] = "error",
-) -> np.ndarray:
-    """Perform data imputation for missing lookup values.
-
-    Depending on the chosen mode, this might raise errors instead.
-
-    Args:
-        row: The data that should be matched with the lookup dataframe.
-        lookup: The lookup dataframe.
-        targets: The campaign targets, providing the required mode information.
-        mode: The used impute mode.
-            See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
-
-    Returns:
-        The filled-in lookup results.
-
-    Raises:
-        IndexError: If the mode ``"error"`` is chosen and at least one of the targets
-            could not be found.
-    """
-    # TODO: this function needs another code cleanup and refactoring
-
-    target_names = [t.name for t in targets]
-    if mode == "mean":
-        match_vals = lookup.loc[:, target_names].mean(axis=0).values
-    elif mode == "worst":
-        worst_vals = []
-        for target in targets:
-            if target.mode is TargetMode.MAX:
-                worst_vals.append(lookup.loc[:, target.name].min().flatten()[0])
-            elif target.mode is TargetMode.MIN:
-                worst_vals.append(lookup.loc[:, target.name].max().flatten()[0])
-            if target.mode is TargetMode.MATCH:
-                worst_vals.append(
-                    lookup.loc[
-                        lookup.loc[
-                            (lookup[target.name] - target.bounds.center).abs().idxmax(),
-                        ],
-                        target.name,
-                    ].flatten()[0]
-                )
-        match_vals = np.array(worst_vals)
-    elif mode == "best":
-        best_vals = []
-        for target in targets:
-            if target.mode is TargetMode.MAX:
-                best_vals.append(lookup.loc[:, target.name].max().flatten()[0])
-            elif target.mode is TargetMode.MIN:
-                best_vals.append(lookup.loc[:, target.name].min().flatten()[0])
-            if target.mode is TargetMode.MATCH:
-                best_vals.append(
-                    lookup.loc[
-                        lookup.loc[
-                            (lookup[target.name] - target.bounds.center).abs().idxmin(),
-                        ],
-                        target.name,
-                    ].flatten()[0]
-                )
-        match_vals = np.array(best_vals)
-    elif mode == "random":
-        vals = []
-        randindex = np.random.choice(lookup.index)
-        for target in targets:
-            vals.append(lookup.loc[randindex, target.name].flatten()[0])
-        match_vals = np.array(vals)
-    else:
-        raise IndexError(
-            f"Cannot match the recommended row {row} to any of "
-            f"the rows in the lookup."
-        )
-
-    return match_vals

--- a/baybe/simulation/lookup.py
+++ b/baybe/simulation/lookup.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
 
-from baybe.campaign import Campaign
+from baybe.targets.base import Target
 from baybe.targets.enum import TargetMode
 from baybe.utils.dataframe import add_fake_results
 
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 
 def _look_up_target_values(
     queries: pd.DataFrame,
-    campaign: Campaign,
+    targets: Collection[Target],
     lookup: pd.DataFrame | Callable | None = None,
     impute_mode: Literal[
         "error", "worst", "best", "mean", "random", "ignore"
@@ -34,7 +34,7 @@ def _look_up_target_values(
 
     Args:
         queries: A dataframe containing points to be queried.
-        campaign: The campaign for which the experiments should be simulated.
+        targets: The targets whose values to look up.
         lookup: The lookup mechanism.
             See :func:`baybe.simulation.scenarios.simulate_scenarios` for details.
         impute_mode: The used impute mode.
@@ -48,11 +48,11 @@ def _look_up_target_values(
     #   the different lookup modes should be implemented via multiple dispatch.
 
     # Extract all target names
-    target_names = [t.name for t in campaign.targets]
+    target_names = [t.name for t in targets]
 
     # If no lookup is provided, invent some fake results
     if lookup is None:
-        add_fake_results(queries, campaign)
+        add_fake_results(queries, targets)
 
     # Compute the target values via a callable
     elif isinstance(lookup, Callable):
@@ -70,13 +70,13 @@ def _look_up_target_values(
         )
         # ... and assign this to measured_targets in order to have one column per target
         measured_targets[split_target_columns.columns] = split_target_columns
-        if measured_targets.shape[1] != len(campaign.targets):
+        if measured_targets.shape[1] != len(targets):
             raise AssertionError(
                 "If you use an analytical function as lookup, make sure "
                 "the configuration has the right amount of targets "
                 "specified."
             )
-        for k_target, target in enumerate(campaign.targets):
+        for k_target, target in enumerate(targets):
             queries[target.name] = measured_targets.iloc[:, k_target]
 
     # Get results via dataframe lookup (works only for exact matches)
@@ -110,7 +110,7 @@ def _look_up_target_values(
                         "It seems the search space was not correctly "
                         "reduced before recommendations were generated."
                     )
-                match_vals = _impute_lookup(row, lookup, campaign.targets, impute_mode)
+                match_vals = _impute_lookup(row, lookup, targets, impute_mode)
 
             else:
                 # Exactly one match has been found

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -101,7 +101,7 @@ def group_duplicate_values(dictionary: dict[_T, _U]) -> dict[_U, list[_T]]:
 
     Example:
         >>> group_duplicate_values({"A": 1, "B": 2, "C": 1, "D": 3})
-        {1: ['B', 'C']}
+        {1: ['A', 'C']}
     """
     group: dict[_U, list[_T]] = {}
     for key, value in dictionary.items():

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
     Literal,
@@ -13,13 +13,13 @@ from typing import (
 import numpy as np
 import pandas as pd
 
+from baybe.targets.base import Target
 from baybe.targets.enum import TargetMode
 from baybe.utils.numerical import DTypeFloatNumpy
 
 if TYPE_CHECKING:
     from torch import Tensor
 
-    from baybe.campaign import Campaign
     from baybe.parameters import Parameter
 
 # Logging
@@ -67,7 +67,7 @@ def to_tensor(*dfs: pd.DataFrame) -> Tensor | Iterator[Tensor]:
 
 def add_fake_results(
     data: pd.DataFrame,
-    campaign: Campaign,
+    targets: Collection[Target],
     good_reference_values: dict[str, list] | None = None,
     good_intervals: dict[str, tuple[float, float]] | None = None,
     bad_intervals: dict[str, tuple[float, float]] | None = None,
@@ -80,9 +80,10 @@ def add_fake_results(
     new dataframe and that the dataframe is changed in-place.
 
     Args:
-        data: Output of the ``recommend`` function of a ``Campaign``, see
+        data: A dataframe containing parameter configurations in experimental
+            representation, for instance, created via
             :func:`baybe.campaign.Campaign.recommend`.
-        campaign: The corresponding campaign, providing configuration, targets, etc.
+        targets: The targets for which fake results should be added to the dataframe.
         good_reference_values: A dictionary containing parameter names (= dict keys) and
             respective parameter values (= dict values) that specify what will be
             considered good parameter settings. Conditions for different parameters are
@@ -125,7 +126,7 @@ def add_fake_results(
     # Set defaults for good intervals
     if good_intervals is None:
         good_intervals = {}
-        for target in campaign.targets:
+        for target in targets:
             if target.mode is TargetMode.MAX:
                 lbound = target.bounds.lower if np.isfinite(target.bounds.lower) else 66
                 ubound = (
@@ -154,7 +155,7 @@ def add_fake_results(
     # Set defaults for bad intervals
     if bad_intervals is None:
         bad_intervals = {}
-        for target in campaign.targets:
+        for target in targets:
             if target.mode is TargetMode.MAX:
                 lbound = target.bounds.lower if np.isfinite(target.bounds.lower) else 0
                 ubound = target.bounds.upper if np.isfinite(target.bounds.upper) else 33
@@ -182,7 +183,7 @@ def add_fake_results(
             bad_intervals[target.name] = interv
 
     # Add the fake data for each target
-    for target in campaign.targets:
+    for target in targets:
         # Add bad values
         data[target.name] = np.random.uniform(
             bad_intervals[target.name][0], bad_intervals[target.name][1], len(data)

--- a/examples/Basics/campaign.py
+++ b/examples/Basics/campaign.py
@@ -85,7 +85,7 @@ print(recommendation)
 # In this example, we use the `add_fake_results()` utility to create fake results.
 # We then update the campaign by adding the measurements.
 
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 print("\n\nRecommended experiments with fake measured values: ")
 print(recommendation)
 

--- a/examples/Basics/recommenders.py
+++ b/examples/Basics/recommenders.py
@@ -176,7 +176,7 @@ recommendation = campaign.recommend(batch_size=3)
 print("\n\nRecommended experiments: ")
 print(recommendation)
 
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 print("\n\nRecommended experiments with fake measured values: ")
 print(recommendation)
 

--- a/examples/Constraints_Discrete/custom_constraints.py
+++ b/examples/Constraints_Discrete/custom_constraints.py
@@ -156,5 +156,5 @@ for kIter in range(N_ITERATIONS):
     )
 
     rec = campaign.recommend(batch_size=5)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/dependency_constraints.py
+++ b/examples/Constraints_Discrete/dependency_constraints.py
@@ -113,5 +113,5 @@ for kIter in range(N_ITERATIONS):
     )
 
     rec = campaign.recommend(batch_size=5)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/exclusion_constraints.py
+++ b/examples/Constraints_Discrete/exclusion_constraints.py
@@ -144,5 +144,5 @@ for kIter in range(N_ITERATIONS):
     )
 
     rec = campaign.recommend(batch_size=5)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/mixture_constraints.py
+++ b/examples/Constraints_Discrete/mixture_constraints.py
@@ -175,5 +175,5 @@ for kIter in range(N_ITERATIONS):
     )
 
     rec = campaign.recommend(batch_size=5)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)

--- a/examples/Constraints_Discrete/prodsum_constraints.py
+++ b/examples/Constraints_Discrete/prodsum_constraints.py
@@ -141,5 +141,5 @@ for kIter in range(N_ITERATIONS):
     )
 
     rec = campaign.recommend(batch_size=5)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)

--- a/examples/Custom_Surrogates/custom_architecture_sklearn.py
+++ b/examples/Custom_Surrogates/custom_architecture_sklearn.py
@@ -147,7 +147,7 @@ print(recommendation)
 
 # Add some fake results
 
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 campaign.add_measurements(recommendation)
 
 # Do another round of recommendations

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -203,7 +203,7 @@ print(recommendation)
 
 # Add some fake results
 
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 campaign.add_measurements(recommendation)
 
 # Do another round of recommendations

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -117,7 +117,7 @@ print(recommendation)
 
 # Add some fake results
 
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 campaign.add_measurements(recommendation)
 
 ### Model Outputs

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -103,7 +103,7 @@ print("Recommendation from campaign:")
 print(recommendation)
 
 # Add some fake results
-add_fake_results(recommendation, campaign)
+add_fake_results(recommendation, campaign.targets)
 campaign.add_measurements(recommendation)
 
 ### Model Outputs

--- a/examples/Multi_Target/desirability.py
+++ b/examples/Multi_Target/desirability.py
@@ -107,7 +107,7 @@ N_ITERATIONS = 3
 
 for kIter in range(N_ITERATIONS):
     rec = campaign.recommend(batch_size=3)
-    add_fake_results(rec, campaign)
+    add_fake_results(rec, campaign.targets)
     campaign.add_measurements(rec)
     desirability = campaign.objective.transform(campaign.measurements)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+addopts = 
+    --doctest-modules 
+    --ignore=examples
+    --ignore=docs
+
+    ; TODO: The following modules are ignored due to optional dependencies, which
+    ;   otherwise break test collection in core test environment.
+    ;   Probably, there is a more elegant solution to it.
+    --ignore=baybe/_optional
+    --ignore=baybe/utils/chemistry.py
+    --ignore=tests/simulate_telemetry.py
+testpaths = 
+    baybe
+    tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -837,7 +837,7 @@ def run_iterations(
         rec = campaign.recommend(batch_size=batch_size)
         # dont use parameter noise for these tests
 
-        add_fake_results(rec, campaign)
+        add_fake_results(rec, campaign.targets)
         if add_noise and (k % 2):
             add_parameter_noise(rec, campaign.parameters, noise_level=0.1)
 

--- a/tests/simulate_telemetry.py
+++ b/tests/simulate_telemetry.py
@@ -85,7 +85,7 @@ print(f"Actual User Details: {get_user_details()}")
 campaign = Campaign(**config)
 for k in range(randint(4, 6)):
     dat = campaign.recommend(randint(2, 3))
-    add_fake_results(dat, campaign)
+    add_fake_results(dat, campaign.targets)
     campaign.add_measurements(dat)
 
 # Fake User1 - 5 iterations
@@ -94,7 +94,7 @@ os.environ[VARNAME_TELEMETRY_USERNAME] = "FAKE_USER_1"
 campaign = Campaign(**config)
 for k in range(randint(2, 3)):
     dat = campaign.recommend(randint(3, 4))
-    add_fake_results(dat, campaign)
+    add_fake_results(dat, campaign.targets)
     campaign.add_measurements(dat)
 
 # Fake User1a - Adds recommenations before calling recommend
@@ -104,7 +104,7 @@ campaign = Campaign(**config)
 campaign.add_measurements(dat)
 for k in range(randint(2, 3)):
     dat = campaign.recommend(randint(3, 4))
-    add_fake_results(dat, campaign)
+    add_fake_results(dat, campaign.targets)
     campaign.add_measurements(dat)
 
 # Fake User2 - 2 iterations
@@ -113,7 +113,7 @@ os.environ[VARNAME_TELEMETRY_USERNAME] = "FAKE_USER_2"
 campaign = Campaign(**config)
 for k in range(2):
     dat = campaign.recommend(4)
-    add_fake_results(dat, campaign)
+    add_fake_results(dat, campaign.targets)
     campaign.add_measurements(dat)
 
 # Fake User3 - no telemetry
@@ -123,7 +123,7 @@ os.environ[VARNAME_TELEMETRY_ENABLED] = "false"
 campaign = Campaign(**config)
 for k in range(randint(5, 7)):
     dat = campaign.recommend(randint(2, 3))
-    add_fake_results(dat, campaign)
+    add_fake_results(dat, campaign.targets)
     campaign.add_measurements(dat)
 
 # Cleanup

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -22,7 +22,7 @@ def test_bad_parameter_input_value(campaign, good_reference_values, bad_val, req
     rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
-        campaign,
+        campaign.targets,
         good_reference_values=good_reference_values,
     )
 
@@ -45,7 +45,7 @@ def test_bad_target_input_value(campaign, good_reference_values, bad_val, reques
     rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
-        campaign,
+        campaign.targets,
         good_reference_values=good_reference_values,
     )
 


### PR DESCRIPTION
This PR is another step toward a cleaned simulation package:
* Decouples the lookup mechanism from `Campaign` so that it can be flexibly used without having to set up a campaign object first (e.g. in tests)
* Splits up the monolithic lookup function into different cases
* Rewrites the docstrings and activates doctests
* ~~Moves simulation-related utilities to the simulation package~~