### PR TITLE
Fix Recommendation Order for BotorchRecommender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SearchSpace.from_dataframe` now creates a proper empty discrete subspace without
   index when called with continuous parameters only
 - Metadata updates are now only triggered when a discrete subspace is present
+- Unintended reordering of discrete search space parts for recommendations obtained
+  with `BotorchRecommender`
 
 ### Removed
 - `register_custom_architecture` decorator

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -123,12 +123,12 @@ class BotorchRecommender(BayesianRecommender):
         #   `SearchSpace._match_measurement_with_searchspace_indices` does, though using
         #   a simpler matching logic. When refactoring the SearchSpace class to
         #   handle continuous parameters, a corresponding utility could be extracted.
-        # IMPROVE: Maintain order of recommendations (currently lost during merge)
         idxs = pd.Index(
             pd.merge(
-                candidates_comp.reset_index(),
                 pd.DataFrame(points, columns=candidates_comp.columns),
+                candidates_comp.reset_index(),
                 on=list(candidates_comp),
+                how="left",
             )["index"]
         )
 
@@ -282,9 +282,10 @@ class BotorchRecommender(BayesianRecommender):
         # Get selected candidate indices
         idxs = pd.Index(
             pd.merge(
-                candidates_comp.reset_index(),
                 pd.DataFrame(disc_points, columns=candidates_comp.columns),
+                candidates_comp.reset_index(),
                 on=list(candidates_comp),
+                how="left",
             )["index"]
         )
 

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,8 +1,13 @@
 """Tests for basic input-output and iterative loop."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
+from baybe.parameters import NumericalDiscreteParameter
+from baybe.recommenders import BotorchRecommender
+from baybe.searchspace import SearchSpace
+from baybe.targets import NumericalTarget
 from baybe.utils.dataframe import add_fake_results
 
 # List of tests that are expected to fail (still missing implementation etc)
@@ -54,3 +59,39 @@ def test_bad_target_input_value(campaign, good_reference_values, bad_val, reques
     rec.Target_max.iloc[0] = bad_val
     with pytest.raises((ValueError, TypeError)):
         campaign.add_measurements(rec)
+
+
+@pytest.mark.parametrize("n_values", [5, 10, 20])
+@pytest.mark.parametrize("n_parameters", [3, 5, 10])
+def test_recommendation_is_not_ordered(n_values, n_parameters):
+    """Test whether recommendations are unintentionally sorted.
+
+    This is to ensure that they are not reordered according to the order they appear
+    in the search space. To this end we create an example where the search space
+    parameter entries are monotonically increasing and a target variable in max mode
+    comprises the sum of the parameters. We feed the first and last point as training
+    data. This should lead to a recommendation order that is very different from the
+    original search space order (albeit not perfectly anti-ordered).
+    """
+    # Set up custom df with entries monotonically increasing
+    values = list(range(n_values))
+    df = pd.DataFrame({f"p{k+1}": values for k in range(n_parameters)})
+    searchspace = SearchSpace.from_dataframe(
+        df,
+        parameters=[
+            NumericalDiscreteParameter(name=f"p{k+1}", values=values)
+            for k in range(n_parameters)
+        ],
+    )
+    objective = NumericalTarget(name="t", mode="MAX").to_objective()
+    recommender = BotorchRecommender()
+
+    # Add first and last point as measurement, target value is the sum of all parameters
+    measurements = df.iloc[[0, -1], :]
+    measurements = measurements.assign(t=measurements.sum(axis=1))
+
+    # Get recommendations and assert that they are not in ascending order regarding
+    # their target value, as would be in the search space.
+    rec = recommender.recommend(5, searchspace, objective, measurements)
+    rec = rec.assign(t=rec.sum(axis=1))
+    assert not rec["t"].is_monotonic_increasing, rec["t"].values


### PR DESCRIPTION
Fixes #353 

Unintended reordering of discrete search space parts in `BotorchRecommender` was caused during pd.merging by the searchspace being on the left, however it should be on the right and the merge is safest done with `how='left'` while having the numerical points returned by botorch on the left -> the resulting rows will follow their order.

A test has been written, perhaps though a little too complicated but anyhow. We can construct a searchspace/target construct where it would be expected that the order of the searchspace is strongly broken when getting recommendations (although I havent been able to create one that is exactly anti-ordered). In the faulty variant the recommendation order would still be monotonically increasing like in the searchspace, while the "correct" order is roughly anti-ordered, or strictly speaking `not monotonically increasing`