### PR TITLE
Fix optional dependency flags

### DIFF
--- a/baybe/_optional/info.py
+++ b/baybe/_optional/info.py
@@ -27,13 +27,20 @@ with exclude_sys_path(os.getcwd()):
     FLAKE8_INSTALLED = find_spec("flake8") is not None
     MORDRED_INSTALLED = find_spec("mordred") is not None
     ONNX_INSTALLED = find_spec("onnxruntime") is not None
-    PRE_COMMIT_INSTALLED = find_spec("pre-commit") is not None
+    PRE_COMMIT_INSTALLED = find_spec("pre_commit") is not None
     PYDOCLINT_INSTALLED = find_spec("pydoclint") is not None
     RDKIT_INSTALLED = find_spec("rdkit") is not None
     RUFF_INSTALLED = find_spec("ruff") is not None
     STREAMLIT_INSTALLED = find_spec("streamlit") is not None
-    TYPOS_INSTALLED = find_spec("typos") is not None
     XYZPY_INSTALLED = find_spec("xyzpy") is not None
+
+# TODO: `find_spec` does not work for `typos` (probably because it's a rust package),
+#   neither seem any versions of `pip show typos` / `pip freeze | grep typos` /
+#   `any(pkg.name == "typos" for pkg in pkgutils.iter_modules())` called as a subprocess
+#   work in CI (probably because stuff is running inside tox and/or paths need to be
+#   configured properly). As a temporary workaround – since the test collection does not
+#   directly depend on the flag – we thus simply set it to `True`.
+TYPOS_INSTALLED = True
 
 # Package combinations
 CHEM_INSTALLED = MORDRED_INSTALLED and RDKIT_INSTALLED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ test = [
     "hypothesis[pandas]>=6.88.4",
     "pytest>=7.2.0",
     "pytest-cov>=4.1.0",
+    "pytest-error-for-skips",
 ]
 
 [build-system]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     BAYBE_TEST_ENV = FULLTEST
 commands =
     python --version
-    pytest -p no:warnings --cov=baybe --durations=5 {posargs}
+    pytest -p no:warnings --cov=baybe --durations=5 --error-for-skips {posargs}
 
 [testenv:coretest,coretest-py{310,311,312}]
 description = Run PyTest with core functionality


### PR DESCRIPTION
Fixes the `PRE_COMMIT_INSTALLED` and `TYPOS_INSTALLED` flags (the latter using a workaround) and adds the `pytest-error-for-skips` plugin to disallow test skips in FULLTEST environment.