### PR TITLE
Fix Name Matching for Retrieving Comp Rep Indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Unsafe name-based matching of columns in `get_comp_rep_parameter_indices`
+
 ## [0.11.0] - 2024-09-09
 ### Breaking Changes
 - The public methods of `Surrogate` models now operate on dataframes in experimental

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -297,22 +297,29 @@ class SearchSpace(SerialMixin):
 
         Raises:
             ValueError: If no parameter with the provided name exists.
+            ValueError: If more than one parameter with the provided name exists.
 
         Returns:
             A tuple containing the integer indices of the columns in the computational
             representation associated with the parameter. When the parameter is not part
             of the computational representation, an empty tuple is returned.
         """
-        if name not in (p.name for p in self.parameters):
+        params = self.get_parameters_by_name([name])
+        if len(params) < 1:
             raise ValueError(
                 f"There exists no parameter named '{name}' in the search space."
             )
+        if len(params) > 1:
+            raise ValueError(
+                f"There exist multiple parameter matches for '{name}' in the search "
+                f"space."
+            )
+        p = params[0]
 
-        # TODO: The "startswith" approach is not ideal since it relies on the implicit
-        #   assumption that the substrings match. A more robust approach would
-        #   be to generate this mapping while building the comp rep.
         return tuple(
-            i for i, col in enumerate(self.comp_rep_columns) if col.startswith(name)
+            i
+            for i, col in enumerate(self.comp_rep_columns)
+            if col in p.comp_rep_columns
         )
 
     @staticmethod


### PR DESCRIPTION
Fixes #352 

Now
- retrieves the parameter object belonging to the requested name
- then exact-matches column names in the comp_rep to the ones of the parameter via its `comp_rep_columns`