### PR TITLE
Fix intersphinx link for torch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -249,7 +249,7 @@ intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "sklearn_extra": ("https://scikit-learn-extra.readthedocs.io/en/stable", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "torch": ("https://pytorch.org/docs/master/", None),
+    "torch": ("https://pytorch.org/docs/main/", None),
     "rdkit": ("https://rdkit.org/docs/", None),
 }
 


### PR DESCRIPTION
This PR fixes the incorrect link for retrieving the documentation parts of `torch`. It seems like they have just switched their naming from `master` to `main`, requiring us to fix the link that we use.