### PR TITLE
Add KnowledgeGradient ACQF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validators for `Campaign` attributes
 _ `_optional` subpackage for managing optional dependencies
 - Acquisition function for active learning: `qNIPV`
+- Acquisition function: `qKG` (knowledge gradient)
 - Abstract `ContinuousNonlinearConstraint` class
 - Abstract `CardinalityConstraint` class and
   `DiscreteCardinalityConstraint`/`ContinuousCardinalityConstraint` subclasses

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -7,6 +7,7 @@ from baybe.acquisition.acqfs import (
     ProbabilityOfImprovement,
     UpperConfidenceBound,
     qExpectedImprovement,
+    qKnowledgeGradient,
     qLogExpectedImprovement,
     qLogNoisyExpectedImprovement,
     qNegIntegratedPosteriorVariance,
@@ -20,6 +21,7 @@ PM = PosteriorMean
 qSR = qSimpleRegret
 EI = ExpectedImprovement
 qEI = qExpectedImprovement
+qKG = qKnowledgeGradient
 LogEI = LogExpectedImprovement
 qLogEI = qLogExpectedImprovement
 qNEI = qNoisyExpectedImprovement
@@ -32,6 +34,8 @@ qUCB = qUpperConfidenceBound
 
 __all__ = [
     ######################### Acquisition functions
+    # Knowledge Gradient
+    "qKnowledgeGradient",
     # Posterior Mean
     "PosteriorMean",
     # Simple Regret
@@ -51,6 +55,8 @@ __all__ = [
     "UpperConfidenceBound",
     "qUpperConfidenceBound",
     ######################### Abbreviations
+    # Knowledge Gradient
+    "qKG",
     # Posterior Mean
     "PM",
     # Simple Regret

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -121,6 +121,21 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
 
 
 ########################################################################################
+### Knowledge Gradient
+@define(frozen=True)
+class qKnowledgeGradient(AcquisitionFunction):
+    """Monte Carlo based knowledge gradient."""
+
+    abbreviation: ClassVar[str] = "qKG"
+
+    num_fantasies: int = field(validator=[instance_of(int), gt(0)], default=128)
+    """Number of fantasies to draw for approximating the knowledge gradient.
+
+    More samples result in a better approximation, at the expense of both memory and
+    wall time."""
+
+
+########################################################################################
 ### Posterior Mean
 @define(frozen=True)
 class PosteriorMean(AcquisitionFunction):

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -124,15 +124,18 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
 ### Knowledge Gradient
 @define(frozen=True)
 class qKnowledgeGradient(AcquisitionFunction):
-    """Monte Carlo based knowledge gradient."""
+    """Monte Carlo based knowledge gradient.
+
+    This acquisition function currently only supports purely continuous spaces.
+    """
 
     abbreviation: ClassVar[str] = "qKG"
 
     num_fantasies: int = field(validator=[instance_of(int), gt(0)], default=128)
     """Number of fantasies to draw for approximating the knowledge gradient.
 
-    More samples result in a better approximation, at the expense of both memory and
-    wall time."""
+    More samples result in a better approximation, at the expense of both increased
+    memory footprint and wall time."""
 
 
 ########################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,6 @@ test = [
     "hypothesis[pandas]>=6.88.4",
     "pytest>=7.2.0",
     "pytest-cov>=4.1.0",
-    "pytest-error-for-skips",
 ]
 
 [build-system]

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -9,6 +9,7 @@ from baybe.acquisition import (
     ProbabilityOfImprovement,
     UpperConfidenceBound,
     qExpectedImprovement,
+    qKnowledgeGradient,
     qLogExpectedImprovement,
     qLogNoisyExpectedImprovement,
     qNegIntegratedPosteriorVariance,
@@ -54,6 +55,9 @@ acquisition_functions = st.one_of(
     st.builds(qUpperConfidenceBound, beta=finite_floats(min_value=0.0)),
     st.builds(qSimpleRegret),
     st.builds(qLogExpectedImprovement),
+    st.builds(
+        qKnowledgeGradient, num_fantasies=st.integers(min_value=1, max_value=512)
+    ),
     st.builds(qNoisyExpectedImprovement),
     st.builds(qLogNoisyExpectedImprovement),
     _qNIPV_strategy(),

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from baybe.acquisition import qNIPV
+from baybe.acquisition import qKG, qNIPV
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.exceptions import UnusedObjectWarning
 from baybe.kernels.base import Kernel
@@ -207,6 +207,9 @@ test_targets = [
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_iter_mc_acquisition_function(campaign, n_iterations, batch_size, acqf):
+    if isinstance(acqf, qKG):
+        pytest.skip(f"{acqf.__class__.__name__} only works with continuous spaces.")
+
     run_iterations(campaign, n_iterations, batch_size)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     BAYBE_TEST_ENV = FULLTEST
 commands =
     python --version
-    pytest -p no:warnings --cov=baybe --durations=5 --error-for-skips {posargs}
+    pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
 [testenv:coretest,coretest-py{310,311,312}]
 description = Run PyTest with core functionality


### PR DESCRIPTION
- adds `qKnowledgeGradient` aka `qKG` to the list of supported acqfs
- the limit of `num_fantasies` is set to max of `512` in the hypothesis test as it seems to be a fairly expensive acqf from an initial trial
- Skips for some iteration tests have been added because `qKG` does not work with discrete optimization