### PR TITLE
Fix batch recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CategoricalParameter` and `TaskParameter` no longer incorrectly coerce a single
   string input to categories/tasks
 - `farthest_point_sampling` no longer depends on the provided point order
-- `RandomForestSurrogate` now produces proper batch predictions
+- Batch predictions for `RandomForestSurrogate`
 - Surrogates providing only marginal posterior information can no longer be used for
   batch recommendation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `py.typed` file to enable the use of type checkers on the user side
-- `GaussianSurrogate` base class for surrogate models with Gaussian posteriors
+- `IndependentGaussianSurrogate` base class for surrogate models providing independent 
+  Gaussian posteriors for all candidates (cannot be used for batch prediction)
 - `comp_rep_columns` property for `Parameter`, `SearchSpace`, `SubspaceDiscrete`
   and `SubspaceContinuous` classes
 - New mechanisms for surrogate input/output scaling configurable per class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CategoricalParameter` and `TaskParameter` no longer incorrectly coerce a single
   string input to categories/tasks
 - `farthest_point_sampling` no longer depends on the provided point order
+- `RandomForestSurrogate` now produces proper batch predictions
+- Surrogates providing only marginal posterior information can no longer be used for
+  batch recommendation
 
 ### Removed
 - `register_custom_architecture` decorator

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -70,4 +70,4 @@ class UnmatchedAttributeError(Exception):
 
 
 class InvalidSurrogateModelError(Exception):
-    """A surrogate model does not behave as required."""
+    """An invalid surrogate model was chosen."""

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -67,3 +67,7 @@ class ModelNotTrainedError(Exception):
 
 class UnmatchedAttributeError(Exception):
     """An attribute cannot be matched against a certain callable signature."""
+
+
+class InvalidSurrogateModelError(Exception):
+    """A surrogate model does not behave as required."""

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -8,12 +8,12 @@ from attrs import define, field
 from baybe.acquisition.acqfs import qLogExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.acquisition.utils import convert_acqf
-from baybe.exceptions import DeprecationError
+from baybe.exceptions import DeprecationError, InvalidSurrogateModelError
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import CustomONNXSurrogate, GaussianProcessSurrogate
-from baybe.surrogates.base import SurrogateProtocol
+from baybe.surrogates.base import IndependentGaussianSurrogate, SurrogateProtocol
 
 
 @define
@@ -74,6 +74,16 @@ class BayesianRecommender(PureRecommender, ABC):
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
                 f"empty training data."
+            )
+
+        if (
+            isinstance(self.surrogate_model, IndependentGaussianSurrogate)
+            and batch_size > 1
+        ):
+            raise InvalidSurrogateModelError(
+                f"The specified surrogate model of type "
+                f"'{self.surrogate_model.__class__.__name__}' "
+                f"cannot be used for batch recommendation."
             )
 
         if isinstance(self.surrogate_model, CustomONNXSurrogate):

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -318,8 +318,8 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
 
 @define
-class GaussianSurrogate(Surrogate, ABC):
-    """A surrogate model providing Gaussian posterior estimates."""
+class IndependentGaussianSurrogate(Surrogate, ABC):
+    """A surrogate base class providing independent Gaussian posteriors."""
 
     def _posterior(self, candidates_comp_scaled: Tensor, /) -> GPyTorchPosterior:
         # See base class.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -89,10 +89,6 @@ class SurrogateProtocol(Protocol):
 class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     """Abstract base class for all surrogate models."""
 
-    # Class variables
-    joint_posterior: ClassVar[bool]
-    """Class variable encoding whether or not a joint posterior is calculated."""
-
     supports_transfer_learning: ClassVar[bool]
     """Class variable encoding whether or not the surrogate supports transfer
     learning."""
@@ -330,21 +326,14 @@ class IndependentGaussianSurrogate(Surrogate, ABC):
 
         # Construct the Gaussian posterior from the estimated first and second moment
         mean, var = self._estimate_moments(candidates_comp_scaled)
-        if not self.joint_posterior:
-            var = torch.diag_embed(var)
-        mvn = MultivariateNormal(mean, var)
+        mvn = MultivariateNormal(mean, torch.diag_embed(var))
         return GPyTorchPosterior(mvn)
 
     @abstractmethod
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:
-        """Estimate first and second moments of the Gaussian posterior.
-
-        The second moment may either be a 1-D tensor of marginal variances for the
-        candidates or a 2-D tensor representing a full covariance matrix over all
-        candidates, depending on the ``joint_posterior`` flag of the model.
-        """
+        """Estimate first and second moments of the Gaussian posterior."""
 
 
 def _make_hook_decode_onnx_str(

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -24,7 +24,7 @@ from baybe.parameters import (
     TaskParameter,
 )
 from baybe.searchspace import SearchSpace
-from baybe.surrogates.base import GaussianSurrogate
+from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction
 from baybe.utils.numerical import DTypeFloatONNX
 
@@ -43,7 +43,7 @@ def register_custom_architecture(*args, **kwargs) -> NoReturn:
 
 
 @define(kw_only=True)
-class CustomONNXSurrogate(GaussianSurrogate):
+class CustomONNXSurrogate(IndependentGaussianSurrogate):
     """A wrapper class for custom pretrained surrogate models.
 
     Note that these surrogates cannot be retrained.

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -25,7 +25,7 @@ from baybe.parameters import (
 )
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.base import GaussianSurrogate
-from baybe.surrogates.utils import batchify
+from baybe.surrogates.utils import batchify_mean_var_prediction
 from baybe.utils.numerical import DTypeFloatONNX
 
 if TYPE_CHECKING:
@@ -78,14 +78,16 @@ class CustomONNXSurrogate(GaussianSurrogate):
         except Exception as exc:
             raise ValueError("Invalid ONNX string") from exc
 
-    @batchify
-    def _estimate_moments(self, candidates_comp: Tensor, /) -> tuple[Tensor, Tensor]:
+    @batchify_mean_var_prediction
+    def _estimate_moments(
+        self, candidates_comp_scaled: Tensor, /
+    ) -> tuple[Tensor, Tensor]:
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
 
         model_inputs = {
-            self.onnx_input_name: candidates_comp.numpy().astype(DTypeFloatONNX)
+            self.onnx_input_name: candidates_comp_scaled.numpy().astype(DTypeFloatONNX)
         }
         results = self._model.run(None, model_inputs)
 

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -49,14 +49,9 @@ class CustomONNXSurrogate(IndependentGaussianSurrogate):
     Note that these surrogates cannot be retrained.
     """
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = False
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
-    # Object variables
     onnx_input_name: str = field(validator=validators.instance_of(str))
     """The input name used for constructing the ONNX str."""
 

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -88,14 +88,9 @@ class GaussianProcessSurrogate(Surrogate):
     # to `optimize_acqf_*`, which is configured to be called on the original scale.
     # Moving the scaling operation into the botorch GP object avoids this conflict.
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = True
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = True
     # See base class.
 
-    # Object variables
     kernel_factory: KernelFactory = field(
         alias="kernel_or_factory",
         factory=DefaultKernelFactory,

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from attr import define, field
 from sklearn.linear_model import ARDRegression
 
-from baybe.surrogates.base import GaussianSurrogate
+from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 @catch_constant_targets
 @define
-class BayesianLinearSurrogate(GaussianSurrogate):
+class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     """A Bayesian linear regression surrogate model."""
 
     # Class variables

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -1,11 +1,4 @@
-"""Linear surrogates.
-
-Currently, the documentation for this surrogate is not available. This is due to a bug
-in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750.
-
-Since we plan to refactor the surrogates, this part of the documentation will be
-available in the future. Thus, please have a look in the source code directly.
-"""
+"""Linear surrogates."""
 
 from __future__ import annotations
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -27,14 +27,9 @@ if TYPE_CHECKING:
 class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     """A Bayesian linear regression surrogate model."""
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = False
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
-    # Object variables
     model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -15,7 +15,7 @@ from attr import define, field
 from sklearn.linear_model import ARDRegression
 
 from baybe.surrogates.base import GaussianSurrogate
-from baybe.surrogates.utils import batchify, catch_constant_targets
+from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class BayesianLinearSurrogate(GaussianSurrogate):
     _model: ARDRegression | None = field(init=False, default=None, eq=False)
     """The actual model."""
 
-    @batchify
+    @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from attr import define, field
 
-from baybe.surrogates.base import GaussianSurrogate
+from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 @define
-class MeanPredictionSurrogate(GaussianSurrogate):
+class MeanPredictionSurrogate(IndependentGaussianSurrogate):
     """A trivial surrogate model.
 
     It provides the average value of the training targets

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -21,14 +21,9 @@ class MeanPredictionSurrogate(IndependentGaussianSurrogate):
     as posterior mean and a (data-independent) constant posterior variance.
     """
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = False
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
-    # Object variables
     _model: float | None = field(init=False, default=None, eq=False)
     """The estimated posterior mean value of the training targets."""
 

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 from attr import define, field
 
 from baybe.surrogates.base import GaussianSurrogate
-from baybe.surrogates.utils import batchify
+from baybe.surrogates.utils import batchify_mean_var_prediction
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -32,7 +32,7 @@ class MeanPredictionSurrogate(GaussianSurrogate):
     _model: float | None = field(init=False, default=None, eq=False)
     """The estimated posterior mean value of the training targets."""
 
-    @batchify
+    @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -30,17 +30,12 @@ if TYPE_CHECKING:
 class NGBoostSurrogate(IndependentGaussianSurrogate):
     """A natural-gradient-boosting surrogate model."""
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = False
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
     _default_model_params: ClassVar[dict] = {"n_estimators": 25, "verbose": False}
     """Class variable encoding the default model parameters."""
 
-    # Object variables
     model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -15,7 +15,7 @@ from attr import define, field
 from ngboost import NGBRegressor
 
 from baybe.parameters.base import Parameter
-from baybe.surrogates.base import GaussianSurrogate
+from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 @catch_constant_targets
 @define
-class NGBoostSurrogate(GaussianSurrogate):
+class NGBoostSurrogate(IndependentGaussianSurrogate):
     """A natural-gradient-boosting surrogate model."""
 
     # Class variables

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -16,7 +16,7 @@ from ngboost import NGBRegressor
 
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import GaussianSurrogate
-from baybe.surrogates.utils import batchify, catch_constant_targets
+from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
 from baybe.surrogates.validation import get_model_params_validator
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class NGBoostSurrogate(GaussianSurrogate):
         # Tree-like models do not require any output scaling
         return None
 
-    @batchify
+    @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -1,11 +1,4 @@
-"""NGBoost surrogates.
-
-Currently, the documentation for this surrogate is not available. This is due to a bug
-in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750.
-
-Since we plan to refactor the surrogates, this part of the documentation will be
-available in the future. Thus, please have a look in the source code directly.
-"""
+"""NGBoost surrogates."""
 
 from __future__ import annotations
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -33,14 +33,9 @@ if TYPE_CHECKING:
 class RandomForestSurrogate(Surrogate):
     """A random forest surrogate model."""
 
-    # Class variables
-    joint_posterior: ClassVar[bool] = True
-    # See base class.
-
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
-    # Object variables
     model_params: dict[str, Any] = field(
         factory=dict,
         converter=dict,

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -99,4 +99,4 @@ class RandomForestSurrogate(GaussianSurrogate):
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
         # See base class.
         self._model = RandomForestRegressor(**(self.model_params))
-        self._model.fit(train_x, train_y.ravel())
+        self._model.fit(train_x.numpy(), train_y.numpy().ravel())

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -1,11 +1,4 @@
-"""Random forest surrogates.
-
-Currently, the documentation for this surrogate is not available. This is due to a bug
-in our documentation tool, see https://github.com/sphinx-doc/sphinx/issues/11750.
-
-Since we plan to refactor the surrogates, this part of the documentation will be
-available in the future. Thus, please have a look in the source code directly.
-"""
+"""Random forest surrogates."""
 
 from __future__ import annotations
 

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typing
 from collections.abc import Callable
 from functools import wraps
 from typing import TYPE_CHECKING
@@ -82,77 +81,38 @@ def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
     return cls
 
 
-# FIXME[typing]: Typing should be reactivated once the `joint_posterior` attribute
-#   has been refactored/removed
-@typing.no_type_check
-def batchify(
+def batchify_mean_var_prediction(
     posterior: Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]],
 ) -> Callable[[Surrogate, Tensor], tuple[Tensor, Tensor]]:
-    """Wrap ``Surrogate`` posterior functions to enable proper batching.
-
-    More precisely, this wraps model that are incompatible with t- and q-batching such
-    that they become able to process batched inputs.
-
-    Args:
-        posterior: The original ``posterior`` function.
-
-    Returns:
-        The wrapped posterior function.
-    """
+    """Wrap a posterior method to make it evaluate t-batches as an augmented q-batch."""
 
     @wraps(posterior)
     def sequential_posterior(
         model: Surrogate, candidates: Tensor
     ) -> tuple[Tensor, Tensor]:
-        """Replace the posterior function by one that processes batches sequentially.
-
-        Args:
-            model: The ``Surrogate`` model.
-            candidates: The candidates tensor.
-
-        Returns:
-            The mean and the covariance.
-        """
-        import torch
-
         # If no batch dimensions are given, call the model directly
         if candidates.ndim == 2:
             return posterior(model, candidates)
 
+        # Parameter batching is not (yet) supported
+        if candidates.ndim > 3:
+            raise ValueError("Multiple t-batch dimensions are not supported.")
+
         # Keep track of batch dimensions
-        t_shape = candidates.shape[:-2]
+        t_shape = candidates.shape[-3]
         q_shape = candidates.shape[-2]
 
-        # If the posterior function provides full covariance information, call it
-        # t-batch by t-batch
-        if model.joint_posterior:
-            # Flatten all t-batch dimensions into a single one
-            flattened = candidates.flatten(end_dim=-3)
+        # Flatten the t-batch dimension into the q-batch dimension
+        flattened = candidates.flatten(end_dim=-2)
 
-            # Call the model on each (flattened) t-batch
-            out = (posterior(model, batch) for batch in flattened)
+        # Call the model on the entire input
+        mean, var = posterior(model, flattened)
 
-            # Collect the results and restore the batch dimensions
-            mean, covar = zip(*out)
-            mean = torch.reshape(torch.stack(mean), t_shape + (q_shape,))
-            covar = torch.reshape(torch.stack(covar), t_shape + (q_shape, q_shape))
+        # Restore the batch dimensions
+        mean = mean.reshape((t_shape, q_shape))
+        var = var.reshape((t_shape, q_shape))
 
-            return mean, covar
-
-        # Otherwise, flatten all t- and q-batches into a single q-batch dimension
-        # and evaluate the posterior function in one go
-        else:
-            # Flatten *all* batches into the q-batch dimension
-            flattened = candidates.flatten(end_dim=-2)
-
-            # Call the model on the entire input
-            mean, var = posterior(model, flattened)
-
-            # Restore the batch dimensions
-            mean = torch.reshape(mean, t_shape + (q_shape,))
-            var = torch.reshape(var, t_shape + (q_shape,))
-
-            return mean, var
+        return mean, var
 
     return sequential_posterior
 

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -110,7 +110,7 @@ campaign = Campaign(
 ### Iterate with recommendations and measurements
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_size=2)
+recommendation = campaign.recommend(batch_size=1)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -122,10 +122,10 @@ campaign.add_measurements(recommendation)
 
 ### Model Outputs
 
-# Do another round of recommendations
-recommendation = campaign.recommend(batch_size=2)
+# Do another round of recommendation
+recommendation = campaign.recommend(batch_size=1)
 
-# Print second round of recommendations
+# Print second round of recommendation
 
 print("Recommendation from campaign:")
 print(recommendation)

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -97,7 +97,7 @@ print("The model object in json format:")
 print(surrogate_model.to_json(), end="\n" * 3)
 
 # Let's do a first round of recommendation
-recommendation = campaign.recommend(batch_size=2)
+recommendation = campaign.recommend(batch_size=1)
 
 print("Recommendation from campaign:")
 print(recommendation)
@@ -112,11 +112,11 @@ campaign.add_measurements(recommendation)
 
 print("Here you will see some model outputs as we set verbose to True")
 
-# Do another round of recommendations
-recommendation = campaign.recommend(batch_size=2)
+# Do another round of recommendation
+recommendation = campaign.recommend(batch_size=1)
 
 
-# Print second round of recommendations
+# Print second round of recommendation
 
 print("Recommendation from campaign:")
 print(recommendation)

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -15,17 +15,20 @@ import streamlit as st
 import torch
 from funcy import rpartial
 
+from baybe.acquisition.acqfs import qLogExpectedImprovement
+from baybe.acquisition.base import AcquisitionFunction
 from baybe.parameters.numerical import NumericalDiscreteParameter
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import CustomONNXSurrogate
 from baybe.surrogates.base import Surrogate
+from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import get_subclasses
 from baybe.utils.random import set_random_seed
 
 # Number of values used for the input parameter
-N_PARAMETER_VALUES = 1000
+N_PARAMETER_VALUES = 200
 
 
 def cubic(
@@ -79,6 +82,13 @@ def main():
         for cls in get_subclasses(Surrogate)
         if not issubclass(cls, CustomONNXSurrogate)
     }
+    surrogate_model_names = list(surrogate_model_classes.keys())
+
+    # Collect all available acquisition functions
+    acquisition_function_classes = {
+        cls.__name__: cls for cls in get_subclasses(AcquisitionFunction)
+    }
+    acquisition_function_names = list(acquisition_function_classes.keys())
 
     # Streamlit simulation parameters
     st.sidebar.markdown("# Domain")
@@ -95,7 +105,14 @@ def main():
     st.sidebar.markdown("---")
     st.sidebar.markdown("# Model")
     st_surrogate_name = st.sidebar.selectbox(
-        "Surrogate model", list(surrogate_model_classes.keys())
+        "Surrogate model",
+        surrogate_model_names,
+        surrogate_model_names.index(GaussianProcessSurrogate.__name__),
+    )
+    st_acqf_name = st.sidebar.selectbox(
+        "Acquisition function",
+        acquisition_function_names,
+        acquisition_function_names.index(qLogExpectedImprovement.__name__),
     )
     st_n_training_points = st.sidebar.slider("Number of training points", 1, 20, 5)
     st_n_recommendations = st.sidebar.slider("Number of recommendations", 1, 20, 5)
@@ -152,9 +169,12 @@ def main():
     searchspace = SearchSpace.from_product(parameters=[parameter])
     objective = NumericalTarget(name="y", mode=st_target_mode).to_objective()
 
-    # Create the surrogate model and the recommender
+    # Create the surrogate model, acquisition function, and the recommender
     surrogate_model = surrogate_model_classes[st_surrogate_name]()
-    recommender = BotorchRecommender(surrogate_model=surrogate_model)
+    acqf = acquisition_function_classes[st_acqf_name]()
+    recommender = BotorchRecommender(
+        surrogate_model=surrogate_model, acquisition_function=acqf
+    )
 
     # Get the recommendations and extract the posterior mean / standard deviation
     recommendations = recommender.recommend(

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import streamlit as st
+import torch
 from funcy import rpartial
 
 from baybe.parameters.numerical import NumericalDiscreteParameter
@@ -55,7 +56,7 @@ def linear(
     x: np.ndarray, x_min: float, x_max: float, amplitude: float, bias: float
 ) -> np.ndarray:
     """Linear test function."""
-    out = amplitude * np.linspace(0, 1, len(x)) + bias
+    out = amplitude * x + bias
     return out
 
 
@@ -159,9 +160,10 @@ def main():
     recommendations = recommender.recommend(
         st_n_recommendations, searchspace, objective, measurements
     )
-    posterior = surrogate_model.posterior(candidates)
-    mean = posterior.mean.squeeze().detach().numpy()
-    std = posterior.stddev.detach().numpy()
+    with torch.no_grad():
+        posterior = surrogate_model.posterior(candidates)
+    mean = posterior.mean.squeeze().numpy()
+    std = posterior.variance.sqrt().squeeze().numpy()
 
     # Visualize the test function, training points, model predictions, recommendations
     fig = plt.figure()

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -37,7 +37,7 @@ from baybe.recommenders.pure.bayesian.botorch import (
 )
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType
-from baybe.surrogates.base import Surrogate
+from baybe.surrogates.base import IndependentGaussianSurrogate, Surrogate
 from baybe.surrogates.custom import CustomONNXSurrogate
 from baybe.surrogates.gaussian_process.presets import (
     DefaultKernelFactory,
@@ -249,7 +249,9 @@ def test_kernel_factories(campaign, n_iterations, batch_size):
     valid_surrogate_models,
     ids=[c.__class__ for c in valid_surrogate_models],
 )
-def test_surrogate_models(campaign, n_iterations, batch_size):
+def test_surrogate_models(campaign, n_iterations, batch_size, surrogate_model):
+    if batch_size > 1 and isinstance(surrogate_model, IndependentGaussianSurrogate):
+        pytest.skip("Batch recommendation is not supported.")
     run_iterations(campaign, n_iterations, batch_size)
 
 


### PR DESCRIPTION
When the non-GP surrogates where added, they were not designed with batch recommendations in mind. Now that batch recommendations can be generally requested, surrogate models providing only marginal posterior information yield unusable results for batch sizes larger than one.

This PR fixes the issue by:
* Making the `RandomForestSurrogate` produce a proper `EnsemblePosterior` that is capable of expressing covariance structure, which is the basic requirement for batch prediction
* Disallowing batch sizes larger than one for surrogates that only provide marginal posteriors