### PR TITLE
Surrogate Posteriors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DiscreteParameter.transform` 
 - `Surrogate` models now operate on dataframes in experimental representation instead of
   tensors in computational representation
+- `Surrogate.posterior` models now returns a `Posterior` object
 
 ### Added
 - `Surrogate` base class now exposes a `to_botorch` method
@@ -31,6 +32,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `register_hooks` utility enabling user-defined augmentation of arbitrary callables
 - `transform` methods of `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous`
   now take additional `allow_missing` and `allow_extra` keyword arguments
+- `GaussianSurrogate` base class for surrogate models with Gaussian posteriors
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -39,10 +41,15 @@ _ `_optional` subpackage for managing optional dependencies
 - Sampling methods in `qNIPV` and `BotorchRecommender` are now specified via 
   `DiscreteSamplingMethod` enum
 - `Interval` class now supports degenerate intervals containing only one element
+- Context information required by `Surrogate` models is now cleanly encapsulated into
+  a `context` object passed to `Surrogate._fit`
+- Fallback models created by `catch_constant_targets` are stored outside of surrogate
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 
   and guidelines from [Scientific Python](https://scientific-python.org/specs/spec-0000/)
+- `register_custom_architecture` decorator
+- `Scalar` and `DefaultScaler` classes
 
 ### Fixed
 - `sequential` flag of `SequentialGreedyRecommender` is now set to `True`
@@ -57,6 +64,8 @@ _ `_optional` subpackage for managing optional dependencies
 - Passing a dataframe via the `data` argument to the `transform` methods of
   `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous` is no longer possible.
   The dataframe must now be passed as positional argument.
+- Role of `register_custom_architecture` has been taken over by
+  `baybe.surrogates.base.SurrogateProtocol`
 
 ## [0.9.1] - 2024-06-04
 ### Changed

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -39,4 +39,12 @@ class AdapterModel(Model):
         **kwargs: Any,
     ) -> Posterior:
         # See base class.
+        if (
+            (output_indices is not None)
+            or observation_noise
+            or (posterior_transform is not None)
+        ):
+            raise NotImplementedError(
+                "The optional model posterior arguments are not yet implemented."
+            )
         return self._surrogate._posterior(X)

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -3,10 +3,8 @@
 from collections.abc import Callable
 from typing import Any
 
-import gpytorch.distributions
 from botorch.models.gpytorch import Model
 from botorch.posteriors import Posterior
-from botorch.posteriors.gpytorch import GPyTorchPosterior
 from torch import Tensor
 
 from baybe.surrogates.base import Surrogate
@@ -41,6 +39,4 @@ class AdapterModel(Model):
         **kwargs: Any,
     ) -> Posterior:
         # See base class.
-        mean, var = self._surrogate.posterior(X)
-        mvn = gpytorch.distributions.MultivariateNormal(mean, var)
-        return GPyTorchPosterior(mvn)
+        return self._surrogate._posterior(X)

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -47,7 +47,7 @@ bytes to string and back, since the specification is a bijection between
 """
 
 
-@define(slots=False)
+@define
 class Surrogate(ABC, SerialMixin):
     """Abstract base class for all surrogate models."""
 
@@ -164,7 +164,7 @@ class Surrogate(ABC, SerialMixin):
         """Perform the actual fitting logic."""
 
 
-@define(slots=False)
+@define
 class GaussianSurrogate(Surrogate, ABC):
     """A surrogate model providing Gaussian posterior estimates."""
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 @catch_constant_targets
 @autoscale
-@define(slots=False)
+@define
 class BayesianLinearSurrogate(GaussianSurrogate):
     """A Bayesian linear regression surrogate model."""
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from attr import define, field
 from sklearn.linear_model import ARDRegression
 
-from baybe.searchspace import SearchSpace
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
 @catch_constant_targets
 @autoscale
 @define(slots=False)
-class BayesianLinearSurrogate(Surrogate):
+class BayesianLinearSurrogate(GaussianSurrogate):
     """A Bayesian linear regression surrogate model."""
 
     # Class variables
@@ -47,7 +46,7 @@ class BayesianLinearSurrogate(Surrogate):
     """The actual model."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
+    def _estimate_moments(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
         import torch
@@ -61,7 +60,7 @@ class BayesianLinearSurrogate(Surrogate):
 
         return mean, var
 
-    def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
+    def _fit(self, train_x: Tensor, train_y: Tensor, context: Any) -> None:
         # See base class.
         self._model = ARDRegression(**(self.model_params))
         self._model.fit(train_x, train_y.ravel())

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import define, field
 
-from baybe.searchspace import SearchSpace
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import batchify
 
 if TYPE_CHECKING:
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 
 @define
-class MeanPredictionSurrogate(Surrogate):
+class MeanPredictionSurrogate(GaussianSurrogate):
     """A trivial surrogate model.
 
     It provides the average value of the training targets
@@ -34,7 +33,7 @@ class MeanPredictionSurrogate(Surrogate):
     """The estimated posterior mean value of the training targets."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
+    def _estimate_moments(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
         import torch
@@ -44,6 +43,6 @@ class MeanPredictionSurrogate(Surrogate):
         var = torch.ones(len(candidates))
         return mean, var
 
-    def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
+    def _fit(self, train_x: Tensor, train_y: Tensor, context: Any) -> None:
         # See base class.
         self._model = train_y.mean().item()

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from attr import define, field
 from ngboost import NGBRegressor
 
-from baybe.searchspace import SearchSpace
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
@@ -25,7 +24,7 @@ if TYPE_CHECKING:
 @catch_constant_targets
 @autoscale
 @define(slots=False)
-class NGBoostSurrogate(Surrogate):
+class NGBoostSurrogate(GaussianSurrogate):
     """A natural-gradient-boosting surrogate model."""
 
     # Class variables
@@ -53,7 +52,7 @@ class NGBoostSurrogate(Surrogate):
         self.model_params = {**self._default_model_params, **self.model_params}
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
+    def _estimate_moments(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
         import torch
@@ -67,6 +66,6 @@ class NGBoostSurrogate(Surrogate):
 
         return mean, var
 
-    def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
+    def _fit(self, train_x: Tensor, train_y: Tensor, context: Any) -> None:
         # See base class.
         self._model = NGBRegressor(**(self.model_params)).fit(train_x, train_y.ravel())

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 @catch_constant_targets
 @autoscale
-@define(slots=False)
+@define
 class NGBoostSurrogate(GaussianSurrogate):
     """A natural-gradient-boosting surrogate model."""
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -14,8 +14,7 @@ import numpy as np
 from attr import define, field
 from sklearn.ensemble import RandomForestRegressor
 
-from baybe.searchspace import SearchSpace
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import autoscale, batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 @catch_constant_targets
 @autoscale
 @define(slots=False)
-class RandomForestSurrogate(Surrogate):
+class RandomForestSurrogate(GaussianSurrogate):
     """A random forest surrogate model."""
 
     # Class variables
@@ -48,7 +47,7 @@ class RandomForestSurrogate(Surrogate):
     """The actual model."""
 
     @batchify
-    def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
+    def _estimate_moments(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         # See base class.
 
         import torch
@@ -72,7 +71,7 @@ class RandomForestSurrogate(Surrogate):
 
         return mean, var
 
-    def _fit(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor) -> None:
+    def _fit(self, train_x: Tensor, train_y: Tensor, context: Any) -> None:
         # See base class.
         self._model = RandomForestRegressor(**(self.model_params))
         self._model.fit(train_x, train_y.ravel())

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @catch_constant_targets
 @autoscale
-@define(slots=False)
+@define
 class RandomForestSurrogate(GaussianSurrogate):
     """A random forest surrogate model."""
 

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -49,6 +49,7 @@ def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
     _posterior_original = cls._posterior
 
     def _posterior_new(self, candidates: Tensor) -> Posterior:
+        """Use fallback model if it exists, otherwise call original posterior."""
         # Alternative model fallback
         if constant_target_model := _constant_target_model_store.get(id(self), None):
             return constant_target_model._posterior(candidates)
@@ -57,6 +58,7 @@ def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
         return _posterior_original(self, candidates)
 
     def _fit_new(self, train_x: Tensor, train_y: Tensor, context: Any) -> None:
+        """Original fit but with fallback model creation for constant targets."""
         if not (train_y.ndim == 2 and train_y.shape[-1] == 1):
             raise NotImplementedError(
                 "The current logic is only implemented for single-target surrogates."


### PR DESCRIPTION
This PR is a next step toward a lean surrogate class layout:
* `Surrogate.(_)posterior` now returns a `Posterior` object
* `Surrogate._fit` no longer expects the `SearchSpace` as an argument, which brings us closer to the state that `.fit` and `.posterior` operate on the user/dataframe/context-level while `_posterior` and `_fit` operate on the purely mathematical level. This means that a user who writes their own surrogate class effectively only needs to implement the corresponding mathematical model in the latter two methods. Optional context information that may be required for this implementation (like the dimension index of the `TaskParameter` in the passed `Tensor` object) is now encapsulated into a surrogate-specific `context` object, that can be arbitrarily populated by the surrogate class, but whose logic is now cleanly separated from the actual fitting logic.
* Adds a new `GaussianSurrogate` base class for (most our other) models that come with the implicit Gaussian noise assumption and effectively only implement mean and (co-)variance estimation.
* ~~Removes current scaling logic --> will be redesigned in upcoming PR~~
* Improves and simplifies logic of the `catch_constant_target`, re-enabling slots for `Surrogates`
* ~~Removes `register_custom_architecture` --> will replaced with `SurrogateProtocol` in upcoming PR~~