### PR TITLE
Deactivate caching in fulltest pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
 # - This runs everything in Python 3.12, except the fulltest which is also run in 3.10
-# - Only coretest and fulltest environments are cached due to space limit
 
 name: Continuous Integration
 on:
@@ -155,10 +154,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.py-version.semantic }}
-      - uses: actions/cache@v4
-        with:
-          path: .tox/fulltest-${{ matrix.py-version.tox }}
-          key: fulltest-${{ matrix.py-version.tox }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}
       - name: Run full tests
         run: |
           pip install tox-uv

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -1,7 +1,7 @@
 # NOTES:
 # - The map syntax used for matrix is flagged red but actually works
 # - This runs everything in Python 3.10, 3.11 and 3.12
-# - No environments are cached due to space limit
+# - Environments are **not** cached in order to perform a full end-to-end test
 
 name: Regular Checks
 on:


### PR DESCRIPTION
This PR removes the last remaining caching steps from our pipeline due to the mysterious interference with serialization. Can be reactivated once the root cause is identified.