### PR TITLE
Register hook with same signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validators for `Campaign` attributes
 _ `_optional` subpackage for managing optional dependencies
 - Acquisition function for active learning: `qNIPV`
+- `register_hook` utility enabling user-defined augmentation of arbitrary callables
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -198,10 +198,16 @@ def register_hook(target: Callable, hook: Callable) -> Callable:
         TypeError: If the signature of the callable does not match the signature of the
             target callable.
     """
-    for p1, p2 in zip(
-        inspect.signature(target, eval_str=True).parameters.values(),
-        inspect.signature(hook, eval_str=True).parameters.values(),
-    ):
+    target_params = inspect.signature(target, eval_str=True).parameters.values()
+    hook_params = inspect.signature(hook, eval_str=True).parameters.values()
+
+    if len(target_params) != len(hook_params):
+        raise TypeError(
+            f"'{target.__name__}' and '{hook.__name__}' have "
+            f"a different number of parameters."
+        )
+
+    for p1, p2 in zip(target_params, hook_params):
         if p1.name != p2.name or p1.annotation != p2.annotation:
             if p2.annotation is not inspect.Parameter.empty:
                 raise TypeError(

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -208,12 +208,18 @@ def register_hook(target: Callable, hook: Callable) -> Callable:
         )
 
     for p1, p2 in zip(target_params, hook_params):
-        if p1.name != p2.name or p1.annotation != p2.annotation:
-            if p2.annotation is not inspect.Parameter.empty:
-                raise TypeError(
-                    f"The signature of '{hook.__name__}' does not match the "
-                    f"signature of '{target.__name__}'."
-                )
+        if p1.name != p2.name:
+            raise TypeError(
+                f"The parameter names of '{target.__name__}' "
+                f"and '{hook.__name__}' do not match."
+            )
+        if (p1.annotation != p2.annotation) and (
+            p2.annotation is not inspect.Parameter.empty
+        ):
+            raise TypeError(
+                f"The type annotations of '{target.__name__}' "
+                f"and '{hook.__name__}' do not match."
+            )
 
     @functools.wraps(target)
     def wraps(*args, **kwargs):

--- a/examples/Custom_Hooks/Custom_Hooks_Header.md
+++ b/examples/Custom_Hooks/Custom_Hooks_Header.md
@@ -1,0 +1,3 @@
+# Custom Hooks
+
+These examples demonstrate how to register and use custom hooks for all callables of package objects.

--- a/examples/Custom_Hooks/callable.py
+++ b/examples/Custom_Hooks/callable.py
@@ -1,0 +1,93 @@
+## E2E Test for using callables
+
+# This example shows how to use the register_hook function to request internal data from different objects such as campaign, recommenders and objective.
+
+# To request internal data from the recommendation process this function can be used by giving it two arguments:
+# - The class method the hook should be attached to
+# - The callable function that will process the data
+# The function wraps the class method and calls the callable function
+
+# This examples assumes some basic familiarity with using BayBE.
+# We refer to [`campaign`](./campaign.md) for a more general and basic example.
+
+### Necessary imports for this example
+
+
+import pandas as pd
+
+from baybe import Campaign
+from baybe.objectives import SingleTargetObjective
+from baybe.objectives.base import Objective
+from baybe.parameters import NumericalDiscreteParameter
+from baybe.recommenders import RandomRecommender
+from baybe.searchspace import SearchSpace
+from baybe.targets import NumericalTarget
+from baybe.utils.basic import register_hook
+from baybe.utils.dataframe import add_fake_results
+
+### Setup
+
+# Define three test functions to test the functionality of register_hook().
+# Note that the callable function needs to have the same signature as the function it is attached to.
+
+
+def recommend_hook(
+    self,
+    batch_size: int,
+    searchspace: SearchSpace,
+    objective: Objective | None = None,
+    measurements: pd.DataFrame | None = None,
+):
+    """Print the compatibility of the recommender, the searchspace and the batch size from the recommend call."""
+    print("start recommend_hook")
+    print(self.compatibility)
+    print(searchspace, batch_size)
+    print("End recommend_hook")
+
+
+### Example
+
+# We create a two phase meta recommender with default values.
+
+recommender = RandomRecommender()
+
+# We overwrite the original recommend method of the sequential greedy recommender class.
+
+RandomRecommender.recommend = register_hook(RandomRecommender.recommend, recommend_hook)
+
+# We define all needen parameters for this example and collect them in a list.
+
+temperature = NumericalDiscreteParameter(
+    "Temperature", values=[90, 105, 120], tolerance=2
+)
+concentration = NumericalDiscreteParameter(
+    "Concentration", values=[0.057, 0.1, 0.153], tolerance=0.005
+)
+parameters = [temperature, concentration]
+
+# We create the searchspace and the objective.
+
+searchspace = SearchSpace.from_product(parameters=parameters)
+objective = SingleTargetObjective(target=NumericalTarget(name="yield", mode="MAX"))
+
+### Creating the campaign
+
+campaign = Campaign(
+    searchspace=searchspace,
+    recommender=recommender,
+    objective=objective,
+)
+
+# This campaign can now be used to get recommendations, add measurements and process the recommend_hook:
+# Note that a for loop is used to train the data of the second recommendation on the data from the first one.
+
+for _ in range(2):
+    recommendation = campaign.recommend(batch_size=3)
+    print("\n\nRecommended experiments: ")
+    print(recommendation)
+
+    add_fake_results(recommendation, campaign)
+    print("\n\nRecommended experiments with fake measured values: ")
+    print(recommendation)
+
+    campaign.add_measurements(recommendation)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,7 +37,7 @@ def f_reversed_annotated(arg2: int, arg1: str):
     pass
 
 
-def f2_annotated(arg: int, arg3: str):
+def f2_plain(arg, arg3):
     pass
 
 
@@ -120,7 +120,7 @@ def test_discrete_sampling(fraction, method):
         ),
         param(
             f_annotated,
-            f2_annotated,
+            f2_plain,
             TypeError,
             id="different_names",
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,23 +17,23 @@ _TARGET = 1337
 _CLOSEST = _TARGET + 0.1
 
 
-def base_func(arg1: str, arg2: int):
+def f_plain(arg1, arg2):
     pass
 
 
-def func_with_default_values(arg1: str, arg2: int = 1):
+def f_annotated(arg1: str, arg2: int):
     pass
 
 
-def func_without_annotations(arg1, arg2):
+def f_annotated_one_default(arg1: str, arg2: int = 1):
     pass
 
 
-def func_with_different_order(arg2: int, arg1: str):
+def f_reversed_annotated(arg2: int, arg1: str):
     pass
 
 
-def func_with_different_names(arg: int, arg3: str):
+def f2_annotated(arg: int, arg3: str):
     pass
 
 
@@ -90,22 +90,35 @@ def test_discrete_sampling(fraction, method):
 @pytest.mark.parametrize(
     ("target, hook, error"),
     [
-        param(base_func, func_with_default_values, None, id="hook_with_default_values"),
         param(
-            func_with_default_values, base_func, None, id="target_with_default_values"
-        ),
-        param(base_func, func_without_annotations, None, id="hook_has_no_annotations"),
-        param(
-            base_func,
-            func_with_different_order,
-            TypeError,
-            id="hook_has_different_signature_order",
+            f_annotated,
+            f_annotated_one_default,
+            None,
+            id="hook_with_defaults",
         ),
         param(
-            base_func,
-            func_with_different_names,
+            f_annotated_one_default,
+            f_annotated,
+            None,
+            id="target_with_defaults",
+        ),
+        param(
+            f_annotated,
+            f_plain,
+            None,
+            id="hook_without_annotations",
+        ),
+        param(
+            f_annotated,
+            f_reversed_annotated,
             TypeError,
-            id="hook_has_different_names",
+            id="different_order",
+        ),
+        param(
+            f_annotated,
+            f2_annotated,
+            TypeError,
+            id="different_names",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,10 @@ def f_plain(arg1, arg2):
     pass
 
 
+def f_reduced_plain(arg1):
+    pass
+
+
 def f_annotated(arg1: str, arg2: int):
     pass
 
@@ -119,6 +123,12 @@ def test_discrete_sampling(fraction, method):
             f2_annotated,
             TypeError,
             id="different_names",
+        ),
+        param(
+            f_annotated,
+            f_reduced_plain,
+            TypeError,
+            id="hook_missing_arguments",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,40 @@
 """Tests for utilities."""
 import math
 
+from contextlib import nullcontext
+
 import numpy as np
 import pandas as pd
 import pytest
 from pytest import param
 
+from baybe.utils.basic import register_hook
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import closest_element
 from baybe.utils.sampling_algorithms import DiscreteSamplingMethod, sample_numerical_df
 
 _TARGET = 1337
 _CLOSEST = _TARGET + 0.1
+
+
+def base_func(arg1: str, arg2: int):
+    pass
+
+
+def func_with_default_values(arg1: str, arg2: int = 1):
+    pass
+
+
+def func_without_annotations(arg1, arg2):
+    pass
+
+
+def func_with_different_order(arg2: int, arg1: str):
+    pass
+
+
+def func_with_different_names(arg: int, arg3: str):
+    pass
 
 
 @pytest.mark.parametrize(
@@ -62,3 +85,43 @@ def test_discrete_sampling(fraction, method):
         assert len(sampled) == len(
             sampled.drop_duplicates()
         ), "Undersized sampling did not return unique points."
+
+
+@pytest.mark.parametrize(
+    ("target, hook, error"),
+    [
+        param(base_func, func_with_default_values, None, id="hook_with_default_values"),
+        param(
+            func_with_default_values, base_func, None, id="target_with_default_values"
+        ),
+        param(base_func, func_without_annotations, None, id="hook_has_no_annotations"),
+        param(
+            base_func,
+            func_with_different_order,
+            TypeError,
+            id="hook_has_different_signature_order",
+        ),
+        param(
+            func_with_different_order,
+            base_func,
+            TypeError,
+            id="target_has_different_signature_order",
+        ),
+        param(
+            base_func,
+            func_with_different_names,
+            TypeError,
+            id="hook_has_different_names",
+        ),
+        param(
+            func_with_different_names,
+            base_func,
+            TypeError,
+            id="target_has_different_names",
+        ),
+    ],
+)
+def test_register_hook(target, hook, error):
+    """Test the behavior of the register_hook function with different scenarios."""
+    with pytest.raises(error) if error is not None else nullcontext():
+        register_hook(target, hook)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,22 +102,10 @@ def test_discrete_sampling(fraction, method):
             id="hook_has_different_signature_order",
         ),
         param(
-            func_with_different_order,
-            base_func,
-            TypeError,
-            id="target_has_different_signature_order",
-        ),
-        param(
             base_func,
             func_with_different_names,
             TypeError,
             id="hook_has_different_names",
-        ),
-        param(
-            func_with_different_names,
-            base_func,
-            TypeError,
-            id="target_has_different_names",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,6 +122,6 @@ def test_discrete_sampling(fraction, method):
     ],
 )
 def test_register_hook(target, hook, error):
-    """Test the behavior of the register_hook function with different scenarios."""
+    """Passing in-/consistent signatures to `register_hook` raises an/no error."""
     with pytest.raises(error) if error is not None else nullcontext():
         register_hook(target, hook)


### PR DESCRIPTION
This PR implements the first version of the `register_hook` utility with a simple example. 

Please note: no big reviewing effort is required since these changes were already approved on #247 .