### PR TITLE
Restore old MLL fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are not passed on to the GPyTorch kernels
 - Positive-valued kernel attributes are now correctly handled by validators
   and hypothesis strategies
+- Reverted `fit_gpytorch_mll` call back to old `fit_gpytorch_mll_torch` call until
+  finetuning is achieved
 
 ### Deprecations
 - `SequentialGreedyRecommender` class replaced with `BotorchRecommender`

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -76,6 +76,7 @@ class GaussianProcessSurrogate(Surrogate):
         import botorch
         import gpytorch
         import torch
+        from botorch.optim.fit import fit_gpytorch_mll_torch
 
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
@@ -138,4 +139,4 @@ class GaussianProcessSurrogate(Surrogate):
             likelihood=likelihood,
         )
         mll = gpytorch.ExactMarginalLogLikelihood(self._model.likelihood, self._model)
-        botorch.fit_gpytorch_mll(mll)
+        fit_gpytorch_mll_torch(mll, step_limit=100)


### PR DESCRIPTION
use torch fitting with 100 steps again until we finetune this better

here some pictures with the new fit indicating previous results are there again
![image](https://github.com/user-attachments/assets/3adf710f-5140-47cf-b87e-0f71edb21ab3)
![image](https://github.com/user-attachments/assets/3f6d2154-4447-42a6-a00b-75203f4e0eed)
![image](https://github.com/user-attachments/assets/ac958162-14b8-44b3-bf89-c9148a256b70)
![image](https://github.com/user-attachments/assets/8edeb1b2-4d60-4bc8-8e74-2064fa9d49f1)

tobis notebook with this PR
![image](https://github.com/user-attachments/assets/937a5c33-7388-404d-ad2f-33c5755d43b5)

vs old (non torch) fitting
![image](https://github.com/user-attachments/assets/5a346fe9-3b4d-4075-adcf-ef8c06f02857)
