### PR TITLE
Comp Rep Transition Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Parameter.is_numeric` has been replaced with `Parameter.is_numerical`
 - `DiscreteParameter.transform_rep_exp2comp` has been replaced with
   `DiscreteParameter.transform` 
+- `Surrogate` models now operate on dataframes in experimental representation instead of
+  tensors in computational representation
 
 ### Added
 - `Surrogate` base class now exposes a `to_botorch` method

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -41,7 +41,11 @@ class AcquisitionFunction(ABC, SerialMixin):
         searchspace: SearchSpace,
         measurements: pd.DataFrame,
     ):
-        """Create the botorch-ready representation of the function."""
+        """Create the botorch-ready representation of the function.
+
+        The required structure of `measurements` is specified in
+        :meth:`babye.recommenders.base.RecommenderProtocol.recommend`.
+        """
         import botorch.acquisition as botorch_acqf_module
 
         acqf_cls = getattr(botorch_acqf_module, self.__class__.__name__)

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -57,7 +57,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         if "best_f" in signature_params:
             additional_params["best_f"] = train_y.max().item()
         if "X_baseline" in signature_params:
-            additional_params["X_baseline"] = train_x
+            additional_params["X_baseline"] = to_tensor(train_x)
         if "mc_points" in signature_params:
             additional_params["mc_points"] = to_tensor(
                 self.get_integration_points(searchspace)  # type: ignore[attr-defined]

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -50,3 +50,7 @@ class DeprecationError(Exception):
 
 class UnidentifiedSubclassError(Exception):
     """A specified subclass cannot be found in the given class hierarchy."""
+
+
+class ModelNotTrainedError(Exception):
+    """A prediction/transformation is attempted before the model has been trained."""

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -122,7 +122,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # Get discrete candidates. The metadata flags are ignored since the search space
         # is hybrid
         # TODO Slight BOILERPLATE CODE, see recommender.py, ll. 47+
-        _, candidates_comp = searchspace.discrete.get_candidates(
+        candidates_exp, _ = searchspace.discrete.get_candidates(
             allow_repeated_recommendations=True,
             allow_recommending_already_measured=True,
         )
@@ -147,7 +147,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         # Call the private function of the discrete recommender and get the indices
         disc_rec_idx = self.disc_recommender._recommend_discrete(
             subspace_discrete=searchspace.discrete,
-            candidates_comp=candidates_comp,
+            candidates_exp=candidates_exp,
             batch_size=batch_size,
         )
 

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -14,7 +14,6 @@ from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import CustomONNXSurrogate, GaussianProcessSurrogate
 from baybe.surrogates.base import Surrogate
-from baybe.utils.dataframe import to_tensor
 
 
 @define
@@ -51,14 +50,9 @@ class BayesianRecommender(PureRecommender, ABC):
         measurements: pd.DataFrame,
     ) -> None:
         """Create the acquisition function for the current training data."""  # noqa: E501
-        # TODO: Transition point from dataframe to tensor needs to be refactored.
-        #   Currently, surrogate models operate with tensors, while acquisition
-        #   functions with dataframes.
-        train_x = searchspace.transform(measurements)
-        train_y = objective.transform(measurements)
-        self.surrogate_model._fit(searchspace, *to_tensor(train_x, train_y))
+        self.surrogate_model.fit(searchspace, objective, measurements)
         self._botorch_acqf = self.acquisition_function.to_botorch(
-            self.surrogate_model, searchspace, train_x, train_y
+            self.surrogate_model, searchspace, measurements
         )
 
     def recommend(  # noqa: D102

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -96,7 +96,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
     def _recommend_discrete(
         self,
         subspace_discrete: SubspaceDiscrete,
-        candidates_comp: pd.DataFrame,
+        candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.Index:
         # See base class.
@@ -106,6 +106,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         scaler = StandardScaler()
         scaler.fit(subspace_discrete.comp_rep)
 
+        candidates_comp = subspace_discrete.transform(candidates_exp)
         candidates_scaled = np.ascontiguousarray(scaler.transform(candidates_comp))
 
         # Set model parameters and perform fit

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -21,13 +21,13 @@ class RandomRecommender(NonPredictiveRecommender):
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
-        candidates_comp: pd.DataFrame,
+        candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.DataFrame:
         # See base class.
 
         if searchspace.type == SearchSpaceType.DISCRETE:
-            return candidates_comp.sample(batch_size)
+            return candidates_exp.sample(batch_size)
 
         cont_random = searchspace.continuous.sample_uniform(batch_size=batch_size)
         if searchspace.type == SearchSpaceType.CONTINUOUS:
@@ -56,7 +56,7 @@ class FPSRecommender(NonPredictiveRecommender):
     def _recommend_discrete(
         self,
         subspace_discrete: SubspaceDiscrete,
-        candidates_comp: pd.DataFrame,
+        candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.Index:
         # See base class.
@@ -65,6 +65,8 @@ class FPSRecommender(NonPredictiveRecommender):
         # TODO [Scaling]: scaling should be handled by search space object
         scaler = StandardScaler()
         scaler.fit(subspace_discrete.comp_rep)
+
+        candidates_comp = subspace_discrete.transform(candidates_exp)
         candidates_scaled = np.ascontiguousarray(scaler.transform(candidates_comp))
         ilocs = farthest_point_sampling(candidates_scaled, batch_size)
         return candidates_comp.index[ilocs]

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -22,7 +22,6 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
-from baybe.surrogates.utils import _prepare_inputs, _prepare_targets
 
 if TYPE_CHECKING:
     from botorch.models.model import Model
@@ -76,9 +75,6 @@ class Surrogate(ABC, SerialMixin):
             candidate points.
         """
         import torch
-
-        # Prepare the input
-        candidates = _prepare_inputs(candidates)
 
         # Evaluate the posterior distribution
         mean, covar = self._posterior(candidates)
@@ -146,10 +142,6 @@ class Surrogate(ABC, SerialMixin):
             raise NotImplementedError(
                 "Continuous search spaces are currently only supported by GPs."
             )
-
-        # Validate and prepare the training data
-        train_x = _prepare_inputs(train_x)
-        train_y = _prepare_targets(train_y)
 
         self._fit(searchspace, train_x, train_y)
 

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -157,6 +157,8 @@ class Surrogate(ABC, SerialMixin):
             NotImplementedError: When using a continuous search space and a non-GP
                 model.
         """
+        # TODO: consider adding a validation step for `measurements`
+
         # Check if transfer learning capabilities are needed
         if (searchspace.n_tasks > 1) and (not self.supports_transfer_learning):
             raise ValueError(

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING, ClassVar
 
 import pandas as pd
@@ -59,14 +60,18 @@ class Surrogate(ABC, SerialMixin):
     """Class variable encoding whether or not the surrogate supports transfer
     learning."""
 
-    _input_transform = field(init=False, default=None, eq=False)
+    _input_transform: Callable[[pd.DataFrame], pd.DataFrame] | None = field(
+        init=False, default=None, eq=False
+    )
     """Callable preparing surrogate inputs for training/prediction.
 
     Transforms a dataframe containing parameter configurations in experimental
     representation to a corresponding dataframe containing their computational
     representation. Only available after the surrogate has been fitted."""
 
-    _target_transform = field(init=False, default=None, eq=False)
+    _target_transform: Callable[[pd.DataFrame], pd.DataFrame] | None = field(
+        init=False, default=None, eq=False
+    )
     """Callable preparing surrogate targets for training.
 
     Transforms a dataframe containing target measurements in experimental

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
-from attrs import define
+import pandas as pd
+from attrs import define, field
 from cattrs import override
 from cattrs.dispatch import (
     StructuredValue,
@@ -15,6 +16,8 @@ from cattrs.dispatch import (
     UnstructureHook,
 )
 
+from baybe.exceptions import ModelNotTrainedError
+from baybe.objectives.base import Objective
 from baybe.searchspace import SearchSpace
 from baybe.serialization.core import (
     converter,
@@ -22,6 +25,7 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
+from baybe.utils.dataframe import to_tensor
 
 if TYPE_CHECKING:
     from botorch.models.model import Model
@@ -55,29 +59,44 @@ class Surrogate(ABC, SerialMixin):
     """Class variable encoding whether or not the surrogate supports transfer
     learning."""
 
+    _input_transformd = field(init=False, default=None, eq=False)
+    """Callable preparing surrogate inputs for training/prediction.
+
+    Transforms a dataframe containing parameter configurations in experimental
+    representation to a tensor containing the same configurations in computational
+    representation. Only available after the surrogate has been fitted."""
+
+    _target_transform = field(init=False, default=None, eq=False)
+    """Callable preparing surrogate targets for training.
+
+    Transforms a dataframe containing target measurements in experimental
+    representation to a tensor containing the same measurements in computational
+    representation. Only available after the surrogate has been fitted."""
+
     def to_botorch(self) -> Model:
         """Create the botorch-ready representation of the model."""
         from baybe.surrogates._adapter import AdapterModel
 
         return AdapterModel(self)
 
-    def posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
-        """Evaluate the surrogate model at the given candidate points.
+    def transform_inputs(self, data: pd.DataFrame) -> Tensor:
+        """Transform an experimental parameter dataframe."""
+        if self._input_transform is None:
+            raise ModelNotTrainedError("The model must be trained first.")
+        return self._input_transform(data)
 
-        Args:
-            candidates: The candidate points, represented as a tensor of shape
-                ``(*t, q, d)``, where ``t`` denotes the "t-batch" shape, ``q``
-                denotes the "q-batch" shape, and ``d`` is the input dimension. For
-                more details about batch shapes, see: https://botorch.org/docs/batching
+    def transform_targets(self, data: pd.DataFrame) -> Tensor:
+        """Transform an experimental measurement dataframe."""
+        if self._target_transform is None:
+            raise ModelNotTrainedError("The model must be trained first.")
+        return self._target_transform(data)
 
-        Returns:
-            The posterior means and posterior covariance matrices of the t-batched
-            candidate points.
-        """
+    def posterior(self, candidates: pd.DataFrame) -> tuple[Tensor, Tensor]:
+        """Evaluate the surrogate model at the given candidate points."""
         import torch
 
         # Evaluate the posterior distribution
-        mean, covar = self._posterior(candidates)
+        mean, covar = self._posterior(self.transform_inputs(candidates))
 
         # Apply covariance transformation for marginal posterior models
         if not self.joint_posterior:
@@ -114,13 +133,18 @@ class Surrogate(ABC, SerialMixin):
             See :func:`baybe.surrogates.Surrogate.posterior`.
         """
 
-    def fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
+    def fit(
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: pd.DataFrame,
+    ) -> None:
         """Train the surrogate model on the provided data.
 
         Args:
             searchspace: The search space in which experiments are conducted.
-            train_x: The training data points.
-            train_y: The training data labels.
+            objective: The objective to be optimized.
+            measurements: The training data in experimental representation.
 
         Raises:
             ValueError: If the search space contains task parameters but the selected
@@ -143,6 +167,15 @@ class Surrogate(ABC, SerialMixin):
                 "Continuous search spaces are currently only supported by GPs."
             )
 
+        # Store context-specific transformations
+        self._input_transform = lambda x: to_tensor(searchspace.transform(x))
+        self._target_transform = lambda x: to_tensor(objective.transform(x))
+
+        # Transform and fit
+        train_x, train_y = (
+            self.transform_inputs(measurements),
+            self.transform_targets(measurements),
+        )
         self._fit(searchspace, train_x, train_y)
 
     @abstractmethod

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -168,7 +168,7 @@ class Surrogate(ABC, SerialMixin):
             )
 
         # Store context-specific transformations
-        self._input_transform = lambda x: searchspace.transform(x)
+        self._input_transform = lambda x: searchspace.transform(x, allow_missing=True)
         self._target_transform = lambda x: objective.transform(x)
 
         # Transform and fit

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -15,47 +15,6 @@ if TYPE_CHECKING:
     from baybe.surrogates.base import Surrogate
 
 
-def _prepare_inputs(x: Tensor) -> Tensor:
-    """Validate and prepare the model input.
-
-    Args:
-        x: The "raw" model input.
-
-    Returns:
-        The prepared input.
-
-    Raises:
-        ValueError: If the model input is empty.
-    """
-    from baybe.utils.torch import DTypeFloatTorch
-
-    if len(x) == 0:
-        raise ValueError("The model input must be non-empty.")
-    return x.to(DTypeFloatTorch)
-
-
-def _prepare_targets(y: Tensor) -> Tensor:
-    """Validate and prepare the model targets.
-
-    Args:
-        y: The "raw" model targets.
-
-    Returns:
-        The prepared targets.
-
-    Raises:
-        NotImplementedError: If there is more than one target.
-    """
-    from baybe.utils.torch import DTypeFloatTorch
-
-    if y.shape[1] != 1:
-        raise NotImplementedError(
-            "The model currently supports only one target or multiple targets in "
-            "DESIRABILITY mode."
-        )
-    return y.to(DTypeFloatTorch)
-
-
 def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
     """Make a ``Surrogate`` class robustly handle constant training targets.
 
@@ -195,7 +154,7 @@ def autoscale(cls: type[Surrogate]):
 
 
 def batchify(
-    posterior: Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]]
+    posterior: Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]],
 ) -> Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]]:
     """Wrap ``Surrogate`` posterior functions to enable proper batching.
 


### PR DESCRIPTION
This PR is a first step toward a refactored `Surrogate` layout:
* It moves the `exp_rep`-to-`comp_rep` transition point into the surrogates, which now become responsible for handling the transformation and can do it in whatever way they need it (which will also simplify scaling later on).
* This cleans up the interface because users / calling classes can now pass data in its canonical form (i.e., `exp_rep`) and do not need to worry about transformations.
* This also means we can easily expose the trained surrogates to users for model inspection (e.g., feature importance).
