### PR TITLE
Switch to log-acqfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two fixed low and high dimensional prior regimes
 - The previous default kernel factory has been renamed to `EDBOKernelFactory` and now
   fully reflects the original logic
+- Regular "EI" acquisition functions are mapped to their "log" versions for improved
+  numerical stability
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two fixed low and high dimensional prior regimes
 - The previous default kernel factory has been renamed to `EDBOKernelFactory` and now
   fully reflects the original logic
+- The default acquisition function has been changed from "qEI" to "qLogEI" for improved
+  numerical stability
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two fixed low and high dimensional prior regimes
 - The previous default kernel factory has been renamed to `EDBOKernelFactory` and now
   fully reflects the original logic
-- Regular "EI" acquisition functions are mapped to their "log" versions for improved
-  numerical stability
 
 ### Removed
 - Support for Python 3.9 removed due to new [BoTorch requirements](https://github.com/pytorch/botorch/pull/2293) 

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -179,6 +179,21 @@ class qSimpleRegret(AcquisitionFunction):
 
 
 ########################################################################################
+### Expected Improvement
+@define(frozen=True)
+class ExpectedImprovement(AcquisitionFunction):
+    """Analytical expected improvement."""
+
+    abbreviation: ClassVar[str] = "EI"
+
+
+@define(frozen=True)
+class qExpectedImprovement(AcquisitionFunction):
+    """Monte Carlo based expected improvement."""
+
+    abbreviation: ClassVar[str] = "qEI"
+
+
 @define(frozen=True)
 class LogExpectedImprovement(AcquisitionFunction):
     """Logarithmic analytical expected improvement."""
@@ -194,6 +209,16 @@ class qLogExpectedImprovement(AcquisitionFunction):
 
 
 @define(frozen=True)
+class qNoisyExpectedImprovement(AcquisitionFunction):
+    """Monte Carlo based noisy expected improvement."""
+
+    abbreviation: ClassVar[str] = "qNEI"
+
+    prune_baseline: bool = field(default=True, validator=instance_of(bool))
+    """Auto-prune candidates that are unlikely to be the best."""
+
+
+@define(frozen=True)
 class qLogNoisyExpectedImprovement(AcquisitionFunction):
     """Logarithmic Monte Carlo based noisy expected improvement."""
 
@@ -201,12 +226,6 @@ class qLogNoisyExpectedImprovement(AcquisitionFunction):
 
     prune_baseline: bool = field(default=True, validator=instance_of(bool))
     """Auto-prune candidates that are unlikely to be the best."""
-
-
-# Remapped because the log versions offer improved numerical stability
-ExpectedImprovement = LogExpectedImprovement
-qExpectedImprovement = qLogExpectedImprovement
-qNoisyExpectedImprovement = qLogNoisyExpectedImprovement
 
 
 ########################################################################################

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -179,21 +179,6 @@ class qSimpleRegret(AcquisitionFunction):
 
 
 ########################################################################################
-### Expected Improvement
-@define(frozen=True)
-class ExpectedImprovement(AcquisitionFunction):
-    """Analytical expected improvement."""
-
-    abbreviation: ClassVar[str] = "EI"
-
-
-@define(frozen=True)
-class qExpectedImprovement(AcquisitionFunction):
-    """Monte Carlo based expected improvement."""
-
-    abbreviation: ClassVar[str] = "qEI"
-
-
 @define(frozen=True)
 class LogExpectedImprovement(AcquisitionFunction):
     """Logarithmic analytical expected improvement."""
@@ -209,16 +194,6 @@ class qLogExpectedImprovement(AcquisitionFunction):
 
 
 @define(frozen=True)
-class qNoisyExpectedImprovement(AcquisitionFunction):
-    """Monte Carlo based noisy expected improvement."""
-
-    abbreviation: ClassVar[str] = "qNEI"
-
-    prune_baseline: bool = field(default=True, validator=instance_of(bool))
-    """Auto-prune candidates that are unlikely to be the best."""
-
-
-@define(frozen=True)
 class qLogNoisyExpectedImprovement(AcquisitionFunction):
     """Logarithmic Monte Carlo based noisy expected improvement."""
 
@@ -226,6 +201,12 @@ class qLogNoisyExpectedImprovement(AcquisitionFunction):
 
     prune_baseline: bool = field(default=True, validator=instance_of(bool))
     """Auto-prune candidates that are unlikely to be the best."""
+
+
+# Remapped because the log versions offer improved numerical stability
+ExpectedImprovement = LogExpectedImprovement
+qExpectedImprovement = qLogExpectedImprovement
+qNoisyExpectedImprovement = qLogNoisyExpectedImprovement
 
 
 ########################################################################################

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -5,7 +5,7 @@ from abc import ABC
 import pandas as pd
 from attrs import define, field
 
-from baybe.acquisition.acqfs import qExpectedImprovement
+from baybe.acquisition.acqfs import qLogExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.acquisition.utils import convert_acqf
 from baybe.exceptions import DeprecationError
@@ -25,7 +25,7 @@ class BayesianRecommender(PureRecommender, ABC):
     """The used surrogate model."""
 
     acquisition_function: AcquisitionFunction = field(
-        converter=convert_acqf, factory=qExpectedImprovement
+        converter=convert_acqf, factory=qLogExpectedImprovement
     )
     """The used acquisition function class."""
 


### PR DESCRIPTION
This PR ~maps the regular "EI" acquisition functions to their "log" versions~ changes the default acquisition function from `qEI` to `qLogEI`, which improves numerical stability and also avoids the warning thrown in `botorch>=0.11.3`.