### PR TITLE
Make Polars Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ The available groups are:
 - `lint`: Required for linting and formatting.
 - `mypy`: Required for static type checking.
 - `onnx`: Required for using custom surrogate models in [ONNX format](https://onnx.ai).
+- `polars`: Required for optimized search space construction via [Polars](https://docs.pola.rs/)
 - `simulation`: Enabling the [simulation](https://emdgroup.github.io/baybe/_autosummary/baybe.simulation.html) module.
 - `test`: Required for running the tests.
 - `dev`: All of the above plus `tox` and `pip-audit`. For code contributors.

--- a/baybe/_optional/info.py
+++ b/baybe/_optional/info.py
@@ -27,6 +27,7 @@ with exclude_sys_path(os.getcwd()):
     FLAKE8_INSTALLED = find_spec("flake8") is not None
     MORDRED_INSTALLED = find_spec("mordred") is not None
     ONNX_INSTALLED = find_spec("onnxruntime") is not None
+    POLARS_INSTALLED = find_spec("polars") is not None
     PRE_COMMIT_INSTALLED = find_spec("pre_commit") is not None
     PYDOCLINT_INSTALLED = find_spec("pydoclint") is not None
     RDKIT_INSTALLED = find_spec("rdkit") is not None

--- a/baybe/_optional/polars.py
+++ b/baybe/_optional/polars.py
@@ -1,0 +1,16 @@
+"""Optional polars import."""
+
+from baybe.exceptions import OptionalImportError
+
+try:
+    import polars
+except ModuleNotFoundError as ex:
+    raise OptionalImportError(
+        "Polars functionality is unavailable because 'polars' is not installed. "
+        "Consider installing BayBE with 'polars' dependency, e.g. via "
+        "`pip install baybe[polars]`."
+    ) from ex
+
+__all__ = [
+    "polars",
+]

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -105,8 +105,8 @@ class DiscreteConstraint(Constraint, ABC):
             The dataframe indices of rows where the constraint is violated.
         """
 
-    def to_polars(self) -> pl.Expr:
-        """Translate the constraint to Polars expression for filtering.
+    def get_invalid_polars(self) -> pl.Expr:
+        """Translate the constraint to Polars expression identifying undesired rows.
 
         Returns:
             The Polars expressions to pass to :meth:`polars.LazyFrame.filter`.

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -1,14 +1,16 @@
 """Functionality for constraint conditions."""
 
+
+from __future__ import annotations
+
 import operator as ops
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
-import polars as pl
 from attr import define, field
 from attr.validators import in_
 from attrs.validators import min_len
@@ -24,6 +26,9 @@ from baybe.serialization import (
     unstructure_base,
 )
 from baybe.utils.numerical import DTypeFloatNumpy
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 def _is_not_close(x: ArrayLike, y: ArrayLike, rtol: float, atol: float) -> np.ndarray:

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -1,11 +1,13 @@
 """Discrete constraints."""
 
+
+from __future__ import annotations
+
 from collections.abc import Callable
 from functools import reduce
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pandas as pd
-import polars as pl
 from attr import define, field
 from attr.validators import in_, min_len
 
@@ -22,6 +24,9 @@ from baybe.serialization import (
     converter,
 )
 from baybe.utils.basic import Dummy
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 @define
@@ -46,6 +51,8 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
 
     def to_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
+        import polars as pl
+
         satisfied = []
         for k, cond in enumerate(self.conditions):
             satisfied.append(cond.to_polars(pl.col(self.parameters[k])))
@@ -78,6 +85,8 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     def to_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
+        import polars as pl
+
         return self.condition.to_polars(pl.sum_horizontal(self.parameters))
 
 
@@ -100,6 +109,8 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
     def to_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
+        import polars as pl
+
         op = _threshold_operators[self.condition.operator]
 
         # Get the product of columns
@@ -131,6 +142,8 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
 
     def to_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
+        import polars as pl
+
         expr = (
             pl.concat_list(pl.col(self.parameters))
             .list.eval(pl.element().n_unique())
@@ -157,6 +170,8 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
 
     def to_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
+        import polars as pl
+
         expr = (
             pl.concat_list(pl.col(self.parameters))
             .list.eval(pl.element().n_unique())

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -51,7 +51,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
 
     def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
-        import polars as pl
+        from baybe._optional.polars import polars as pl
 
         satisfied = []
         for k, cond in enumerate(self.conditions):
@@ -81,7 +81,7 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
-        import polars as pl
+        from baybe._optional.polars import polars as pl
 
         return self.condition.to_polars(pl.sum_horizontal(self.parameters)).not_()
 
@@ -105,7 +105,7 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
     def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
-        import polars as pl
+        from baybe._optional.polars import polars as pl
 
         op = _threshold_operators[self.condition.operator]
 
@@ -138,7 +138,7 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
 
     def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
-        import polars as pl
+        from baybe._optional.polars import polars as pl
 
         expr = (
             pl.concat_list(pl.col(self.parameters))
@@ -166,7 +166,7 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
 
     def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
         # See base class.
-        import polars as pl
+        from baybe._optional.polars import polars as pl
 
         expr = (
             pl.concat_list(pl.col(self.parameters))

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
-import polars as pl
 from attr import define, field
 from cattrs import IterableValidationError
 
@@ -34,6 +33,8 @@ from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import DTypeFloatNumpy
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from baybe.searchspace.core import SearchSpace
 
 _METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
@@ -741,6 +742,8 @@ def parameter_cartesian_prod_polars(parameters: Sequence[Parameter]) -> pl.LazyF
     Returns:
         A lazy dataframe containing all possible discrete parameter value combinations.
     """
+    import polars as pl
+
     discrete_parameters = [p for p in parameters if p.is_discrete]
     if not discrete_parameters:
         return pl.LazyFrame()

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -723,8 +723,8 @@ def _apply_polars_constraint_filter(
     """
     for c in constraints:
         try:
-            pl_expr = c.to_polars()
-            ldf = ldf.filter(pl_expr)
+            to_keep = c.get_invalid_polars().not_()
+            ldf = ldf.filter(to_keep)
         except NotImplementedError:
             pass
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Collection, Sequence
 from math import prod
 from typing import TYPE_CHECKING, Any
@@ -261,7 +262,7 @@ class SubspaceDiscrete(SerialMixin):
             key=lambda x: DISCRETE_CONSTRAINTS_FILTERING_ORDER.index(x.__class__),
         )
 
-        if POLARS_INSTALLED:
+        if POLARS_INSTALLED and not os.environ.get("BAYBE_DEACTIVATE_POLARS"):
             # Apply polars product and filtering
             lazy_df = parameter_cartesian_prod_polars(parameters)
             mask: list[bool] = []

--- a/docs/userguide/envvars.md
+++ b/docs/userguide/envvars.md
@@ -75,12 +75,12 @@ opt-out dependencies, but the baybe package will work without them.
 ```
 
 ## Polars
-If baybe was installed with the additional polars dependency (`baybe[polars]`), it will
-use the advanced methods of polars to create the searchspace lazily and perform a
+If BayBE was installed with the additional `polars` dependency (`baybe[polars]`), it
+will use the advanced methods of Polars to create the searchspace lazily and perform a
 streamed evaluation of constraints. This will improve speed and memory consumption
 during this process, and thus might be beneficial for very large search spaces.
 
-Since this is still somewhat experimental, you might want to deactivate polars without
+Since this is still somewhat experimental, you might want to deactivate Polars without
 changing the Python environment. To do so, you can set the environment variable 
 `BAYBE_DEACTIVATE_POLARS` to any value.
 

--- a/docs/userguide/envvars.md
+++ b/docs/userguide/envvars.md
@@ -74,6 +74,17 @@ are being shipped in the default dependencies because there is no good way of cr
 opt-out dependencies, but the baybe package will work without them.
 ```
 
+## Polars
+If baybe was installed with the additional polars dependency (`baybe[polars]`), it will
+use the advanced methods of polars to create the searchspace lazily and perform a
+streamed evaluation of constraints. This will improve speed and memory consumption
+during this process, and thus might be beneficial for very large search spaces.
+
+Since this is still somewhat experimental, you might want to deactivate polars without
+changing the Python environment. To do so, you can set the environment variable 
+`BAYBE_DEACTIVATE_POLARS` to any value.
+
+
 ## Disk Caching
 For some components, such as the
 [`SubstanceParameter`](baybe.parameters.substance.SubstanceParameter), some of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "ngboost>=0.3.12,<1",
     "numpy>=1.24.1,<2",
     "pandas>=1.4.2",
-    "polars[pyarrow]>=0.19.19",
     "protobuf<=3.20.3,<4",
     "scikit-learn>=1.1.1,<2",
     "scikit-learn-extra>=0.3.0,<1",
@@ -86,6 +85,7 @@ dev = [
     "baybe[lint]",
     "baybe[mypy]",
     "baybe[onnx]",
+    "baybe[polars]",
     "baybe[simulation]",
     "baybe[test]",
     "pip-audit>=2.5.5",
@@ -129,6 +129,10 @@ mypy = [
     "pandas-stubs>=2.0.3.230814",
     "funcy-stubs>=0.1.1",
     "types-seaborn>=0.12.2"
+]
+
+polars = [
+    "polars[pyarrow]>=0.19.19,<2",
 ]
 
 simulation = [

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -1,14 +1,17 @@
 """Test Polars implementations of constraints."""
-import polars as pl
 import pytest
 from pandas.testing import assert_frame_equal
 
+from baybe._optional.info import POLARS_INSTALLED
 from baybe.searchspace.discrete import (
     _apply_pandas_constraint_filter,
     _apply_polars_constraint_filter,
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )
+
+if POLARS_INSTALLED:
+    import polars as pl
 
 
 def _lazyframe_from_product(parameters):
@@ -27,6 +30,9 @@ def _lazyframe_from_product(parameters):
     return res
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
 def test_polars_prodsum1(parameters, constraints):
@@ -43,6 +49,9 @@ def test_polars_prodsum1(parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
 def test_polars_prodsum2(parameters, constraints):
@@ -63,6 +72,9 @@ def test_polars_prodsum2(parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
 def test_polars_prodsum3(parameters, constraints):
@@ -80,6 +92,9 @@ def test_polars_prodsum3(parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize(
     "parameter_names",
     [["Solvent_1", "SomeSetting", "Temperature", "Pressure"]],
@@ -116,6 +131,9 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_7"]])
 def test_polars_label_duplicates(parameters, constraints):
@@ -135,6 +153,9 @@ def test_polars_label_duplicates(parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_14"]])
 def test_polars_linked_parameters(parameters, constraints):
@@ -154,6 +175,9 @@ def test_polars_linked_parameters(parameters, constraints):
     assert num_entries == 0
 
 
+@pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
 @pytest.mark.parametrize(
     "parameter_names",
     [

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -105,11 +105,9 @@ def test_polars_prodsum3(parameters, constraints):
 def test_polars_exclusion(mock_substances, parameters, constraints):
     """Tests Polars implementation of exclusion constraint."""
     ldf = _lazyframe_from_product(parameters)
-
     ldf = _apply_polars_constraint_filter(ldf, constraints)
 
     # Number of entries with either first/second substance and a temperature above 151
-
     df = ldf.filter(
         (pl.col("Temperature") > 151)
         & (pl.col("Solvent_1").is_in(list(mock_substances)[:2]))

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -40,8 +40,7 @@ def _lazyframe_from_product(parameters):
 def test_polars_prodsum1(parameters, constraints):
     """Tests Polars implementation of sum constraint."""
     ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with 1,2-sum above 150
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -56,8 +55,7 @@ def test_polars_prodsum1(parameters, constraints):
 def test_polars_prodsum2(parameters, constraints):
     """Tests Polars implementation of product constrain."""
     ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with product under 30
     df = ldf.filter(
@@ -76,8 +74,7 @@ def test_polars_prodsum2(parameters, constraints):
 def test_polars_prodsum3(parameters, constraints):
     """Tests Polars implementation of exact sum constraint."""
     ldf = _lazyframe_from_product(parameters)
-
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with sum unequal to 100
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -98,7 +95,7 @@ def test_polars_prodsum3(parameters, constraints):
 def test_polars_exclusion(mock_substances, parameters, constraints):
     """Tests Polars implementation of exclusion constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with either first/second substance and a temperature above 151
     df = ldf.filter(
@@ -127,7 +124,7 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
 def test_polars_label_duplicates(parameters, constraints):
     """Tests Polars implementation of no-label duplicates constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -146,7 +143,7 @@ def test_polars_label_duplicates(parameters, constraints):
 def test_polars_linked_parameters(parameters, constraints):
     """Tests Polars implementation of linked parameters constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_constraint_filter_polars(ldf, constraints)
+    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -197,7 +194,7 @@ def test_polars_product(constraints, parameters):
     # Apply constraints
     df_pd_filtered = _apply_constraint_filter_pandas(df_pd, constraints)
     df_pl_filtered = (
-        _apply_constraint_filter_polars(ldf, constraints).collect().to_pandas()
+        _apply_constraint_filter_polars(ldf, constraints)[0].collect().to_pandas()
     )
 
     # Assert strict equality of two dataframes

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -10,6 +10,11 @@ from baybe.searchspace.discrete import (
     parameter_cartesian_prod_polars,
 )
 
+pytestmark = pytest.mark.skipif(
+    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
+)
+
+
 if POLARS_INSTALLED:
     import polars as pl
 
@@ -30,9 +35,6 @@ def _lazyframe_from_product(parameters):
     return res
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_8"]])
 def test_polars_prodsum1(parameters, constraints):
@@ -49,9 +51,6 @@ def test_polars_prodsum1(parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_9"]])
 def test_polars_prodsum2(parameters, constraints):
@@ -72,9 +71,6 @@ def test_polars_prodsum2(parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize("parameter_names", [["Fraction_1", "Fraction_2"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_10"]])
 def test_polars_prodsum3(parameters, constraints):
@@ -92,9 +88,6 @@ def test_polars_prodsum3(parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize(
     "parameter_names",
     [["Solvent_1", "SomeSetting", "Temperature", "Pressure"]],
@@ -129,9 +122,6 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_7"]])
 def test_polars_label_duplicates(parameters, constraints):
@@ -151,9 +141,6 @@ def test_polars_label_duplicates(parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_14"]])
 def test_polars_linked_parameters(parameters, constraints):
@@ -173,9 +160,6 @@ def test_polars_linked_parameters(parameters, constraints):
     assert num_entries == 0
 
 
-@pytest.mark.skipif(
-    not POLARS_INSTALLED, reason="Optional polars dependency not installed."
-)
 @pytest.mark.parametrize(
     "parameter_names",
     [

--- a/tests/test_constraints_polars.py
+++ b/tests/test_constraints_polars.py
@@ -4,8 +4,8 @@ from pandas.testing import assert_frame_equal
 
 from baybe._optional.info import POLARS_INSTALLED
 from baybe.searchspace.discrete import (
-    _apply_pandas_constraint_filter,
-    _apply_polars_constraint_filter,
+    _apply_constraint_filter_pandas,
+    _apply_constraint_filter_polars,
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )
@@ -39,7 +39,7 @@ def test_polars_prodsum1(parameters, constraints):
     """Tests Polars implementation of sum constraint."""
     ldf = _lazyframe_from_product(parameters)
 
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with 1,2-sum above 150
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -58,7 +58,7 @@ def test_polars_prodsum2(parameters, constraints):
     """Tests Polars implementation of product constrain."""
     ldf = _lazyframe_from_product(parameters)
 
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with product under 30
     df = ldf.filter(
@@ -81,7 +81,7 @@ def test_polars_prodsum3(parameters, constraints):
     """Tests Polars implementation of exact sum constraint."""
     ldf = _lazyframe_from_product(parameters)
 
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with sum unequal to 100
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -105,7 +105,7 @@ def test_polars_prodsum3(parameters, constraints):
 def test_polars_exclusion(mock_substances, parameters, constraints):
     """Tests Polars implementation of exclusion constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with either first/second substance and a temperature above 151
     df = ldf.filter(
@@ -137,7 +137,7 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
 def test_polars_label_duplicates(parameters, constraints):
     """Tests Polars implementation of no-label duplicates constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -159,7 +159,7 @@ def test_polars_label_duplicates(parameters, constraints):
 def test_polars_linked_parameters(parameters, constraints):
     """Tests Polars implementation of linked parameters constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf = _apply_polars_constraint_filter(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -211,9 +211,9 @@ def test_polars_product(constraints, parameters):
     assert_frame_equal(df_pl.to_pandas(), df_pd)
 
     # Apply constraints
-    df_pd_filtered = _apply_pandas_constraint_filter(df_pd, constraints)
+    df_pd_filtered = _apply_constraint_filter_pandas(df_pd, constraints)
     df_pl_filtered = (
-        _apply_polars_constraint_filter(ldf, constraints).collect().to_pandas()
+        _apply_constraint_filter_polars(ldf, constraints).collect().to_pandas()
     )
 
     # Assert strict equality of two dataframes

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = True
 
 [testenv:fulltest,fulltest-py{310,311,312}]
 description = Run PyTest with all extra functionality
-extras = test,lint,chem,examples,simulation,onnx
+extras = chem,examples,lint,onnx,polars,simulation,test
 passenv =
     CI
     BAYBE_NUMPY_USE_SINGLE_PRECISION


### PR DESCRIPTION
based on #306 
- make `polars` optional dependency
- reworked `Constraint.to_polars` into `Constraint.get_invalid_polars` to make it consistent with the pandas version
- skipped optional tests