### PR TITLE
Change path from sys.path[0] to .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _ `_optional` subpackage for managing optional dependencies
   `DiscreteSamplingMethod` enum
 - `Interval` class now supports degenerate intervals containing only one element
 - `add_fake_results` now directly processes `Target` objects instead of a `Campaign`
+- `path` argument in plotting utility is now optional and defaults to `Path(".")`
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/baybe/utils/plotting.py
+++ b/baybe/utils/plotting.py
@@ -19,10 +19,6 @@ def create_example_plots(
 ) -> None:
     """Create plots from an Axes object and save them as a svg file.
 
-    The attribute ``base_name`` is used to define the name of the outputs.
-    The optional argument ``path`` can be used to specify a specific location for
-    saving the outputs.
-
     If the ``SMOKE_TEST`` variable is set, no plots are being created and this method
     immediately returns.
 

--- a/baybe/utils/plotting.py
+++ b/baybe/utils/plotting.py
@@ -15,7 +15,6 @@ from matplotlib.figure import Figure
 def create_example_plots(
     ax: Axes,
     base_name: str,
-    *,
     path: Path = Path("."),
 ) -> None:
     """Create plots from an Axes object and save them as a svg file.

--- a/baybe/utils/plotting.py
+++ b/baybe/utils/plotting.py
@@ -51,7 +51,7 @@ def create_example_plots(
 
     # Try to find the plotting themes by backtracking
     # Get the absolute path of the current script
-    script_path = Path(sys.path[0]).resolve()
+    script_path = Path(sys.argv[0]).resolve()
     while (
         not Path(script_path / "plotting_themes.json").is_file()
         and script_path != script_path.parent

--- a/baybe/utils/plotting.py
+++ b/baybe/utils/plotting.py
@@ -14,13 +14,15 @@ from matplotlib.figure import Figure
 
 def create_example_plots(
     ax: Axes,
-    path: Path,
     base_name: str,
+    *,
+    path: Path = Path("."),
 ) -> None:
     """Create plots from an Axes object and save them as a svg file.
 
-    The plots will be saved in the location specified by ``path``.
     The attribute ``base_name`` is used to define the name of the outputs.
+    The optional argument ``path`` can be used to specify a specific location for
+    saving the outputs.
 
     If the ``SMOKE_TEST`` variable is set, no plots are being created and this method
     immediately returns.
@@ -32,8 +34,8 @@ def create_example_plots(
 
     Args:
         ax: The Axes object containing the figure that should be plotted.
-        path: The path to the directory in which the plots should be saved.
         base_name: The base name that is used for naming the output files.
+        path: Optional path to the directory in which the plots should be saved.
     """
     # Check whether we immediately return due to just running a SMOKE_TEST
     if "SMOKE_TEST" in os.environ:

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -35,8 +35,8 @@ from baybe.utils.plotting import create_example_plots
 
 SMOKE_TEST = "SMOKE_TEST" in os.environ
 
-N_MC_ITERATIONS = 2 if SMOKE_TEST else 30
-N_DOE_ITERATIONS = 2 if SMOKE_TEST else 15
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 2
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 2
 BATCH_SIZE = 1 if SMOKE_TEST else 3
 POINTS_PER_DIM = 10
 
@@ -110,6 +110,9 @@ results = simulate_scenarios(
 )
 
 # We use the plotting utility to create plots.
+# Note that the path chosen here refers to the current working directory.
+# #This means that it represents the directory from which the Python script is being
+# executed which is not necessarily the folder in which this example is contained.
 
 path = Path(".")
 ax = sns.lineplot(

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -12,7 +12,6 @@
 ### Imports
 
 import os
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -112,7 +111,7 @@ results = simulate_scenarios(
 
 # We use the plotting utility to create plots.
 
-path = Path(sys.path[0])
+path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -35,8 +35,8 @@ from baybe.utils.plotting import create_example_plots
 
 SMOKE_TEST = "SMOKE_TEST" in os.environ
 
-N_MC_ITERATIONS = 2 if SMOKE_TEST else 2
-N_DOE_ITERATIONS = 2 if SMOKE_TEST else 2
+N_MC_ITERATIONS = 2 if SMOKE_TEST else 30
+N_DOE_ITERATIONS = 2 if SMOKE_TEST else 15
 BATCH_SIZE = 1 if SMOKE_TEST else 3
 POINTS_PER_DIM = 10
 
@@ -110,9 +110,6 @@ results = simulate_scenarios(
 )
 
 # We use the plotting utility to create plots.
-# Note that the path chosen here refers to the current working directory.
-# #This means that it represents the directory from which the Python script is being
-# executed which is not necessarily the folder in which this example is contained.
 
 path = Path(".")
 ax = sns.lineplot(

--- a/examples/Backtesting/botorch_analytical.py
+++ b/examples/Backtesting/botorch_analytical.py
@@ -12,7 +12,6 @@
 ### Imports
 
 import os
-from pathlib import Path
 
 import numpy as np
 import seaborn as sns
@@ -111,7 +110,6 @@ results = simulate_scenarios(
 
 # We use the plotting utility to create plots.
 
-path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",
@@ -120,8 +118,4 @@ ax = sns.lineplot(
     y="Target_CumBest",
     hue="Scenario",
 )
-create_example_plots(
-    ax=ax,
-    path=path,
-    base_name="botorch_analytical",
-)
+create_example_plots(ax=ax, base_name="botorch_analytical")

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -164,6 +164,10 @@ results = simulate_scenarios(
 # Let's visualize the results. As you can see, the type of encoding has a tremendous
 # impact on the outcome, with chemical encodings performing much better than
 # traditional ones at almost no extra cost.
+# Note that the path chosen here refers to the current working directory.
+# #This means that it represents the directory from which the Python script is being
+# executed which is not necessarily the folder in which this example is contained.
+
 
 results.rename(columns={"Scenario": "Substance Encoding"}, inplace=True)
 path = Path(".")

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -9,7 +9,6 @@
 ### Necessary imports for this example
 
 import os
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -167,7 +166,7 @@ results = simulate_scenarios(
 # traditional ones at almost no extra cost.
 
 results.rename(columns={"Scenario": "Substance Encoding"}, inplace=True)
-path = Path(sys.path[0])
+path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -164,10 +164,6 @@ results = simulate_scenarios(
 # Let's visualize the results. As you can see, the type of encoding has a tremendous
 # impact on the outcome, with chemical encodings performing much better than
 # traditional ones at almost no extra cost.
-# Note that the path chosen here refers to the current working directory.
-# #This means that it represents the directory from which the Python script is being
-# executed which is not necessarily the folder in which this example is contained.
-
 
 results.rename(columns={"Scenario": "Substance Encoding"}, inplace=True)
 path = Path(".")

--- a/examples/Backtesting/full_lookup.py
+++ b/examples/Backtesting/full_lookup.py
@@ -9,7 +9,6 @@
 ### Necessary imports for this example
 
 import os
-from pathlib import Path
 
 import pandas as pd
 import seaborn as sns
@@ -166,7 +165,6 @@ results = simulate_scenarios(
 # traditional ones at almost no extra cost.
 
 results.rename(columns={"Scenario": "Substance Encoding"}, inplace=True)
-path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",
@@ -175,8 +173,4 @@ ax = sns.lineplot(
     y="yield_CumBest",
     hue="Substance Encoding",
 )
-create_example_plots(
-    ax=ax,
-    path=path,
-    base_name="full_lookup",
-)
+create_example_plots(ax=ax, base_name="full_lookup")

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -11,7 +11,6 @@
 ### Imports
 
 import os
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -165,7 +164,7 @@ for func_name, function in test_functions.items():
 results.rename(columns={"Scenario": "Function"}, inplace=True)
 # Add column to enable different styles for non-TL examples
 results["Uses TL"] = results["Function"].apply(lambda val: "No_TL" not in val)
-path = Path(sys.path[0])
+path = Path(".")
 ax = sns.lineplot(
     data=results,
     markers=["o", "s"],

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -160,6 +160,10 @@ for func_name, function in test_functions.items():
 # All that remains is to visualize the results.
 # As the example shows, the optimization speed can be significantly increased by
 # using even small amounts of training data from related optimization tasks.
+# Note that the path chosen here refers to the current working directory.
+# #This means that it represents the directory from which the Python script is being
+# executed which is not necessarily the folder in which this example is contained.
+
 
 results.rename(columns={"Scenario": "Function"}, inplace=True)
 # Add column to enable different styles for non-TL examples

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -11,7 +11,6 @@
 ### Imports
 
 import os
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -164,7 +163,6 @@ for func_name, function in test_functions.items():
 results.rename(columns={"Scenario": "Function"}, inplace=True)
 # Add column to enable different styles for non-TL examples
 results["Uses TL"] = results["Function"].apply(lambda val: "No_TL" not in val)
-path = Path(".")
 ax = sns.lineplot(
     data=results,
     markers=["o", "s"],
@@ -174,8 +172,4 @@ ax = sns.lineplot(
     hue="Function",
     style="Uses TL",
 )
-create_example_plots(
-    ax=ax,
-    path=path,
-    base_name="backtesting",
-)
+create_example_plots(ax=ax, base_name="backtesting")

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -160,10 +160,6 @@ for func_name, function in test_functions.items():
 # All that remains is to visualize the results.
 # As the example shows, the optimization speed can be significantly increased by
 # using even small amounts of training data from related optimization tasks.
-# Note that the path chosen here refers to the current working directory.
-# #This means that it represents the directory from which the Python script is being
-# executed which is not necessarily the folder in which this example is contained.
-
 
 results.rename(columns={"Scenario": "Function"}, inplace=True)
 # Add column to enable different styles for non-TL examples

--- a/examples/Transfer_Learning/basic_transfer_learning.py
+++ b/examples/Transfer_Learning/basic_transfer_learning.py
@@ -10,7 +10,6 @@
 ### Imports
 
 import os
-import sys
 from pathlib import Path
 
 import numpy as np
@@ -161,7 +160,7 @@ results = pd.concat([result_baseline, *results])
 # using even small amounts of training data from related optimization tasks.
 
 results.rename(columns={"Scenario": "% of data used"}, inplace=True)
-path = Path(sys.path[0])
+path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",

--- a/examples/Transfer_Learning/basic_transfer_learning.py
+++ b/examples/Transfer_Learning/basic_transfer_learning.py
@@ -158,6 +158,10 @@ results = pd.concat([result_baseline, *results])
 # All that remains is to visualize the results.
 # As the example shows, the optimization speed can be significantly increased by
 # using even small amounts of training data from related optimization tasks.
+# Note that the path chosen here refers to the current working directory.
+# #This means that it represents the directory from which the Python script is being
+# executed which is not necessarily the folder in which this example is contained.
+
 
 results.rename(columns={"Scenario": "% of data used"}, inplace=True)
 path = Path(".")

--- a/examples/Transfer_Learning/basic_transfer_learning.py
+++ b/examples/Transfer_Learning/basic_transfer_learning.py
@@ -158,10 +158,6 @@ results = pd.concat([result_baseline, *results])
 # All that remains is to visualize the results.
 # As the example shows, the optimization speed can be significantly increased by
 # using even small amounts of training data from related optimization tasks.
-# Note that the path chosen here refers to the current working directory.
-# #This means that it represents the directory from which the Python script is being
-# executed which is not necessarily the folder in which this example is contained.
-
 
 results.rename(columns={"Scenario": "% of data used"}, inplace=True)
 path = Path(".")

--- a/examples/Transfer_Learning/basic_transfer_learning.py
+++ b/examples/Transfer_Learning/basic_transfer_learning.py
@@ -10,7 +10,6 @@
 ### Imports
 
 import os
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -160,7 +159,6 @@ results = pd.concat([result_baseline, *results])
 # using even small amounts of training data from related optimization tasks.
 
 results.rename(columns={"Scenario": "% of data used"}, inplace=True)
-path = Path(".")
 ax = sns.lineplot(
     data=results,
     marker="o",
@@ -169,8 +167,4 @@ ax = sns.lineplot(
     y="Target_CumBest",
     hue="% of data used",
 )
-create_example_plots(
-    ax=ax,
-    path=path,
-    base_name="basic_transfer_learning",
-)
+create_example_plots(ax=ax, base_name="basic_transfer_learning")


### PR DESCRIPTION
This PR changes the path for saving the results from `sys.path[0]` to `"."`.

As far as I understand, this has the consequence of the images being created in the directory from which `python` is being called, and I added a corresponding explanation at the corresponding positions.
Note that this change should not have any influence on the shown images: The tests that I did on my fork showed that the static images that we insert manually into the jupyter notebooks are still correctly inserted, even with this change.