### PR TITLE
Remove core test caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.py-version.semantic }}
-      - uses: actions/cache@v4
-        with:
-          path: .tox/coretest-${{ matrix.py-version.tox }}
-          key: coretest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run core tests
         run: |
           pip install tox-uv

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -124,10 +124,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.py-version.semantic }}
-      - uses: actions/cache@v4
-        with:
-          path: .tox/coretest-${{ matrix.py-version.tox }}
-          key: coretest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run core tests
         run: |
           pip install tox-uv


### PR DESCRIPTION
lets try to fix the coretest issues we face regularly by removing the caching for these tox envs
I think it will add between 30 and 60s to an execution time of about 6,5 min, so not terrible and still shorter than the fulltests which run in parallel