### PR TITLE
Ignore `UnusedObjectWarning` caused by nonpred recommenders in simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Interval` class now supports degenerate intervals containing only one element
 - `add_fake_results` now directly processes `Target` objects instead of a `Campaign`
 - `path` argument in plotting utility is now optional and defaults to `Path(".")`
+- `UnusedObjectWarning` by non-predictive recommenders is now ignored during simulations
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
@@ -11,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from baybe.campaign import Campaign
-from baybe.exceptions import NothingToSimulateError
+from baybe.exceptions import NothingToSimulateError, UnusedObjectWarning
 from baybe.simulation.core import simulate_experiment
 
 if TYPE_CHECKING:
@@ -136,7 +137,15 @@ def simulate_scenarios(
     # Simulate and unpack
     result_variable = "simulation_result"
     batch_simulator = make_xyzpy_callable(result_variable)
-    da_results = batch_simulator.run_combos(combos)[result_variable]
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=UnusedObjectWarning,
+            module="baybe.recommenders.pure.nonpredictive.base",
+        )
+        da_results = batch_simulator.run_combos(combos)[result_variable]
+
     df_results = unpack_simulation_results(da_results)
 
     return df_results


### PR DESCRIPTION
- ignore `UnusedObjectWarning` caused by recommenders in simulations
- this was caused for isntance by using the `RandomRecommender`, a common use case because its a baseline
- I tried to use warning action modes `once` and `module` but that didnt work at all