### PR TITLE
Add py.typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `py.typed` file to enable the use of type checkers on the user side
+
 ## [0.10.0] - 2024-08-02
 ### Breaking Changes
 - Providing an explicit `batch_size` is now mandatory when asking for recommendations


### PR DESCRIPTION
Adds a `py.typed` file to enable the use of type checkers on the user side.

Before:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/3568dc62-d5fc-4b39-b0f8-05d26c5dfc2e">

After:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/d8074403-8be1-4ea7-b92a-857703e8042a">
