### PR TITLE
Fix `SubspaceDiscrete.from_dataframe` edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Batch predictions for `RandomForestSurrogate`
 - Surrogates providing only marginal posterior information can no longer be used for
   batch recommendation
+- `SearchSpace.from_dataframe` now creates a proper empty discrete subspace without
+  index when called with continuous parameters only
+- Metadata updates are now only triggered when a discrete subspace is present
 
 ### Removed
 - `register_custom_architecture` decorator

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -191,7 +191,7 @@ class Campaign(SerialMixin):
 
         # Update meta data
         # TODO: refactor responsibilities
-        if self.searchspace.type is SearchSpaceType.DISCRETE:
+        if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
             self.searchspace.discrete.mark_as_measured(
                 data, numerical_measurements_must_be_within_tolerance
             )

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -17,6 +17,7 @@ from baybe.recommenders.base import RecommenderProtocol
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.searchspace.core import (
     SearchSpace,
+    SearchSpaceType,
     to_searchspace,
     validate_searchspace_from_config,
 )
@@ -190,9 +191,10 @@ class Campaign(SerialMixin):
 
         # Update meta data
         # TODO: refactor responsibilities
-        self.searchspace.discrete.mark_as_measured(
-            data, numerical_measurements_must_be_within_tolerance
-        )
+        if self.searchspace.type is SearchSpaceType.DISCRETE:
+            self.searchspace.discrete.mark_as_measured(
+                data, numerical_measurements_must_be_within_tolerance
+            )
 
         # Read in measurements and add them to the database
         self.n_batches_done += 1

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -347,6 +347,10 @@ class SubspaceDiscrete(SerialMixin):
             except IterableValidationError:
                 return CategoricalParameter(name=name, values=values)
 
+        # Catch edge case
+        if df.shape[1] == 0:
+            return cls.empty()
+
         # Get the full list of both explicitly and implicitly defined parameter
         parameters = get_parameters_from_dataframe(
             df, discrete_parameter_factory, parameters

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hypothesis import given
+from pandas.testing import assert_frame_equal
 from pytest import param
 
 from baybe.parameters import (
@@ -102,6 +103,13 @@ def test_searchspace_creation_from_dataframe(df, parameters, expected):
     else:
         with pytest.raises(expected):
             SearchSpace.from_dataframe(df, parameters)
+
+
+def test_discrete_searchspace_creation_from_degenerate_dataframe():
+    """A degenerate dataframe with index but no columns yields an empty space."""
+    df = pd.DataFrame(index=[0])
+    subspace = SubspaceDiscrete.from_dataframe(df)
+    assert_frame_equal(subspace.exp_rep, pd.DataFrame())
 
 
 @pytest.mark.parametrize("boundary_only", (False, True))


### PR DESCRIPTION
Fixes #358 by:
* Catching the edge case when a degenerate dataframe with no columns is provided
* Updating the meta data only when discrete subspace is present (not required for the bugfix but still to be changed)