### PR TITLE
Conditional solver selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are not passed on to the GPyTorch kernels
 - Positive-valued kernel attributes are now correctly handled by validators
   and hypothesis strategies
-- Reverted `fit_gpytorch_mll` call back to old `fit_gpytorch_mll_torch` call until
-  finetuning is achieved
+- As a temporary workaround to compensate for missing `IndexKernel` priors, 
+ `fit_gpytorch_mll_torch` is used instead of `fit_gpytorch_mll` when a `TaskParameter`
+  is present, which acts as regularization via early stopping during model fitting
 
 ### Deprecations
 - `SequentialGreedyRecommender` class replaced with `BotorchRecommender`

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -76,7 +76,6 @@ class GaussianProcessSurrogate(Surrogate):
         import botorch
         import gpytorch
         import torch
-        from botorch.optim.fit import fit_gpytorch_mll_torch
 
         # identify the indexes of the task and numeric dimensions
         # TODO: generalize to multiple task parameters
@@ -139,4 +138,11 @@ class GaussianProcessSurrogate(Surrogate):
             likelihood=likelihood,
         )
         mll = gpytorch.ExactMarginalLogLikelihood(self._model.likelihood, self._model)
-        fit_gpytorch_mll_torch(mll, step_limit=100)
+
+        # TODO: This is a simple temporary workaround to avoid model overfitting
+        #   via early stopping in the presence of task parameters, which currently
+        #   have no prior configured.
+        if n_task_params > 0:
+            botorch.optim.fit.fit_gpytorch_mll_torch(mll, step_limit=200)
+        else:
+            botorch.fit.fit_gpytorch_mll(mll)


### PR DESCRIPTION
Transfer learning using the `scipy` solver invoked via `fit_gpytorch_mll` is currently unstable because it seems we run into overfitting problems due to missing priors on the involved `IndexKernel`. Using the old `fit_gpytorch_mll_torch` routine mitigates this problem, probably because the MLL fitting does not fully converge, which effectively acts as regularization via early stopping. In a non-transfer-learning context, however, the `scipy` solver produces generally better results.

This PR thus implements a temporary workaround where the solver is chosen adaptively based on the presence of a `TaskParameter`.