### PR TITLE
`MIN` mode via acquisition function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the recommender but in the surrogate
 - Fallback models created by `catch_constant_targets` are stored outside the surrogate
 - `to_tensor` now also handles `numpy` arrays
+- `MIN` mode of `NumericalTarget` is now implemented via the acquisition function
+  instead of negating the computational representation
 
 ### Fixed
 - `CategoricalParameter` and `TaskParameter` no longer incorrectly coerce a single

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -57,7 +57,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         The required structure of `measurements` is specified in
         :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`.
         """
-        import botorch.acquisition as bacqf
+        import botorch.acquisition as bo_acqf
         import torch
         from botorch.acquisition.objective import LinearMCObjective
 
@@ -66,7 +66,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         train_y = objective.transform(measurements)
 
         # Retrieve corresponding botorch class
-        acqf_cls = getattr(bacqf, self.__class__.__name__)
+        acqf_cls = getattr(bo_acqf, self.__class__.__name__)
 
         # Match relevant attributes
         params_dict = match_attributes(
@@ -91,9 +91,9 @@ class AcquisitionFunction(ABC, SerialMixin):
                 if "best_f" in signature_params:
                     additional_params["best_f"] = train_y.min().item()
 
-                if issubclass(acqf_cls, bacqf.AnalyticAcquisitionFunction):
+                if issubclass(acqf_cls, bo_acqf.AnalyticAcquisitionFunction):
                     additional_params["maximize"] = False
-                elif issubclass(acqf_cls, bacqf.MCAcquisitionFunction):
+                elif issubclass(acqf_cls, bo_acqf.MCAcquisitionFunction):
                     additional_params["objective"] = LinearMCObjective(
                         torch.tensor([-1.0])
                     )

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -150,13 +150,6 @@ class NumericalTarget(Target, SerialMixin):
             transformed = pd.DataFrame(
                 func(data, *self.bounds.to_tuple()), index=data.index
             )
-
-        # Otherwise, simply negate all target values for ``MIN`` mode.
-        # For ``MAX`` mode, nothing needs to be done.
-        # For ``MATCH`` mode, the validators avoid a situation without specified bounds.
-        elif self.mode is TargetMode.MIN:
-            transformed = -data
-
         else:
             transformed = data.copy()
 

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -80,16 +80,26 @@ def main():
     }
 
     # Streamlit simulation parameters
+    st.sidebar.markdown("# Domain")
     st_random_seed = int(st.sidebar.number_input("Random seed", value=1337))
     st_function_name = st.sidebar.selectbox(
         "Test function", list(test_functions.keys())
     )
+    st_target_mode = st.sidebar.radio(
+        "Objective",
+        ["MAX", "MIN"],
+        format_func=lambda x: {"MAX": "Maximization", "MIN": "Minimization"}[x],
+        horizontal=True,
+    )
+    st.sidebar.markdown("---")
+    st.sidebar.markdown("# Model")
     st_surrogate_name = st.sidebar.selectbox(
         "Surrogate model", list(surrogate_model_classes.keys())
     )
     st_n_training_points = st.sidebar.slider("Number of training points", 1, 20, 5)
     st_n_recommendations = st.sidebar.slider("Number of recommendations", 1, 20, 5)
     st.sidebar.markdown("---")
+    st.sidebar.markdown("# Validation")
     st.sidebar.markdown(
         """
         When scaling is implemented correctly, the plot should remain static (except for
@@ -139,7 +149,7 @@ def main():
         ),
     )
     searchspace = SearchSpace.from_product(parameters=[parameter])
-    objective = NumericalTarget(name="y", mode="MAX").to_objective()
+    objective = NumericalTarget(name="y", mode=st_target_mode).to_objective()
 
     # Create the surrogate model and the recommender
     surrogate_model = surrogate_model_classes[st_surrogate_name]()


### PR DESCRIPTION
This PR changes the behavior of `NumericalTarget` in `MIN` mode in that the minimization is lo longer implement by negating the computational representation of the target but placing an objective on the acquisition function.

This approach avoids the problem that otherwise the surrogate would be trained on inverted targets, resulting in inverted predictions, which prevents us from exposing the surrogate as-is to the user. Also, it cleanly separates the objective (i.e. "minimization") from the target representation.