### PR TITLE
Searchspace convenience constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ _ `_optional` subpackage for managing optional dependencies
   now take additional `allow_missing` and `allow_extra` keyword arguments
 - More details to the transfer learning user guide
 - Activated doctests
+- `SubspaceDiscrete.from_parameter`, `SubspaceContinuous.from_parameter`,
+  `SubspaceContinuous.from_product` and `SearchSpace.from_parameter`
+   convenience constructors
+- `DiscreteParameter.to_subspace`, `ContinuousParameter.to_subspace` and
+  `Parameter.to_searchspace` convenience constructors
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -18,6 +18,7 @@ from baybe.recommenders.base import RecommenderProtocol
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.searchspace.core import (
     SearchSpace,
+    to_searchspace,
     validate_searchspace_from_config,
 )
 from baybe.serialization import SerialMixin, converter
@@ -46,13 +47,17 @@ class Campaign(SerialMixin):
     """
 
     # DOE specifications
-    searchspace: SearchSpace = field(validator=instance_of(SearchSpace))
-    """The search space in which the experiments are conducted."""
+    searchspace: SearchSpace = field(converter=to_searchspace)
+    """The search space in which the experiments are conducted.
+    When passing a :class:`baybe.parameters.base.Parameter`,
+    a :class:`baybe.searchspace.discrete.SubspaceDiscrete`, or a
+    a :class:`baybe.searchspace.continuous.SubspaceContinuous`, conversion to
+    :class:`baybe.searchspace.core.SearchSpace` is automatically applied."""
 
     objective: Objective | None = field(default=None, converter=optional(to_objective))
     """The optimization objective.
-    When passing a single :class:`baybe.targets.base.Target`, it gets automatically
-    wrapped into a :class:`baybe.objectives.single.SingleTargetObjective`."""
+    When passing a :class:`baybe.targets.base.Target`, conversion to
+    :class:`baybe.objectives.single.SingleTargetObjective` is automatically applied."""
 
     recommender: RecommenderProtocol = field(
         factory=TwoPhaseMetaRecommender,

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -1,8 +1,10 @@
 """Base classes for all parameters."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from functools import cached_property, partial
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pandas as pd
 from attrs import define, field
@@ -16,6 +18,11 @@ from baybe.serialization import (
     get_base_structure_hook,
     unstructure_base,
 )
+
+if TYPE_CHECKING:
+    from baybe.searchspace.continuous import SubspaceContinuous
+    from baybe.searchspace.core import SearchSpace
+    from baybe.searchspace.discrete import SubspaceDiscrete
 
 # TODO: Reactive slots in all classes once cached_property is supported:
 #   https://github.com/python-attrs/attrs/issues/164
@@ -65,6 +72,12 @@ class Parameter(ABC, SerialMixin):
         """Boolean indicating if this is a discrete parameter."""
         return isinstance(self, DiscreteParameter)
 
+    def to_searchspace(self) -> SearchSpace:
+        """Create a one-dimensional search space from the parameter."""
+        from baybe.searchspace.core import SearchSpace
+
+        return SearchSpace.from_parameter(self)
+
 
 @define(frozen=True, slots=False)
 class DiscreteParameter(Parameter, ABC):
@@ -85,6 +98,12 @@ class DiscreteParameter(Parameter, ABC):
     @abstractmethod
     def comp_df(self) -> pd.DataFrame:
         """Return the computational representation of the parameter."""
+
+    def to_subspace(self) -> SubspaceDiscrete:
+        """Create a one-dimensional search space from the parameter."""
+        from baybe.searchspace.discrete import SubspaceDiscrete
+
+        return SubspaceDiscrete.from_parameter(self)
 
     def is_in_range(self, item: Any) -> bool:  # noqa: D102
         # See base class.
@@ -127,6 +146,12 @@ class DiscreteParameter(Parameter, ABC):
 @define(frozen=True, slots=False)
 class ContinuousParameter(Parameter):
     """Abstract class for continuous parameters."""
+
+    def to_subspace(self) -> SubspaceContinuous:
+        """Create a one-dimensional search space from the parameter."""
+        from baybe.searchspace.continuous import SubspaceContinuous
+
+        return SubspaceContinuous.from_parameter(self)
 
 
 # Register (un-)structure hooks

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -129,6 +129,18 @@ class SubspaceContinuous(SerialMixin):
         return SubspaceContinuous([])
 
     @classmethod
+    def from_parameter(cls, parameter: ContinuousParameter) -> SubspaceContinuous:
+        """Create a subspace from a single parameter.
+
+        Args:
+            parameter: The parameter to span the subspace.
+
+        Returns:
+            The created subspace.
+        """
+        return cls.from_product([parameter])
+
+    @classmethod
     def from_bounds(cls, bounds: pd.DataFrame) -> SubspaceContinuous:
         """Create a hyperrectangle-shaped continuous subspace with given bounds.
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -16,7 +16,7 @@ from baybe.constraints import (
     ContinuousLinearEqualityConstraint,
     ContinuousLinearInequalityConstraint,
 )
-from baybe.constraints.base import ContinuousNonlinearConstraint
+from baybe.constraints.base import ContinuousConstraint, ContinuousNonlinearConstraint
 from baybe.constraints.validation import (
     validate_cardinality_constraints_are_nonoverlapping,
 )
@@ -139,6 +139,31 @@ class SubspaceContinuous(SerialMixin):
             The created subspace.
         """
         return cls.from_product([parameter])
+
+    @classmethod
+    def from_product(
+        cls,
+        parameters: Sequence[ContinuousParameter],
+        constraints: Sequence[ContinuousConstraint] | None = None,
+    ) -> SubspaceContinuous:
+        """See :class:`baybe.searchspace.core.SearchSpace`."""
+        constraints = constraints or []
+        return SubspaceContinuous(
+            parameters=[p for p in parameters if p.is_continuous],  # type:ignore[misc]
+            constraints_lin_eq=[  # type:ignore[misc]
+                c
+                for c in constraints
+                if isinstance(c, ContinuousLinearEqualityConstraint)
+            ],
+            constraints_lin_ineq=[  # type:ignore[misc]
+                c
+                for c in constraints
+                if isinstance(c, ContinuousLinearInequalityConstraint)
+            ],
+            constraints_nonlin=[
+                c for c in constraints if isinstance(c, ContinuousNonlinearConstraint)
+            ],
+        )
 
     @classmethod
     def from_bounds(cls, bounds: pd.DataFrame) -> SubspaceContinuous:

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -12,11 +12,9 @@ import pandas as pd
 from attr import define, field
 
 from baybe.constraints import (
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
     validate_constraints,
 )
-from baybe.constraints.base import Constraint, ContinuousNonlinearConstraint
+from baybe.constraints.base import Constraint
 from baybe.parameters import SubstanceEncoding, TaskParameter
 from baybe.parameters.base import Parameter
 from baybe.searchspace.continuous import SubspaceContinuous
@@ -146,26 +144,14 @@ class SearchSpace(SerialMixin):
         else:
             constraints = []
 
-        discrete: SubspaceDiscrete = SubspaceDiscrete.from_product(
+        discrete = SubspaceDiscrete.from_product(
             parameters=[p for p in parameters if p.is_discrete],  # type:ignore[misc]
             constraints=[c for c in constraints if c.is_discrete],  # type:ignore[misc]
             empty_encoding=empty_encoding,
         )
-        continuous: SubspaceContinuous = SubspaceContinuous(
+        continuous = SubspaceContinuous.from_product(
             parameters=[p for p in parameters if p.is_continuous],  # type:ignore[misc]
-            constraints_lin_eq=[  # type:ignore[misc]
-                c
-                for c in constraints
-                if isinstance(c, ContinuousLinearEqualityConstraint)
-            ],
-            constraints_lin_ineq=[  # type:ignore[misc]
-                c
-                for c in constraints
-                if isinstance(c, ContinuousLinearInequalityConstraint)
-            ],
-            constraints_nonlin=[
-                c for c in constraints if isinstance(c, ContinuousNonlinearConstraint)
-            ],
+            constraints=[c for c in constraints if c.is_continuous],  # type:ignore[misc]
         )
 
         return SearchSpace(discrete=discrete, continuous=continuous)

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -97,6 +97,18 @@ class SearchSpace(SerialMixin):
         )
 
     @classmethod
+    def from_parameter(cls, parameter: Parameter) -> SearchSpace:
+        """Create a search space from a single parameter.
+
+        Args:
+            parameter: The parameter to span the search space.
+
+        Returns:
+            The created search space.
+        """
+        return cls.from_product([parameter])
+
+    @classmethod
     def from_product(
         cls,
         parameters: Sequence[Parameter],

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -393,6 +393,13 @@ class SearchSpace(SerialMixin):
         return comp_rep
 
 
+def to_searchspace(
+    x: Parameter | SubspaceDiscrete | SubspaceContinuous | SearchSpace, /
+) -> SearchSpace:
+    """Convert a parameter/subspace into a search space (with search space passthrough)."""  # noqa: E501
+    return x if isinstance(x, SearchSpace) else x.to_searchspace()
+
+
 def validate_searchspace_from_config(specs: dict, _) -> None:
     """Validate the search space specifications while skipping costly creation steps."""
     # Validate product inputs without constructing it

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -249,6 +249,18 @@ class SubspaceDiscrete(SerialMixin):
         )
 
     @classmethod
+    def from_parameter(cls, parameter: DiscreteParameter) -> SubspaceDiscrete:
+        """Create a subspace from a single parameter.
+
+        Args:
+            parameter: The parameter to span the subspace.
+
+        Returns:
+            The created subspace.
+        """
+        return cls.from_product([parameter])
+
+    @classmethod
     def from_product(
         cls,
         parameters: Sequence[DiscreteParameter],


### PR DESCRIPTION
This PR brings new `to_searchspace`, `to_subspace`, `from_parameter` and `from_product` convenience constructors, and enables search space autoconversion in the `Campaign` class, for improved user experience. A main improvement is that they allow to avoid the common pattern `Searchspace.from_product([parameter])`, which was so far the only way to specify a one-dimensional search space and was rather confusing for the user since there is effectively no product involved.