### PR TITLE
Augmentation Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ _ `_optional` subpackage for managing optional dependencies
    convenience constructors
 - `DiscreteParameter.to_subspace`, `ContinuousParameter.to_subspace` and
   `Parameter.to_searchspace` convenience constructors
+- Utilities for permutation and dependency data augmentation
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -36,6 +36,10 @@ class Constraint(ABC, SerialMixin):
     eval_during_modeling: ClassVar[bool]
     """Class variable encoding whether the condition is evaluated during modeling."""
 
+    eval_during_augmentation: ClassVar[bool] = False
+    """Class variable encoding whether the constraint could be considered during data
+    augmentation."""
+
     numerical_only: ClassVar[bool] = False
     """Class variable encoding whether the constraint is valid only for numerical
     parameters."""

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -133,6 +133,10 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
     a single constraint.
     """
 
+    # class variables
+    eval_during_augmentation: ClassVar[bool] = True
+    # See base class
+
     # object variables
     conditions: list[Condition] = field()
     """The list of individual conditions."""
@@ -219,6 +223,10 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
     *Note:* This constraint is evaluated during creation. In the future it might also be
     evaluated during modeling to make use of the invariance.
     """
+
+    # class variables
+    eval_during_augmentation: ClassVar[bool] = True
+    # See base class
 
     # object variables
     dependencies: DiscreteDependenciesConstraint | None = field(default=None)

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -495,6 +495,19 @@ class SubspaceContinuous(SerialMixin):
 
         return pd.DataFrame(index=index).reset_index()
 
+    def get_parameters_by_name(
+        self, names: Sequence[str]
+    ) -> tuple[NumericalContinuousParameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of parameter names.
+
+        Returns:
+            The named parameters.
+        """
+        return tuple(p for p in self.parameters if p.name in names)
+
 
 # Register deserialization hook
 converter.register_structure_hook(SubspaceContinuous, select_constructor_hook)

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -383,6 +383,19 @@ class SearchSpace(SerialMixin):
         """The searchspace constraints that can be considered during augmentation."""
         return tuple(c for c in self.constraints if c.eval_during_augmentation)
 
+    def get_parameters_by_name(self, names: Sequence[str]) -> tuple[Parameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of parameter names.
+
+        Returns:
+            The named parameters.
+        """
+        return self.discrete.get_parameters_by_name(
+            names
+        ) + self.continuous.get_parameters_by_name(names)
+
 
 def to_searchspace(
     x: Parameter | SubspaceDiscrete | SubspaceContinuous | SearchSpace, /

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -378,6 +378,11 @@ class SearchSpace(SerialMixin):
 
         return comp_rep
 
+    @property
+    def constraints_augmentable(self) -> tuple[Constraint, ...]:
+        """The searchspace constraints that can be considered during augmentation."""
+        return tuple(c for c in self.constraints if c.eval_during_augmentation)
+
 
 def to_searchspace(
     x: Parameter | SubspaceDiscrete | SubspaceContinuous | SearchSpace, /

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -725,6 +725,19 @@ class SubspaceDiscrete(SerialMixin):
         except AttributeError:
             return comp_rep
 
+    def get_parameters_by_name(
+        self, names: Sequence[str]
+    ) -> tuple[DiscreteParameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of parameter names.
+
+        Returns:
+            The named parameters.
+        """
+        return tuple(p for p in self.parameters if p.name in names)
+
 
 def _apply_constraint_filter(
     df: pd.DataFrame, constraints: Collection[DiscreteConstraint]

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -1,6 +1,6 @@
 """Utilities related to data augmentation."""
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from itertools import permutations, product
 
 import pandas as pd
@@ -110,7 +110,7 @@ def df_apply_permutation_augmentation(
 def df_apply_dependency_augmentation(
     df: pd.DataFrame,
     causing: tuple[str, Sequence],
-    affected: Sequence[tuple[str, Sequence]],
+    affected: Collection[tuple[str, Sequence]],
 ) -> pd.DataFrame:
     """Augment a dataframe if dependency invariant columns are present.
 

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -31,33 +31,93 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
 
 
 def df_apply_permutation_augmentation(
-    df: pd.DataFrame, columns: Sequence[str]
+    df: pd.DataFrame,
+    columns: Sequence[str],
+    dependents: Sequence[str] | None = None,
 ) -> pd.DataFrame:
     """Augment a dataframe if permutation invariant columns are present.
 
     Indices are preserved so that each augmented row will have the same index as its
-    original.
+    original. `dependent` columns are augmented in the same order as the `columns`.
+
+    *   Original
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+
+    *   Result with ``columns = ["A", "B"]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+        | b | a | x | y |
+        +---+---+---+---+
+        | a | b | x | z |
+        +---+---+---+---+
+
+    *   Result with ``columns = ["A", "B"]``, ``dependents = ["C", "D"]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+        | b | a | y | x |
+        +---+---+---+---+
+        | a | b | z | x |
+        +---+---+---+---+
 
     Args:
         df: The dataframe that should be augmented.
-        columns: Sequence indicating the permutation invariant columns.
+        columns: The permutation invariant columns.
+        dependents: Columns that are connected to `columns` and should be permuted in
+            the same manner.
 
     Returns:
         The augmented dataframe containing the original one.
+
+    Raises:
+        ValueError: If `dependents` has length incompatible with `columns`.
     """
+    dependents = dependents or []
     new_rows: list[pd.DataFrame] = []
+
+    if dependents and len(columns) != len(dependents):
+        raise ValueError(
+            "When augmenting permutation invariance with dependent columns, there must "
+            "be exactly the same amount of 'dependents' as there are 'columns'."
+        )
+
     for _, row in df.iterrows():
         # Extract the values from the specified columns
         original_values = row[columns].tolist()  # type: ignore[call-overload]
+        dependent_values = row[dependents].tolist() if dependents else None  # type: ignore[call-overload]
 
         # Generate all permutations of these values
-        all_perms = list(permutations(original_values))
+        column_perms = list(permutations(original_values))
+        dependent_perms = (
+            list(permutations(dependent_values)) if dependent_values else None
+        )
 
         # For each permutation, create a new row if it's not already in the dataframe
-        for perm in all_perms:
+        for k, perm in enumerate(column_perms):
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
             new_row[columns] = perm
+            if dependent_perms:
+                new_row[dependents] = dependent_perms[k]
+
             if not _row_in_df(new_row, df):
                 new_rows.append(new_row)
 
@@ -78,10 +138,64 @@ def df_apply_dependency_augmentation(
     will trigger an augmentation on the affected columns. The latter are augmented by
     going through all their invariant values and adding respective new rows.
 
+    *   Original
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0])``, ``affected = [("B", [2,3,4])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 0 | 4 | 5 | y |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0, 1])`, `affected = [("B", [2,3])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 1 | 2 | 5 | z |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0])`, `affected = [("B", [2,3]), ("C", [5, 6])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 0 | 2 | 6 | y |
+        +---+---+---+---+
+        | 0 | 3 | 6 | y |
+        +---+---+---+---+
+
     Args:
         df: The dataframe that should be augmented.
         causing: Causing column name and its causing values.
-        affected: List of affected columns and their invariant values.
+        affected: Affected columns and their invariant values.
 
     Returns:
         The augmented dataframe containing the original one.

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -27,6 +27,7 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
             )
         row = row.iloc[0]
 
+    row = row.reindex(df.columns)
     return (df == row).all(axis=1).any()
 
 

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -17,13 +17,13 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
         Boolean result.
 
     Raises:
-        ValueError: If `row` is a dataframe that contains more than one row.
+        ValueError: If ``row`` is a dataframe that contains more than one row.
     """
     if isinstance(row, pd.DataFrame):
         if len(row) != 1:
             raise ValueError(
                 f"{_row_in_df.__name__} can only be called with pd.Series or "
-                f"pd.DataFrame's that have exactly one row."
+                f"pd.DataFrames that have exactly one row."
             )
         row = row.iloc[0]
 
@@ -39,7 +39,7 @@ def df_apply_permutation_augmentation(
     """Augment a dataframe if permutation invariant columns are present.
 
     Indices are preserved so that each augmented row will have the same index as its
-    original. `dependent` columns are augmented in the same order as the `columns`.
+    original. ``dependent`` columns are augmented in the same order as the ``columns``.
 
     *   Original
 
@@ -82,14 +82,14 @@ def df_apply_permutation_augmentation(
     Args:
         df: The dataframe that should be augmented.
         columns: The permutation invariant columns.
-        dependents: Columns that are connected to `columns` and should be permuted in
+        dependents: Columns that are connected to ``columns`` and should be permuted in
             the same manner.
 
     Returns:
         The augmented dataframe containing the original one.
 
     Raises:
-        ValueError: If `dependents` has length incompatible with `columns`.
+        ValueError: If ``dependents`` has length incompatible with ``columns``.
     """
     dependents = dependents or []
     new_rows: list[pd.DataFrame] = []
@@ -163,7 +163,7 @@ def df_apply_dependency_augmentation(
         | 0 | 4 | 5 | y |
         +---+---+---+---+
 
-    *   Result with ``causing = ("A", [0, 1])`, `affected = [("B", [2,3])]``
+    *   Result with ``causing = ("A", [0, 1])``, ``affected = [("B", [2,3])]``
 
         +---+---+---+---+
         | A | B | C | D |
@@ -177,7 +177,8 @@ def df_apply_dependency_augmentation(
         | 1 | 2 | 5 | z |
         +---+---+---+---+
 
-    *   Result with ``causing = ("A", [0])`, `affected = [("B", [2,3]), ("C", [5, 6])]``
+    *   Result with ``causing = ("A", [0])``,
+        ``affected = [("B", [2,3]), ("C", [5, 6])]``
 
         +---+---+---+---+
         | A | B | C | D |

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -6,12 +6,25 @@ from itertools import permutations
 import pandas as pd
 
 
+def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
+    """Bla."""
+    if isinstance(row, pd.DataFrame):
+        if len(row) != 1:
+            raise ValueError(
+                f"{_row_in_df.__name__} can only be called with pd.Series or "
+                f"pd.DataFrame's that have exactly one row."
+            )
+        row = row.iloc[0]
+
+    return (df == row).all(axis=1).any()
+
+
 def df_apply_permutation_augmentation(
     df: pd.DataFrame, columns: Sequence[str]
 ) -> pd.DataFrame:
     """Bla."""
     new_rows: list[pd.DataFrame] = []
-    for index, row in df.iterrows():
+    for _, row in df.iterrows():
         # Extract the values from the specified columns
         original_values = row[columns].tolist()
 
@@ -23,11 +36,50 @@ def df_apply_permutation_augmentation(
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
             new_row[columns] = perm
-            new_rows.append(new_row)
+            if not _row_in_df(new_row, df):
+                new_rows.append(new_row)
 
     augmented_df = pd.concat([df] + new_rows)
 
-    # Drop duplicates if any created inadvertently
-    augmented_df.drop_duplicates(inplace=True)
+    return augmented_df
+
+
+def df_apply_dependency_augmentation(
+    df: pd.DataFrame,
+    causing: tuple[str, Sequence],
+    affected: Sequence[tuple[str, Sequence]],
+) -> pd.DataFrame:
+    """Bla."""
+    new_rows: list[pd.DataFrame] = []
+
+    # Iterate through all rows that have an invariance-causing value in the respective
+    # column
+    col_causing, vals_causing = causing
+    df_filtered = df.loc[df[col_causing].isin(vals_causing), :]
+    for _, row in df_filtered.iterrows():
+        # Augment the  specific row by growing a dataframe iteratively going through
+        # the affected columns. In each iteration augmented rows with that column
+        # changed to all possible values are added.
+        original_row = row.to_frame().T
+
+        current_augmented = original_row.copy()
+        for col_affected, vals_affected in affected:
+            to_add = []
+            for _, temp_row in current_augmented.iterrows():
+                to_add += [
+                    new_row
+                    for val in vals_affected
+                    if not _row_in_df(
+                        new_row := temp_row.to_frame().T.assign(**{col_affected: val}),
+                        current_augmented,
+                    )
+                ]
+            current_augmented = pd.concat([current_augmented] + to_add)
+
+        # Drop first entry because it's the original row
+        current_augmented = current_augmented.iloc[1:, :]
+        new_rows.append(current_augmented)
+
+    augmented_df = pd.concat([df] + new_rows)
 
     return augmented_df

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -1,0 +1,33 @@
+"""Utilities related to data augmentation."""
+
+from collections.abc import Sequence
+from itertools import permutations
+
+import pandas as pd
+
+
+def df_apply_permutation_augmentation(
+    df: pd.DataFrame, columns: Sequence[str]
+) -> pd.DataFrame:
+    """Bla."""
+    new_rows: list[pd.DataFrame] = []
+    for index, row in df.iterrows():
+        # Extract the values from the specified columns
+        original_values = row[columns].tolist()
+
+        # Generate all permutations of these values
+        all_perms = list(permutations(original_values))
+
+        # For each permutation, create a new row if it's not already in the DataFrame
+        for perm in all_perms:
+            # Create a new row dictionary with the permuted values
+            new_row = row.copy().to_frame().T
+            new_row[columns] = perm
+            new_rows.append(new_row)
+
+    augmented_df = pd.concat([df] + new_rows)
+
+    # Drop duplicates if any created inadvertently
+    augmented_df.drop_duplicates(inplace=True)
+
+    return augmented_df

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -113,7 +113,7 @@ def df_apply_permutation_augmentation(
         # For each permutation, create a new row if it's not already in the dataframe
         for k, perm in enumerate(column_perms):
             # Create a new row dictionary with the permuted values
-            new_row = row.copy().to_frame().T
+            new_row = pd.DataFrame([row])
             new_row[columns] = perm
             if dependent_perms:
                 new_row[dependents] = dependent_perms[k]
@@ -211,7 +211,7 @@ def df_apply_dependency_augmentation(
         # changed to all possible values are added. If there is more than one affected
         # column, it is important to include the augmented rows stemming from the
         # preceding columns as well.
-        original_row = row.to_frame().T
+        original_row = pd.DataFrame([row])
 
         currently_added = original_row.copy()  # Start with the original row
         for col_affected, vals_invariant in affected:
@@ -223,7 +223,7 @@ def df_apply_dependency_augmentation(
                     new_row
                     for val in vals_invariant
                     if not _row_in_df(
-                        new_row := temp_row.to_frame().T.assign(
+                        new_row := temp_row.pipe(lambda x: pd.DataFrame([x])).assign(
                             **{col_affected: val}
                         ),  # this takes the current row and replaces the affected value
                         currently_added,

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -7,7 +7,18 @@ import pandas as pd
 
 
 def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
-    """Bla."""
+    """Check whether a row is fully contained in a dataframe.
+
+    Args:
+        row: The row to be checked.
+        df: The dataframe to be checked.
+
+    Returns:
+        Boolean result.
+
+    Raises:
+        ValueError: If `row` is a dataframe that contains more than one row.
+    """
     if isinstance(row, pd.DataFrame):
         if len(row) != 1:
             raise ValueError(
@@ -22,16 +33,27 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
 def df_apply_permutation_augmentation(
     df: pd.DataFrame, columns: Sequence[str]
 ) -> pd.DataFrame:
-    """Bla."""
+    """Augment a dataframe if permutation invariant columns are present.
+
+    Indices are preserved so that each augmented row will have the same index as its
+    original.
+
+    Args:
+        df: The dataframe that should be augmented.
+        columns: Sequence indicating the permutation invariant columns.
+
+    Returns:
+        The augmented dataframe containing the original one.
+    """
     new_rows: list[pd.DataFrame] = []
     for _, row in df.iterrows():
         # Extract the values from the specified columns
-        original_values = row[columns].tolist()
+        original_values = row[columns].tolist()  # type: ignore[call-overload]
 
         # Generate all permutations of these values
         all_perms = list(permutations(original_values))
 
-        # For each permutation, create a new row if it's not already in the DataFrame
+        # For each permutation, create a new row if it's not already in the dataframe
         for perm in all_perms:
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
@@ -49,36 +71,56 @@ def df_apply_dependency_augmentation(
     causing: tuple[str, Sequence],
     affected: Sequence[tuple[str, Sequence]],
 ) -> pd.DataFrame:
-    """Bla."""
+    """Augment a dataframe if dependency invariant columns are present.
+
+    This works with the concept of column-values pairs for causing and affected column.
+    Any row present where the specified causing column has one of the provided values
+    will trigger an augmentation on the affected columns. The latter are augmented by
+    going through all their invariant values and adding respective new rows.
+
+    Args:
+        df: The dataframe that should be augmented.
+        causing: Causing column name and its causing values.
+        affected: List of affected columns and their invariant values.
+
+    Returns:
+        The augmented dataframe containing the original one.
+    """
     new_rows: list[pd.DataFrame] = []
 
-    # Iterate through all rows that have an invariance-causing value in the respective
-    # column
+    # Iterate through all rows that have a causing value in the respective column.
     col_causing, vals_causing = causing
     df_filtered = df.loc[df[col_causing].isin(vals_causing), :]
     for _, row in df_filtered.iterrows():
         # Augment the  specific row by growing a dataframe iteratively going through
         # the affected columns. In each iteration augmented rows with that column
-        # changed to all possible values are added.
+        # changed to all possible values are added. If there is more than one affected
+        # column, it is important to include the augmented rows stemming from the
+        # preceding columns as well.
         original_row = row.to_frame().T
 
-        current_augmented = original_row.copy()
-        for col_affected, vals_affected in affected:
+        currently_added = original_row.copy()  # Start with the original row
+        for col_affected, vals_invariant in affected:
             to_add = []
-            for _, temp_row in current_augmented.iterrows():
+
+            # Go through all previously added rows + the original row
+            for _, temp_row in currently_added.iterrows():
                 to_add += [
                     new_row
-                    for val in vals_affected
+                    for val in vals_invariant
                     if not _row_in_df(
-                        new_row := temp_row.to_frame().T.assign(**{col_affected: val}),
-                        current_augmented,
+                        new_row := temp_row.to_frame().T.assign(
+                            **{col_affected: val}
+                        ),  # this takes the current row and replaces the affected value
+                        currently_added,
                     )
                 ]
-            current_augmented = pd.concat([current_augmented] + to_add)
+            # Update the currently added rows
+            currently_added = pd.concat([currently_added] + to_add)
 
-        # Drop first entry because it's the original row
-        current_augmented = current_augmented.iloc[1:, :]
-        new_rows.append(current_augmented)
+        # Drop first entry because it's the original row and store added rows
+        currently_added = currently_added.iloc[1:, :]
+        new_rows.append(currently_added)
 
     augmented_df = pd.concat([df] + new_rows)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from pytest import param
 
+from baybe.utils.augmentation import df_apply_permutation_augmentation
 from baybe.utils.basic import register_hooks
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import closest_element
@@ -120,3 +121,91 @@ def test_invalid_register_hooks(target, hook):
     """Passing inconsistent signatures to `register_hooks` raises an error."""
     with pytest.raises(TypeError):
         register_hooks(target, [hook])
+
+
+@pytest.mark.parametrize(
+    ("data", "columns", "data_expected"),
+    [
+        param(  # 2 invariant cols and 1 unaffected col
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "C": ["x", "y"],
+            },
+            ["A", "B"],
+            {
+                "A": [1, 2, 1, 2],
+                "B": [2, 1, 2, 1],
+                "C": ["x", "x", "y", "y"],
+            },
+            id="2inv+1add",
+        ),
+        param(  # 2 invariant cols with identical values
+            {"A": [1, 1], "B": [2, 2]},
+            ["A", "B"],
+            {
+                "A": [1, 2],
+                "B": [2, 1],
+            },
+            id="2inv_degen",
+        ),
+        param(  # 2 invariant cols with identical values but different targets
+            {"A": [1, 1], "B": [2, 2], "T": ["x", "y"]},
+            ["A", "B"],
+            {
+                "A": [1, 1, 2, 2],
+                "B": [2, 2, 1, 1],
+                "T": ["x", "y", "x", "y"],
+            },
+            id="2inv_degen+target_unique",
+        ),
+        param(  # 2 invariant cols with identical values but different targets
+            {"A": [1, 1], "B": [2, 2], "T": ["x", "x"]},
+            ["A", "B"],
+            {
+                "A": [1, 2],
+                "B": [2, 1],
+                "T": ["x", "x"],
+            },
+            id="2inv_degen+target_degen",
+        ),
+        param(  # 3 invariant cols
+            {"A": [1, 1], "B": [2, 4], "C": [3, 5]},
+            ["A", "B", "C"],
+            {
+                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
+                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
+                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
+            },
+            id="3inv",
+        ),
+        param(  # 3 invariant cols
+            {"A": [1, 1], "B": [2, 4], "C": [3, 5], "D": ["x", "y"]},
+            ["A", "B", "C"],
+            {
+                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
+                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
+                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
+                "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
+            },
+            id="3inv+1add",
+        ),
+    ],
+)
+def test_df_invariance_augmentation(data, columns, data_expected):
+    """Test invariance data augmentation is done correctly."""
+    # Create all needed dataframes
+    df = pd.DataFrame(data)
+    df_augmented = df_apply_permutation_augmentation(df, columns)
+    df_expected = pd.DataFrame(data_expected)
+
+    # Determine equality ignoring row order
+    are_equal = (
+        pd.merge(left=df_augmented, right=df_expected, how="outer", indicator=True)[
+            "_merge"
+        ]
+        .eq("both")
+        .all()
+    )
+
+    assert are_equal, (df, df_augmented, df_expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,20 +142,27 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 1, 2, 1],
                 "C": ["x", "x", "y", "y"],
             },
-            id="2inv+1add",
+            id="2inv_1add",
         ),
         param(  # 2 invariant cols with identical values
-            {"A": [1, 1], "B": [2, 2]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+            },
             ["A", "B"],
             None,
             {
-                "A": [1, 2],
-                "B": [2, 1],
+                "A": [1, 1, 2],
+                "B": [2, 2, 1],
             },
-            id="2inv_degen",
+            id="2inv+degen",
         ),
         param(  # 2 invariant cols with identical values but different targets
-            {"A": [1, 1], "B": [2, 2], "T": ["x", "y"]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "T": ["x", "y"],
+            },
             ["A", "B"],
             None,
             {
@@ -163,10 +170,14 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2, 1, 1],
                 "T": ["x", "y", "x", "y"],
             },
-            id="2inv_degen+target_unique",
+            id="2inv+degen_target",
         ),
         param(  # 2 invariant cols with identical values but different targets
-            {"A": [1, 1], "B": [2, 2], "T": ["x", "x"]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "T": ["x", "x"],
+            },
             ["A", "B"],
             None,
             {
@@ -174,10 +185,14 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 1],
                 "T": ["x", "x"],
             },
-            id="2inv_degen+target_degen",
+            id="2inv+degen_target+degen",
         ),
         param(  # 3 invariant cols
-            {"A": [1, 1], "B": [2, 4], "C": [3, 5]},
+            {
+                "A": [1, 1],
+                "B": [2, 4],
+                "C": [3, 5],
+            },
             ["A", "B", "C"],
             None,
             {
@@ -188,7 +203,12 @@ def test_invalid_register_hooks(target, hook):
             id="3inv",
         ),
         param(  # 3 invariant cols
-            {"A": [1, 1], "B": [2, 4], "C": [3, 5], "D": ["x", "y"]},
+            {
+                "A": [1, 1],
+                "B": [2, 4],
+                "C": [3, 5],
+                "D": ["x", "y"],
+            },
             ["A", "B", "C"],
             None,
             {
@@ -197,7 +217,7 @@ def test_invalid_register_hooks(target, hook):
                 "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
                 "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
             },
-            id="3inv+1add",
+            id="3inv_1add",
         ),
         param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
             {
@@ -209,7 +229,7 @@ def test_invalid_register_hooks(target, hook):
                 "Other2": ["C", "D"],
             },
             ["Slot1", "Slot2"],
-            ["Frac1", "Frac2"],
+            [["Frac1"], ["Frac2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -218,11 +238,34 @@ def test_invalid_register_hooks(target, hook):
                 "Other1": ["A", "B", "A", "B"],
                 "Other2": ["C", "D", "C", "D"],
             },
-            id="2inv_degen+2dependent+2add",
+            id="2inv_2dependent_2add",
+        ),
+        param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
+            {
+                "Slot1": ["s1", "s2"],
+                "Slot2": ["s2", "s4"],
+                "Frac1": [0.1, 0.6],
+                "Frac2": [0.9, 0.4],
+                "Temp1": [10, 20],
+                "Temp2": [50, 60],
+                "Other": ["x", "y"],
+            },
+            ["Slot1", "Slot2"],
+            [["Frac1", "Temp1"], ["Frac2", "Temp2"]],
+            {
+                "Slot1": ["s1", "s2", "s2", "s4"],
+                "Slot2": ["s2", "s4", "s1", "s2"],
+                "Frac1": [0.1, 0.6, 0.9, 0.4],
+                "Frac2": [0.9, 0.4, 0.1, 0.6],
+                "Temp1": [10, 20, 50, 60],
+                "Temp2": [50, 60, 10, 20],
+                "Other": ["x", "y", "x", "y"],
+            },
+            id="2inv_4dependent2each_1add",
         ),
     ],
 )
-def test_df_permutation_augmentation(data, columns, dependents, data_expected):
+def test_df_permutation_aug(data, columns, dependents, data_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
@@ -241,6 +284,21 @@ def test_df_permutation_augmentation(data, columns, dependents, data_expected):
     assert (
         are_equal
     ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"
+
+
+@pytest.mark.parametrize(
+    ("columns", "dependents", "msg"),
+    [
+        param(["A"], [["B"], ["C"]], "exactly as many", id="too_manydependents"),
+        param(["A", "B"], [[], []], "same for all", id="dep_length_zero"),
+        param(["A", "B"], [["C"], []], "same for all", id="different_dep_lengths"),
+    ],
+)
+def test_df_permutation_aug_invalid(columns, dependents, msg):
+    """Test correct errors for invalid permutation attempts."""
+    df = pd.DataFrame({"A": [1, 1], "B": [2, 2], "C": ["x", "y"]})
+    with pytest.raises(ValueError, match=msg):
+        df_apply_permutation_augmentation(df, columns, dependents)
 
 
 @pytest.mark.parametrize(
@@ -308,7 +366,7 @@ def test_df_permutation_augmentation(data, columns, dependents, data_expected):
         ),
     ],
 )
-def test_df_dependency_augmentation(data, causing, affected, data_expected):
+def test_df_dependency_aug(data, causing, affected, data_expected):
     """Test dependency data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,8 +222,8 @@ def test_invalid_register_hooks(target, hook):
         ),
     ],
 )
-def test_df_invariance_augmentation(data, columns, dependents, data_expected):
-    """Test invariance data augmentation is done correctly."""
+def test_df_permutation_augmentation(data, columns, dependents, data_expected):
+    """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
     df_augmented = df_apply_permutation_augmentation(df, columns, dependents)
@@ -238,7 +238,9 @@ def test_df_invariance_augmentation(data, columns, dependents, data_expected):
         .all()
     )
 
-    assert are_equal, (df, df_augmented, df_expected)
+    assert (
+        are_equal
+    ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"
 
 
 @pytest.mark.parametrize(
@@ -322,4 +324,6 @@ def test_df_dependency_augmentation(data, causing, affected, data_expected):
         .all()
     )
 
-    assert are_equal, (df, df_augmented, df_expected)
+    assert (
+        are_equal
+    ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,7 +127,7 @@ def test_invalid_register_hooks(target, hook):
 
 
 @pytest.mark.parametrize(
-    ("data", "columns", "dependents", "data_expected"),
+    ("data", "columns", "data_expected"),
     [
         param(  # 2 invariant cols and 1 unaffected col
             {
@@ -135,8 +135,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "C": ["x", "y"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 2, 1, 2],
                 "B": [2, 1, 2, 1],
@@ -149,8 +148,7 @@ def test_invalid_register_hooks(target, hook):
                 "A": [1, 1],
                 "B": [2, 2],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 1, 2],
                 "B": [2, 2, 1],
@@ -163,8 +161,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "T": ["x", "y"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 1, 2, 2],
                 "B": [2, 2, 1, 1],
@@ -178,8 +175,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "T": ["x", "x"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 2],
                 "B": [2, 1],
@@ -192,25 +188,9 @@ def test_invalid_register_hooks(target, hook):
                 "A": [1, 1],
                 "B": [2, 4],
                 "C": [3, 5],
-            },
-            ["A", "B", "C"],
-            None,
-            {
-                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
-                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
-                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
-            },
-            id="3inv",
-        ),
-        param(  # 3 invariant cols
-            {
-                "A": [1, 1],
-                "B": [2, 4],
-                "C": [3, 5],
                 "D": ["x", "y"],
             },
-            ["A", "B", "C"],
-            None,
+            [["A"], ["B"], ["C"]],
             {
                 "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
                 "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
@@ -228,8 +208,7 @@ def test_invalid_register_hooks(target, hook):
                 "Other1": ["A", "B"],
                 "Other2": ["C", "D"],
             },
-            ["Slot1", "Slot2"],
-            [["Frac1"], ["Frac2"]],
+            [["Slot1", "Frac1"], ["Slot2", "Frac2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -250,8 +229,7 @@ def test_invalid_register_hooks(target, hook):
                 "Temp2": [50, 60],
                 "Other": ["x", "y"],
             },
-            ["Slot1", "Slot2"],
-            [["Frac1", "Temp1"], ["Frac2", "Temp2"]],
+            [["Slot1", "Frac1", "Temp1"], ["Slot2", "Frac2", "Temp2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -265,11 +243,11 @@ def test_invalid_register_hooks(target, hook):
         ),
     ],
 )
-def test_df_permutation_aug(data, columns, dependents, data_expected):
+def test_df_permutation_aug(data, columns, data_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
-    df_augmented = df_apply_permutation_augmentation(df, columns, dependents)
+    df_augmented = df_apply_permutation_augmentation(df, columns)
     df_expected = pd.DataFrame(data_expected)
 
     # Determine equality ignoring row order
@@ -287,18 +265,19 @@ def test_df_permutation_aug(data, columns, dependents, data_expected):
 
 
 @pytest.mark.parametrize(
-    ("columns", "dependents", "msg"),
+    ("columns", "msg"),
     [
-        param(["A"], [["B"], ["C"]], "exactly as many", id="too_manydependents"),
-        param(["A", "B"], [[], []], "same for all", id="dep_length_zero"),
-        param(["A", "B"], [["C"], []], "same for all", id="different_dep_lengths"),
+        param([], "at least two column sequences", id="no_seqs"),
+        param([["A"]], "at least two column sequences", id="just_one_seq"),
+        param([["A"], ["B", "C"]], "sequence is the same", id="different_lengths"),
+        param([[], []], "sequence is the same", id="empty_seqs"),
     ],
 )
-def test_df_permutation_aug_invalid(columns, dependents, msg):
+def test_df_permutation_aug_invalid(columns, msg):
     """Test correct errors for invalid permutation attempts."""
     df = pd.DataFrame({"A": [1, 1], "B": [2, 2], "C": ["x", "y"]})
     with pytest.raises(ValueError, match=msg):
-        df_apply_permutation_augmentation(df, columns, dependents)
+        df_apply_permutation_augmentation(df, columns)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -12,137 +12,173 @@ from baybe.utils.augmentation import (
 
 
 @pytest.mark.parametrize(
-    ("data", "col_groups", "data_expected"),
+    ("content", "col_groups", "content_expected"),
     [
         param(  # 2 invariant cols and 1 unaffected col
             {
-                "A": [1, 1],
-                "B": [2, 2],
-                "C": ["x", "y"],
+                "data": {
+                    "A": [1, 1],
+                    "B": [2, 2],
+                    "C": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             [["A"], ["B"]],
             {
-                "A": [1, 2, 1, 2],
-                "B": [2, 1, 2, 1],
-                "C": ["x", "x", "y", "y"],
+                "data": {
+                    "A": [1, 2, 1, 2],
+                    "B": [2, 1, 2, 1],
+                    "C": ["x", "x", "y", "y"],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv_1add",
         ),
-        param(  # 2 invariant cols with identical values
+        param(  # 2 invariant cols with identical row values
             {
-                "A": [1, 1],
-                "B": [2, 2],
+                "data": {
+                    "A": [1, 1],
+                    "B": [2, 2],
+                },
+                "index": [0, 1],
             },
             [["A"], ["B"]],
             {
-                "A": [1, 1, 2],
-                "B": [2, 2, 1],
+                "data": {
+                    "A": [1, 2, 1, 2],
+                    "B": [2, 1, 2, 1],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv+degen",
         ),
-        param(  # 2 invariant cols with identical values but different targets
+        param(  # 2 groups with identical row values but different targets
             {
-                "A": [1, 1],
-                "B": [2, 2],
-                "T": ["x", "y"],
+                "data": {
+                    "A": [1, 1],
+                    "B": [2, 2],
+                    "T": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             [["A"], ["B"]],
             {
-                "A": [1, 1, 2, 2],
-                "B": [2, 2, 1, 1],
-                "T": ["x", "y", "x", "y"],
+                "data": {
+                    "A": [1, 2, 1, 2],
+                    "B": [2, 1, 2, 1],
+                    "T": ["x", "x", "y", "y"],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv+degen_target",
         ),
-        param(  # 2 invariant cols with identical values but different targets
+        param(  # 2 groups with identical row values but same targets
             {
-                "A": [1, 1],
-                "B": [2, 2],
-                "T": ["x", "x"],
+                "data": {
+                    "A": [1, 1],
+                    "B": [2, 2],
+                    "T": ["x", "x"],
+                },
+                "index": [0, 1],
             },
             [["A"], ["B"]],
             {
-                "A": [1, 2],
-                "B": [2, 1],
-                "T": ["x", "x"],
+                "data": {
+                    "A": [1, 2, 1, 2],
+                    "B": [2, 1, 2, 1],
+                    "T": ["x", "x", "x", "x"],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv+degen_target+degen",
         ),
-        param(  # 3 invariant cols
+        param(  # 3 invariant groups with 1 entry each
             {
-                "A": [1, 1],
-                "B": [2, 4],
-                "C": [3, 5],
-                "D": ["x", "y"],
+                "data": {
+                    "A": [1, 1],
+                    "B": [2, 4],
+                    "C": [3, 5],
+                    "D": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             [["A"], ["B"], ["C"]],
             {
-                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
-                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
-                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
-                "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
+                "data": {
+                    "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
+                    "B": [2, 3, 1, 3, 1, 2, 4, 5, 1, 5, 1, 4],
+                    "C": [3, 2, 3, 1, 2, 1, 5, 4, 5, 1, 4, 1],
+                    "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
+                },
+                "index": [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
             },
             id="3inv_1add",
         ),
-        param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
+        param(  # 2 groups with 2 entries each, 2 additional columns
             {
-                "Slot1": ["s1", "s2"],
-                "Slot2": ["s2", "s4"],
-                "Frac1": [0.1, 0.6],
-                "Frac2": [0.9, 0.4],
-                "Other1": ["A", "B"],
-                "Other2": ["C", "D"],
+                "data": {
+                    "Slot1": ["s1", "s2"],
+                    "Slot2": ["s2", "s4"],
+                    "Frac1": [0.1, 0.6],
+                    "Frac2": [0.9, 0.4],
+                    "Other1": ["A", "B"],
+                    "Other2": ["C", "D"],
+                },
+                "index": [0, 1],
             },
             [["Slot1", "Frac1"], ["Slot2", "Frac2"]],
             {
-                "Slot1": ["s1", "s2", "s2", "s4"],
-                "Slot2": ["s2", "s4", "s1", "s2"],
-                "Frac1": [0.1, 0.6, 0.9, 0.4],
-                "Frac2": [0.9, 0.4, 0.1, 0.6],
-                "Other1": ["A", "B", "A", "B"],
-                "Other2": ["C", "D", "C", "D"],
+                "data": {
+                    "Slot1": ["s1", "s2", "s2", "s4"],
+                    "Slot2": ["s2", "s1", "s4", "s2"],
+                    "Frac1": [0.1, 0.9, 0.6, 0.4],
+                    "Frac2": [0.9, 0.1, 0.4, 0.6],
+                    "Other1": ["A", "A", "B", "B"],
+                    "Other2": ["C", "C", "D", "D"],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv_2dependent_2add",
         ),
-        param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
+        param(  # 2 groups with 3 entries each, 1 additional column
             {
-                "Slot1": ["s1", "s2"],
-                "Slot2": ["s2", "s4"],
-                "Frac1": [0.1, 0.6],
-                "Frac2": [0.9, 0.4],
-                "Temp1": [10, 20],
-                "Temp2": [50, 60],
-                "Other": ["x", "y"],
+                "data": {
+                    "Slot1": ["s1", "s2"],
+                    "Slot2": ["s2", "s4"],
+                    "Frac1": [0.1, 0.6],
+                    "Frac2": [0.9, 0.4],
+                    "Temp1": [10, 20],
+                    "Temp2": [50, 60],
+                    "Other": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             [["Slot1", "Frac1", "Temp1"], ["Slot2", "Frac2", "Temp2"]],
             {
-                "Slot1": ["s1", "s2", "s2", "s4"],
-                "Slot2": ["s2", "s4", "s1", "s2"],
-                "Frac1": [0.1, 0.6, 0.9, 0.4],
-                "Frac2": [0.9, 0.4, 0.1, 0.6],
-                "Temp1": [10, 20, 50, 60],
-                "Temp2": [50, 60, 10, 20],
-                "Other": ["x", "y", "x", "y"],
+                "data": {
+                    "Slot1": ["s1", "s2", "s2", "s4"],
+                    "Slot2": ["s2", "s1", "s4", "s2"],
+                    "Frac1": [0.1, 0.9, 0.6, 0.4],
+                    "Frac2": [0.9, 0.1, 0.4, 0.6],
+                    "Temp1": [10, 50, 20, 60],
+                    "Temp2": [50, 10, 60, 20],
+                    "Other": ["x", "x", "y", "y"],
+                },
+                "index": [0, 0, 1, 1],
             },
             id="2inv_4dependent2each_1add",
         ),
     ],
 )
-def test_df_permutation_aug(data, col_groups, data_expected):
+def test_df_permutation_aug(content, col_groups, content_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
-    df = pd.DataFrame(data)
+    df = pd.DataFrame(**content)
     df_augmented = df_apply_permutation_augmentation(df, col_groups)
-    df_expected = pd.DataFrame(data_expected)
+    df_expected = pd.DataFrame(**content_expected)
 
     # Determine equality ignoring row order
-    are_equal = (
-        pd.merge(left=df_augmented, right=df_expected, how="outer", indicator=True)[
-            "_merge"
-        ]
-        .eq("both")
-        .all()
-    )
+    are_equal = df_augmented.equals(df_expected)
 
     assert (
         are_equal
@@ -166,85 +202,103 @@ def test_df_permutation_aug_invalid(col_groups, msg):
 
 
 @pytest.mark.parametrize(
-    ("data", "causing", "affected", "data_expected"),
+    ("content", "causing", "affected", "content_expected"),
     [
         param(  # 1 causing val, 1 col affected (with 3 values)
             {
-                "A": [0, 1],
-                "B": [3, 4],
-                "C": ["x", "y"],
+                "data": {
+                    "A": [0, 1],
+                    "B": [3, 4],
+                    "C": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             ("A", [0]),
             [("B", [3, 4, 5])],
             {
-                "A": [0, 1, 0, 0],
-                "B": [3, 4, 4, 5],
-                "C": ["x", "y", "x", "x"],
+                "data": {
+                    "A": [0, 0, 0, 1],
+                    "B": [3, 4, 5, 4],
+                    "C": ["x", "x", "x", "y"],
+                },
+                "index": [0, 0, 0, 1],
             },
             id="1causing_1affected",
         ),
         param(  # 1 causing val, 2 cols affected (with 2 values each)
             {
-                "A": [0, 1],
-                "B": [3, 4],
-                "C": ["x", "y"],
+                "data": {
+                    "A": [0, 1],
+                    "B": [3, 4],
+                    "C": ["x", "y"],
+                },
+                "index": [0, 1],
             },
             ("A", [0]),
             [("B", [3, 4]), ("C", ["x", "y"])],
             {
-                "A": [0, 1, 0, 0, 0],
-                "B": [3, 4, 4, 3, 4],
-                "C": ["x", "y", "x", "y", "y"],
+                "data": {
+                    "A": [0, 0, 0, 0, 1],
+                    "B": [3, 3, 4, 4, 4],
+                    "C": ["x", "y", "x", "y", "y"],
+                },
+                "index": [0, 0, 0, 0, 1],
             },
             id="1causing_2affected",
         ),
         param(  # 2 causing vals, 1 col affected (with 3 values)
             {
-                "A": [0, 1, 2],
-                "B": [3, 4, 3],
-                "C": ["x", "y", "z"],
+                "data": {
+                    "A": [0, 1, 2],
+                    "B": [3, 4, 3],
+                    "C": ["x", "y", "z"],
+                },
+                "index": [0, 1, 2],
             },
             ("A", [0, 1]),
             [("B", [3, 4, 5])],
             {
-                "A": [0, 1, 2, 0, 0, 1, 1],
-                "B": [3, 4, 3, 4, 5, 3, 5],
-                "C": ["x", "y", "z", "x", "x", "y", "y"],
+                "data": {
+                    "A": [0, 0, 0, 1, 1, 1, 2],
+                    "B": [3, 4, 5, 3, 4, 5, 3],
+                    "C": ["x", "x", "x", "y", "y", "y", "z"],
+                },
+                "index": [0, 0, 0, 1, 1, 1, 2],
             },
             id="2causing_1affected",
         ),
         param(  # 2 causing vals, 2 cols affected (with 2 values each)
             {
-                "A": [0, 1, 2],
-                "B": [3, 4, 3],
-                "C": ["x", "y", "x"],
+                "data": {
+                    "A": [0, 1, 2],
+                    "B": [3, 4, 3],
+                    "C": ["x", "y", "x"],
+                },
+                "index": [0, 1, 2],
             },
             ("A", [0, 1]),
             [("B", [3, 4]), ("C", ["x", "y"])],
             {
-                "A": [0, 1, 2, 0, 0, 0, 1, 1, 1],
-                "B": [3, 4, 3, 4, 3, 4, 3, 3, 4],
-                "C": ["x", "y", "x", "x", "y", "y", "y", "x", "x"],
+                "data": {
+                    "A": [0, 0, 0, 0, 1, 1, 1, 1, 2],
+                    "B": [3, 3, 4, 4, 3, 3, 4, 4, 3],
+                    "C": ["x", "y", "x", "y", "x", "y", "x", "y", "x"],
+                },
+                "index": [0, 0, 0, 0, 1, 1, 1, 1, 2],
             },
             id="2causing_2affected",
         ),
     ],
 )
-def test_df_dependency_aug(data, causing, affected, data_expected):
+def test_df_dependency_aug(content, causing, affected, content_expected):
     """Test dependency data augmentation is done correctly."""
     # Create all needed dataframes
-    df = pd.DataFrame(data)
+    df = pd.DataFrame(**content)
     df_augmented = df_apply_dependency_augmentation(df, causing, affected)
-    df_expected = pd.DataFrame(data_expected)
+    df_expected = pd.DataFrame(**content_expected)
 
     # Determine equality ignoring row order
-    are_equal = (
-        pd.merge(left=df_augmented, right=df_expected, how="outer", indicator=True)[
-            "_merge"
-        ]
-        .eq("both")
-        .all()
-    )
+    are_equal = df_augmented.equals(df_expected)
 
     assert (
         are_equal

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -12,7 +12,7 @@ from baybe.utils.augmentation import (
 
 
 @pytest.mark.parametrize(
-    ("data", "columns", "data_expected"),
+    ("data", "col_groups", "data_expected"),
     [
         param(  # 2 invariant cols and 1 unaffected col
             {
@@ -128,11 +128,11 @@ from baybe.utils.augmentation import (
         ),
     ],
 )
-def test_df_permutation_aug(data, columns, data_expected):
+def test_df_permutation_aug(data, col_groups, data_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
-    df_augmented = df_apply_permutation_augmentation(df, columns)
+    df_augmented = df_apply_permutation_augmentation(df, col_groups)
     df_expected = pd.DataFrame(data_expected)
 
     # Determine equality ignoring row order
@@ -150,19 +150,19 @@ def test_df_permutation_aug(data, columns, data_expected):
 
 
 @pytest.mark.parametrize(
-    ("columns", "msg"),
+    ("col_groups", "msg"),
     [
-        param([], "at least two column sequences", id="no_seqs"),
-        param([["A"]], "at least two column sequences", id="just_one_seq"),
-        param([["A"], ["B", "C"]], "sequence is the same", id="different_lengths"),
-        param([[], []], "sequence is the same", id="empty_seqs"),
+        param([], "at least two column sequences", id="no_groups"),
+        param([["A"]], "at least two column sequences", id="just_one_group"),
+        param([["A"], ["B", "C"]], "the amount of columns in", id="different_lengths"),
+        param([[], []], "each column group has", id="empty_group"),
     ],
 )
-def test_df_permutation_aug_invalid(columns, msg):
+def test_df_permutation_aug_invalid(col_groups, msg):
     """Test correct errors for invalid permutation attempts."""
     df = pd.DataFrame({"A": [1, 1], "B": [2, 2], "C": ["x", "y"]})
     with pytest.raises(ValueError, match=msg):
-        df_apply_permutation_augmentation(df, columns)
+        df_apply_permutation_augmentation(df, col_groups)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_augmentation.py
+++ b/tests/utils/test_augmentation.py
@@ -1,7 +1,6 @@
-"""Tests for utilities."""
-import math
+"""Tests for augmentation utilities."""
 
-import numpy as np
+
 import pandas as pd
 import pytest
 from pytest import param
@@ -10,120 +9,6 @@ from baybe.utils.augmentation import (
     df_apply_dependency_augmentation,
     df_apply_permutation_augmentation,
 )
-from baybe.utils.basic import register_hooks
-from baybe.utils.memory import bytes_to_human_readable
-from baybe.utils.numerical import closest_element
-from baybe.utils.sampling_algorithms import DiscreteSamplingMethod, sample_numerical_df
-
-_TARGET = 1337
-_CLOSEST = _TARGET + 0.1
-
-
-def f_plain(arg1, arg2):
-    pass
-
-
-def f_annotated(arg1: str, arg2: int):
-    pass
-
-
-def f_annotated_one_default(arg1: str, arg2: int = 1):
-    pass
-
-
-def f2_plain(arg, arg3):
-    pass
-
-
-@pytest.mark.parametrize(
-    "as_ndarray", [param(False, id="list"), param(True, id="array")]
-)
-@pytest.mark.parametrize(
-    "array",
-    [
-        param(_CLOSEST, id="0D"),
-        param([0, _CLOSEST], id="1D"),
-        param([[2, 3], [0, _CLOSEST]], id="2D"),
-    ],
-)
-def test_closest_element(as_ndarray, array):
-    """The closest element can be found irrespective of the input type."""
-    if as_ndarray:
-        array = np.asarray(array)
-    actual = closest_element(array, _TARGET)
-    assert actual == _CLOSEST, (actual, _CLOSEST)
-
-
-def test_memory_human_readable_conversion():
-    """The memory conversion to human readable format is correct."""
-    assert bytes_to_human_readable(1024) == (1.0, "KB")
-    assert bytes_to_human_readable(1024**2) == (1.0, "MB")
-    assert bytes_to_human_readable(4.3 * 1024**4) == (4.3, "TB")
-
-
-@pytest.mark.parametrize("fraction", [0.2, 0.8, 1.0, 1.2, 2.0, 2.4, 3.5])
-@pytest.mark.parametrize("method", list(DiscreteSamplingMethod))
-def test_discrete_sampling(fraction, method):
-    """Size consistency tests for discrete sampling utility."""
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
-
-    n_points = math.ceil(fraction * len(df))
-    sampled = sample_numerical_df(df, n_points, method=method)
-
-    assert (
-        len(sampled) == n_points
-    ), "Sampling did not return expected number of points."
-    if fraction >= 1.0:
-        # Ensure the entire dataframe is contained in the sampled points
-        assert (
-            pd.merge(df, sampled, how="left", indicator=True)["_merge"].eq("both").all()
-        ), "Oversized sampling did not return all original points at least once."
-    else:
-        # Assure all points are unique
-        assert len(sampled) == len(
-            sampled.drop_duplicates()
-        ), "Undersized sampling did not return unique points."
-
-
-@pytest.mark.parametrize(
-    ("target", "hook"),
-    [
-        param(
-            f_annotated,
-            f_annotated_one_default,
-            id="hook_with_defaults",
-        ),
-        param(
-            f_annotated_one_default,
-            f_annotated,
-            id="target_with_defaults",
-        ),
-        param(
-            f_annotated,
-            f_plain,
-            id="hook_without_annotations",
-        ),
-    ],
-)
-def test_valid_register_hooks(target, hook):
-    """Passing consistent signatures to `register_hooks` raises no error."""
-    register_hooks(target, [hook])
-
-
-@pytest.mark.parametrize(
-    ("target", "hook"),
-    [
-        param(
-            f_annotated,
-            f2_plain,
-            id="different_names",
-        ),
-    ],
-)
-def test_invalid_register_hooks(target, hook):
-    """Passing inconsistent signatures to `register_hooks` raises an error."""
-    with pytest.raises(TypeError):
-        register_hooks(target, [hook])
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_basic.py
+++ b/tests/utils/test_basic.py
@@ -1,0 +1,63 @@
+"""Tests for basic utilities."""
+
+import pytest
+from pytest import param
+
+from baybe.utils.basic import register_hooks
+
+
+def f_plain(arg1, arg2):
+    pass
+
+
+def f_annotated(arg1: str, arg2: int):
+    pass
+
+
+def f_annotated_one_default(arg1: str, arg2: int = 1):
+    pass
+
+
+def f2_plain(arg, arg3):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("target", "hook"),
+    [
+        param(
+            f_annotated,
+            f_annotated_one_default,
+            id="hook_with_defaults",
+        ),
+        param(
+            f_annotated_one_default,
+            f_annotated,
+            id="target_with_defaults",
+        ),
+        param(
+            f_annotated,
+            f_plain,
+            id="hook_without_annotations",
+        ),
+    ],
+)
+def test_valid_register_hooks(target, hook):
+    """Passing consistent signatures to `register_hooks` raises no error."""
+    register_hooks(target, [hook])
+
+
+@pytest.mark.parametrize(
+    ("target", "hook"),
+    [
+        param(
+            f_annotated,
+            f2_plain,
+            id="different_names",
+        ),
+    ],
+)
+def test_invalid_register_hooks(target, hook):
+    """Passing inconsistent signatures to `register_hooks` raises an error."""
+    with pytest.raises(TypeError):
+        register_hooks(target, [hook])

--- a/tests/utils/test_memory.py
+++ b/tests/utils/test_memory.py
@@ -1,0 +1,11 @@
+"""Tests for memory utilities."""
+
+
+from baybe.utils.memory import bytes_to_human_readable
+
+
+def test_memory_human_readable_conversion():
+    """The memory conversion to human readable format is correct."""
+    assert bytes_to_human_readable(1024) == (1.0, "KB")
+    assert bytes_to_human_readable(1024**2) == (1.0, "MB")
+    assert bytes_to_human_readable(4.3 * 1024**4) == (4.3, "TB")

--- a/tests/utils/test_numerical.py
+++ b/tests/utils/test_numerical.py
@@ -1,0 +1,28 @@
+"""Tests for numerical utilities."""
+import numpy as np
+import pytest
+from pytest import param
+
+from baybe.utils.numerical import closest_element
+
+_TARGET = 1337
+_CLOSEST = _TARGET + 0.1
+
+
+@pytest.mark.parametrize(
+    "as_ndarray", [param(False, id="list"), param(True, id="array")]
+)
+@pytest.mark.parametrize(
+    "array",
+    [
+        param(_CLOSEST, id="0D"),
+        param([0, _CLOSEST], id="1D"),
+        param([[2, 3], [0, _CLOSEST]], id="2D"),
+    ],
+)
+def test_closest_element(as_ndarray, array):
+    """The closest element can be found irrespective of the input type."""
+    if as_ndarray:
+        array = np.asarray(array)
+    actual = closest_element(array, _TARGET)
+    assert actual == _CLOSEST, (actual, _CLOSEST)

--- a/tests/utils/test_sampling_algorithms.py
+++ b/tests/utils/test_sampling_algorithms.py
@@ -1,0 +1,32 @@
+"""Tests for sampling algorithm utilities."""
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from baybe.utils.sampling_algorithms import DiscreteSamplingMethod, sample_numerical_df
+
+
+@pytest.mark.parametrize("fraction", [0.2, 0.8, 1.0, 1.2, 2.0, 2.4, 3.5])
+@pytest.mark.parametrize("method", list(DiscreteSamplingMethod))
+def test_discrete_sampling(fraction, method):
+    """Size consistency tests for discrete sampling utility."""
+    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 4)), columns=list("ABCD"))
+
+    n_points = math.ceil(fraction * len(df))
+    sampled = sample_numerical_df(df, n_points, method=method)
+
+    assert (
+        len(sampled) == n_points
+    ), "Sampling did not return expected number of points."
+    if fraction >= 1.0:
+        # Ensure the entire dataframe is contained in the sampled points
+        assert (
+            pd.merge(df, sampled, how="left", indicator=True)["_merge"].eq("both").all()
+        ), "Oversized sampling did not return all original points at least once."
+    else:
+        # Assure all points are unique
+        assert len(sampled) == len(
+            sampled.drop_duplicates()
+        ), "Undersized sampling did not return unique points."


### PR DESCRIPTION
Adds utilities for data augmentation and small modifications to constraints:
- dataframe based utilities `df_apply_permutation_augmentation` and `df_apply_dependency_augmentation` + tests
- Constraints have the new `eval_during_augmentation` flag

These will be useful for upcoming PRs on `add_measurements` allowing inputs affected by constraints (@Scienfitz) and data augmentation of measurements (@mhrmsn)

The example are rendered in the doc like:
![image](https://github.com/emdgroup/baybe/assets/17951239/7636649e-62a1-46c3-b6cb-fc8a537eebc8)