### PR TITLE
Silence mypy type-abstract errors

### DIFF
--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -60,7 +60,7 @@ class Campaign(SerialMixin):
 
     recommender: RecommenderProtocol = field(
         factory=TwoPhaseMetaRecommender,
-        validator=instance_of(RecommenderProtocol),  # type: ignore[type-abstract]
+        validator=instance_of(RecommenderProtocol),
     )
     """The employed recommender"""
 

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -67,7 +67,7 @@ class DesirabilityObjective(Objective):
 
     _targets: tuple[Target, ...] = field(
         converter=to_tuple,
-        validator=[min_len(2), deep_iterable(member_validator=instance_of(Target))],  # type: ignore[type-abstract]
+        validator=[min_len(2), deep_iterable(member_validator=instance_of(Target))],
         alias="targets",
     )
     "The targets considered by the objective."

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -12,7 +12,7 @@ from baybe.targets.base import Target
 class SingleTargetObjective(Objective):
     """An objective focusing on a single target."""
 
-    _target: Target = field(validator=instance_of(Target), alias="target")  # type: ignore[type-abstract]
+    _target: Target = field(validator=instance_of(Target), alias="target")
     """The single target considered by the objective."""
 
     def __str__(self) -> str:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,11 @@
 [mypy]
 packages = baybe
 
+; Avoid false positives for `type[P]` when `P` is abstract.
+; * https://svcs.hynek.me/en/stable/typing-caveats.html#abstract-classes-and-pep-544
+; * https://github.com/python/mypy/issues/4717
+disable_error_code = type-abstract
+
 ; at some point, these excludes should all be gone ...
 exclude = (?x)(
           baybe/serialization


### PR DESCRIPTION
With `cattrs==24.1.0` released, we suddenly get more `type-abstract` errors. Since these are basically false positives, this PR globally disables the warnings. References are provided in `mypy.ini`.