### PR TITLE
Fix Deprecated Calls

### DIFF
--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -107,7 +107,7 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
                     f"provided for '{self.__class__.__name__}' when sampling purely "
                     f"continuous search spaces."
                 )
-            sampled_conti = searchspace.continuous.samples_random(n_candidates)
+            sampled_conti = searchspace.continuous.sample_uniform(n_candidates)
 
             # Align indices if discrete part is present
             if len(sampled_parts) > 0:

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -54,7 +54,7 @@ class BayesianRecommender(PureRecommender, ABC):
         # TODO: Transition point from dataframe to tensor needs to be refactored.
         #   Currently, surrogate models operate with tensors, while acquisition
         #   functions with dataframes.
-        train_x = searchspace.transform(measurements)
+        train_x = searchspace.transform(measurements, allow_extra=True)
         train_y = objective.transform(measurements)
         self.surrogate_model._fit(searchspace, *to_tensor(train_x, train_y))
         self._botorch_acqf = self.acquisition_function.to_botorch(


### PR DESCRIPTION
There have been two instances of internal calls of deprecated functionality, causing unintended deprecation calls
- random recommedner called `samples_random`
- transformation of measurements did not explicitly set `allow_extra=True`