### PR TITLE
Fix MetaRecommender Warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ _ `_optional` subpackage for managing optional dependencies
 ### Fixed
 - `sequential` flag of `SequentialGreedyRecommender` is now set to `True`
 - Serialization bug related to class layout of `SKLearnClusteringRecommender`
+- `MetaRecommender`s no longer trigger warnings about non-empty objectives or
+  measurements when calling a `NonPredictiveRecommender`
 
 ### Deprecations
 - `SequentialGreedyRecommender` class replaced with `BotorchRecommender`

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -2,9 +2,9 @@
 
 
 ##### Warnings #####
-class NonPredictiveRecommenderWarning(UserWarning):
+class UnusedObjectWarning(UserWarning):
     """
-    A non-predictive recommender was called with undesired arguments which indicates an
+    A method or function was called with undesired arguments which indicates an
     unintended user fault.
     """
 

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -1,6 +1,15 @@
-"""Custom exceptions."""
+"""Custom exceptions and warnings."""
 
 
+##### Warnings #####
+class NonPredictiveRecommenderWarning(UserWarning):
+    """
+    A non-predictive recommender was called with undesired arguments which indicates an
+    unintended user fault.
+    """
+
+
+##### Exceptions #####
 class NotEnoughPointsLeftError(Exception):
     """
     More recommendations are requested than there are viable parameter configurations

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -11,6 +11,7 @@ from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
 from baybe.recommenders.deprecation import structure_recommender_protocol
 from baybe.recommenders.pure.base import PureRecommender
+from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin, converter, unstructure_base
 
@@ -85,11 +86,20 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
             objective=objective,
             measurements=measurements,
         )
+
+        # Non-predictive recommenders should not be called with an objective or
+        # measurements
+        nonstandard_args = (
+            {}
+            if isinstance(recommender, NonPredictiveRecommender)
+            else {
+                "objective": objective,
+                "measurements": measurements,
+            }
+        )
+
         return recommender.recommend(
-            batch_size=batch_size,
-            searchspace=searchspace,
-            objective=objective,
-            measurements=measurements,
+            batch_size=batch_size, searchspace=searchspace, **nonstandard_args
         )
 
 

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -1,6 +1,7 @@
 """Base classes for all meta recommenders."""
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import cattrs
 import pandas as pd
@@ -88,8 +89,9 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         )
 
         # Non-predictive recommenders should not be called with an objective or
-        # measurements
-        nonstandard_args = (
+        # measurements. Using dict value type Any here due to known mypy complication:
+        # https://github.com/python/mypy/issues/5382
+        optional_args: dict[str, Any] = (
             {}
             if isinstance(recommender, NonPredictiveRecommender)
             else {
@@ -99,7 +101,7 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         )
 
         return recommender.recommend(
-            batch_size=batch_size, searchspace=searchspace, **nonstandard_args
+            batch_size=batch_size, searchspace=searchspace, **optional_args
         )
 
 

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -6,6 +6,7 @@ from abc import ABC
 import pandas as pd
 from attrs import define
 
+from baybe.exceptions import NonPredictiveRecommenderWarning
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace.core import SearchSpace
@@ -29,14 +30,14 @@ class NonPredictiveRecommender(PureRecommender, ABC):
                 f"'{self.recommend.__name__}' was called with a non-empty "
                 f"set of measurements but '{self.__class__.__name__}' does not "
                 f"utilize any training data, meaning that the argument is ignored.",
-                UserWarning,
+                NonPredictiveRecommenderWarning,
             )
         if objective is not None:
             warnings.warn(
                 f"'{self.recommend.__name__}' was called with a an explicit objective "
                 f"but '{self.__class__.__name__}' does not "
                 f"consider any objectives, meaning that the argument is ignored.",
-                UserWarning,
+                NonPredictiveRecommenderWarning,
             )
         return super().recommend(
             batch_size=batch_size,

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -6,7 +6,7 @@ from abc import ABC
 import pandas as pd
 from attrs import define
 
-from baybe.exceptions import NonPredictiveRecommenderWarning
+from baybe.exceptions import UnusedObjectWarning
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace.core import SearchSpace
@@ -30,14 +30,14 @@ class NonPredictiveRecommender(PureRecommender, ABC):
                 f"'{self.recommend.__name__}' was called with a non-empty "
                 f"set of measurements but '{self.__class__.__name__}' does not "
                 f"utilize any training data, meaning that the argument is ignored.",
-                NonPredictiveRecommenderWarning,
+                UnusedObjectWarning,
             )
         if objective is not None:
             warnings.warn(
                 f"'{self.recommend.__name__}' was called with a an explicit objective "
                 f"but '{self.__class__.__name__}' does not "
                 f"consider any objectives, meaning that the argument is ignored.",
-                NonPredictiveRecommenderWarning,
+                UnusedObjectWarning,
             )
         return super().recommend(
             batch_size=batch_size,

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -5,6 +5,7 @@ import pytest
 
 from baybe.acquisition import qNIPV
 from baybe.acquisition.base import AcquisitionFunction
+from baybe.exceptions import NonPredictiveRecommenderWarning
 from baybe.kernels.base import Kernel
 from baybe.kernels.basic import (
     LinearKernel,
@@ -243,7 +244,8 @@ def test_iter_surrogate_model(campaign, n_iterations, batch_size):
 @pytest.mark.slow
 @pytest.mark.parametrize("recommender", valid_initial_recommenders)
 def test_iter_initial_recommender(campaign, n_iterations, batch_size):
-    run_iterations(campaign, n_iterations, batch_size)
+    with pytest.warns(NonPredictiveRecommenderWarning):
+        run_iterations(campaign, n_iterations, batch_size)
 
 
 @pytest.mark.slow

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -5,7 +5,7 @@ import pytest
 
 from baybe.acquisition import qNIPV
 from baybe.acquisition.base import AcquisitionFunction
-from baybe.exceptions import NonPredictiveRecommenderWarning
+from baybe.exceptions import UnusedObjectWarning
 from baybe.kernels.base import Kernel
 from baybe.kernels.basic import (
     LinearKernel,
@@ -244,7 +244,7 @@ def test_iter_surrogate_model(campaign, n_iterations, batch_size):
 @pytest.mark.slow
 @pytest.mark.parametrize("recommender", valid_initial_recommenders)
 def test_iter_initial_recommender(campaign, n_iterations, batch_size):
-    with pytest.warns(NonPredictiveRecommenderWarning):
+    with pytest.warns(UnusedObjectWarning):
         run_iterations(campaign, n_iterations, batch_size)
 
 


### PR DESCRIPTION
Adjustments to avoid annoying warnings
- `MetaRecommender`s do not use `objective` and `measurements` arguments with `NonPredictiveRecommender`s anymore --> source of the warnings flood in many simulations
- Added a custom warning to distinguish the non-predictive recommender warnings
- Caught some expected warnings in tests