### PR TITLE
Refactor search space `transform` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dataframe in experimental representation instead of two separate dataframes in
   computational representation
 - `Parameter.is_numeric` has been replaced with `Parameter.is_numerical`
+- `DiscreteParameter.transform_rep_exp2comp` has been replaced with
+  `DiscreteParameter.transform` 
 
 ### Added
 - `Surrogate` base class now exposes a `to_botorch` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ _ `_optional` subpackage for managing optional dependencies
   `DiscreteCardinalityConstraint`/`ContinuousCardinalityConstraint` subclasses
 - Uniform sampling mechanism for continuous spaces with cardinality constraints
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
+- `transform` methods of `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous`
+  now take additional `allow_missing` and `allow_extra` keyword arguments
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -48,6 +50,9 @@ _ `_optional` subpackage for managing optional dependencies
   `SubspaceContinuous.sample_uniform`
 - `SubspaceContinuous.samples_full_factorial` has been replaced with
   `SubspaceContinuous.sample_from_full_factorial`
+- Passing a dataframe via the `data` argument to the `transform` methods of
+  `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous` is no longer possible.
+  The dataframe must now be passed as positional argument.
 
 ## [0.9.1] - 2024-06-04
 ### Changed

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -90,26 +90,26 @@ class DiscreteParameter(Parameter, ABC):
         # See base class.
         return item in self.values
 
-    def transform_rep_exp2comp(self, data: pd.Series) -> pd.DataFrame:
-        """Transform data from experimental to computational representation.
+    def transform(self, series: pd.Series, /) -> pd.DataFrame:
+        """Transform parameter values from experimental to computational representation.
 
         Args:
-            data: Data to be transformed.
+            series: The parameter values to be transformed.
 
         Returns:
-            The transformed version of the data.
+            The transformed parameter values.
         """
         if self.encoding:
             # replace each label with the corresponding encoding
             transformed = pd.merge(
-                left=data.rename("Labels").to_frame(),
+                left=series.rename("Labels").to_frame(),
                 left_on="Labels",
                 right=self.comp_df,
                 right_index=True,
                 how="left",
             ).drop(columns="Labels")
         else:
-            transformed = data.to_frame()
+            transformed = series.to_frame()
 
         return transformed
 

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -54,7 +54,7 @@ class BayesianRecommender(PureRecommender, ABC):
         # TODO: Transition point from dataframe to tensor needs to be refactored.
         #   Currently, surrogate models operate with tensors, while acquisition
         #   functions with dataframes.
-        train_x = searchspace.transform(measurements)
+        train_x = searchspace.transform(measurements, allow_extra=False)
         train_y = objective.transform(measurements)
         self.surrogate_model._fit(searchspace, *to_tensor(train_x, train_y))
         self._botorch_acqf = self.acquisition_function.to_botorch(

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -54,7 +54,7 @@ class BayesianRecommender(PureRecommender, ABC):
         # TODO: Transition point from dataframe to tensor needs to be refactored.
         #   Currently, surrogate models operate with tensors, while acquisition
         #   functions with dataframes.
-        train_x = searchspace.transform(measurements, allow_extra=False)
+        train_x = searchspace.transform(measurements)
         train_y = objective.transform(measurements)
         self.surrogate_model._fit(searchspace, *to_tensor(train_x, train_y))
         self._botorch_acqf = self.acquisition_function.to_botorch(

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -245,14 +245,7 @@ class SubspaceContinuous(SerialMixin):
         allow_extra: bool | None = None,
         data: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        """See :func:`baybe.searchspace.discrete.SubspaceDiscrete.transform`.
-
-        Args:
-            data: The data that should be transformed.
-
-        Returns:
-            The transformed data.
-        """
+        """See :func:`baybe.searchspace.core.SearchSpace.transform`."""
         if allow_extra is None:
             allow_extra = True
             warnings.warn(

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -261,6 +261,9 @@ class SubspaceContinuous(SerialMixin):
                 DeprecationWarning,
             )
 
+        # Mypy does not infer from the above that `df` must be a dataframe here
+        assert isinstance(df, pd.DataFrame)
+
         if allow_extra is None:
             allow_extra = True
             if set(df) - {p.name for p in self.parameters}:

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -246,16 +246,7 @@ class SubspaceContinuous(SerialMixin):
         data: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """See :func:`baybe.searchspace.core.SearchSpace.transform`."""
-        if allow_extra is None:
-            allow_extra = True
-            warnings.warn(
-                "For backward compatibility, the new `allow_extra` flag is set "
-                "to `True` when left unspecified. However, this behavior will be "
-                "changed in a future version. If you want to invoke the old behavior, "
-                "please explicitly set `allow_extra=True`.",
-                DeprecationWarning,
-            )
-
+        # >>>>>>>>>> Deprecation
         if not ((df is None) ^ (data is None)):
             raise ValueError(
                 "Provide the dataframe to be transformed as argument to `df`."
@@ -269,6 +260,18 @@ class SubspaceContinuous(SerialMixin):
                 "as positional argument instead.",
                 DeprecationWarning,
             )
+
+        if allow_extra is None:
+            allow_extra = True
+            if set(df) - {p.name for p in self.parameters}:
+                warnings.warn(
+                    "For backward compatibility, the new `allow_extra` flag is set "
+                    "to `True` when left unspecified. However, this behavior will be "
+                    "changed in a future version. If you want to invoke the old "
+                    "behavior, please explicitly set `allow_extra=True`.",
+                    DeprecationWarning,
+                )
+        # <<<<<<<<<< Deprecation
 
         # Extract the parameters to be transformed
         parameters = get_transform_parameters(

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -316,12 +316,17 @@ class SearchSpace(SerialMixin):
         Args:
             df: The dataframe to be transformed. The allowed columns of the dataframe
                 are dictated by the ``allow_missing`` and ``allow_extra`` flags.
-            allow_missing: If ``False``, each parameter of the space must have one
-                corresponding column in the given dataframe. If ``True``, the dataframe
-                may contain only a subset of parameter columns.
+                The ``None`` default value is for temporary backward compatibility only
+                and will be removed in a future version.
+            allow_missing: If ``False``, each parameter of the space must have
+                (exactly) one corresponding column in the given dataframe. If ``True``,
+                the dataframe may contain only a subset of parameter columns.
             allow_extra: If ``False``, every column present in the dataframe must
-                correspond to one parameter of the space. If ``True``, the dataframe
-                may contain additional non-parameter-related columns.
+                correspond to (exactly) one parameter of the space. If ``True``, the
+                dataframe may contain additional non-parameter-related columns, which
+                will be ignored.
+                The ``None`` default value is for temporary backward compatibility only
+                and will be removed in a future version.
             data: Ignore! For backward compatibility only.
 
         Raises:
@@ -330,6 +335,8 @@ class SearchSpace(SerialMixin):
         Returns:
             A corresponding dataframe with parameters in computational representation.
         """
+        # TODO: Remove deprecation-related explanation of `None` default values
+        #   from docstring once deprecation expires
         # >>>>>>>>>> Deprecation
         if not ((df is None) ^ (data is None)):
             raise ValueError(

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -330,16 +330,7 @@ class SearchSpace(SerialMixin):
         Returns:
             A corresponding dataframe with parameters in computational representation.
         """
-        if allow_extra is None:
-            allow_extra = True
-            warnings.warn(
-                "For backward compatibility, the new `allow_extra` flag is set "
-                "to `True` when left unspecified. However, this behavior will be "
-                "changed in a future version. If you want to invoke the old behavior, "
-                "please explicitly set `allow_extra=True`.",
-                DeprecationWarning,
-            )
-
+        # >>>>>>>>>> Deprecation
         if not ((df is None) ^ (data is None)):
             raise ValueError(
                 "Provide the dataframe to be transformed as argument to `df`."
@@ -353,6 +344,18 @@ class SearchSpace(SerialMixin):
                 "as positional argument instead.",
                 DeprecationWarning,
             )
+
+        if allow_extra is None:
+            allow_extra = True
+            if set(df) - {p.name for p in self.parameters}:
+                warnings.warn(
+                    "For backward compatibility, the new `allow_extra` flag is set "
+                    "to `True` when left unspecified. However, this behavior will be "
+                    "changed in a future version. If you want to invoke the old "
+                    "behavior, please explicitly set `allow_extra=True`.",
+                    DeprecationWarning,
+                )
+        # <<<<<<<<<< Deprecation
 
         # Transform subspaces separately
         df_discrete = self.discrete.transform(

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -311,17 +311,24 @@ class SearchSpace(SerialMixin):
         allow_extra: bool | None = None,
         data: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        """Transform data from experimental to computational representation.
-
-        This function can e.g. be used to transform data obtained from measurements.
-        Continuous parameters are not transformed but included.
+        """Transform parameters from experimental to computational representation.
 
         Args:
-            data: The data to be transformed. Must contain all specified parameters, can
-                contain more columns.
+            df: The dataframe to be transformed. The allowed columns of the dataframe
+                are dictated by the ``allow_missing`` and ``allow_extra`` flags.
+            allow_missing: If ``False``, each parameter of the space must have one
+                corresponding column in the given dataframe. If ``True``, the dataframe
+                may contain only a subset of parameter columns.
+            allow_extra: If ``False``, every column present in the dataframe must
+                correspond to one parameter of the space. If ``True``, the dataframe
+                may contain additional non-parameter-related columns.
+            data: Ignore! For backward compatibility only.
+
+        Raises:
+            ValueError: If dataframes are passed to both ``df`` and ``data``.
 
         Returns:
-            A dataframe with the parameters in computational representation.
+            A corresponding dataframe with parameters in computational representation.
         """
         if allow_extra is None:
             allow_extra = True

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -345,6 +345,9 @@ class SearchSpace(SerialMixin):
                 DeprecationWarning,
             )
 
+        # Mypy does not infer from the above that `df` must be a dataframe here
+        assert isinstance(df, pd.DataFrame)
+
         if allow_extra is None:
             allow_extra = True
             if set(df) - {p.name for p in self.parameters}:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -701,7 +701,7 @@ class SubspaceDiscrete(SerialMixin):
         # Transform the parameters
         dfs = []
         for param in parameters:
-            comp_df = param.transform_rep_exp2comp(df[param.name])
+            comp_df = param.transform(df[param.name])
             dfs.append(comp_df)
         comp_rep = pd.concat(dfs, axis=1) if dfs else pd.DataFrame()
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -202,7 +202,7 @@ class SubspaceDiscrete(SerialMixin):
     def _default_comp_rep(self) -> pd.DataFrame:
         """Create the default computational representation."""
         # Create a dataframe containing the computational parameter representation
-        comp_rep = self.transform(self.exp_rep, allow_extra=False)
+        comp_rep = self.transform(self.exp_rep)
 
         # Ignore all columns that do not carry any covariate information
         # TODO[12758]: This logic needs to be refined, i.e. when should we drop columns
@@ -659,16 +659,7 @@ class SubspaceDiscrete(SerialMixin):
         data: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """See :func:`baybe.searchspace.core.SearchSpace.transform`."""
-        if allow_extra is None:
-            allow_extra = True
-            warnings.warn(
-                "For backward compatibility, the new `allow_extra` flag is set "
-                "to `True` when left unspecified. However, this behavior will be "
-                "changed in a future version. If you want to invoke the old behavior, "
-                "please explicitly set `allow_extra=True`.",
-                DeprecationWarning,
-            )
-
+        # >>>>>>>>>> Deprecation
         if not ((df is None) ^ (data is None)):
             raise ValueError(
                 "Provide the dataframe to be transformed as argument to `df`."
@@ -682,6 +673,18 @@ class SubspaceDiscrete(SerialMixin):
                 "as positional argument instead.",
                 DeprecationWarning,
             )
+
+        if allow_extra is None:
+            allow_extra = True
+            if set(df) - {p.name for p in self.parameters}:
+                warnings.warn(
+                    "For backward compatibility, the new `allow_extra` flag is set "
+                    "to `True` when left unspecified. However, this behavior will be "
+                    "changed in a future version. If you want to invoke the old "
+                    "behavior, please explicitly set `allow_extra=True`.",
+                    DeprecationWarning,
+                )
+        # <<<<<<<<<< Deprecation
 
         # Extract the parameters to be transformed
         parameters = get_transform_parameters(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -674,9 +674,12 @@ class SubspaceDiscrete(SerialMixin):
                 DeprecationWarning,
             )
 
+        # Mypy does not infer from the above that `df` must be a dataframe here
+        assert isinstance(df, pd.DataFrame)
+
         if allow_extra is None:
             allow_extra = True
-            if set(df) - {p.name for p in self.parameters}:
+            if set(df.columns) - {p.name for p in self.parameters}:
                 warnings.warn(
                     "For backward compatibility, the new `allow_extra` flag is set "
                     "to `True` when left unspecified. However, this behavior will be "

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Collection, Iterable, Sequence
 from math import prod
 from typing import TYPE_CHECKING, Any
@@ -20,7 +21,11 @@ from baybe.parameters import (
 )
 from baybe.parameters.base import DiscreteParameter, Parameter
 from baybe.parameters.utils import get_parameters_from_dataframe
-from baybe.searchspace.validation import validate_parameter_names, validate_parameters
+from baybe.searchspace.validation import (
+    get_transform_parameters,
+    validate_parameter_names,
+    validate_parameters,
+)
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.basic import to_tuple
 from baybe.utils.boolean import eq_dataframe
@@ -646,28 +651,51 @@ class SubspaceDiscrete(SerialMixin):
 
     def transform(
         self,
-        data: pd.DataFrame,
+        df: pd.DataFrame | None = None,
+        /,
+        *,
+        allow_missing: bool = False,
+        allow_extra: bool | None = None,
+        data: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        """Transform parameters from experimental to computational representation.
+        """See :func:`baybe.searchspace.core.SearchSpace.transform`."""
+        if allow_extra is None:
+            allow_extra = True
+            warnings.warn(
+                "For backward compatibility, the new `allow_extra` flag is set "
+                "to `True` when left unspecified. However, this behavior will be "
+                "changed in a future version. If you want to invoke the old behavior, "
+                "please explicitly set `allow_extra=True`.",
+                DeprecationWarning,
+            )
 
-        Continuous parameters and additional columns are ignored.
+        if not ((df is None) ^ (data is None)):
+            raise ValueError(
+                "Provide the dataframe to be transformed as argument to `df`."
+            )
 
-        Args:
-            data: The data to be transformed. Must contain all specified parameters, can
-                contain more columns.
+        if data is not None:
+            df = data
+            warnings.warn(
+                "Providing the dataframe via the `data` argument is deprecated and "
+                "will be removed in a future version. Please pass your dataframe "
+                "as positional argument instead.",
+                DeprecationWarning,
+            )
 
-        Returns:
-            A dataframe with the parameters in computational representation.
-        """
+        # Extract the parameters to be transformed
+        parameters = get_transform_parameters(
+            self.parameters, df, allow_missing, allow_extra
+        )
+
         # If the transformed values are not required, return an empty dataframe
-        if self.empty_encoding or len(data) < 1:
-            comp_rep = pd.DataFrame(index=data.index)
-            return comp_rep
+        if self.empty_encoding or len(df) < 1:
+            return pd.DataFrame(index=df.index)
 
         # Transform the parameters
         dfs = []
-        for param in self.parameters:
-            comp_df = param.transform_rep_exp2comp(data[param.name])
+        for param in parameters:
+            comp_df = param.transform_rep_exp2comp(df[param.name])
             dfs.append(comp_df)
         comp_rep = pd.concat(dfs, axis=1) if dfs else pd.DataFrame()
 
@@ -675,11 +703,9 @@ class SubspaceDiscrete(SerialMixin):
         # removing some columns, e.g. due to decorrelation or dropping constant ones),
         # any subsequent transformation should yield the same columns.
         try:
-            comp_rep = comp_rep[self.comp_rep.columns]
+            return comp_rep[self.comp_rep.columns]
         except AttributeError:
-            pass
-
-        return comp_rep
+            return comp_rep
 
 
 def _apply_constraint_filter(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -202,7 +202,7 @@ class SubspaceDiscrete(SerialMixin):
     def _default_comp_rep(self) -> pd.DataFrame:
         """Create the default computational representation."""
         # Create a dataframe containing the computational parameter representation
-        comp_rep = self.transform(self.exp_rep)
+        comp_rep = self.transform(self.exp_rep, allow_extra=False)
 
         # Ignore all columns that do not carry any covariate information
         # TODO[12758]: This logic needs to be refined, i.e. when should we drop columns

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -52,7 +52,7 @@ def get_transform_parameters(
     """Extract the parameters relevant for transforming a given dataframe."""
     parameter_names = [p.name for p in parameters]
 
-    if (not allow_missing) and (missing := set(parameter_names) - set(df)):
+    if (not allow_missing) and (missing := set(parameter_names) - set(df)):  # type: ignore[arg-type]
         raise ValueError(
             f"The search space parameter(s) {missing} cannot be matched against "
             f"the provided dataframe. If you want to transform a subset of "

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -1,12 +1,15 @@
 """Validation functionality for search spaces."""
 
 from collections.abc import Collection, Sequence
+from typing import TypeVar
 
 import pandas as pd
 
 from baybe.exceptions import EmptySearchSpaceError
 from baybe.parameters import TaskParameter
 from baybe.parameters.base import Parameter
+
+_T = TypeVar("_T", bound=Parameter)
 
 
 def validate_parameter_names(  # noqa: DOC101, DOC103
@@ -44,11 +47,11 @@ def validate_parameters(parameters: Collection[Parameter]) -> None:  # noqa: DOC
 
 
 def get_transform_parameters(
-    parameters: Sequence[Parameter],
+    parameters: Sequence[_T],
     df: pd.DataFrame,
     allow_missing: bool,
     allow_extra: bool,
-) -> list[Parameter]:
+) -> list[_T]:
     """Extract the parameters relevant for transforming a given dataframe.
 
     Args:
@@ -81,4 +84,6 @@ def get_transform_parameters(
             f"with additional columns, explicitly set `allow_extra=True'."
         )
 
-    return [p for p in parameters if p.name in df] if allow_missing else parameters
+    return (
+        [p for p in parameters if p.name in df] if allow_missing else list(parameters)
+    )

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -48,8 +48,23 @@ def get_transform_parameters(
     df: pd.DataFrame,
     allow_missing: bool,
     allow_extra: bool,
-):
-    """Extract the parameters relevant for transforming a given dataframe."""
+) -> list[Parameter]:
+    """Extract the parameters relevant for transforming a given dataframe.
+
+    Args:
+        parameters: The parameters to be considered for transformation (provided
+            they have match in the given dataframe).
+        df: See :meth:`baybe.searchspace.core.SearchSpace.transform`.
+        allow_missing: See :meth:`baybe.searchspace.core.SearchSpace.transform`.
+        allow_extra: See :meth:`baybe.searchspace.core.SearchSpace.transform`.
+
+    Raises:
+        ValueError: If the given parameters and dataframe are not compatible
+            under the specified values for the Boolean flags.
+
+    Returns:
+        The (subset of) parameters that need to be considered for the transformation.
+    """
     parameter_names = [p.name for p in parameters]
 
     if (not allow_missing) and (missing := set(parameter_names) - set(df)):  # type: ignore[arg-type]

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
 from baybe import Campaign
@@ -225,15 +226,13 @@ def test_deprecated_samples_full_factorial():
         SubspaceContinuous(parameters).samples_full_factorial(n_points=1)
 
 
-# TODO: When expiring the deprecation, the explicitly `allow_extra=False` arguments
-#   can be removed from the backend code, since the default should become `False`.
-
-
 def test_deprecated_transform_interface(searchspace):
     """Using the deprecated transform interface raises a warning."""
-    # Not providing allow_extra
+    # Not providing `allow_extra` when there are additional columns
     with pytest.warns(DeprecationWarning):
-        searchspace.discrete.transform(searchspace.discrete.exp_rep)
+        searchspace.discrete.transform(
+            pd.DataFrame(columns=["additional", *searchspace.discrete.exp_rep.columns])
+        )
 
     # Passing dataframe via `data`
     with pytest.warns(DeprecationWarning):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -223,3 +223,20 @@ def test_deprecated_samples_full_factorial():
     with pytest.warns(DeprecationWarning):
         parameters = [NumericalContinuousParameter("x", (0, 1))]
         SubspaceContinuous(parameters).samples_full_factorial(n_points=1)
+
+
+# TODO: When expiring the deprecation, the explicitly `allow_extra=False` arguments
+#   can be removed from the backend code, since the default should become `False`.
+
+
+def test_deprecated_transform_interface(searchspace):
+    """Using the deprecated transform interface raises a warning."""
+    # Not providing allow_extra
+    with pytest.warns(DeprecationWarning):
+        searchspace.discrete.transform(searchspace.discrete.exp_rep)
+
+    # Passing dataframe via `data`
+    with pytest.warns(DeprecationWarning):
+        searchspace.discrete.transform(
+            data=searchspace.discrete.exp_rep, allow_extra=True
+        )

--- a/tests/validation/test_searchspace_validation.py
+++ b/tests/validation/test_searchspace_validation.py
@@ -1,0 +1,44 @@
+"""Validation tests for search spaces."""
+
+import pandas as pd
+import pytest
+from pytest import param
+
+from baybe.parameters.numerical import NumericalDiscreteParameter
+from baybe.searchspace.validation import get_transform_parameters
+
+parameters = [NumericalDiscreteParameter("d1", [0, 1])]
+
+
+@pytest.mark.parametrize(
+    ("df", "match"),
+    [
+        param(
+            pd.DataFrame(columns=[]),
+            r"parameter\(s\) \{'d1'\} cannot be matched",
+            id="missing",
+        ),
+        param(
+            pd.DataFrame(columns=["d1", "d2"]),
+            r"column\(s\) \{'d2'\} cannot be matched",
+            id="extra",
+        ),
+    ],
+)
+def test_invalid_transforms(df, match):
+    """Transforming dataframes with incorrect columns raises an error."""
+    with pytest.raises(ValueError, match=match):
+        get_transform_parameters(parameters, df, allow_missing=False, allow_extra=False)
+
+
+@pytest.mark.parametrize(
+    ("df", "missing", "extra"),
+    [
+        param(pd.DataFrame(columns=["d1"]), False, False, id="equal"),
+        param(pd.DataFrame(columns=[]), True, False, id="missing"),
+        param(pd.DataFrame(columns=["d1", "d2"]), False, True, id="extra"),
+    ],
+)
+def test_valid_transforms(df, missing, extra):
+    """When providing the appropriate flags, the columns of the dataframe to be transformed can be flexibly chosen."""  # noqa
+    get_transform_parameters(parameters, df, allow_missing=missing, allow_extra=extra)


### PR DESCRIPTION
The behavior of the search space `transform` methods was not very precise and invalid input was not caught appropriately.
This PR makes the following changes:
* The dataframe to be transformed must now be passed as positional argument. This avoids explicit use of the somewhat unclear argument name "data".
* Which columns the dataframe may or may not contain is now clearly controlled through new boolean flags added as keyword-only arguments.
* The docstrings of all methods are reworked and centrally maintained in the `SearchSpace` class, with references in subspace classes.
* All changes are made backward-compatible through a deprecation mechanism.
* Both test for the new logic and the deprecation are in place.
* Renames `DiscreteParameter.transform_rep_exp2comp` to `transform` and optimizes its signature