### PR TITLE
Data Input With Invariant Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
 - `transform` methods of `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous`
   now take additional `allow_missing` and `allow_extra` keyword arguments
+- Utilities for permutation and dependency data augmentation
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -36,6 +36,10 @@ class Constraint(ABC, SerialMixin):
     eval_during_modeling: ClassVar[bool]
     """Class variable encoding whether the condition is evaluated during modeling."""
 
+    eval_during_augmentation: ClassVar[bool] = False
+    """Class variable encoding whether the constraint could be considered during data
+    augmentation."""
+
     numerical_only: ClassVar[bool] = False
     """Class variable encoding whether the constraint is valid only for numerical
     parameters."""

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -133,6 +133,10 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
     a single constraint.
     """
 
+    # class variables
+    eval_during_augmentation: ClassVar[bool] = True
+    # See base class
+
     # object variables
     conditions: list[Condition] = field()
     """The list of individual conditions."""
@@ -219,6 +223,10 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
     *Note:* This constraint is evaluated during creation. In the future it might also be
     evaluated during modeling to make use of the invariance.
     """
+
+    # class variables
+    eval_during_augmentation: ClassVar[bool] = True
+    # See base class
 
     # object variables
     dependencies: DiscreteDependenciesConstraint | None = field(default=None)

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -9,6 +9,14 @@ class UnusedObjectWarning(UserWarning):
     """
 
 
+class NoSearchspaceMatchWarning(UserWarning):
+    """The provided input has no match in the searchspace."""
+
+
+class TooManySearchspaceMatchesWarning(UserWarning):
+    """The provided input has multiple matches in the searchspace."""
+
+
 ##### Exceptions #####
 class NotEnoughPointsLeftError(Exception):
     """

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -458,6 +458,19 @@ class SubspaceContinuous(SerialMixin):
 
         return pd.DataFrame(index=index).reset_index()
 
+    def get_parameters_by_name(
+        self, names: Sequence[str]
+    ) -> tuple[NumericalContinuousParameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of names.
+
+        Returns:
+            The named parameters.
+        """
+        return tuple(p for p in self.parameters if p.name in names)
+
 
 # Register deserialization hook
 converter.register_structure_hook(SubspaceContinuous, select_constructor_hook)

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -385,6 +385,19 @@ class SearchSpace(SerialMixin):
         """The searchspace constraints that can be considered during augmentation."""
         return tuple(c for c in self.constraints if c.eval_during_augmentation)
 
+    def get_parameters_by_name(self, names: Sequence[str]) -> tuple[Parameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of names.
+
+        Returns:
+            The named parameters.
+        """
+        return self.discrete.get_parameters_by_name(
+            names
+        ) + self.continuous.get_parameters_by_name(names)
+
 
 def validate_searchspace_from_config(specs: dict, _) -> None:
     """Validate the search space specifications while skipping costly creation steps."""

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -380,6 +380,11 @@ class SearchSpace(SerialMixin):
 
         return comp_rep
 
+    @property
+    def constraints_augmentable(self) -> tuple[Constraint, ...]:
+        """The searchspace constraints that can be considered during augmentation."""
+        return tuple(c for c in self.constraints if c.eval_during_augmentation)
+
 
 def validate_searchspace_from_config(specs: dict, _) -> None:
     """Validate the search space specifications while skipping costly creation steps."""

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -713,6 +713,19 @@ class SubspaceDiscrete(SerialMixin):
         except AttributeError:
             return comp_rep
 
+    def get_parameters_by_name(
+        self, names: Sequence[str]
+    ) -> tuple[DiscreteParameter, ...]:
+        """Return parameters with the specified names.
+
+        Args:
+            names: Sequence of names.
+
+        Returns:
+            The named parameters.
+        """
+        return tuple(p for p in self.parameters if p.name in names)
+
 
 def _apply_constraint_filter(
     df: pd.DataFrame, constraints: Collection[DiscreteConstraint]

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -31,33 +31,93 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
 
 
 def df_apply_permutation_augmentation(
-    df: pd.DataFrame, columns: Sequence[str]
+    df: pd.DataFrame,
+    columns: Sequence[str],
+    dependents: Sequence[str] | None = None,
 ) -> pd.DataFrame:
     """Augment a dataframe if permutation invariant columns are present.
 
     Indices are preserved so that each augmented row will have the same index as its
-    original.
+    original. `dependent` columns are augmented in the same order as the `columns`.
+
+    *   Original
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+
+    *   Result with ``columns = ["A", "B"]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+        | b | a | x | y |
+        +---+---+---+---+
+        | a | b | x | z |
+        +---+---+---+---+
+
+    *   Result with ``columns = ["A", "B"]``, ``dependents = ["C", "D"]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | a | b | x | y |
+        +---+---+---+---+
+        | b | a | x | z |
+        +---+---+---+---+
+        | b | a | y | x |
+        +---+---+---+---+
+        | a | b | z | x |
+        +---+---+---+---+
 
     Args:
         df: The dataframe that should be augmented.
-        columns: Sequence indicating the permutation invariant columns.
+        columns: The permutation invariant columns.
+        dependents: Columns that are connected to `columns` and should be permuted in
+            the same manner.
 
     Returns:
         The augmented dataframe containing the original one.
+
+    Raises:
+        ValueError: If `dependents` has length incompatible with `columns`.
     """
+    dependents = dependents or []
     new_rows: list[pd.DataFrame] = []
+
+    if dependents and len(columns) != len(dependents):
+        raise ValueError(
+            "When augmenting permutation invariance with dependent columns, there must "
+            "be exactly the same amount of 'dependents' as there are 'columns'."
+        )
+
     for _, row in df.iterrows():
         # Extract the values from the specified columns
         original_values = row[columns].tolist()  # type: ignore[call-overload]
+        dependent_values = row[dependents].tolist() if dependents else None  # type: ignore[call-overload]
 
         # Generate all permutations of these values
-        all_perms = list(permutations(original_values))
+        column_perms = list(permutations(original_values))
+        dependent_perms = (
+            list(permutations(dependent_values)) if dependent_values else None
+        )
 
         # For each permutation, create a new row if it's not already in the dataframe
-        for perm in all_perms:
+        for k, perm in enumerate(column_perms):
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
             new_row[columns] = perm
+            if dependent_perms:
+                new_row[dependents] = dependent_perms[k]
+
             if not _row_in_df(new_row, df):
                 new_rows.append(new_row)
 
@@ -78,10 +138,64 @@ def df_apply_dependency_augmentation(
     will trigger an augmentation on the affected columns. The latter are augmented by
     going through all their invariant values and adding respective new rows.
 
+    *   Original
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0])``, ``affected = [("B", [2,3,4])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 0 | 4 | 5 | y |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0, 1])`, `affected = [("B", [2,3])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 1 | 2 | 5 | z |
+        +---+---+---+---+
+
+    *   Result with ``causing = ("A", [0])`, `affected = [("B", [2,3]), ("C", [5, 6])]``
+
+        +---+---+---+---+
+        | A | B | C | D |
+        +===+===+===+===+
+        | 0 | 2 | 5 | y |
+        +---+---+---+---+
+        | 1 | 3 | 5 | z |
+        +---+---+---+---+
+        | 0 | 3 | 5 | y |
+        +---+---+---+---+
+        | 0 | 2 | 6 | y |
+        +---+---+---+---+
+        | 0 | 3 | 6 | y |
+        +---+---+---+---+
+
     Args:
         df: The dataframe that should be augmented.
         causing: Causing column name and its causing values.
-        affected: List of affected columns and their invariant values.
+        affected: Affected columns and their invariant values.
 
     Returns:
         The augmented dataframe containing the original one.

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -27,6 +27,7 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
             )
         row = row.iloc[0]
 
+    row = row.reindex(df.columns)
     return (df == row).all(axis=1).any()
 
 

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -17,13 +17,13 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
         Boolean result.
 
     Raises:
-        ValueError: If `row` is a dataframe that contains more than one row.
+        ValueError: If ``row`` is a dataframe that contains more than one row.
     """
     if isinstance(row, pd.DataFrame):
         if len(row) != 1:
             raise ValueError(
                 f"{_row_in_df.__name__} can only be called with pd.Series or "
-                f"pd.DataFrame's that have exactly one row."
+                f"pd.DataFrames that have exactly one row."
             )
         row = row.iloc[0]
 
@@ -39,7 +39,7 @@ def df_apply_permutation_augmentation(
     """Augment a dataframe if permutation invariant columns are present.
 
     Indices are preserved so that each augmented row will have the same index as its
-    original. `dependent` columns are augmented in the same order as the `columns`.
+    original. ``dependent`` columns are augmented in the same order as the ``columns``.
 
     *   Original
 
@@ -82,14 +82,14 @@ def df_apply_permutation_augmentation(
     Args:
         df: The dataframe that should be augmented.
         columns: The permutation invariant columns.
-        dependents: Columns that are connected to `columns` and should be permuted in
+        dependents: Columns that are connected to ``columns`` and should be permuted in
             the same manner.
 
     Returns:
         The augmented dataframe containing the original one.
 
     Raises:
-        ValueError: If `dependents` has length incompatible with `columns`.
+        ValueError: If ``dependents`` has length incompatible with ``columns``.
     """
     dependents = dependents or []
     new_rows: list[pd.DataFrame] = []
@@ -163,7 +163,7 @@ def df_apply_dependency_augmentation(
         | 0 | 4 | 5 | y |
         +---+---+---+---+
 
-    *   Result with ``causing = ("A", [0, 1])`, `affected = [("B", [2,3])]``
+    *   Result with ``causing = ("A", [0, 1])``, ``affected = [("B", [2,3])]``
 
         +---+---+---+---+
         | A | B | C | D |
@@ -177,7 +177,8 @@ def df_apply_dependency_augmentation(
         | 1 | 2 | 5 | z |
         +---+---+---+---+
 
-    *   Result with ``causing = ("A", [0])`, `affected = [("B", [2,3]), ("C", [5, 6])]``
+    *   Result with ``causing = ("A", [0])``,
+        ``affected = [("B", [2,3]), ("C", [5, 6])]``
 
         +---+---+---+---+
         | A | B | C | D |

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -6,12 +6,25 @@ from itertools import permutations
 import pandas as pd
 
 
+def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
+    """Bla."""
+    if isinstance(row, pd.DataFrame):
+        if len(row) != 1:
+            raise ValueError(
+                f"{_row_in_df.__name__} can only be called with pd.Series or "
+                f"pd.DataFrame's that have exactly one row."
+            )
+        row = row.iloc[0]
+
+    return (df == row).all(axis=1).any()
+
+
 def df_apply_permutation_augmentation(
     df: pd.DataFrame, columns: Sequence[str]
 ) -> pd.DataFrame:
     """Bla."""
     new_rows: list[pd.DataFrame] = []
-    for index, row in df.iterrows():
+    for _, row in df.iterrows():
         # Extract the values from the specified columns
         original_values = row[columns].tolist()
 
@@ -23,11 +36,50 @@ def df_apply_permutation_augmentation(
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
             new_row[columns] = perm
-            new_rows.append(new_row)
+            if not _row_in_df(new_row, df):
+                new_rows.append(new_row)
 
     augmented_df = pd.concat([df] + new_rows)
 
-    # Drop duplicates if any created inadvertently
-    augmented_df.drop_duplicates(inplace=True)
+    return augmented_df
+
+
+def df_apply_dependency_augmentation(
+    df: pd.DataFrame,
+    causing: tuple[str, Sequence],
+    affected: Sequence[tuple[str, Sequence]],
+) -> pd.DataFrame:
+    """Bla."""
+    new_rows: list[pd.DataFrame] = []
+
+    # Iterate through all rows that have an invariance-causing value in the respective
+    # column
+    col_causing, vals_causing = causing
+    df_filtered = df.loc[df[col_causing].isin(vals_causing), :]
+    for _, row in df_filtered.iterrows():
+        # Augment the  specific row by growing a dataframe iteratively going through
+        # the affected columns. In each iteration augmented rows with that column
+        # changed to all possible values are added.
+        original_row = row.to_frame().T
+
+        current_augmented = original_row.copy()
+        for col_affected, vals_affected in affected:
+            to_add = []
+            for _, temp_row in current_augmented.iterrows():
+                to_add += [
+                    new_row
+                    for val in vals_affected
+                    if not _row_in_df(
+                        new_row := temp_row.to_frame().T.assign(**{col_affected: val}),
+                        current_augmented,
+                    )
+                ]
+            current_augmented = pd.concat([current_augmented] + to_add)
+
+        # Drop first entry because it's the original row
+        current_augmented = current_augmented.iloc[1:, :]
+        new_rows.append(current_augmented)
+
+    augmented_df = pd.concat([df] + new_rows)
 
     return augmented_df

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -1,0 +1,33 @@
+"""Utilities related to data augmentation."""
+
+from collections.abc import Sequence
+from itertools import permutations
+
+import pandas as pd
+
+
+def df_apply_permutation_augmentation(
+    df: pd.DataFrame, columns: Sequence[str]
+) -> pd.DataFrame:
+    """Bla."""
+    new_rows: list[pd.DataFrame] = []
+    for index, row in df.iterrows():
+        # Extract the values from the specified columns
+        original_values = row[columns].tolist()
+
+        # Generate all permutations of these values
+        all_perms = list(permutations(original_values))
+
+        # For each permutation, create a new row if it's not already in the DataFrame
+        for perm in all_perms:
+            # Create a new row dictionary with the permuted values
+            new_row = row.copy().to_frame().T
+            new_row[columns] = perm
+            new_rows.append(new_row)
+
+    augmented_df = pd.concat([df] + new_rows)
+
+    # Drop duplicates if any created inadvertently
+    augmented_df.drop_duplicates(inplace=True)
+
+    return augmented_df

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -113,7 +113,7 @@ def df_apply_permutation_augmentation(
         # For each permutation, create a new row if it's not already in the dataframe
         for k, perm in enumerate(column_perms):
             # Create a new row dictionary with the permuted values
-            new_row = row.copy().to_frame().T
+            new_row = pd.DataFrame([row])
             new_row[columns] = perm
             if dependent_perms:
                 new_row[dependents] = dependent_perms[k]
@@ -211,7 +211,7 @@ def df_apply_dependency_augmentation(
         # changed to all possible values are added. If there is more than one affected
         # column, it is important to include the augmented rows stemming from the
         # preceding columns as well.
-        original_row = row.to_frame().T
+        original_row = pd.DataFrame([row])
 
         currently_added = original_row.copy()  # Start with the original row
         for col_affected, vals_invariant in affected:
@@ -223,7 +223,7 @@ def df_apply_dependency_augmentation(
                     new_row
                     for val in vals_invariant
                     if not _row_in_df(
-                        new_row := temp_row.to_frame().T.assign(
+                        new_row := temp_row.pipe(lambda x: pd.DataFrame([x])).assign(
                             **{col_affected: val}
                         ),  # this takes the current row and replaces the affected value
                         currently_added,

--- a/baybe/utils/augmentation.py
+++ b/baybe/utils/augmentation.py
@@ -7,7 +7,18 @@ import pandas as pd
 
 
 def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
-    """Bla."""
+    """Check whether a row is fully contained in a dataframe.
+
+    Args:
+        row: The row to be checked.
+        df: The dataframe to be checked.
+
+    Returns:
+        Boolean result.
+
+    Raises:
+        ValueError: If `row` is a dataframe that contains more than one row.
+    """
     if isinstance(row, pd.DataFrame):
         if len(row) != 1:
             raise ValueError(
@@ -22,16 +33,27 @@ def _row_in_df(row: pd.Series | pd.DataFrame, df: pd.DataFrame) -> bool:
 def df_apply_permutation_augmentation(
     df: pd.DataFrame, columns: Sequence[str]
 ) -> pd.DataFrame:
-    """Bla."""
+    """Augment a dataframe if permutation invariant columns are present.
+
+    Indices are preserved so that each augmented row will have the same index as its
+    original.
+
+    Args:
+        df: The dataframe that should be augmented.
+        columns: Sequence indicating the permutation invariant columns.
+
+    Returns:
+        The augmented dataframe containing the original one.
+    """
     new_rows: list[pd.DataFrame] = []
     for _, row in df.iterrows():
         # Extract the values from the specified columns
-        original_values = row[columns].tolist()
+        original_values = row[columns].tolist()  # type: ignore[call-overload]
 
         # Generate all permutations of these values
         all_perms = list(permutations(original_values))
 
-        # For each permutation, create a new row if it's not already in the DataFrame
+        # For each permutation, create a new row if it's not already in the dataframe
         for perm in all_perms:
             # Create a new row dictionary with the permuted values
             new_row = row.copy().to_frame().T
@@ -49,36 +71,56 @@ def df_apply_dependency_augmentation(
     causing: tuple[str, Sequence],
     affected: Sequence[tuple[str, Sequence]],
 ) -> pd.DataFrame:
-    """Bla."""
+    """Augment a dataframe if dependency invariant columns are present.
+
+    This works with the concept of column-values pairs for causing and affected column.
+    Any row present where the specified causing column has one of the provided values
+    will trigger an augmentation on the affected columns. The latter are augmented by
+    going through all their invariant values and adding respective new rows.
+
+    Args:
+        df: The dataframe that should be augmented.
+        causing: Causing column name and its causing values.
+        affected: List of affected columns and their invariant values.
+
+    Returns:
+        The augmented dataframe containing the original one.
+    """
     new_rows: list[pd.DataFrame] = []
 
-    # Iterate through all rows that have an invariance-causing value in the respective
-    # column
+    # Iterate through all rows that have a causing value in the respective column.
     col_causing, vals_causing = causing
     df_filtered = df.loc[df[col_causing].isin(vals_causing), :]
     for _, row in df_filtered.iterrows():
         # Augment the  specific row by growing a dataframe iteratively going through
         # the affected columns. In each iteration augmented rows with that column
-        # changed to all possible values are added.
+        # changed to all possible values are added. If there is more than one affected
+        # column, it is important to include the augmented rows stemming from the
+        # preceding columns as well.
         original_row = row.to_frame().T
 
-        current_augmented = original_row.copy()
-        for col_affected, vals_affected in affected:
+        currently_added = original_row.copy()  # Start with the original row
+        for col_affected, vals_invariant in affected:
             to_add = []
-            for _, temp_row in current_augmented.iterrows():
+
+            # Go through all previously added rows + the original row
+            for _, temp_row in currently_added.iterrows():
                 to_add += [
                     new_row
-                    for val in vals_affected
+                    for val in vals_invariant
                     if not _row_in_df(
-                        new_row := temp_row.to_frame().T.assign(**{col_affected: val}),
-                        current_augmented,
+                        new_row := temp_row.to_frame().T.assign(
+                            **{col_affected: val}
+                        ),  # this takes the current row and replaces the affected value
+                        currently_added,
                     )
                 ]
-            current_augmented = pd.concat([current_augmented] + to_add)
+            # Update the currently added rows
+            currently_added = pd.concat([currently_added] + to_add)
 
-        # Drop first entry because it's the original row
-        current_augmented = current_augmented.iloc[1:, :]
-        new_rows.append(current_augmented)
+        # Drop first entry because it's the original row and store added rows
+        currently_added = currently_added.iloc[1:, :]
+        new_rows.append(currently_added)
 
     augmented_df = pd.concat([df] + new_rows)
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
@@ -13,6 +14,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 
+from baybe.exceptions import NoSearchspaceMatchWarning, TooManySearchspaceMatchesWarning
 from baybe.targets.enum import TargetMode
 from baybe.utils.numerical import DTypeFloatNumpy
 
@@ -417,17 +419,17 @@ def fuzzy_row_match(
         # We expect exactly one match. If that's not the case, print a warning.
         inds_found = left_df.index[match].to_list()
         if len(inds_found) == 0 and len(num_cols) > 0:
-            _logger.warning(
-                "Input row with index %s could not be matched to the search space. "
+            warnings.warn(
+                f"Input row with index {ind} could not be matched to the search space. "
                 "This could indicate that something went wrong.",
-                ind,
+                NoSearchspaceMatchWarning,
             )
         elif len(inds_found) > 1:
-            _logger.warning(
-                "Input row with index %s has multiple matches with "
+            warnings.warn(
+                f"Input row with index {ind} has multiple matches with "
                 "the search space. This could indicate that something went wrong. "
                 "Matching only first occurrence.",
-                ind,
+                TooManySearchspaceMatchesWarning,
             )
             inds_matched.append(inds_found[0])
         else:

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,12 +1,17 @@
 """Tests for basic input-output and iterative loop."""
+import warnings
+
 import numpy as np
+import pandas as pd
 import pytest
 
+from baybe.constraints import DiscreteNoLabelDuplicatesConstraint
+from baybe.exceptions import NoSearchspaceMatchWarning
+from baybe.utils.augmentation import (
+    df_apply_dependency_augmentation,
+    df_apply_permutation_augmentation,
+)
 from baybe.utils.dataframe import add_fake_results
-
-# List of tests that are expected to fail (still missing implementation etc)
-param_xfails = []
-target_xfails = []
 
 
 @pytest.mark.parametrize(
@@ -16,9 +21,6 @@ target_xfails = []
 )
 def test_bad_parameter_input_value(campaign, good_reference_values, bad_val, request):
     """Test attempting to read in an invalid parameter value."""
-    if request.node.callspec.id in param_xfails:
-        pytest.xfail()
-
     rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
@@ -27,7 +29,11 @@ def test_bad_parameter_input_value(campaign, good_reference_values, bad_val, req
     )
 
     # Add an invalid value
-    rec.Num_disc_1.iloc[0] = bad_val
+    with warnings.catch_warnings():
+        # Ignore warning about incompatible data type assignment
+        warnings.simplefilter("ignore", FutureWarning)
+        rec.iloc[0, rec.columns.get_loc("Num_disc_1")] = bad_val
+
     with pytest.raises((ValueError, TypeError)):
         campaign.add_measurements(rec)
 
@@ -39,9 +45,6 @@ def test_bad_parameter_input_value(campaign, good_reference_values, bad_val, req
 )
 def test_bad_target_input_value(campaign, good_reference_values, bad_val, request):
     """Test attempting to read in an invalid target value."""
-    if request.node.callspec.id in target_xfails:
-        pytest.xfail()
-
     rec = campaign.recommend(batch_size=3)
     add_fake_results(
         rec,
@@ -50,6 +53,131 @@ def test_bad_target_input_value(campaign, good_reference_values, bad_val, reques
     )
 
     # Add an invalid value
-    rec.Target_max.iloc[0] = bad_val
+    with warnings.catch_warnings():
+        # Ignore warning about incompatible data type assignment
+        warnings.simplefilter("ignore", FutureWarning)
+        rec.iloc[0, rec.columns.get_loc("Target_max")] = bad_val
+
     with pytest.raises((ValueError, TypeError)):
         campaign.add_measurements(rec)
+
+
+# Reused parameter names for the mixture mock example
+_mixture_columns = [
+    "Solvent_1",
+    "Solvent_2",
+    "Solvent_3",
+    "Fraction_1",
+    "Fraction_2",
+    "Fraction_3",
+]
+
+
+@pytest.mark.parametrize("n_grid_points", [5])
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pd.DataFrame.from_records(
+            [["THF", "Water", "DMF", 0.0, 25.0, 75.0]], columns=_mixture_columns
+        ),
+    ],
+)
+@pytest.mark.parametrize("parameter_names", [_mixture_columns])
+@pytest.mark.parametrize(
+    "constraint_names", [["Constraint_7", "Constraint_11", "Constraint_12"]]
+)
+def test_permutation_invariant_input(campaign, entry):
+    """Test whether permutation invariant measurements can be added."""
+    add_fake_results(entry, campaign)
+
+    # Create augmented combinations
+    entries = df_apply_permutation_augmentation(
+        entry,
+        columns=["Solvent_1", "Solvent_2", "Solvent_3"],
+        dependents=["Fraction_1", "Fraction_2", "Fraction_3"],
+    )
+
+    for _, row in entries.iterrows():
+        # Reset searchspace metadata
+        campaign.searchspace.discrete.metadata["was_measured"] = False
+
+        # Assert that not NoSearchspaceMatchWarning is thrown
+        with warnings.catch_warnings():
+            print(row.to_frame().T)
+            warnings.simplefilter("error", category=NoSearchspaceMatchWarning)
+            campaign.add_measurements(pd.DataFrame([row]))
+
+        # Assert exactly one searchspace entry has been marked
+        num_nonzero = campaign.searchspace.discrete.metadata["was_measured"].sum()
+        assert num_nonzero == 1, (
+            "Measurement ingestion was successful, but did not correctly update the "
+            f"searchspace metadata. Number of non-zero entries: {num_nonzero} "
+            f"(expected 1)"
+        )
+
+
+@pytest.mark.parametrize("n_grid_points", [5], ids=["grid5"])
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pd.DataFrame.from_records(
+            [["THF", "Water", "DMF", 0.0, 25.0, 75.0]],
+            columns=_mixture_columns,
+        ),
+        pd.DataFrame.from_records(
+            [["THF", "Water", "DMF", 0.0, 0.0, 50.0]],
+            columns=_mixture_columns,
+        ),
+    ],
+    ids=["single_degen", "double_degen"],
+)
+@pytest.mark.parametrize("parameter_names", [_mixture_columns])
+@pytest.mark.parametrize(
+    "constraint_names", [["Constraint_7", "Constraint_11", "Constraint_12"]]
+)
+def test_dependency_invariant_input(campaign, entry):
+    """Test whether dependency invariant measurements can be added."""
+    # Get an entry from the searchspace
+    add_fake_results(entry, campaign)
+    sol_vals = campaign.searchspace.get_parameters_by_name(["Solvent_1"])[0].values
+
+    # Create augmented combinations
+    entries = df_apply_dependency_augmentation(
+        entry, causing=("Fraction_1", [0.0]), affected=[("Solvent_1", sol_vals)]
+    )
+    entries = df_apply_dependency_augmentation(
+        entries, causing=("Fraction_2", [0.0]), affected=[("Solvent_2", sol_vals)]
+    )
+    entries = df_apply_dependency_augmentation(
+        entries, causing=("Fraction_3", [0.0]), affected=[("Solvent_3", sol_vals)]
+    )
+
+    # Remove falsely created label duplicates
+    entries.reset_index(drop=True, inplace=True)
+    for c in campaign.searchspace.discrete.constraints:
+        if isinstance(c, DiscreteNoLabelDuplicatesConstraint):
+            entries.drop(index=c.get_invalid(entries), inplace=True)
+
+    # Add nan entries for testing nan input in the invariant parameters
+    entry_nan = entry.copy()
+    entry_nan.loc[entry_nan["Fraction_1"] == 0.0, "Solvent_1"] = np.nan
+    entry_nan.loc[entry_nan["Fraction_2"] == 0.0, "Solvent_2"] = np.nan
+    entry_nan.loc[entry_nan["Fraction_3"] == 0.0, "Solvent_3"] = np.nan
+
+    for _, row in pd.concat([entries, entry_nan]).iterrows():
+        # Reset searchspace metadata
+        campaign.searchspace.discrete.metadata["was_measured"] = False
+
+        # Assert that not NoSearchspaceMatchWarning is thrown
+        with warnings.catch_warnings():
+            print(row.to_frame().T)
+            warnings.simplefilter("error", category=NoSearchspaceMatchWarning)
+            campaign.add_measurements(pd.DataFrame([row]))
+
+        # Assert exactly one searchspace entry has been marked
+        num_nonzero = campaign.searchspace.discrete.metadata["was_measured"].sum()
+        assert num_nonzero == 1, (
+            "Measurement ingestion was successful, but did not correctly update the "
+            f"searchspace metadata. Number of non-zero entries: {num_nonzero} "
+            f"(expected 1)"
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from pytest import param
 
+from baybe.utils.augmentation import df_apply_permutation_augmentation
 from baybe.utils.basic import register_hooks
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import closest_element
@@ -120,3 +121,91 @@ def test_invalid_register_hooks(target, hook):
     """Passing inconsistent signatures to `register_hooks` raises an error."""
     with pytest.raises(TypeError):
         register_hooks(target, [hook])
+
+
+@pytest.mark.parametrize(
+    ("data", "columns", "data_expected"),
+    [
+        param(  # 2 invariant cols and 1 unaffected col
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "C": ["x", "y"],
+            },
+            ["A", "B"],
+            {
+                "A": [1, 2, 1, 2],
+                "B": [2, 1, 2, 1],
+                "C": ["x", "x", "y", "y"],
+            },
+            id="2inv+1add",
+        ),
+        param(  # 2 invariant cols with identical values
+            {"A": [1, 1], "B": [2, 2]},
+            ["A", "B"],
+            {
+                "A": [1, 2],
+                "B": [2, 1],
+            },
+            id="2inv_degen",
+        ),
+        param(  # 2 invariant cols with identical values but different targets
+            {"A": [1, 1], "B": [2, 2], "T": ["x", "y"]},
+            ["A", "B"],
+            {
+                "A": [1, 1, 2, 2],
+                "B": [2, 2, 1, 1],
+                "T": ["x", "y", "x", "y"],
+            },
+            id="2inv_degen+target_unique",
+        ),
+        param(  # 2 invariant cols with identical values but different targets
+            {"A": [1, 1], "B": [2, 2], "T": ["x", "x"]},
+            ["A", "B"],
+            {
+                "A": [1, 2],
+                "B": [2, 1],
+                "T": ["x", "x"],
+            },
+            id="2inv_degen+target_degen",
+        ),
+        param(  # 3 invariant cols
+            {"A": [1, 1], "B": [2, 4], "C": [3, 5]},
+            ["A", "B", "C"],
+            {
+                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
+                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
+                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
+            },
+            id="3inv",
+        ),
+        param(  # 3 invariant cols
+            {"A": [1, 1], "B": [2, 4], "C": [3, 5], "D": ["x", "y"]},
+            ["A", "B", "C"],
+            {
+                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
+                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
+                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
+                "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
+            },
+            id="3inv+1add",
+        ),
+    ],
+)
+def test_df_invariance_augmentation(data, columns, data_expected):
+    """Test invariance data augmentation is done correctly."""
+    # Create all needed dataframes
+    df = pd.DataFrame(data)
+    df_augmented = df_apply_permutation_augmentation(df, columns)
+    df_expected = pd.DataFrame(data_expected)
+
+    # Determine equality ignoring row order
+    are_equal = (
+        pd.merge(left=df_augmented, right=df_expected, how="outer", indicator=True)[
+            "_merge"
+        ]
+        .eq("both")
+        .all()
+    )
+
+    assert are_equal, (df, df_augmented, df_expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,20 +142,27 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 1, 2, 1],
                 "C": ["x", "x", "y", "y"],
             },
-            id="2inv+1add",
+            id="2inv_1add",
         ),
         param(  # 2 invariant cols with identical values
-            {"A": [1, 1], "B": [2, 2]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+            },
             ["A", "B"],
             None,
             {
-                "A": [1, 2],
-                "B": [2, 1],
+                "A": [1, 1, 2],
+                "B": [2, 2, 1],
             },
-            id="2inv_degen",
+            id="2inv+degen",
         ),
         param(  # 2 invariant cols with identical values but different targets
-            {"A": [1, 1], "B": [2, 2], "T": ["x", "y"]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "T": ["x", "y"],
+            },
             ["A", "B"],
             None,
             {
@@ -163,10 +170,14 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2, 1, 1],
                 "T": ["x", "y", "x", "y"],
             },
-            id="2inv_degen+target_unique",
+            id="2inv+degen_target",
         ),
         param(  # 2 invariant cols with identical values but different targets
-            {"A": [1, 1], "B": [2, 2], "T": ["x", "x"]},
+            {
+                "A": [1, 1],
+                "B": [2, 2],
+                "T": ["x", "x"],
+            },
             ["A", "B"],
             None,
             {
@@ -174,10 +185,14 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 1],
                 "T": ["x", "x"],
             },
-            id="2inv_degen+target_degen",
+            id="2inv+degen_target+degen",
         ),
         param(  # 3 invariant cols
-            {"A": [1, 1], "B": [2, 4], "C": [3, 5]},
+            {
+                "A": [1, 1],
+                "B": [2, 4],
+                "C": [3, 5],
+            },
             ["A", "B", "C"],
             None,
             {
@@ -188,7 +203,12 @@ def test_invalid_register_hooks(target, hook):
             id="3inv",
         ),
         param(  # 3 invariant cols
-            {"A": [1, 1], "B": [2, 4], "C": [3, 5], "D": ["x", "y"]},
+            {
+                "A": [1, 1],
+                "B": [2, 4],
+                "C": [3, 5],
+                "D": ["x", "y"],
+            },
             ["A", "B", "C"],
             None,
             {
@@ -197,7 +217,7 @@ def test_invalid_register_hooks(target, hook):
                 "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
                 "D": ["x", "x", "x", "x", "x", "x", "y", "y", "y", "y", "y", "y"],
             },
-            id="3inv+1add",
+            id="3inv_1add",
         ),
         param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
             {
@@ -209,7 +229,7 @@ def test_invalid_register_hooks(target, hook):
                 "Other2": ["C", "D"],
             },
             ["Slot1", "Slot2"],
-            ["Frac1", "Frac2"],
+            [["Frac1"], ["Frac2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -218,11 +238,34 @@ def test_invalid_register_hooks(target, hook):
                 "Other1": ["A", "B", "A", "B"],
                 "Other2": ["C", "D", "C", "D"],
             },
-            id="2inv_degen+2dependent+2add",
+            id="2inv_2dependent_2add",
+        ),
+        param(  # 2 invariant cols, 2 dependent ones, 2 additional ones
+            {
+                "Slot1": ["s1", "s2"],
+                "Slot2": ["s2", "s4"],
+                "Frac1": [0.1, 0.6],
+                "Frac2": [0.9, 0.4],
+                "Temp1": [10, 20],
+                "Temp2": [50, 60],
+                "Other": ["x", "y"],
+            },
+            ["Slot1", "Slot2"],
+            [["Frac1", "Temp1"], ["Frac2", "Temp2"]],
+            {
+                "Slot1": ["s1", "s2", "s2", "s4"],
+                "Slot2": ["s2", "s4", "s1", "s2"],
+                "Frac1": [0.1, 0.6, 0.9, 0.4],
+                "Frac2": [0.9, 0.4, 0.1, 0.6],
+                "Temp1": [10, 20, 50, 60],
+                "Temp2": [50, 60, 10, 20],
+                "Other": ["x", "y", "x", "y"],
+            },
+            id="2inv_4dependent2each_1add",
         ),
     ],
 )
-def test_df_permutation_augmentation(data, columns, dependents, data_expected):
+def test_df_permutation_aug(data, columns, dependents, data_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
@@ -241,6 +284,21 @@ def test_df_permutation_augmentation(data, columns, dependents, data_expected):
     assert (
         are_equal
     ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"
+
+
+@pytest.mark.parametrize(
+    ("columns", "dependents", "msg"),
+    [
+        param(["A"], [["B"], ["C"]], "exactly as many", id="too_manydependents"),
+        param(["A", "B"], [[], []], "same for all", id="dep_length_zero"),
+        param(["A", "B"], [["C"], []], "same for all", id="different_dep_lengths"),
+    ],
+)
+def test_df_permutation_aug_invalid(columns, dependents, msg):
+    """Test correct errors for invalid permutation attempts."""
+    df = pd.DataFrame({"A": [1, 1], "B": [2, 2], "C": ["x", "y"]})
+    with pytest.raises(ValueError, match=msg):
+        df_apply_permutation_augmentation(df, columns, dependents)
 
 
 @pytest.mark.parametrize(
@@ -308,7 +366,7 @@ def test_df_permutation_augmentation(data, columns, dependents, data_expected):
         ),
     ],
 )
-def test_df_dependency_augmentation(data, causing, affected, data_expected):
+def test_df_dependency_aug(data, causing, affected, data_expected):
     """Test dependency data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,8 +222,8 @@ def test_invalid_register_hooks(target, hook):
         ),
     ],
 )
-def test_df_invariance_augmentation(data, columns, dependents, data_expected):
-    """Test invariance data augmentation is done correctly."""
+def test_df_permutation_augmentation(data, columns, dependents, data_expected):
+    """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
     df_augmented = df_apply_permutation_augmentation(df, columns, dependents)
@@ -238,7 +238,9 @@ def test_df_invariance_augmentation(data, columns, dependents, data_expected):
         .all()
     )
 
-    assert are_equal, (df, df_augmented, df_expected)
+    assert (
+        are_equal
+    ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"
 
 
 @pytest.mark.parametrize(
@@ -322,4 +324,6 @@ def test_df_dependency_augmentation(data, causing, affected, data_expected):
         .all()
     )
 
-    assert are_equal, (df, df_augmented, df_expected)
+    assert (
+        are_equal
+    ), f"\norig:\n{df}\n\naugmented:\n{df_augmented}\n\nexpected:\n{df_expected}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,7 +127,7 @@ def test_invalid_register_hooks(target, hook):
 
 
 @pytest.mark.parametrize(
-    ("data", "columns", "dependents", "data_expected"),
+    ("data", "columns", "data_expected"),
     [
         param(  # 2 invariant cols and 1 unaffected col
             {
@@ -135,8 +135,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "C": ["x", "y"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 2, 1, 2],
                 "B": [2, 1, 2, 1],
@@ -149,8 +148,7 @@ def test_invalid_register_hooks(target, hook):
                 "A": [1, 1],
                 "B": [2, 2],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 1, 2],
                 "B": [2, 2, 1],
@@ -163,8 +161,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "T": ["x", "y"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 1, 2, 2],
                 "B": [2, 2, 1, 1],
@@ -178,8 +175,7 @@ def test_invalid_register_hooks(target, hook):
                 "B": [2, 2],
                 "T": ["x", "x"],
             },
-            ["A", "B"],
-            None,
+            [["A"], ["B"]],
             {
                 "A": [1, 2],
                 "B": [2, 1],
@@ -192,25 +188,9 @@ def test_invalid_register_hooks(target, hook):
                 "A": [1, 1],
                 "B": [2, 4],
                 "C": [3, 5],
-            },
-            ["A", "B", "C"],
-            None,
-            {
-                "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
-                "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
-                "C": [3, 2, 3, 1, 1, 2, 5, 4, 5, 1, 4, 1],
-            },
-            id="3inv",
-        ),
-        param(  # 3 invariant cols
-            {
-                "A": [1, 1],
-                "B": [2, 4],
-                "C": [3, 5],
                 "D": ["x", "y"],
             },
-            ["A", "B", "C"],
-            None,
+            [["A"], ["B"], ["C"]],
             {
                 "A": [1, 1, 2, 2, 3, 3, 1, 1, 4, 4, 5, 5],
                 "B": [2, 3, 1, 3, 2, 1, 4, 5, 1, 5, 1, 4],
@@ -228,8 +208,7 @@ def test_invalid_register_hooks(target, hook):
                 "Other1": ["A", "B"],
                 "Other2": ["C", "D"],
             },
-            ["Slot1", "Slot2"],
-            [["Frac1"], ["Frac2"]],
+            [["Slot1", "Frac1"], ["Slot2", "Frac2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -250,8 +229,7 @@ def test_invalid_register_hooks(target, hook):
                 "Temp2": [50, 60],
                 "Other": ["x", "y"],
             },
-            ["Slot1", "Slot2"],
-            [["Frac1", "Temp1"], ["Frac2", "Temp2"]],
+            [["Slot1", "Frac1", "Temp1"], ["Slot2", "Frac2", "Temp2"]],
             {
                 "Slot1": ["s1", "s2", "s2", "s4"],
                 "Slot2": ["s2", "s4", "s1", "s2"],
@@ -265,11 +243,11 @@ def test_invalid_register_hooks(target, hook):
         ),
     ],
 )
-def test_df_permutation_aug(data, columns, dependents, data_expected):
+def test_df_permutation_aug(data, columns, data_expected):
     """Test permutation invariance data augmentation is done correctly."""
     # Create all needed dataframes
     df = pd.DataFrame(data)
-    df_augmented = df_apply_permutation_augmentation(df, columns, dependents)
+    df_augmented = df_apply_permutation_augmentation(df, columns)
     df_expected = pd.DataFrame(data_expected)
 
     # Determine equality ignoring row order
@@ -287,18 +265,19 @@ def test_df_permutation_aug(data, columns, dependents, data_expected):
 
 
 @pytest.mark.parametrize(
-    ("columns", "dependents", "msg"),
+    ("columns", "msg"),
     [
-        param(["A"], [["B"], ["C"]], "exactly as many", id="too_manydependents"),
-        param(["A", "B"], [[], []], "same for all", id="dep_length_zero"),
-        param(["A", "B"], [["C"], []], "same for all", id="different_dep_lengths"),
+        param([], "at least two column sequences", id="no_seqs"),
+        param([["A"]], "at least two column sequences", id="just_one_seq"),
+        param([["A"], ["B", "C"]], "sequence is the same", id="different_lengths"),
+        param([[], []], "sequence is the same", id="empty_seqs"),
     ],
 )
-def test_df_permutation_aug_invalid(columns, dependents, msg):
+def test_df_permutation_aug_invalid(columns, msg):
     """Test correct errors for invalid permutation attempts."""
     df = pd.DataFrame({"A": [1, 1], "B": [2, 2], "C": ["x", "y"]})
     with pytest.raises(ValueError, match=msg):
-        df_apply_permutation_augmentation(df, columns, dependents)
+        df_apply_permutation_augmentation(df, columns)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Aims to enable usage of `add_measurements` without providing the exact row that has been kept in the searchspace in case of invariant or dependency constraints. The aim is that this will still mark the corresponding entry in the metadata correctly.

Also added: Two new custom warnings.

Based on #290 