### PR TITLE
Fix kernel translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Parameter.is_numeric` has been replaced with `Parameter.is_numerical`
 - `DiscreteParameter.transform_rep_exp2comp` has been replaced with
   `DiscreteParameter.transform` 
+- `filter_attributes` has been replaced with `match_attributes`
 
 ### Added
 - `Surrogate` base class now exposes a `to_botorch` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _ `_optional` subpackage for managing optional dependencies
   `Parameter.to_searchspace` convenience constructors
 - Utilities for permutation and dependency data augmentation
 - Validation and translation tests for kernels
+- `BasicKernel` and `CompositeKernel` base classes
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _ `_optional` subpackage for managing optional dependencies
 - `DiscreteParameter.to_subspace`, `ContinuousParameter.to_subspace` and
   `Parameter.to_searchspace` convenience constructors
 - Utilities for permutation and dependency data augmentation
+- Validation and translation tests for kernels
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -61,6 +62,8 @@ _ `_optional` subpackage for managing optional dependencies
   measurements when calling a `NonPredictiveRecommender`
 - Bug introduced in 0.9.0 (PR #221, commit 3078f3), where arguments to `to_gpytorch` 
   are not passed on to the GPyTorch kernels
+- Positive-valued kernel attributes are now correctly handled by validators
+  and hypothesis strategies
 
 ### Deprecations
 - `SequentialGreedyRecommender` class replaced with `BotorchRecommender`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ _ `_optional` subpackage for managing optional dependencies
 - Serialization bug related to class layout of `SKLearnClusteringRecommender`
 - `MetaRecommender`s no longer trigger warnings about non-empty objectives or
   measurements when calling a `NonPredictiveRecommender`
+- Bug introduced in 0.9.0 (PR #221, commit 3078f3), where arguments to `to_gpytorch` 
+  are not passed on to the GPyTorch kernels
 
 ### Deprecations
 - `SequentialGreedyRecommender` class replaced with `BotorchRecommender`

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -11,6 +11,7 @@ from attrs.validators import ge, gt, instance_of, le
 
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.searchspace import SearchSpace
+from baybe.utils.basic import classproperty
 from baybe.utils.sampling_algorithms import (
     DiscreteSamplingMethod,
     sample_numerical_df,
@@ -64,6 +65,15 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
                 f"'{fields(self.__class__).sampling_n_points.name}' cannot "
                 f"be specified at the same time."
             )
+
+    @classproperty
+    def _non_botorch_attrs(cls) -> tuple[str, ...]:
+        flds = fields(qNegIntegratedPosteriorVariance)
+        return (
+            flds.sampling_n_points.name,
+            flds.sampling_method.name,
+            flds.sampling_fraction.name,
+        )
 
     def get_integration_points(self, searchspace: SearchSpace) -> pd.DataFrame:
         """Sample points from a search space for integration purposes.

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -18,7 +18,7 @@ from baybe.serialization.core import (
 )
 from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import Surrogate
-from baybe.utils.basic import classproperty, filter_attributes
+from baybe.utils.basic import classproperty, match_attributes
 from baybe.utils.boolean import is_abstract
 from baybe.utils.dataframe import to_tensor
 
@@ -46,7 +46,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         import botorch.acquisition as botorch_acqf_module
 
         acqf_cls = getattr(botorch_acqf_module, self.__class__.__name__)
-        params_dict = filter_attributes(object=self, callable_=acqf_cls.__init__)
+        params_dict = match_attributes(self, acqf_cls.__init__)[0]
 
         signature_params = signature(acqf_cls).parameters
         additional_params = {}

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -59,3 +59,7 @@ class DeprecationError(Exception):
 
 class UnidentifiedSubclassError(Exception):
     """A specified subclass cannot be found in the given class hierarchy."""
+
+
+class UnmatchedAttributeError(Exception):
+    """An attribute cannot be matched against a certain callable signature."""

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -73,7 +73,12 @@ class Kernel(ABC, SerialMixin):
         # Create the kernel with all its inner gpytorch objects
         fields_dict.update(kernel_dict)
         fields_dict.update(prior_dict)
-        gpytorch_kernel = kernel_cls(**fields_dict)
+        gpytorch_kernel = kernel_cls(
+            **fields_dict,
+            ard_num_dims=ard_num_dims,
+            batch_shape=batch_shape,
+            active_dims=active_dims,
+        )
 
         # If the kernel has a lengthscale, set its initial value
         if kernel_cls.has_lengthscale:

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -114,6 +114,16 @@ class Kernel(ABC, SerialMixin):
         return gpytorch_kernel
 
 
+@define(frozen=True)
+class BasicKernel(Kernel, ABC):
+    """Abstract base class for all basic kernels."""
+
+
+@define(frozen=True)
+class CompositeKernel(Kernel, ABC):
+    """Abstract base class for all composite kernels."""
+
+
 # Register de-/serialization hooks
 converter.register_structure_hook(Kernel, get_base_structure_hook(Kernel))
 converter.register_unstructure_hook(Kernel, unstructure_base)

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -47,7 +47,7 @@ class Kernel(ABC, SerialMixin):
         # makes use of kwargs, i.e. differentiates if certain keywords are explicitly
         # passed or not. For instance, `ard_num_dims = kwargs.get("ard_num_dims", 1)`
         # fails if we explicitly pass `ard_num_dims=None`.
-        kw = dict(
+        kw: dict[str, Any] = dict(
             ard_num_dims=ard_num_dims, batch_shape=batch_shape, active_dims=active_dims
         )
         kw = {k: v for k, v in kw.items() if v is not None}

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -6,14 +6,14 @@ from attrs.converters import optional as optional_c
 from attrs.validators import ge, gt, in_, instance_of
 from attrs.validators import optional as optional_v
 
-from baybe.kernels.base import Kernel
+from baybe.kernels.base import BasicKernel
 from baybe.priors.base import Prior
 from baybe.utils.conversion import fraction_to_float
 from baybe.utils.validation import finite_float
 
 
 @define(frozen=True)
-class LinearKernel(Kernel):
+class LinearKernel(BasicKernel):
     """A linear kernel."""
 
     variance_prior: Prior | None = field(
@@ -43,7 +43,7 @@ class LinearKernel(Kernel):
 
 
 @define(frozen=True)
-class MaternKernel(Kernel):
+class MaternKernel(BasicKernel):
     """A Matern kernel using a smoothness parameter."""
 
     nu: float = field(
@@ -68,7 +68,7 @@ class MaternKernel(Kernel):
 
 
 @define(frozen=True)
-class PeriodicKernel(Kernel):
+class PeriodicKernel(BasicKernel):
     """A periodic kernel."""
 
     lengthscale_prior: Prior | None = field(
@@ -112,7 +112,7 @@ class PeriodicKernel(Kernel):
 
 
 @define(frozen=True)
-class PiecewisePolynomialKernel(Kernel):
+class PiecewisePolynomialKernel(BasicKernel):
     """A piecewise polynomial kernel."""
 
     q: int = field(validator=in_([0, 1, 2, 3]), default=2)
@@ -132,7 +132,7 @@ class PiecewisePolynomialKernel(Kernel):
 
 
 @define(frozen=True)
-class PolynomialKernel(Kernel):
+class PolynomialKernel(BasicKernel):
     """A polynomial kernel."""
 
     power: int = field(validator=[instance_of(int), ge(0)])
@@ -163,7 +163,7 @@ class PolynomialKernel(Kernel):
 
 
 @define(frozen=True)
-class RBFKernel(Kernel):
+class RBFKernel(BasicKernel):
     """A radial basis function (RBF) kernel."""
 
     lengthscale_prior: Prior | None = field(
@@ -180,7 +180,7 @@ class RBFKernel(Kernel):
 
 
 @define(frozen=True)
-class RFFKernel(Kernel):
+class RFFKernel(BasicKernel):
     """A random Fourier features (RFF) kernel."""
 
     num_samples: int = field(validator=[instance_of(int), ge(1)])
@@ -200,7 +200,7 @@ class RFFKernel(Kernel):
 
 
 @define(frozen=True)
-class RQKernel(Kernel):
+class RQKernel(BasicKernel):
     """A rational quadratic (RQ) kernel."""
 
     lengthscale_prior: Prior | None = field(

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -3,7 +3,7 @@
 
 from attrs import define, field
 from attrs.converters import optional as optional_c
-from attrs.validators import ge, in_, instance_of
+from attrs.validators import ge, gt, in_, instance_of
 from attrs.validators import optional as optional_v
 
 from baybe.kernels.base import Kernel
@@ -22,7 +22,9 @@ class LinearKernel(Kernel):
     """An optional prior on the kernel variance parameter."""
 
     variance_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel variance parameter."""
 
@@ -58,7 +60,9 @@ class MaternKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
 
@@ -73,7 +77,9 @@ class PeriodicKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
 
@@ -83,7 +89,9 @@ class PeriodicKernel(Kernel):
     """An optional prior on the kernel period length."""
 
     period_length_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel period length."""
 
@@ -116,7 +124,9 @@ class PiecewisePolynomialKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
 
@@ -134,7 +144,9 @@ class PolynomialKernel(Kernel):
     """An optional prior on the kernel offset."""
 
     offset_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel offset."""
 
@@ -160,7 +172,9 @@ class RBFKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
 
@@ -178,7 +192,9 @@ class RFFKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
 
@@ -193,6 +209,8 @@ class RQKernel(Kernel):
     """An optional prior on the kernel lengthscale."""
 
     lengthscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -7,13 +7,13 @@ from attrs.converters import optional as optional_c
 from attrs.validators import deep_iterable, gt, instance_of, min_len
 from attrs.validators import optional as optional_v
 
-from baybe.kernels.base import Kernel
+from baybe.kernels.base import CompositeKernel, Kernel
 from baybe.priors.base import Prior
 from baybe.utils.validation import finite_float
 
 
 @define(frozen=True)
-class ScaleKernel(Kernel):
+class ScaleKernel(CompositeKernel):
     """A kernel for decorating existing kernels with an outputscale."""
 
     base_kernel: Kernel = field(validator=instance_of(Kernel))
@@ -46,7 +46,7 @@ class ScaleKernel(Kernel):
 
 
 @define(frozen=True)
-class AdditiveKernel(Kernel):
+class AdditiveKernel(CompositeKernel):
     """A kernel representing the sum of a collection of base kernels."""
 
     base_kernels: tuple[Kernel, ...] = field(
@@ -64,7 +64,7 @@ class AdditiveKernel(Kernel):
 
 
 @define(frozen=True)
-class ProductKernel(Kernel):
+class ProductKernel(CompositeKernel):
     """A kernel representing the product of a collection of base kernels."""
 
     base_kernels: tuple[Kernel, ...] = field(

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -4,7 +4,7 @@ from operator import add, mul
 
 from attrs import define, field
 from attrs.converters import optional as optional_c
-from attrs.validators import deep_iterable, instance_of
+from attrs.validators import deep_iterable, gt, instance_of, min_len
 from attrs.validators import optional as optional_v
 
 from baybe.kernels.base import Kernel
@@ -25,7 +25,9 @@ class ScaleKernel(Kernel):
     """An optional prior on the output scale."""
 
     outputscale_initial_value: float | None = field(
-        default=None, converter=optional_c(float), validator=optional_v(finite_float)
+        default=None,
+        converter=optional_c(float),
+        validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the output scale."""
 
@@ -48,7 +50,10 @@ class AdditiveKernel(Kernel):
     """A kernel representing the sum of a collection of base kernels."""
 
     base_kernels: tuple[Kernel, ...] = field(
-        converter=tuple, validator=deep_iterable(member_validator=instance_of(Kernel))
+        converter=tuple,
+        validator=deep_iterable(
+            member_validator=instance_of(Kernel), iterable_validator=min_len(2)
+        ),
     )
     """The individual kernels to be summed."""
 
@@ -63,7 +68,10 @@ class ProductKernel(Kernel):
     """A kernel representing the product of a collection of base kernels."""
 
     base_kernels: tuple[Kernel, ...] = field(
-        converter=tuple, validator=deep_iterable(member_validator=instance_of(Kernel))
+        converter=tuple,
+        validator=deep_iterable(
+            member_validator=instance_of(Kernel), iterable_validator=min_len(2)
+        ),
     )
     """The individual kernels to be multiplied."""
 

--- a/baybe/priors/base.py
+++ b/baybe/priors/base.py
@@ -10,7 +10,7 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
-from baybe.utils.basic import match_attributes, set_default_torch_dtype
+from baybe.utils.basic import match_attributes
 
 
 @define(frozen=True)
@@ -20,8 +20,14 @@ class Prior(ABC, SerialMixin):
     def to_gpytorch(self, *args, **kwargs):
         """Create the gpytorch representation of the prior."""
         import gpytorch.priors
+        import torch
 
-        set_default_torch_dtype()
+        from baybe.utils.torch import DTypeFloatTorch
+
+        # TODO: This is only a temporary workaround. A proper solution requires
+        #   modifying the torch import procedure using the built-in tools of importlib
+        #   so that the dtype is set whenever torch is lazily loaded.
+        torch.set_default_dtype(DTypeFloatTorch)
 
         prior_cls = getattr(gpytorch.priors, self.__class__.__name__)
         fields_dict = match_attributes(self, prior_cls.__init__)[0]

--- a/baybe/priors/base.py
+++ b/baybe/priors/base.py
@@ -10,7 +10,7 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
-from baybe.utils.basic import filter_attributes
+from baybe.utils.basic import match_attributes
 
 
 @define(frozen=True)
@@ -22,7 +22,7 @@ class Prior(ABC, SerialMixin):
         import gpytorch.priors
 
         prior_cls = getattr(gpytorch.priors, self.__class__.__name__)
-        fields_dict = filter_attributes(object=self, callable_=prior_cls.__init__)
+        fields_dict = match_attributes(self, prior_cls.__init__)[0]
 
         # Update kwargs to contain class-specific attributes
         kwargs.update(fields_dict)

--- a/baybe/priors/base.py
+++ b/baybe/priors/base.py
@@ -10,7 +10,7 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
-from baybe.utils.basic import match_attributes
+from baybe.utils.basic import match_attributes, set_default_torch_dtype
 
 
 @define(frozen=True)
@@ -20,6 +20,8 @@ class Prior(ABC, SerialMixin):
     def to_gpytorch(self, *args, **kwargs):
         """Create the gpytorch representation of the prior."""
         import gpytorch.priors
+
+        set_default_torch_dtype()
 
         prior_cls = getattr(gpytorch.priors, self.__class__.__name__)
         fields_dict = match_attributes(self, prior_cls.__init__)[0]

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -311,14 +311,3 @@ def register_hooks(
         return result
 
     return wraps
-
-
-def set_default_torch_dtype():
-    """Lazily set the torch default dtype."""
-    # TODO: This is only a temporary workaround. A proper solution requires
-    #   modifying the torch import procedure using the built-in tools of importlib.
-    import torch
-
-    from baybe.utils.torch import DTypeFloatTorch
-
-    torch.set_default_dtype(DTypeFloatTorch)

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -2,11 +2,13 @@
 
 import functools
 import inspect
-from collections.abc import Callable, Collection, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
-from baybe.exceptions import UnidentifiedSubclassError
+from attrs import asdict, has
+
+from baybe.exceptions import UnidentifiedSubclassError, UnmatchedAttributeError
 
 _C = TypeVar("_C", bound=type)
 _T = TypeVar("_T")
@@ -121,31 +123,54 @@ def to_tuple(x: Sequence) -> tuple:
     return tuple(x)
 
 
-def filter_attributes(
+def match_attributes(
     object: Any,
     callable_: Callable,
-    ignore: Collection[str] = ("self", "kwargs", "args"),
-) -> dict[str, Any]:
+    /,
+    strict: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """Find the attributes of an object that match with a given callable signature.
 
     Parameters appearing in the callable signature that have no match with the given
     object attributes are ignored.
 
     Args:
-        object: The object whose attributes are to be returned.
+        object: The object whose attributes are to be matched.
         callable_: The callable against whose signature the attributes are to be
             matched.
-        ignore: A collection of parameter names to be ignored in the signature.
+        strict: If ``True``, an error is raised when the object has attributes that
+            are not found in the callable signature. If ``False``, these attributes are
+            returned separately.
+
+    Raises:
+        ValueError: If applied to a non-attrs object.
+        UnmatchedAttributeError: In strict mode, if not all attributes can be matched.
 
     Returns:
-        A dictionary mapping the matched attribute names to their values.
+        * A dictionary mapping the matched attribute names to their values.
+        * A dictionary mapping the unmatched attribute names to their values.
     """
-    params = inspect.signature(callable_).parameters
-    return {
-        p: getattr(object, p)
-        for p in params
-        if (p not in ignore) and hasattr(object, p)
-    }
+    if not has(object):
+        raise ValueError(
+            f"'{match_attributes.__name__}' only works with attrs objects."
+        )
+    # Get attribute/parameter sets
+    set_object = set(asdict(object))
+    set_callable = set(inspect.signature(callable_).parameters)
+
+    # Match
+    in_signature = set_object.intersection(set_callable)
+    not_in_signature = set_object - set_callable
+    if strict and not_in_signature:
+        raise UnmatchedAttributeError(
+            f"The following attributes cannot be matched: {not_in_signature}."
+        )
+
+    # Collect attributes for both sets
+    in_signature = {p: getattr(object, p) for p in in_signature}
+    not_in_signature = {p: getattr(object, p) for p in not_in_signature}
+
+    return in_signature, not_in_signature
 
 
 class classproperty:

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -150,7 +150,7 @@ def match_attributes(
         * A dictionary mapping the matched attribute names to their values.
         * A dictionary mapping the unmatched attribute names to their values.
     """
-    if not has(object):
+    if not has(object.__class__):
         raise ValueError(
             f"'{match_attributes.__name__}' only works with attrs objects."
         )
@@ -167,10 +167,10 @@ def match_attributes(
         )
 
     # Collect attributes for both sets
-    in_signature = {p: getattr(object, p) for p in in_signature}
-    not_in_signature = {p: getattr(object, p) for p in not_in_signature}
+    attrs_in_signature = {p: getattr(object, p) for p in in_signature}
+    attrs_not_in_signature = {p: getattr(object, p) for p in not_in_signature}
 
-    return in_signature, not_in_signature
+    return attrs_in_signature, attrs_not_in_signature
 
 
 class classproperty:

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -2,7 +2,7 @@
 
 import functools
 import inspect
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -128,6 +128,7 @@ def match_attributes(
     callable_: Callable,
     /,
     strict: bool = True,
+    ignore: Collection[str] = (),
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Find the attributes of an object that match with a given callable signature.
 
@@ -139,8 +140,9 @@ def match_attributes(
         callable_: The callable against whose signature the attributes are to be
             matched.
         strict: If ``True``, an error is raised when the object has attributes that
-            are not found in the callable signature. If ``False``, these attributes are
-            returned separately.
+            are not found in the callable signature (see also ``ignore``).
+            If ``False``, these attributes are returned separately.
+        ignore: A collection of attributes names that are to be ignored during matching.
 
     Raises:
         ValueError: If applied to a non-attrs object.
@@ -155,7 +157,7 @@ def match_attributes(
             f"'{match_attributes.__name__}' only works with attrs objects."
         )
     # Get attribute/parameter sets
-    set_object = set(asdict(object))
+    set_object = set(asdict(object)) - set(ignore)
     set_callable = set(inspect.signature(callable_).parameters)
 
     # Match

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -309,3 +309,14 @@ def register_hooks(
         return result
 
     return wraps
+
+
+def set_default_torch_dtype():
+    """Lazily set the torch default dtype."""
+    # TODO: This is only a temporary workaround. A proper solution requires
+    #   modifying the torch import procedure using the built-in tools of importlib.
+    import torch
+
+    from baybe.utils.torch import DTypeFloatTorch
+
+    torch.set_default_dtype(DTypeFloatTorch)

--- a/examples/Custom_Surrogates/custom_architecture_torch.py
+++ b/examples/Custom_Surrogates/custom_architecture_torch.py
@@ -30,6 +30,8 @@ from baybe.surrogates import register_custom_architecture
 from baybe.targets import NumericalTarget
 from baybe.utils.dataframe import add_fake_results
 
+torch.set_default_dtype(torch.float64)
+
 ### Architecture definition
 
 # Note that the following is an example `PyTorch` Neural Network.
@@ -118,8 +120,6 @@ class NeuralNetDropoutSurrogate:
     def _posterior(self, candidates: Tensor) -> tuple[Tensor, Tensor]:
         """See :class:`baybe.surrogates.Surrogate`."""
         self.model = self.model.train()  # keep dropout
-        # Convert input from double to float
-        candidates = candidates.float()
         # Run mc experiments through the NN with dropout
         predictions = torch.cat(
             [self.model(candidates).unsqueeze(dim=0) for _ in range(MC)]
@@ -139,10 +139,6 @@ class NeuralNetDropoutSurrogate:
         # Training hyperparameters
         opt = HYPERPARAMS["optimizer"](self.model.parameters(), lr=HYPERPARAMS["lr"])
         criterion = HYPERPARAMS["criterion"]()
-
-        # Convert input from double to float
-        train_x = train_x.float()
-        train_y = train_y.float()
 
         # Training loop
         for _ in range(HYPERPARAMS["epochs"]):

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,6 +29,7 @@ extend-ignore = [
 "tests/docs/__init__.py" = ["D100", "D104"]
 "tests/serialization/__init__.py" = ["D100", "D104"]
 "tests/validation/__init__.py" = ["D100", "D104"]
+"tests/validation/kernels/__init__.py" = ["D100", "D104"]
 "docs/conf.py" = ["D100"]
 # Ignore missing docstrings in public methods/functions and imperative mood in tests
 "tests/*" = ["D102", "D103", "D401"]

--- a/tests/hypothesis_strategies/basic.py
+++ b/tests/hypothesis_strategies/basic.py
@@ -14,3 +14,6 @@ finite_floats = partial(
     width=32 if DTypeFloatNumpy == np.float32 else 64,
 )
 """A strategy producing finite (i.e., non-nan and non-infinite) floats."""
+
+positive_finite_floats = partial(finite_floats, min_value=0.0, exclude_min=True)
+""""A strategy producing positive finite (i.e., non-nan and non-infinite) floats."""

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -1,7 +1,6 @@
 """Hypothesis strategies for kernels."""
 
 from enum import Enum
-from functools import partial
 
 import hypothesis.strategies as st
 
@@ -17,10 +16,8 @@ from baybe.kernels.basic import (
 )
 from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 
-from ..hypothesis_strategies.basic import finite_floats
+from ..hypothesis_strategies.basic import positive_finite_floats
 from ..hypothesis_strategies.priors import priors
-
-_positive_finite_float = partial(finite_floats, min_value=0.0, exclude_min=True)
 
 
 class KernelType(Enum):
@@ -34,7 +31,7 @@ class KernelType(Enum):
 linear_kernels = st.builds(
     LinearKernel,
     variance_prior=st.one_of(st.none(), priors),
-    variance_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    variance_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates linear kernels."""
 
@@ -42,16 +39,16 @@ matern_kernels = st.builds(
     MaternKernel,
     nu=st.sampled_from((0.5, 1.5, 2.5)),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates Matern kernels."""
 
 periodic_kernels = st.builds(
     PeriodicKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
     period_length_prior=st.one_of(st.none(), priors),
-    period_length_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    period_length_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates periodic kernels."""
 
@@ -59,7 +56,7 @@ piecewise_polynomial_kernels = st.builds(
     PiecewisePolynomialKernel,
     q=st.integers(min_value=0, max_value=3),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates piecewise polynomial kernels."""
 
@@ -67,14 +64,14 @@ polynomial_kernels = st.builds(
     PolynomialKernel,
     power=st.integers(min_value=0),
     offset_prior=st.one_of(st.none(), priors),
-    offset_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    offset_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates polynomial kernels."""
 
 rbf_kernels = st.builds(
     RBFKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates radial basis function (RBF) kernels."""
 
@@ -82,14 +79,14 @@ rff_kernels = st.builds(
     RFFKernel,
     num_samples=st.integers(min_value=1),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates random Fourier features (RFF) kernels."""
 
 rq_kernels = st.builds(
     RQKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
+    lengthscale_initial_value=st.one_of(st.none(), positive_finite_floats()),
 )
 """A strategy that generates rational quadratic (RQ) kernels."""
 
@@ -118,7 +115,7 @@ def single_kernels(draw: st.DrawFn):
             base_kernel=base_kernel,
             outputscale_prior=draw(st.one_of(st.none(), priors)),
             outputscale_initial_value=draw(
-                st.one_of(st.none(), _positive_finite_float()),
+                st.one_of(st.none(), positive_finite_floats()),
             ),
         )
     else:

--- a/tests/hypothesis_strategies/kernels.py
+++ b/tests/hypothesis_strategies/kernels.py
@@ -1,6 +1,7 @@
 """Hypothesis strategies for kernels."""
 
 from enum import Enum
+from functools import partial
 
 import hypothesis.strategies as st
 
@@ -19,6 +20,8 @@ from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 from ..hypothesis_strategies.basic import finite_floats
 from ..hypothesis_strategies.priors import priors
 
+_positive_finite_float = partial(finite_floats, min_value=0.0, exclude_min=True)
+
 
 class KernelType(Enum):
     """Taxonomy of kernel types."""
@@ -31,7 +34,7 @@ class KernelType(Enum):
 linear_kernels = st.builds(
     LinearKernel,
     variance_prior=st.one_of(st.none(), priors),
-    variance_initial_value=st.one_of(st.none(), finite_floats()),
+    variance_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates linear kernels."""
 
@@ -39,16 +42,16 @@ matern_kernels = st.builds(
     MaternKernel,
     nu=st.sampled_from((0.5, 1.5, 2.5)),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates Matern kernels."""
 
 periodic_kernels = st.builds(
     PeriodicKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
     period_length_prior=st.one_of(st.none(), priors),
-    period_length_initial_value=st.one_of(st.none(), finite_floats()),
+    period_length_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates periodic kernels."""
 
@@ -56,7 +59,7 @@ piecewise_polynomial_kernels = st.builds(
     PiecewisePolynomialKernel,
     q=st.integers(min_value=0, max_value=3),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates piecewise polynomial kernels."""
 
@@ -64,14 +67,14 @@ polynomial_kernels = st.builds(
     PolynomialKernel,
     power=st.integers(min_value=0),
     offset_prior=st.one_of(st.none(), priors),
-    offset_initial_value=st.one_of(st.none(), finite_floats()),
+    offset_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates polynomial kernels."""
 
 rbf_kernels = st.builds(
     RBFKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates radial basis function (RBF) kernels."""
 
@@ -79,14 +82,14 @@ rff_kernels = st.builds(
     RFFKernel,
     num_samples=st.integers(min_value=1),
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates random Fourier features (RFF) kernels."""
 
 rq_kernels = st.builds(
     RQKernel,
     lengthscale_prior=st.one_of(st.none(), priors),
-    lengthscale_initial_value=st.one_of(st.none(), finite_floats()),
+    lengthscale_initial_value=st.one_of(st.none(), _positive_finite_float()),
 )
 """A strategy that generates rational quadratic (RQ) kernels."""
 
@@ -115,7 +118,7 @@ def single_kernels(draw: st.DrawFn):
             base_kernel=base_kernel,
             outputscale_prior=draw(st.one_of(st.none(), priors)),
             outputscale_initial_value=draw(
-                st.one_of(st.none(), finite_floats()),
+                st.one_of(st.none(), _positive_finite_float()),
             ),
         )
     else:
@@ -124,13 +127,13 @@ def single_kernels(draw: st.DrawFn):
 
 @st.composite
 def kernels(draw: st.DrawFn):
-    """Generate :class:`baybe.kernels.basic.Kernel`."""
+    """Generate :class:`baybe.kernels.base.Kernel`."""
     kernel_type = draw(st.sampled_from(KernelType))
 
     if kernel_type is KernelType.SINGLE:
         return draw(single_kernels())
 
-    base_kernels = draw(st.lists(single_kernels()))
+    base_kernels = draw(st.lists(single_kernels(), min_size=2))
     if kernel_type is KernelType.ADDITIVE:
         return AdditiveKernel(base_kernels)
     if kernel_type is KernelType.PRODUCT:

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -7,8 +7,7 @@ import torch
 from attrs import asdict, has
 from hypothesis import given
 
-from baybe.kernels.base import Kernel
-from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
+from baybe.kernels.base import BasicKernel, Kernel
 
 from .hypothesis_strategies.kernels import kernels
 
@@ -28,11 +27,7 @@ def validate_gpytorch_kernel_components(obj: Any, mapped: Any, **kwargs) -> None
         **kwargs: Optional kernel arguments that were passed to the GPyTorch kernel.
     """
     # Assert that the kernel kwargs are correctly mapped
-    # TODO: Consider introducing intermediate kernel classes or class variables
-    #   to differentiate basic kernels from composite ones
-    if isinstance(obj, Kernel) and not isinstance(
-        obj, (ScaleKernel, AdditiveKernel, ProductKernel)
-    ):
+    if isinstance(obj, BasicKernel):
         for k, v in kwargs.items():
             assert torch.tensor(getattr(mapped, k)).equal(torch.tensor(v))
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,13 @@
+"""Kernel tests."""
+
+from hypothesis import given
+
+from baybe.kernels.base import Kernel
+
+from .hypothesis_strategies.kernels import kernels
+
+
+@given(kernels())
+def test_kernel_assembly(kernel: Kernel):
+    """Turning a BayBE kernel into a GPyTorch kernel raises no errors."""
+    kernel.to_gpytorch()

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,13 +1,66 @@
 """Kernel tests."""
 
+from typing import Any
+
+import numpy as np
+from attrs import asdict, has
 from hypothesis import given
 
 from baybe.kernels.base import Kernel
 
 from .hypothesis_strategies.kernels import kernels
 
+_RENAME_DICT: dict[str, str] = {
+    "base_kernels": "kernels",
+}
+"""Dictionary for resolving name differences between BayBE and GPyTorch attributes."""
+
+
+def validate_kernel_components(obj: Any, mapped: Any) -> None:
+    """Validate that all kernel components are translated correctly.
+
+    Args:
+        obj: An object occurring as part of a BayBE kernel.
+        mapped: The corresponding object in the translated GPyTorch kernel.
+    """
+    # Compare attribute by attribute
+    for name, component in asdict(obj, recurse=False).items():
+        # If the BayBE component is `None`, the GPyTorch component might not even
+        # exist, so we skip
+        if component is None:
+            continue
+
+        # Resolve attribute naming differences
+        mapped_name = _RENAME_DICT.get(name, name)
+
+        # If the attribute does not exist in the GPyTorch version, it must be an
+        # initial value. Because setting initial values involves going through
+        # constraint transformations on GPyTorch side (i.e., difference between
+        # `<attr>` and `raw_<attr>`), the numerical values will not be exact, so
+        # we check only for approximate matches.
+        if (mapped_component := getattr(mapped, mapped_name, None)) is None:
+            assert name.endswith("_initial_value")
+            assert np.isclose(
+                component, getattr(mapped, name.removesuffix("_initial_value")).item()
+            )
+
+        # If the component is itself another attrs object, recurse
+        elif has(component):
+            validate_kernel_components(component, mapped_component)
+
+        # Same for collections of BayBE objects (coming from composite kernels)
+        elif isinstance(component, tuple) and all(has(c) for c in component):
+            for c, m in zip(component, mapped_component):
+                validate_kernel_components(c, m)
+
+        # On the lowest component level, simply check for equality
+        else:
+            assert component == mapped_component
+
 
 @given(kernels())
 def test_kernel_assembly(kernel: Kernel):
-    """Turning a BayBE kernel into a GPyTorch kernel raises no errors."""
-    kernel.to_gpytorch()
+    """Turning a BayBE kernel into a GPyTorch kernel raises no errors and all its
+    components are translated correctly."""  # noqa
+    k = kernel.to_gpytorch()
+    validate_kernel_components(kernel, k)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -19,8 +19,8 @@ _RENAME_DICT: dict[str, str] = {
 """Dictionary for resolving name differences between BayBE and GPyTorch attributes."""
 
 
-def validate_kernel_components(obj: Any, mapped: Any, **kwargs) -> None:
-    """Validate that all kernel components are translated correctly.
+def validate_gpytorch_kernel_components(obj: Any, mapped: Any, **kwargs) -> None:
+    """Validate that all kernel components are correctly translated to GPyTorch.
 
     Args:
         obj: An object occurring as part of a BayBE kernel.
@@ -60,12 +60,12 @@ def validate_kernel_components(obj: Any, mapped: Any, **kwargs) -> None:
 
         # If the component is itself another attrs object, recurse
         elif has(component):
-            validate_kernel_components(component, mapped_component, **kwargs)
+            validate_gpytorch_kernel_components(component, mapped_component, **kwargs)
 
         # Same for collections of BayBE objects (coming from composite kernels)
         elif isinstance(component, tuple) and all(has(c) for c in component):
             for c, m in zip(component, mapped_component):
-                validate_kernel_components(c, m, **kwargs)
+                validate_gpytorch_kernel_components(c, m, **kwargs)
 
         # On the lowest component level, simply check for equality
         else:
@@ -86,4 +86,4 @@ def test_kernel_assembly(kernel: Kernel):
     )
 
     k = kernel.to_gpytorch(**kwargs)
-    validate_kernel_components(kernel, k, **kwargs)
+    validate_gpytorch_kernel_components(kernel, k, **kwargs)

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -3,26 +3,39 @@
 from typing import Any
 
 import numpy as np
+import torch
 from attrs import asdict, has
 from hypothesis import given
 
 from baybe.kernels.base import Kernel
+from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 
 from .hypothesis_strategies.kernels import kernels
 
+# TODO: Consider deprecating these attribute names to avoid inconsistencies
 _RENAME_DICT: dict[str, str] = {
     "base_kernels": "kernels",
 }
 """Dictionary for resolving name differences between BayBE and GPyTorch attributes."""
 
 
-def validate_kernel_components(obj: Any, mapped: Any) -> None:
+def validate_kernel_components(obj: Any, mapped: Any, **kwargs) -> None:
     """Validate that all kernel components are translated correctly.
 
     Args:
         obj: An object occurring as part of a BayBE kernel.
         mapped: The corresponding object in the translated GPyTorch kernel.
+        **kwargs: Optional kernel arguments that were passed to the GPyTorch kernel.
     """
+    # Assert that the kernel kwargs are correctly mapped
+    # TODO: Consider introducing intermediate kernel classes or class variables
+    #   to differentiate basic kernels from composite ones
+    if isinstance(obj, Kernel) and not isinstance(
+        obj, (ScaleKernel, AdditiveKernel, ProductKernel)
+    ):
+        for k, v in kwargs.items():
+            assert torch.tensor(getattr(mapped, k)).equal(torch.tensor(v))
+
     # Compare attribute by attribute
     for name, component in asdict(obj, recurse=False).items():
         # If the BayBE component is `None`, the GPyTorch component might not even
@@ -40,18 +53,19 @@ def validate_kernel_components(obj: Any, mapped: Any) -> None:
         # we check only for approximate matches.
         if (mapped_component := getattr(mapped, mapped_name, None)) is None:
             assert name.endswith("_initial_value")
-            assert np.isclose(
-                component, getattr(mapped, name.removesuffix("_initial_value")).item()
+            assert np.allclose(
+                component,
+                getattr(mapped, name.removesuffix("_initial_value")).detach().numpy(),
             )
 
         # If the component is itself another attrs object, recurse
         elif has(component):
-            validate_kernel_components(component, mapped_component)
+            validate_kernel_components(component, mapped_component, **kwargs)
 
         # Same for collections of BayBE objects (coming from composite kernels)
         elif isinstance(component, tuple) and all(has(c) for c in component):
             for c, m in zip(component, mapped_component):
-                validate_kernel_components(c, m)
+                validate_kernel_components(c, m, **kwargs)
 
         # On the lowest component level, simply check for equality
         else:
@@ -62,5 +76,14 @@ def validate_kernel_components(obj: Any, mapped: Any) -> None:
 def test_kernel_assembly(kernel: Kernel):
     """Turning a BayBE kernel into a GPyTorch kernel raises no errors and all its
     components are translated correctly."""  # noqa
-    k = kernel.to_gpytorch()
-    validate_kernel_components(kernel, k)
+    # Create some arbitrary kernel kwargs to ensure that they are correctly translated
+    kwargs = dict(
+        ard_num_dims=np.random.randint(0, 32),
+        batch_shape=torch.Size(
+            [np.random.randint(0, 4) for _ in range(np.random.randint(0, 4))]
+        ),
+        active_dims=[np.random.randint(0, 4) for _ in range(np.random.randint(0, 4))],
+    )
+
+    k = kernel.to_gpytorch(**kwargs)
+    validate_kernel_components(kernel, k, **kwargs)

--- a/tests/validation/kernels/test_basic_kernel_validation.py
+++ b/tests/validation/kernels/test_basic_kernel_validation.py
@@ -1,0 +1,167 @@
+"""Validation tests for basic kernels."""
+
+
+import pytest
+from pytest import param
+
+from baybe.kernels.basic import (
+    LinearKernel,
+    MaternKernel,
+    PeriodicKernel,
+    PiecewisePolynomialKernel,
+    PolynomialKernel,
+    RBFKernel,
+    RFFKernel,
+    RQKernel,
+)
+
+
+@pytest.mark.parametrize(
+    ("variance_prior", "variance_initial_value", "error"),
+    [
+        param("wrong", None, TypeError, id="not_a_prior"),
+        param(None, "wrong", ValueError, id="not_a_variance"),
+        param(None, -1, ValueError, id="negative_variance"),
+        param(None, 0, ValueError, id="zero_variance"),
+    ],
+)
+def test_linear_kernel_validation(variance_prior, variance_initial_value, error):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        LinearKernel(variance_prior, variance_initial_value)
+
+
+@pytest.mark.parametrize(
+    ("nu", "lengthscale_prior", "lengthscale_initial_value", "error"),
+    [
+        param(0, None, None, ValueError, id="invalid_nu"),
+        param(2.5, "wrong", None, TypeError, id="not_a_prior"),
+        param(2.5, None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(2.5, None, -1, ValueError, id="negative_lengthscale"),
+        param(2.5, None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_matern_kernel_validation(
+    nu, lengthscale_prior, lengthscale_initial_value, error
+):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        MaternKernel(nu, lengthscale_prior, lengthscale_initial_value)
+
+
+@pytest.mark.parametrize(
+    (
+        "lengthscale_prior",
+        "lengthscale_initial_value",
+        "period_length_prior",
+        "period_length_initial_value",
+        "error",
+    ),
+    [
+        param("wrong", None, None, None, TypeError, id="not_a_lengthscale_prior"),
+        param(None, "wrong", None, None, ValueError, id="not_a_lengthscale"),
+        param(None, -1, None, None, ValueError, id="negative_lengthscale"),
+        param(None, 0, None, None, ValueError, id="zero_lengthscale"),
+        param(None, None, "wrong", None, TypeError, id="not_a_period_length_prior"),
+        param(None, None, None, "wrong", ValueError, id="not_a_period_length"),
+        param(None, None, None, -1, ValueError, id="negative_period_length"),
+        param(None, None, None, 0, ValueError, id="zero_period_length"),
+    ],
+)
+def test_periodic_kernel_validation(
+    lengthscale_prior,
+    lengthscale_initial_value,
+    period_length_prior,
+    period_length_initial_value,
+    error,
+):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        PeriodicKernel(
+            lengthscale_prior,
+            lengthscale_initial_value,
+            period_length_prior,
+            period_length_initial_value,
+        )
+
+
+@pytest.mark.parametrize(
+    ("q", "lengthscale_prior", "lengthscale_initial_value", "error"),
+    [
+        param(4, None, None, ValueError, id="invalid_q"),
+        param(0, "wrong", None, TypeError, id="not_a_prior"),
+        param(0, None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(0, None, -1, ValueError, id="negative_lengthscale"),
+        param(0, None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_piecewise_polynomial_kernel_validation(
+    q, lengthscale_prior, lengthscale_initial_value, error
+):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        PiecewisePolynomialKernel(q, lengthscale_prior, lengthscale_initial_value)
+
+
+@pytest.mark.parametrize(
+    ("power", "offset_prior", "offset_initial_value", "error"),
+    [
+        param(-1, None, None, ValueError, id="invalid_power"),
+        param(0, "wrong", None, TypeError, id="not_a_prior"),
+        param(0, None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(0, None, -1, ValueError, id="negative_lengthscale"),
+        param(0, None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_polynomial_kernel_validation(power, offset_prior, offset_initial_value, error):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        PolynomialKernel(power, offset_prior, offset_initial_value)
+
+
+@pytest.mark.parametrize(
+    ("lengthscale_prior", "lengthscale_initial_value", "error"),
+    [
+        param("wrong", None, TypeError, id="not_a_prior"),
+        param(None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(None, -1, ValueError, id="negative_lengthscale"),
+        param(None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_rbf_kernel_validation(lengthscale_prior, lengthscale_initial_value, error):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        RBFKernel(lengthscale_prior, lengthscale_initial_value)
+
+
+@pytest.mark.parametrize(
+    ("num_samples", "lengthscale_prior", "lengthscale_initial_value", "error"),
+    [
+        param(0, None, None, ValueError, id="invalid_num_samples"),
+        param(1, "wrong", None, TypeError, id="not_a_prior"),
+        param(1, None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(1, None, -1, ValueError, id="negative_lengthscale"),
+        param(1, None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_rff_kernel_validation(
+    num_samples, lengthscale_prior, lengthscale_initial_value, error
+):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        RFFKernel(num_samples, lengthscale_prior, lengthscale_initial_value)
+
+
+@pytest.mark.parametrize(
+    ("lengthscale_prior", "lengthscale_initial_value", "error"),
+    [
+        param("wrong", None, TypeError, id="not_a_prior"),
+        param(None, "wrong", ValueError, id="not_a_lengthscale"),
+        param(None, -1, ValueError, id="negative_lengthscale"),
+        param(None, 0, ValueError, id="zero_lengthscale"),
+    ],
+)
+def test_rq_kernel_validation(lengthscale_prior, lengthscale_initial_value, error):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        RQKernel(lengthscale_prior, lengthscale_initial_value)

--- a/tests/validation/kernels/test_composite_kernel_validation.py
+++ b/tests/validation/kernels/test_composite_kernel_validation.py
@@ -1,0 +1,44 @@
+"""Validation tests for composite kernels."""
+
+
+import pytest
+from pytest import param
+
+from baybe.kernels.basic import MaternKernel
+from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
+
+base_kernel = MaternKernel()
+
+
+@pytest.mark.parametrize(
+    ("base_kernel", "outputscale_prior", "outputscale_initial_value", "error"),
+    [
+        param("wrong", None, None, TypeError, id="not_a_kernel"),
+        param(base_kernel, "wrong", None, TypeError, id="not_a_prior"),
+        param(base_kernel, None, "wrong", ValueError, id="not_a_scale"),
+        param(base_kernel, None, -1, ValueError, id="negative_scale"),
+        param(base_kernel, None, 0, ValueError, id="zero_scale"),
+    ],
+)
+def test_scale_kernel_validation(
+    base_kernel, outputscale_prior, outputscale_initial_value, error
+):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        ScaleKernel(base_kernel, outputscale_prior, outputscale_initial_value)
+
+
+@pytest.mark.parametrize("kernel_cls", [AdditiveKernel, ProductKernel])
+@pytest.mark.parametrize(
+    ("base_kernels", "error"),
+    [
+        param(1, TypeError, id="not_an_iterable"),
+        param([], ValueError, id="empty_iterable"),
+        param([base_kernel], ValueError, id="only_one_kernel"),
+        param([1, base_kernel], TypeError, id="not_a_kernel"),
+    ],
+)
+def test_additive_and_product_kernel_validation(kernel_cls, base_kernels, error):
+    """Providing invalid kernel arguments raises an exception."""
+    with pytest.raises(error):
+        kernel_cls(base_kernels)


### PR DESCRIPTION
This PR fixes one of the two issues that caused transfer learning performance to deteriorate, fixing several other issues along the way.

### Bug fixes
* Main issue fixed: the arguments provided to `to_gpytorch` (e.g. `ard_num_dims`) were not passed on to the GPyTorch kernel class.
* The `to_gpytorch` call was not tested and did in fact not succeed in all cases. Causing issues:
    * Hypothesis strategies did not account for positive-valued attributes, and no validators where in place. --> fixed
    * ~~The torch dtype was not correctly set when translating priors to GPyTorch. --> fixed using temporary workaround (see below)~~

### ~~Added workarounds~~
* ~~A proper solution to setting the default torch dtype requires overriding the torch import mechanism using `importlib`s machinery, due to lazy loading. A preliminary workaround is added in form of the `set_default_torch_dtype` utility, which manages the temporary code in a single place.~~

### Improvements
* The new `match_attributes` utility, which replaces `filter_attributes` now raises an error when attributes cannot be matched to the target callable, instead of silently dropping them. In `strict=False` mode, the unmatched arguments can be inspected as second return value for further processing.
* Kernel translation to GPyTorch now ensures that all attributes are actually mapped
* Added kernel validation, ensuring that invalid arguments trigger the expected errors
* Added kernel translation tests, ensuring that all kernel components are correctly mapped to corresponding GPyTorch components
