### PR TITLE
Surrogate interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ _ `_optional` subpackage for managing optional dependencies
 - `comp_rep_columns` property for `Parameter`, `SearchSpace`, `SubspaceDiscrete`
   and `SubspaceContinuous` classes
 - Reworked mechanisms for surrogate input/output scaling configurable per class
-- `ParameterScalerProtocol` class for enabling user-defined input scaling mechanisms
 - `SurrogateProtocol` as an interface for user-defined surrogate architectures 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _ `_optional` subpackage for managing optional dependencies
   and `SubspaceContinuous` classes
 - Reworked mechanisms for surrogate input/output scaling configurable per class
 - `ParameterScalerProtocol` class for enabling user-defined input scaling mechanisms
+- `SurrogateProtocol` as an interface for user-defined surrogate architectures 
 
 ### Changed
 - Passing an `Objective` to `Campaign` is now optional
@@ -72,7 +73,8 @@ _ `_optional` subpackage for managing optional dependencies
 - Passing a dataframe via the `data` argument to the `transform` methods of
   `SearchSpace`, `SubspaceDiscrete` and `SubspaceContinuous` is no longer possible.
   The dataframe must now be passed as positional argument.
-- A deprecation error is thrown when attempting to use `register_custom_architecture`
+- The role of `register_custom_architecture` has been taken over by
+  `baybe.surrogates.base.SurrogateProtocol`
 
 ## [0.9.1] - 2024-06-04
 ### Changed

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -81,6 +81,8 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
             ValueError: If the search space is purely continuous and
                 'sampling_n_points' was not provided.
         """
+        # TODO: Move the core logic to `SearchSpace` and ``Subspace*`` classes
+
         sampled_parts: list[pd.DataFrame] = []
         n_candidates: int | None = None
 

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -17,7 +17,7 @@ from baybe.serialization.core import (
     unstructure_base,
 )
 from baybe.serialization.mixin import SerialMixin
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import SurrogateProtocol
 from baybe.utils.basic import classproperty, filter_attributes
 from baybe.utils.boolean import is_abstract
 from baybe.utils.dataframe import to_tensor
@@ -37,7 +37,7 @@ class AcquisitionFunction(ABC, SerialMixin):
 
     def to_botorch(
         self,
-        surrogate: Surrogate,
+        surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
         measurements: pd.DataFrame,
     ):

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -53,7 +53,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         acqf_cls = getattr(botorch_acqf_module, self.__class__.__name__)
         params_dict = filter_attributes(object=self, callable_=acqf_cls.__init__)
 
-        train_x = searchspace.transform(measurements)
+        train_x = searchspace.transform(measurements, allow_extra=True)
         train_y = objective.transform(measurements)
 
         signature_params = signature(acqf_cls).parameters

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -44,7 +44,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         """Create the botorch-ready representation of the function.
 
         The required structure of `measurements` is specified in
-        :meth:`babye.recommenders.base.RecommenderProtocol.recommend`.
+        :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`.
         """
         import botorch.acquisition as botorch_acqf_module
 

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -10,7 +10,8 @@ from typing import ClassVar
 import pandas as pd
 from attrs import define
 
-from baybe.searchspace import SearchSpace
+from baybe.objectives.base import Objective
+from baybe.searchspace.core import SearchSpace
 from baybe.serialization.core import (
     converter,
     get_base_structure_hook,
@@ -39,6 +40,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         self,
         surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
+        objective: Objective,
         measurements: pd.DataFrame,
     ):
         """Create the botorch-ready representation of the function.
@@ -51,8 +53,8 @@ class AcquisitionFunction(ABC, SerialMixin):
         acqf_cls = getattr(botorch_acqf_module, self.__class__.__name__)
         params_dict = filter_attributes(object=self, callable_=acqf_cls.__init__)
 
-        train_x = surrogate.transform_inputs(measurements)
-        train_y = surrogate.transform_outputs(measurements)
+        train_x = searchspace.transform(measurements)
+        train_y = objective.transform(measurements)
 
         signature_params = signature(acqf_cls).parameters
         additional_params = {}

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -52,7 +52,7 @@ class BayesianRecommender(PureRecommender, ABC):
         """Create the acquisition function for the current training data."""  # noqa: E501
         self.surrogate_model.fit(searchspace, objective, measurements)
         self._botorch_acqf = self.acquisition_function.to_botorch(
-            self.surrogate_model, searchspace, measurements
+            self.surrogate_model, searchspace, objective, measurements
         )
 
     def recommend(  # noqa: D102

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -13,14 +13,14 @@ from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import CustomONNXSurrogate, GaussianProcessSurrogate
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import SurrogateProtocol
 
 
 @define
 class BayesianRecommender(PureRecommender, ABC):
     """An abstract class for Bayesian Recommenders."""
 
-    surrogate_model: Surrogate = field(factory=GaussianProcessSurrogate)
+    surrogate_model: SurrogateProtocol = field(factory=GaussianProcessSurrogate)
     """The used surrogate model."""
 
     acquisition_function: AcquisitionFunction = field(

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -216,7 +216,7 @@ class BotorchRecommender(BayesianRecommender):
         from botorch.optim import optimize_acqf_mixed
 
         # Transform discrete candidates
-        candidates_comp = searchspace.transform(candidates_exp)
+        candidates_comp = searchspace.transform(candidates_exp, allow_missing=True)
 
         if len(candidates_comp) > 0:
             # Calculate the number of samples from the given percentage

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -104,7 +104,7 @@ class BotorchRecommender(BayesianRecommender):
         from botorch.optim import optimize_acqf_discrete
 
         # determine the next set of points to be tested
-        candidates_comp = self.surrogate_model.transform_inputs(candidates_exp)
+        candidates_comp = subspace_discrete.transform(candidates_exp)
         points, _ = optimize_acqf_discrete(
             self._botorch_acqf, batch_size, to_tensor(candidates_comp)
         )
@@ -216,7 +216,7 @@ class BotorchRecommender(BayesianRecommender):
         from botorch.optim import optimize_acqf_mixed
 
         # Transform discrete candidates
-        candidates_comp = self.surrogate_model.transform_inputs(candidates_exp)
+        candidates_comp = searchspace.transform(candidates_exp)
 
         if len(candidates_comp) > 0:
             # Calculate the number of samples from the given percentage

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -216,7 +216,7 @@ class BotorchRecommender(BayesianRecommender):
         from botorch.optim import optimize_acqf_mixed
 
         # Transform discrete candidates
-        candidates_comp = searchspace.transform(candidates_exp, allow_missing=True)
+        candidates_comp = searchspace.discrete.transform(candidates_exp)
 
         if len(candidates_comp) > 0:
             # Calculate the number of samples from the given percentage

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -292,6 +292,11 @@ class SearchSpace(SerialMixin):
 
     def get_comp_rep_parameter_indices(self, name: str, /) -> tuple[int, ...]:
         """Find a parameter's column indices in the computational representation."""
+        if name not in (p.name for p in self.parameters):
+            raise ValueError(
+                f"There exists no parameter named '{name}' in the search space."
+            )
+
         # TODO: The "startswith" approach is not ideal since it relies on the implicit
         #   assumption that the substrings match. A more robust approach would
         #   be to generate this mapping while building the comp rep.

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -291,7 +291,19 @@ class SearchSpace(SerialMixin):
             return 1
 
     def get_comp_rep_parameter_indices(self, name: str, /) -> tuple[int, ...]:
-        """Find a parameter's column indices in the computational representation."""
+        """Find a parameter's column indices in the computational representation.
+
+        Args:
+            name: The name of the parameter whose columns indices are to be retrieved.
+
+        Raises:
+            ValueError: If no parameter with the provided name exists.
+
+        Returns:
+            A tuple containing the integer indices of the columns in the computational
+            representation associated with the parameter. When the parameter is not part
+            of the computational representation, an empty tuple is returned.
+        """
         if name not in (p.name for p in self.parameters):
             raise ValueError(
                 f"There exists no parameter named '{name}' in the search space."

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -290,6 +290,15 @@ class SearchSpace(SerialMixin):
         except StopIteration:
             return 1
 
+    def get_comp_rep_parameter_indices(self, name: str, /) -> tuple[int, ...]:
+        """Find a parameter's column indices in the computational representation."""
+        # TODO: The "startswith" approach is not ideal since it relies on the implicit
+        #   assumption that the substrings match. A more robust approach would
+        #   be to generate this mapping while building the comp rep.
+        return tuple(
+            i for i, col in enumerate(self.comp_rep_columns) if col.startswith(name)
+        )
+
     @staticmethod
     def estimate_product_space_size(parameters: Iterable[Parameter]) -> MemorySize:
         """Estimate an upper bound for the memory size of a product space.

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -47,4 +47,4 @@ class AdapterModel(Model):
             raise NotImplementedError(
                 "The optional model posterior arguments are not yet implemented."
             )
-        return self._surrogate._posterior(X)
+        return self._surrogate._posterior_comp_rep(X)

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -137,10 +137,9 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         # Create a composite scaler from parameter-wise scaler objects
         mapping: dict[tuple[int, ...], InputTransform] = {}
         for p in searchspace.parameters:
-            idxs = searchspace.get_comp_rep_parameter_indices(p.name)
-            factory = self._make_parameter_scaler_factory(p)
-            if factory is None:
+            if (factory := self._make_parameter_scaler_factory(p)) is None:
                 continue
+            idxs = searchspace.get_comp_rep_parameter_indices(p.name)
             transformer = factory(len(idxs))
             mapping[idxs] = transformer
         scaler = ColumnTransformer(mapping)

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -119,14 +119,22 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     def _make_parameter_scaler_factory(
         parameter: Parameter,
     ) -> type[InputTransform] | None:
-        """Return the scaler factory to be used for the given parameter."""
+        """Return the scaler factory to be used for the given parameter.
+
+        This method is supposed to be overridden by subclasses to implement their
+        custom parameter scaling logic.
+        """
         from botorch.models.transforms.input import Normalize
 
         return Normalize
 
     @staticmethod
     def _make_target_scaler_factory() -> type[OutcomeTransform] | None:
-        """Return the scaler factory to be used for target scaling."""
+        """Return the scaler factory to be used for target scaling.
+
+        This method is supposed to be overridden by subclasses to implement their
+        custom target scaling logic.
+        """
         from botorch.models.transforms.outcome import Standardize
 
         return Standardize

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -75,7 +75,13 @@ class SurrogateProtocol(Protocol):
         """
 
     def to_botorch(self) -> Model:
-        """Create the botorch-ready representation of the fitted model."""
+        """Create the botorch-ready representation of the fitted model.
+
+        The :class:`botorch.models.model.Model` created by this method needs to be
+        configured such that it can be called with candidate points in **computational
+        representation**, that is, input of the form as obtained via
+        :meth:`baybe.searchspace.core.SearchSpace.transform`.
+        """
 
 
 @define

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -178,6 +178,17 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         Takes a dataframe of parameter configurations in **experimental representation**
         and returns the corresponding posterior object. Therefore, the method serves as
         the user-facing entry point for accessing model predictions.
+
+        Args:
+            candidates: A dataframe containing parameter configurations in
+                **experimental representation**.
+
+        Returns:
+            A :class:`botorch.posteriors.Posterior` object representing the posterior
+            distribution at the given candidate points, where the posterior is also
+            described in **experimental representation**. That is, the posterior values
+            lie in the same domain as the modelled targets/objective on which the
+            surrogate was trained via :meth:`baybe.surrogates.base.Surrogate.fit`.
         """
         return self._posterior_comp_rep(
             to_tensor(self._searchspace.transform(candidates))
@@ -190,6 +201,14 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         and returns the corresponding posterior object. Therefore, the method provides
         the entry point for queries coming from computational layers, for instance,
         BoTorch's `optimize_*` functions.
+
+        Args:
+            candidates: A tensor containing parameter configurations in **computational
+                representation**.
+
+        Returns:
+            The same :class:`botorch.posteriors.Posterior` object as returned via
+            :meth:`baybe.surrogates.base.Surrogate.posterior`.
         """
         p = self._posterior(self._input_scaler.transform(candidates))
         if self._output_scaler is not _IDENTITY_TRANSFORM:
@@ -215,6 +234,17 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         to their model specifications and can implicitly that scaling is handled
         appropriately outside. In short: the returned posterior simply needs to be on
         the same scale as the given input.
+
+        Args:
+            candidates: A tensor containing **pre-scaled** parameter configurations
+                in **computational representation**, as defined through the input scaler
+                obtained via :meth:`baybe.surrogates.base.Surrogate._make_input_scaler`.
+
+        Returns:
+            A :class:`botorch.posteriors.Posterior` object representing the
+            **scale-transformed** posterior distributions at the given candidate points,
+            where the posterior is described on the scale dictated by the output scaler
+            obtained via :meth:`baybe.surrogates.base.Surrogate._make_output_scaler`.
         """
 
     @staticmethod

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -304,7 +304,11 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             objective.transform(measurements),
         )
         train_x = self._input_scaler.transform(train_x_comp_rep)
-        train_y = self._output_scaler(train_y_comp_rep)[0]
+        train_y = (
+            train_y_comp_rep
+            if self._output_scaler is _IDENTITY_TRANSFORM
+            else self._output_scaler(train_y_comp_rep)[0]
+        )
         self._fit(train_x, train_y, self._get_model_context(searchspace, objective))
 
     @abstractmethod

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -256,7 +256,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
         # Transform and fit
         train_x_comp_rep, train_y_comp_rep = to_tensor(
-            searchspace.transform(measurements),
+            searchspace.transform(measurements, allow_extra=True),
             objective.transform(measurements),
         )
         train_x = self._input_scaler.transform(train_x_comp_rep)

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -353,14 +353,17 @@ def _block_serialize_custom_architecture(
 #   class, which would avoid the nested wrapping below. However, this requires
 #   adjusting the base class (un-)structure hooks such that they consistently apply
 #   existing hooks of the concrete subclasses.
-converter.register_unstructure_hook(
-    Surrogate,
-    _make_hook_decode_onnx_str(
-        _block_serialize_custom_architecture(
-            lambda x: unstructure_base(x, overrides={"_model": override(omit=True)})
-        )
-    ),
+_unstructure_hook = _make_hook_decode_onnx_str(
+    _block_serialize_custom_architecture(
+        lambda x: unstructure_base(x, overrides={"_model": override(omit=True)})
+    )
 )
+converter.register_unstructure_hook(Surrogate, _unstructure_hook)
 converter.register_structure_hook(
     Surrogate, _make_hook_encode_onnx_str(get_base_structure_hook(Surrogate))
+)
+converter.register_unstructure_hook(SurrogateProtocol, _unstructure_hook)
+converter.register_structure_hook(
+    SurrogateProtocol,
+    _make_hook_encode_onnx_str(get_base_structure_hook(SurrogateProtocol)),
 )

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -37,7 +37,8 @@ def register_custom_architecture(*args, **kwargs) -> NoReturn:
     """Deprecated! Raises an error when used."""  # noqa: D401
     raise DeprecationError(
         "The 'register_custom_architecture' decorator is no longer available. "
-        "There will be a replacement based on Python's `typing.Protocol` soon."
+        "Use :class:`baybe.surrogates.base.SurrogateProtocol` instead to define "
+        "your custom architectures."
     )
 
 

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar
 
 from attrs import define, field
 from attrs.validators import instance_of
-from sklearn.preprocessing import MinMaxScaler
 
 from baybe.objective import Objective
 from baybe.parameters.base import Parameter
@@ -25,10 +24,10 @@ from baybe.surrogates.gaussian_process.presets.default import (
     DefaultKernelFactory,
     _default_noise_factory,
 )
-from baybe.utils.scaling import ParameterScalerProtocol
 
 if TYPE_CHECKING:
     from botorch.models.model import Model
+    from botorch.models.transforms.input import InputTransform
     from botorch.posteriors import Posterior
     from torch import Tensor
 
@@ -113,16 +112,18 @@ class GaussianProcessSurrogate(Surrogate):
         return self._model
 
     @staticmethod
-    def _make_parameter_scaler(
+    def _make_parameter_scaler_factory(
         parameter: Parameter,
-    ) -> ParameterScalerProtocol | None:
+    ) -> type[InputTransform] | None:
         # See base class.
 
         # Task parameters are handled separately through an index kernel
         if isinstance(parameter, TaskParameter):
             return
 
-        return MinMaxScaler()
+        from botorch.models.transforms.input import Normalize
+
+        return Normalize
 
     @staticmethod
     def _get_model_context(

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -9,7 +9,6 @@ from attrs.validators import instance_of
 
 from baybe.objective import Objective
 from baybe.parameters.base import Parameter
-from baybe.parameters.categorical import TaskParameter
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.gaussian_process.kernel_factory import (
@@ -26,7 +25,9 @@ from baybe.surrogates.gaussian_process.presets.default import (
 )
 
 if TYPE_CHECKING:
+    from botorch.models.model import Model
     from botorch.models.transforms.input import InputTransform
+    from botorch.models.transforms.outcome import OutcomeTransform
     from botorch.posteriors import Posterior
     from torch import Tensor
 
@@ -75,6 +76,19 @@ class _ModelContext:
 class GaussianProcessSurrogate(Surrogate):
     """A Gaussian process surrogate model."""
 
+    # Note [Scaling Workaround]
+    # -------------------------
+    # For GPs, we deactivate the base class scaling and instead let the botorch
+    # model internally handle input/output scaling. The reasons is that we need to
+    # make `to_botorch` expose the actual botorch GP object, instead of going
+    # via the `AdapterModel`, because certain acquisition functions (like qNIPV)
+    # require the capability to `fantasize`, which the `AdapterModel` does not support.
+    # The base class scaling thus needs to be disabled since otherwise the botorch GP
+    # object would be trained on pre-scaled input/output data. This would cause a
+    # problem since the resulting `posterior` method of that object is exposed
+    # to `optimize_acqf_*`, which is configured to be called on the original scale.
+    # Moving the scaling operation into the botorch GP object avoids this conflict.
+
     # Class variables
     joint_posterior: ClassVar[bool] = True
     # See base class.
@@ -105,19 +119,26 @@ class GaussianProcessSurrogate(Surrogate):
         """Create a Gaussian process surrogate from one of the defined presets."""
         return make_gp_from_preset(preset)
 
+    def to_botorch(self) -> Model:  # noqa: D102
+        # See base class.
+
+        return self._model
+
     @staticmethod
     def _make_parameter_scaler_factory(
         parameter: Parameter,
     ) -> type[InputTransform] | None:
         # See base class.
 
-        # Task parameters are handled separately through an index kernel
-        if isinstance(parameter, TaskParameter):
-            return
+        # For GPs, we let botorch handle the scaling. See [Scaling Workaround] above.
+        return
 
-        from botorch.models.transforms.input import Normalize
+    @staticmethod
+    def _make_target_scaler_factory() -> type[OutcomeTransform] | None:
+        # See base class.
 
-        return Normalize
+        # For GPs, we let botorch handle the scaling. See [Scaling Workaround] above.
+        return
 
     @staticmethod
     def _get_model_context(
@@ -138,6 +159,12 @@ class GaussianProcessSurrogate(Surrogate):
         import torch
 
         numerical_idxs = context.get_numerical_indices(train_x.shape[-1])
+
+        # For GPs, we let botorch handle the scaling. See [Scaling Workaround] above.
+        input_transform = botorch.models.transforms.Normalize(
+            train_x.shape[-1], bounds=context.parameter_bounds, indices=numerical_idxs
+        )
+        outcome_transform = botorch.models.transforms.Standardize(train_y.shape[-1])
 
         # extract the batch shape of the training data
         batch_shape = train_x.shape[:-2]
@@ -176,6 +203,8 @@ class GaussianProcessSurrogate(Surrogate):
         self._model = botorch.models.SingleTaskGP(
             train_x,
             train_y,
+            input_transform=input_transform,
+            outcome_transform=outcome_transform,
             mean_module=mean_module,
             covar_module=covar_module,
             likelihood=likelihood,

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -26,7 +26,6 @@ from baybe.surrogates.gaussian_process.presets.default import (
 )
 
 if TYPE_CHECKING:
-    from botorch.models.model import Model
     from botorch.models.transforms.input import InputTransform
     from botorch.posteriors import Posterior
     from torch import Tensor
@@ -105,11 +104,6 @@ class GaussianProcessSurrogate(Surrogate):
     def from_preset(preset: GaussianProcessPreset) -> GaussianProcessSurrogate:
         """Create a Gaussian process surrogate from one of the defined presets."""
         return make_gp_from_preset(preset)
-
-    def to_botorch(self) -> Model:  # noqa: D102
-        # See base class.
-
-        return self._model
 
     @staticmethod
     def _make_parameter_scaler_factory(

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -18,9 +18,9 @@ from baybe.parameters.base import Parameter
 from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
-from baybe.utils.scaling import ParameterScalerProtocol
 
 if TYPE_CHECKING:
+    from botorch.models.transforms.input import InputTransform
     from torch import Tensor
 
 
@@ -54,9 +54,9 @@ class NGBoostSurrogate(GaussianSurrogate):
         self.model_params = {**self._default_model_params, **self.model_params}
 
     @staticmethod
-    def _make_parameter_scaler(
+    def _make_parameter_scaler_factory(
         parameter: Parameter,
-    ) -> ParameterScalerProtocol | None:
+    ) -> type[InputTransform] | None:
         # See base class.
 
         # Tree-like models do not require any input scaling

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -19,9 +19,9 @@ from baybe.parameters.base import Parameter
 from baybe.surrogates.base import GaussianSurrogate
 from baybe.surrogates.utils import batchify, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
-from baybe.utils.scaling import ParameterScalerProtocol
 
 if TYPE_CHECKING:
+    from botorch.models.transforms.input import InputTransform
     from torch import Tensor
 
 
@@ -49,9 +49,9 @@ class RandomForestSurrogate(GaussianSurrogate):
     """The actual model."""
 
     @staticmethod
-    def _make_parameter_scaler(
+    def _make_parameter_scaler_factory(
         parameter: Parameter,
-    ) -> ParameterScalerProtocol | None:
+    ) -> type[InputTransform] | None:
         # See base class.
 
         # Tree-like models do not require any input scaling

--- a/baybe/utils/scaling.py
+++ b/baybe/utils/scaling.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 @define
 class ColumnTransformer:
-    """Class for applying transforms to individual columns of tensors."""
+    """Class for applying separate transforms to different column groups of tensors."""
 
     mapping: dict[tuple[int, ...], InputTransform] = field()
     """A mapping defining what transform to apply to which columns."""

--- a/baybe/utils/scaling.py
+++ b/baybe/utils/scaling.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import itertools
 from typing import Protocol
 
 import pandas as pd
+from attrs import define, field
+from attrs.validators import deep_iterable, deep_mapping, instance_of
+from botorch.models.transforms.input import InputTransform
+from torch import Tensor
 
 
 class ParameterScalerProtocol(Protocol):
@@ -20,3 +25,42 @@ class ParameterScalerProtocol(Protocol):
 
     def transform(self, df: pd.DataFrame, /) -> pd.DataFrame:
         """Transform a parameter dataframe using the fitted scaling logic."""
+
+
+@define
+class ColumnTransformer:
+    """Class for applying transforms to individual columns of tensors."""
+
+    mapping: dict[tuple[int, ...], InputTransform] = field(
+        validator=deep_mapping(
+            mapping_validator=instance_of(dict),
+            key_validator=deep_iterable(
+                member_validator=instance_of(int), iterable_validator=instance_of(tuple)
+            ),
+            value_validator=instance_of(InputTransform),
+        )
+    )
+    """A mapping defining what transform to apply to which columns."""
+
+    @mapping.validator
+    def _validate_mapping(self, _, value: dict):
+        """Validate that the each column is assigned to at most one transformer."""
+        for x, y in itertools.combinations(value.keys(), 2):
+            if not set(x).isdisjoint(y):
+                raise ValueError(
+                    f"The provided column specifications {x} and {y} are not disjoint."
+                )
+
+    def fit(self, x: Tensor, /) -> None:
+        """Fit the transformer to the given tensor."""
+        for cols, transformer in self.mapping.items():
+            transformer.train()
+            transformer(x[..., cols])
+
+    def transform(self, x: Tensor, /) -> Tensor:
+        """Transform the given tensor."""
+        out = x.clone()
+        for cols, transformer in self.mapping.items():
+            transformer.eval()
+            out[..., cols] = transformer(out[..., cols])
+        return out

--- a/baybe/utils/scaling.py
+++ b/baybe/utils/scaling.py
@@ -3,28 +3,11 @@
 from __future__ import annotations
 
 import itertools
-from typing import Protocol
 
-import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_iterable, deep_mapping, instance_of
 from botorch.models.transforms.input import InputTransform
 from torch import Tensor
-
-
-class ParameterScalerProtocol(Protocol):
-    """Type protocol specifying the interface parameter scalers need to implement.
-
-    The protocol is compatible with sklearn scalers such as
-    :class:`sklearn.preprocessing.MinMaxScaler` or
-    :class:`sklearn.preprocessing.MaxAbsScaler`.
-    """
-
-    def fit(self, df: pd.DataFrame, /) -> None:
-        """Fit the scaler to a given dataframe containing parameter configurations."""
-
-    def transform(self, df: pd.DataFrame, /) -> pd.DataFrame:
-        """Transform a parameter dataframe using the fitted scaling logic."""
 
 
 @define

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,56 @@
+"""Scaling tests."""
+
+import math
+from unittest.mock import Mock
+
+import pytest
+import torch
+from botorch.models.transforms.input import InputStandardize, InputTransform, Normalize
+
+from baybe.utils.scaling import ColumnTransformer
+
+
+def test_column_transformer():
+    """Basic test that validates the transformation of a ColumnTransformer."""
+    # Define test input
+    base = torch.stack([-1 * torch.ones(5), torch.ones(5)])
+    x_train = 20 * base
+    x_test = 10 * base
+
+    # Create and fit transformer
+    mapping = {
+        (0, 2): Normalize(2),
+        (1, 3): InputStandardize(2),
+    }
+    transformer = ColumnTransformer(mapping)
+    transformer.fit(x_train)
+
+    # Transform data
+    y_train = transformer.transform(x_train)
+    y_test = transformer.transform(x_test)
+
+    # Expected results
+    s = 1 / math.sqrt(2)
+    target_train = torch.tensor(
+        [
+            [0.0, -s, 0.0, -s, -20.0],
+            [1.0, s, 1.0, s, 20.0],
+        ]
+    )
+    target_test = torch.tensor(
+        [
+            [0.25, -s / 2, 0.25, -s / 2, -10.0],
+            [0.75, s / 2, 0.75, s / 2, 10.0],
+        ]
+    )
+
+    assert torch.allclose(y_train, target_train)
+    assert torch.allclose(y_test, target_test)
+
+
+def test_non_disjoint_column_mapping():
+    """Creating a column transformer with non-disjoint columns raises an error."""
+    t = Mock(InputTransform)
+    mapping = {(0, 1): t, (1, 2): t}
+    with pytest.raises(ValueError, match="are not disjoint"):
+        ColumnTransformer(mapping)


### PR DESCRIPTION
PR #315 introduced the new configurable class-based scaling approach, but:
* did so using some rather heavy hierarchy of methods
* introduced a conceptual bug in that the scaling logic was not consistently applied in the correct way (e.g. `best_f` should not have been scaled)
* the resulting layout implied a rather unclear interface for a `SurrogateProtocol`, where users providing such protocols would also need to expose transform related methods that should actually stay surrogate internal.

This PR refactors scaling mechanism with the final interfaces in mind, in particular the newly introduced `SurrogateProtocol` class.

### Problems solved
* Much of the transform-related machinery was removed. Left are only two scaler attributes (one for input, one for output) which are purely class internal.
* The result is a clean `SurrogateProtocol` interface, which imposes the two required mechanisms on the user: 
    * `fit` (i.e. how is the custom-defined surrogate to be trained) and 
    * `to_botorch` (i.e. how is the trained surrogate converted to be made compatible with `botorch`'s machinery)
* The `Surrogate` base class now clearly offers the three layers of connection that are dictated from the surrounding:
    * a posterior method intended for the user, interfacing experimental representations
    * a posterior method for the computational layer operating with tensors in computational representation, for interplay with `botorch`
    * a posterior method that focusses only on the surrogate architecture where transformation and scaling is abstracted away, intended for overriding in subclasses
* As a result, scaling is now completely encapsulated inside the surrogate so that objects outside do not need to bother about surrogate internals. That means, questions like "do we need to scale certain quantities before passing them to the surrogate" (such as `best_f` or `X_pending`) are trivially answered with "No", since scaling is not visible outside the surrogate.
* Because scaling happens inside the torch layer, it is now part of the computational torch graph, meaning that backpropagation through the entire surrogate model is supported.
