### PR TITLE
Consolidate Continuous Linear Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Convenience choice for the `operator` used in `ContinuousLinearInequalityConstraint`,
-  which takes care of required negation for `<=` constraints
+- Continuous linear constraints have been consolidated in the new
+  `ContinuousLinearConstraint` class
 
 ### Changed
 - `get_surrogate` now also returns the model for transformed single targets or
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Unsafe name-based matching of columns in `get_comp_rep_parameter_indices`
+
+### Deprecated
+- `ContinuousLinearEqualityConstraint` and `ContinuousLinearInequalityConstraint`
+  replaced by `ContinuousLinearConstraint` with the corresponding `operator` keyword
 
 ## [0.11.0] - 2024-09-09
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Convenience choice for the `operator` used in `ContinuousLinearInequalityConstraint`,
+  which takes care of required negation for `<=` constraints
+
 ### Changed
 - `get_surrogate` now also returns the model for transformed single targets or
   desirability objectives

--- a/baybe/constraints/__init__.py
+++ b/baybe/constraints/__init__.py
@@ -3,6 +3,9 @@
 from baybe.constraints.conditions import SubSelectionCondition, ThresholdCondition
 from baybe.constraints.continuous import (
     ContinuousCardinalityConstraint,
+    ContinuousLinearConstraint,
+)
+from baybe.constraints.deprecation import (
     ContinuousLinearEqualityConstraint,
     ContinuousLinearInequalityConstraint,
 )
@@ -25,6 +28,7 @@ __all__ = [
     "SubSelectionCondition",
     "ThresholdCondition",
     # --- Continuous constraints ---#
+    "ContinuousLinearConstraint",
     "ContinuousCardinalityConstraint",
     "ContinuousLinearEqualityConstraint",
     "ContinuousLinearInequalityConstraint",

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -3,27 +3,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import numpy as np
 import pandas as pd
 from attr import define, field
 from attr.validators import ge, instance_of, min_len
 
-from baybe.parameters import NumericalContinuousParameter
+from baybe.constraints.deprecation import structure_constraints
 from baybe.serialization import (
     SerialMixin,
     converter,
-    get_base_structure_hook,
     unstructure_base,
 )
-from baybe.utils.numerical import DTypeFloatNumpy
-from baybe.utils.validation import finite_float
 
 if TYPE_CHECKING:
     import polars as pl
-    from torch import Tensor
 
 
 @define
@@ -197,105 +191,13 @@ class CardinalityConstraint(Constraint, ABC):
             )
 
 
-@define
-class ContinuousLinearConstraint(ContinuousConstraint, ABC):
-    """Abstract base class for continuous linear constraints.
-
-    Continuous linear constraints use parameter lists and coefficients to define
-    in-/equality constraints over a continuous parameter space.
-    """
-
-    # object variables
-    coefficients: list[float] = field()
-    """In-/equality coefficient for each entry in ``parameters``."""
-
-    rhs: float = field(default=0.0, converter=float, validator=finite_float)
-    """Right-hand side value of the in-/equality."""
-
-    @coefficients.validator
-    def _validate_coefficients(  # noqa: DOC101, DOC103
-        self, _: Any, coefficients: list[float]
-    ) -> None:
-        """Validate the coefficients.
-
-        Raises:
-            ValueError: If the number of coefficients does not match the number of
-                parameters.
-        """
-        if len(self.parameters) != len(coefficients):
-            raise ValueError(
-                "The given 'coefficients' list must have one floating point entry for "
-                "each entry in 'parameters'."
-            )
-
-    @coefficients.default
-    def _default_coefficients(self):
-        """Return equal weight coefficients as default."""
-        return [1.0] * len(self.parameters)
-
-    def _drop_parameters(
-        self, parameter_names: Collection[str]
-    ) -> ContinuousLinearConstraint:
-        """Create a copy of the constraint with certain parameters removed.
-
-        Args:
-            parameter_names: The names of the parameter to be removed.
-
-        Returns:
-            The reduced constraint.
-        """
-        parameters = [p for p in self.parameters if p not in parameter_names]
-        coefficients = [
-            c
-            for p, c in zip(self.parameters, self.coefficients)
-            if p not in parameter_names
-        ]
-        return ContinuousLinearConstraint(parameters, coefficients, self.rhs)
-
-    def to_botorch(
-        self, parameters: Sequence[NumericalContinuousParameter], idx_offset: int = 0
-    ) -> tuple[Tensor, Tensor, float]:
-        """Cast the constraint in a format required by botorch.
-
-        Used in calling ``optimize_acqf_*`` functions, for details see
-        https://botorch.org/api/optim.html#botorch.optim.optimize.optimize_acqf
-
-        Args:
-            parameters: The parameter objects of the continuous space.
-            idx_offset: Offset to the provided parameter indices.
-
-        Returns:
-            The tuple required by botorch.
-        """
-        import torch
-
-        from baybe.utils.torch import DTypeFloatTorch
-
-        param_names = [p.name for p in parameters]
-        param_indices = [
-            param_names.index(p) + idx_offset
-            for p in self.parameters
-            if p in param_names
-        ]
-
-        return (
-            torch.tensor(param_indices),
-            torch.tensor(
-                [self._multiplier * c for c in self.coefficients], dtype=DTypeFloatTorch
-            ),
-            np.asarray(self._multiplier * self.rhs, dtype=DTypeFloatNumpy).item(),
-        )
-
-    @property
-    def _multiplier(self) -> float:
-        """The internal multiplier for rhs and coefficients."""
-        return 1.0
-
-
 class ContinuousNonlinearConstraint(ContinuousConstraint, ABC):
     """Abstract base class for continuous nonlinear constraints."""
 
 
 # Register (un-)structure hooks
 converter.register_unstructure_hook(Constraint, unstructure_base)
-converter.register_structure_hook(Constraint, get_base_structure_hook(Constraint))
+
+# Currently affected by a deprecation
+# converter.register_structure_hook(Constraint, get_base_structure_hook(Constraint))
+converter.register_structure_hook(Constraint, structure_constraints)

--- a/baybe/constraints/continuous.py
+++ b/baybe/constraints/continuous.py
@@ -1,9 +1,11 @@
 """Continuous constraints."""
 
 import math
+from typing import Literal
 
 import numpy as np
-from attrs import define
+from attr.validators import in_
+from attrs import define, field
 
 from baybe.constraints.base import (
     CardinalityConstraint,
@@ -31,13 +33,19 @@ class ContinuousLinearInequalityConstraint(ContinuousLinearConstraint):
 
     The constraint is defined as ``sum_i[ x_i * c_i ] >= rhs``, where x_i are the
     parameter names from ``parameters`` and c_i are the entries of ``coefficients``.
-    If you want to implement a constraint of the form `<=`, multiply ``rhs`` and
-    ``coefficients`` by -1. The constraint is typically fulfilled up to a small
-    numerical tolerance.
-
-    The class has no real content as it only serves the purpose of
-    distinguishing the constraints.
+    A constraint of the form `<=` can be achieved by changing the ``operator`` or
+    multiplying ``rhs`` and ``coefficients`` by -1. The constraint is typically
+    fulfilled up to a small numerical tolerance.
     """
+
+    operator: Literal[">=", "<="] = field(default=">=", validator=in_((">=", "<=")))
+    """Defines the inequality operator used in the equation. Internally this will
+    negate rhs and coefficients for `<=`."""
+
+    @property
+    def _multiplier(self) -> float:
+        """The internal multiplier for rhs and coefficients."""
+        return 1.0 if self.operator == ">=" else -1.0
 
 
 @define

--- a/baybe/constraints/deprecation.py
+++ b/baybe/constraints/deprecation.py
@@ -1,0 +1,97 @@
+"""Deprecation for constraints."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from cattrs.gen import make_dict_structure_fn
+
+from baybe.serialization import converter
+from baybe.utils.basic import find_subclass, refers_to
+from baybe.utils.boolean import is_abstract
+
+if TYPE_CHECKING:
+    from baybe.constraints.base import Constraint
+
+
+def ContinuousLinearEqualityConstraint(
+    parameters: list[str],
+    coefficients: list[float] | None = None,
+    rhs: float | None = None,
+):
+    """Return the appropriate new constraint class."""
+    warnings.warn(
+        "The use of `ContinuousLinearEqualityConstraint` is deprecated and will be"
+        "disabled in a future version. Use `ContinuousLinearConstraint` with operator"
+        "'=' instead.",
+        DeprecationWarning,
+    )
+
+    from baybe.constraints.continuous import ContinuousLinearConstraint
+
+    kwargs: dict[Any, Any] = {"parameters": parameters, "operator": "="}
+    if coefficients is not None:
+        kwargs["coefficients"] = coefficients
+    if rhs is not None:
+        kwargs["rhs"] = rhs
+
+    return ContinuousLinearConstraint(**kwargs)
+
+
+def ContinuousLinearInequalityConstraint(
+    parameters: list[str],
+    coefficients: list[float] | None = None,
+    rhs: float | None = None,
+):
+    """Return the appropriate new constraint class."""
+    warnings.warn(
+        "The use of `ContinuousLinearInequalityConstraint` is deprecated and will be"
+        "disabled in a future version. Use `ContinuousLinearConstraint` with operator"
+        "'>=' or '<=' instead.",
+        DeprecationWarning,
+    )
+
+    from baybe.constraints.continuous import ContinuousLinearConstraint
+
+    kwargs: dict[Any, Any] = {"parameters": parameters, "operator": ">="}
+    if coefficients is not None:
+        kwargs["coefficients"] = coefficients
+    if rhs is not None:
+        kwargs["rhs"] = rhs
+
+    return ContinuousLinearConstraint(**kwargs)
+
+
+def structure_constraints(val: dict, cls: type) -> Constraint:
+    """A structure hook taking care of deprecations."""  # noqa: D401 (imperative mood)
+    from baybe.constraints.base import Constraint
+
+    # If the given class can be instantiated, only ensure there is no conflict with
+    # a potentially specified type field
+    if not is_abstract(cls):
+        if (type_ := val.pop("type", None)) and not refers_to(cls, type_):
+            raise ValueError(
+                f"The class '{cls.__name__}' specified for deserialization "
+                f"does not match with the given type information '{type_}'."
+            )
+        concrete_cls = cls
+
+    # Otherwise, extract the type information from the given input and find
+    # the corresponding class in the hierarchy
+    else:
+        type_ = val if isinstance(val, str) else val.pop("type")
+
+        if type_ == "ContinuousLinearEqualityConstraint":
+            return ContinuousLinearEqualityConstraint(**val)
+        elif type_ == "ContinuousLinearInequalityConstraint":
+            return ContinuousLinearInequalityConstraint(**val)
+
+        concrete_cls = find_subclass(Constraint, type_)
+
+    # Create the structuring function for the class and call it
+    fn: Callable = make_dict_structure_fn(
+        concrete_cls, converter, _cattrs_forbid_extra_keys=True
+    )
+    return fn({} if isinstance(val, str) else val, concrete_cls)

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
-from attr import define, field
+from attrs import define, field, fields
 
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
@@ -102,6 +102,32 @@ class SubspaceContinuous(SerialMixin):
             for c in self.constraints_nonlin
             if isinstance(c, ContinuousCardinalityConstraint)
         )
+
+    @constraints_lin_eq.validator
+    def _validate_constraints_lin_eq(
+        self, _, lst: list[ContinuousLinearConstraint]
+    ) -> None:
+        """Validate linear equality constraints."""
+        # TODO Remove once eq and ineq constraints are consolidated into one list
+        if not all(c.is_eq for c in lst):
+            raise ValueError(
+                f"The list '{fields(self.__class__).constraints_lin_eq.name}' of "
+                f"{self.__class__.__name__} only accepts equality constraints, i.e. "
+                f"the 'operator' for all list items should be '='."
+            )
+
+    @constraints_lin_ineq.validator
+    def _validate_constraints_lin_ineq(
+        self, _, lst: list[ContinuousLinearConstraint]
+    ) -> None:
+        """Validate linear inequality constraints."""
+        # TODO Remove once eq and ineq constraints are consolidated into one list
+        if any(c.is_eq for c in lst):
+            raise ValueError(
+                f"The list '{fields(self.__class__).constraints_lin_ineq.name}' of "
+                f"{self.__class__.__name__} only accepts inequality constraints, i.e. "
+                f"the 'operator' for all list items should be '>=' or '<='."
+            )
 
     @constraints_nonlin.validator
     def _validate_constraints_nonlin(self, _, __) -> None:

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -13,8 +13,7 @@ from attr import define, field
 
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
+    ContinuousLinearConstraint,
 )
 from baybe.constraints.base import ContinuousConstraint, ContinuousNonlinearConstraint
 from baybe.constraints.validation import (
@@ -53,12 +52,12 @@ class SubspaceContinuous(SerialMixin):
     )
     """The parameters of the subspace."""
 
-    constraints_lin_eq: tuple[ContinuousLinearEqualityConstraint, ...] = field(
+    constraints_lin_eq: tuple[ContinuousLinearConstraint, ...] = field(
         converter=to_tuple, factory=tuple
     )
     """Linear equality constraints."""
 
-    constraints_lin_ineq: tuple[ContinuousLinearInequalityConstraint, ...] = field(
+    constraints_lin_ineq: tuple[ContinuousLinearConstraint, ...] = field(
         converter=to_tuple, factory=tuple
     )
     """Linear inequality constraints."""
@@ -121,7 +120,7 @@ class SubspaceContinuous(SerialMixin):
     @classmethod
     def empty(cls) -> SubspaceContinuous:
         """Create an empty continuous subspace."""
-        return SubspaceContinuous([])
+        return SubspaceContinuous(())
 
     @classmethod
     def from_parameter(cls, parameter: ContinuousParameter) -> SubspaceContinuous:
@@ -145,17 +144,17 @@ class SubspaceContinuous(SerialMixin):
         constraints = constraints or []
         return SubspaceContinuous(
             parameters=[p for p in parameters if p.is_continuous],  # type:ignore[misc]
-            constraints_lin_eq=[  # type:ignore[misc]
+            constraints_lin_eq=[  # type:ignore[attr-misc]
                 c
                 for c in constraints
-                if isinstance(c, ContinuousLinearEqualityConstraint)
+                if (isinstance(c, ContinuousLinearConstraint) and c.is_eq)
             ],
-            constraints_lin_ineq=[  # type:ignore[misc]
+            constraints_lin_ineq=[  # type:ignore[attr-misc]
                 c
                 for c in constraints
-                if isinstance(c, ContinuousLinearInequalityConstraint)
+                if (isinstance(c, ContinuousLinearConstraint) and not c.is_eq)
             ],
-            constraints_nonlin=[
+            constraints_nonlin=[  # type:ignore[attr-misc]
                 c for c in constraints if isinstance(c, ContinuousNonlinearConstraint)
             ],
         )

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -69,11 +69,14 @@ $$
 where $x_i$ is the value of the $i$'th parameter affected by the constraint,
 $c_i$ is the coefficient for that parameter, and $\text{rhs}$ is a user-chosen number.
 
-```{admonition} Reversing the inequality
-:class: note
-You can specify a constraint involving `<=` instead of `>=` by multiplying
-both sides, i.e. the coefficients and rhs, by -1.
-```
+A constraint of the form
+
+$$
+\sum_{i} x_i \cdot c_i <= \text{rhs}
+$$
+
+can be achieved by multiplying both sides, i.e. the coefficients and rhs, by -1 or
+by using the convenience keyword `operator`.
 
 Let us amend [the example from `ContinuousLinearEqualityConstraint`](#CLEQ) and assume
 that there is always a fourth component to the mixture that serves as a "filler".
@@ -84,9 +87,10 @@ The following constraint would achieve this:
 from baybe.constraints import ContinuousLinearInequalityConstraint
 
 ContinuousLinearInequalityConstraint(
-    parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
-    coefficients=[-1.0, -1.0, -1.0],
-    rhs=-0.8,  # coefficients and rhs are negated because we model a `<=` constraint
+    parameters=["x_1", "x_2", "x_3"],
+    coefficients=[1.0, 1.0, 1.0],
+    rhs=0.8,
+    operator="<=",
 )
 ```
 

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -54,9 +54,9 @@ from baybe.constraints import ContinuousLinearConstraint
 
 ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
+    operator="=",
     coefficients=[1.0, 1.0, 1.0],
     rhs=1.0,
-    operator="=",
 )
 ```
 
@@ -70,9 +70,9 @@ from baybe.constraints import ContinuousLinearConstraint
 
 ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],
+    operator="<=",
     coefficients=[1.0, 1.0, 1.0],
     rhs=0.8,
-    operator="<=",
 )
 ```
 

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -30,63 +30,45 @@ Not all surrogate models are able to treat continuous constraints. In such situa
 the constraints are currently silently ignored.
 ```   
 
-(CLEQ)=
-### ContinuousLinearEqualityConstraint
-The [`ContinuousLinearEqualityConstraint`](baybe.constraints.continuous.ContinuousLinearEqualityConstraint)
-asserts that the following equation is true (up to numerical rounding errors):
+(CLC)=
+### ContinuousLinearConstraint
+The [`ContinuousLinearConstraint`](baybe.constraints.continuous.ContinuousLinearConstraint)
+asserts that the following kind of equations are true (up to numerical rounding errors):
 
 $$
-\sum_{i} x_i \cdot c_i = \text{rhs}
+\sum_{i} x_i \cdot c_i = \text{rhs} \\
+\sum_{i} x_i \cdot c_i >= \text{rhs} \\
+\sum_{i} x_i \cdot c_i <= \text{rhs}
 $$
 
 where $x_i$ is the value of the $i$'th parameter affected by the constraint,
 $c_i$ is the coefficient for that parameter, and $\text{rhs}$ is a user-chosen number.
+The (in)equality type is defined by the `operator` keyword.
 
 As an example, let's assume we have three parameters named `x_1`, `x_2` and
 `x_3`, which describe the relative concentrations in a mixture campaign.
 The constraint assuring that they always sum up to 1.0 would look like this:
-```python
-from baybe.constraints import ContinuousLinearEqualityConstraint
 
-ContinuousLinearEqualityConstraint(
+```python
+from baybe.constraints import ContinuousLinearConstraint
+
+ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
     coefficients=[1.0, 1.0, 1.0],
     rhs=1.0,
+    operator="=",
 )
 ```
 
-A more detailed example can be found
-[here](../../examples/Constraints_Continuous/linear_constraints).
-
-### ContinuousLinearInequalityConstraint
-The [`ContinuousLinearInequalityConstraint`](baybe.constraints.continuous.ContinuousLinearInequalityConstraint)
-asserts that the following equation is true (up to numerical rounding errors):
-
-$$
-\sum_{i} x_i \cdot c_i >= \text{rhs}
-$$
-
-where $x_i$ is the value of the $i$'th parameter affected by the constraint,
-$c_i$ is the coefficient for that parameter, and $\text{rhs}$ is a user-chosen number.
-
-A constraint of the form
-
-$$
-\sum_{i} x_i \cdot c_i <= \text{rhs}
-$$
-
-can be achieved by multiplying both sides, i.e. the coefficients and rhs, by -1 or
-by using the convenience keyword `operator`.
-
-Let us amend [the example from `ContinuousLinearEqualityConstraint`](#CLEQ) and assume
-that there is always a fourth component to the mixture that serves as a "filler".
-In such a case, we might want to ensure that the first three components only make up to
-80% of the mixture.
+Let us amend the example from above and assume that there is always a fourth component
+to the mixture that serves as a "filler". In such a case, we might want to ensure that
+the first three components only make up to 80% of the mixture.
 The following constraint would achieve this:
-```python
-from baybe.constraints import ContinuousLinearInequalityConstraint
 
-ContinuousLinearInequalityConstraint(
+```python
+from baybe.constraints import ContinuousLinearConstraint
+
+ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],
     coefficients=[1.0, 1.0, 1.0],
     rhs=0.8,
@@ -170,7 +152,7 @@ A more detailed example can be found
 [`DiscreteSumConstraint`](baybe.constraints.discrete.DiscreteSumConstraint)
 and [`DiscreteProductConstraint`](baybe.constraints.discrete.DiscreteProductConstraint)
 impose conditions on sums or products of numerical parameters.
-[In the example from `ContinuousLinearEqualityConstraint`](#CLEQ), we
+[In the first example from `ContinuousLinearConstraint`](#CLC), we
 had three continuous parameters `x_1`, `x_2` and `x_3`, which needed to sum
 up to 1.0.
 If these parameters were instead discrete, the corresponding constraint would look like:

--- a/examples/Backtesting/multi_target.py
+++ b/examples/Backtesting/multi_target.py
@@ -69,7 +69,7 @@ searchspace = SearchSpace.from_product(parameters=parameters)
 ### Creating multiple target object
 
 # The multi target mode is handled when creating the objective object.
-# Thus we first need to define the different targets.
+# Thus, we first need to define the different targets.
 # We use two targets here.
 # The first target is maximized and the second target is minimized during the optimization process.
 

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -18,7 +18,7 @@ from botorch.test_functions import Rastrigin
 
 from baybe import Campaign
 from baybe.constraints import (
-    ContinuousLinearEqualityConstraint,
+    ContinuousLinearConstraint,
     DiscreteSumConstraint,
     ThresholdCondition,
 )
@@ -84,8 +84,8 @@ constraints = [
             threshold=1.0, operator="==", tolerance=STRIDE / 2.0
         ),
     ),
-    ContinuousLinearEqualityConstraint(
-        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0
+    ContinuousLinearConstraint(
+        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0, operator="="
     ),
 ]
 

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -85,7 +85,7 @@ constraints = [
         ),
     ),
     ContinuousLinearConstraint(
-        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0, operator="="
+        parameters=["x_3", "x_4"], operator="=", coefficients=[1.0, -1.0], rhs=2.0
     ),
 ]
 

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -18,10 +18,7 @@ import numpy as np
 from botorch.test_functions import Rastrigin
 
 from baybe import Campaign
-from baybe.constraints import (
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
-)
+from baybe.constraints import ContinuousLinearConstraint
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalContinuousParameter
 from baybe.searchspace import SearchSpace
@@ -64,16 +61,16 @@ parameters = [
 # - $2.0*x_2 + 3.0*x_4 <= 1.0$ which is equivalent to $-2.0*x_2 - 3.0*x_4 >= -1.0$
 
 constraints = [
-    ContinuousLinearEqualityConstraint(
-        parameters=["x_1", "x_2"], coefficients=[1.0, 1.0], rhs=1.0
+    ContinuousLinearConstraint(
+        parameters=["x_1", "x_2"], coefficients=[1.0, 1.0], rhs=1.0, operator="="
     ),
-    ContinuousLinearEqualityConstraint(
-        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0
+    ContinuousLinearConstraint(
+        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0, operator="="
     ),
-    ContinuousLinearInequalityConstraint(
-        parameters=["x_1", "x_3"], coefficients=[1.0, 1.0], rhs=1.0
+    ContinuousLinearConstraint(
+        parameters=["x_1", "x_3"], coefficients=[1.0, 1.0], rhs=1.0, operator=">="
     ),
-    ContinuousLinearInequalityConstraint(
+    ContinuousLinearConstraint(
         parameters=["x_2", "x_4"], coefficients=[2.0, 3.0], rhs=-1.0, operator="<="
     ),
 ]

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -74,7 +74,7 @@ constraints = [
         parameters=["x_1", "x_3"], coefficients=[1.0, 1.0], rhs=1.0
     ),
     ContinuousLinearInequalityConstraint(
-        parameters=["x_2", "x_4"], coefficients=[-2.0, -3.0], rhs=-1.0
+        parameters=["x_2", "x_4"], coefficients=[2.0, 3.0], rhs=-1.0, operator="<="
     ),
 ]
 

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -62,16 +62,16 @@ parameters = [
 
 constraints = [
     ContinuousLinearConstraint(
-        parameters=["x_1", "x_2"], coefficients=[1.0, 1.0], rhs=1.0, operator="="
+        parameters=["x_1", "x_2"], operator="=", coefficients=[1.0, 1.0], rhs=1.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_3", "x_4"], coefficients=[1.0, -1.0], rhs=2.0, operator="="
+        parameters=["x_3", "x_4"], operator="=", coefficients=[1.0, -1.0], rhs=2.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_1", "x_3"], coefficients=[1.0, 1.0], rhs=1.0, operator=">="
+        parameters=["x_1", "x_3"], operator=">=", coefficients=[1.0, 1.0], rhs=1.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_2", "x_4"], coefficients=[2.0, 3.0], rhs=-1.0, operator="<="
+        parameters=["x_2", "x_4"], operator="<=", coefficients=[2.0, 3.0], rhs=-1.0
     ),
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -544,6 +544,12 @@ def fixture_constraints(constraint_names: list[str], mock_substances, n_grid_poi
             min_cardinality=1,
             max_cardinality=2,
         ),
+        "ContiConstraint_6": ContinuousLinearInequalityConstraint(
+            parameters=["Conti_finite1", "Conti_finite2"],
+            coefficients=[1.0, 3.0],
+            rhs=0.3,
+            operator="<=",
+        ),
     }
     return [
         c_item

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -520,27 +520,27 @@ def fixture_constraints(constraint_names: list[str], mock_substances, n_grid_poi
         ),
         "ContiConstraint_1": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
+            operator="=",
             coefficients=[1.0, 1.0],
             rhs=0.3,
-            operator="=",
         ),
         "ContiConstraint_2": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
+            operator="=",
             coefficients=[1.0, 3.0],
             rhs=0.3,
-            operator="=",
         ),
         "ContiConstraint_3": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
+            operator=">=",
             coefficients=[1.0, 1.0],
             rhs=0.3,
-            operator=">=",
         ),
         "ContiConstraint_4": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
+            operator=">=",
             coefficients=[1.0, 3.0],
             rhs=0.3,
-            operator=">=",
         ),
         "ContiConstraint_5": ContinuousCardinalityConstraint(
             parameters=["Conti_finite1", "Conti_finite2", "Conti_finite3"],
@@ -549,9 +549,9 @@ def fixture_constraints(constraint_names: list[str], mock_substances, n_grid_poi
         ),
         "ContiConstraint_6": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
+            operator="<=",
             coefficients=[1.0, 3.0],
             rhs=0.3,
-            operator="<=",
         ),
     }
     return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,7 @@ from baybe.acquisition import qExpectedImprovement
 from baybe.campaign import Campaign
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
+    ContinuousLinearConstraint,
     DiscreteCardinalityConstraint,
     DiscreteCustomConstraint,
     DiscreteDependenciesConstraint,
@@ -519,32 +518,36 @@ def fixture_constraints(constraint_names: list[str], mock_substances, n_grid_poi
         "Constraint_15": DiscreteLinkedParametersConstraint(
             parameters=["Solvent_1", "Solvent_2", "Solvent_3"],
         ),
-        "ContiConstraint_1": ContinuousLinearEqualityConstraint(
+        "ContiConstraint_1": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
             coefficients=[1.0, 1.0],
             rhs=0.3,
+            operator="=",
         ),
-        "ContiConstraint_2": ContinuousLinearEqualityConstraint(
+        "ContiConstraint_2": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
             coefficients=[1.0, 3.0],
             rhs=0.3,
+            operator="=",
         ),
-        "ContiConstraint_3": ContinuousLinearInequalityConstraint(
+        "ContiConstraint_3": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
             coefficients=[1.0, 1.0],
             rhs=0.3,
+            operator=">=",
         ),
-        "ContiConstraint_4": ContinuousLinearInequalityConstraint(
+        "ContiConstraint_4": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
             coefficients=[1.0, 3.0],
             rhs=0.3,
+            operator=">=",
         ),
         "ContiConstraint_5": ContinuousCardinalityConstraint(
             parameters=["Conti_finite1", "Conti_finite2", "Conti_finite3"],
             min_cardinality=1,
             max_cardinality=2,
         ),
-        "ContiConstraint_6": ContinuousLinearInequalityConstraint(
+        "ContiConstraint_6": ContinuousLinearConstraint(
             parameters=["Conti_finite1", "Conti_finite2"],
             coefficients=[1.0, 3.0],
             rhs=0.3,

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -8,8 +8,7 @@ import pytest
 
 from baybe.constraints.continuous import (
     ContinuousCardinalityConstraint,
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
+    ContinuousLinearConstraint,
 )
 from baybe.parameters import NumericalContinuousParameter
 from baybe.recommenders.pure.nonpredictive.sampling import RandomRecommender
@@ -102,13 +101,17 @@ def test_polytope_sampling_with_cardinality_constraint():
     rhs_inequality = 1.3
     params_cardinality = ["x_1", "x_2", "x_3", "x_5"]
     constraints = [
-        ContinuousLinearEqualityConstraint(
-            parameters=params_equality, coefficients=coeffs_equality, rhs=rhs_equality
+        ContinuousLinearConstraint(
+            parameters=params_equality,
+            coefficients=coeffs_equality,
+            rhs=rhs_equality,
+            operator="=",
         ),
-        ContinuousLinearInequalityConstraint(
+        ContinuousLinearConstraint(
             parameters=params_inequality,
             coefficients=coeffs_inequality,
             rhs=rhs_equality,
+            operator=">=",
         ),
         ContinuousCardinalityConstraint(
             parameters=params_cardinality,

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -103,15 +103,15 @@ def test_polytope_sampling_with_cardinality_constraint():
     constraints = [
         ContinuousLinearConstraint(
             parameters=params_equality,
+            operator="=",
             coefficients=coeffs_equality,
             rhs=rhs_equality,
-            operator="=",
         ),
         ContinuousLinearConstraint(
             parameters=params_inequality,
+            operator=">=",
             coefficients=coeffs_inequality,
             rhs=rhs_equality,
-            operator=">=",
         ),
         ContinuousCardinalityConstraint(
             parameters=params_cardinality,

--- a/tests/constraints/test_constraints_continuous.py
+++ b/tests/constraints/test_constraints_continuous.py
@@ -4,10 +4,7 @@ import numpy as np
 import pytest
 from pytest import param
 
-from baybe.constraints import (
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
-)
+from baybe.constraints import ContinuousLinearConstraint
 from tests.conftest import run_iterations
 
 
@@ -106,75 +103,21 @@ def test_hybridspace_ineq(campaign, n_iterations, batch_size):
 
 
 @pytest.mark.parametrize(
-    ("cl", "parameters", "coefficients", "rhs", "kws"),
+    ("parameters", "coefficients", "rhs", "operator"),
     [
-        param(
-            ContinuousLinearEqualityConstraint,
-            ["A", "B"],
-            [1.0],
-            0.0,
-            {},
-            id="eq_too_few_coeffs",
-        ),
-        param(
-            ContinuousLinearEqualityConstraint,
-            ["A", "B"],
-            [1.0, 2.0, 3.0],
-            0.0,
-            {},
-            id="eq_too_many_coeffs",
-        ),
-        param(
-            ContinuousLinearEqualityConstraint,
-            ["A", "B"],
-            [1.0, 2.0],
-            "bla",
-            {},
-            id="eq_invalid_rhs",
-        ),
-        param(
-            ContinuousLinearInequalityConstraint,
-            ["A", "B"],
-            [1.0],
-            0.0,
-            {},
-            id="ineq_too_few_coeffs",
-        ),
-        param(
-            ContinuousLinearInequalityConstraint,
-            ["A", "B"],
-            [1.0, 2.0, 3.0],
-            0.0,
-            {},
-            id="ineq_too_many_coeffs",
-        ),
-        param(
-            ContinuousLinearInequalityConstraint,
-            ["A", "B"],
-            [1.0, 2.0],
-            "bla",
-            {},
-            id="ineq_invalid_rhs",
-        ),
-        param(
-            ContinuousLinearInequalityConstraint,
-            ["A", "B"],
-            [1.0, 2.0],
-            0.0,
-            {"operator": "=="},
-            id="ineq_invalid_operator1",
-        ),
-        param(
-            ContinuousLinearInequalityConstraint,
-            ["A", "B"],
-            [1.0, 2.0],
-            0.0,
-            {"operator": 2.0},
-            id="ineq_invalid_operator1",
-        ),
+        param(["A", "B"], [1.0], 0.0, "=", id="eq_too_few_coeffs"),
+        param(["A", "B"], [1.0, 2.0, 3.0], 0.0, "=", id="eq_too_many_coeffs"),
+        param(["A", "B"], [1.0, 2.0], "bla", "=", id="eq_invalid_rhs"),
+        param(["A", "B"], [1.0], 0.0, ">=", id="ineq_too_few_coeffs"),
+        param(["A", "B"], [1.0, 2.0, 3.0], 0.0, ">=", id="ineq_too_many_coeffs"),
+        param(["A", "B"], [1.0, 2.0], "bla", ">=", id="ineq_invalid_rhs"),
+        param(["A", "B"], [1.0, 2.0], 0.0, "invalid", id="ineq_invalid_operator1"),
+        param(["A", "B"], [1.0, 2.0], 0.0, 2.0, id="ineq_invalid_operator1"),
     ],
 )
-def test_invalid_constraints(cl, parameters, coefficients, rhs, kws):
+def test_invalid_constraints(parameters, coefficients, rhs, operator):
     """Test invalid continuous constraint creations."""
     with pytest.raises(ValueError):
-        cl(parameters=parameters, coefficients=coefficients, rhs=rhs, **kws)
+        ContinuousLinearConstraint(
+            parameters=parameters, coefficients=coefficients, rhs=rhs, operator=operator
+        )

--- a/tests/constraints/test_constraints_continuous.py
+++ b/tests/constraints/test_constraints_continuous.py
@@ -103,7 +103,7 @@ def test_hybridspace_ineq(campaign, n_iterations, batch_size):
 
 
 @pytest.mark.parametrize(
-    ("parameters", "coefficients", "rhs", "operator"),
+    ("parameters", "coefficients", "rhs", "op"),
     [
         param(["A", "B"], [1.0], 0.0, "=", id="eq_too_few_coeffs"),
         param(["A", "B"], [1.0, 2.0, 3.0], 0.0, "=", id="eq_too_many_coeffs"),
@@ -115,9 +115,9 @@ def test_hybridspace_ineq(campaign, n_iterations, batch_size):
         param(["A", "B"], [1.0, 2.0], 0.0, 2.0, id="ineq_invalid_operator1"),
     ],
 )
-def test_invalid_constraints(parameters, coefficients, rhs, operator):
+def test_invalid_constraints(parameters, coefficients, rhs, op):
     """Test invalid continuous constraint creations."""
     with pytest.raises(ValueError):
         ContinuousLinearConstraint(
-            parameters=parameters, coefficients=coefficients, rhs=rhs, operator=operator
+            parameters=parameters, operator=op, coefficients=coefficients, rhs=rhs
         )

--- a/tests/hypothesis_strategies/constraints.py
+++ b/tests/hypothesis_strategies/constraints.py
@@ -241,7 +241,7 @@ def continuous_linear_constraints(
     operators = operators or ["=", ">=", "<="]
     operator = draw(st.sampled_from(operators))
 
-    return ContinuousLinearConstraint(parameter_names, coefficients, rhs, operator)
+    return ContinuousLinearConstraint(parameter_names, operator, coefficients, rhs)
 
 
 continuous_linear_equality_constraints = partial(

--- a/tests/hypothesis_strategies/constraints.py
+++ b/tests/hypothesis_strategies/constraints.py
@@ -240,7 +240,13 @@ def _continuous_linear_constraints(
         )
     )
     rhs = draw(finite_floats())
-    return constraint_type(parameter_names, coefficients, rhs)
+
+    # Optionally add the operator
+    kwargs = {}
+    if constraint_type is ContinuousLinearInequalityConstraint:
+        kwargs["operator"] = draw(st.sampled_from([">=", "<="]))
+
+    return constraint_type(parameter_names, coefficients, rhs, **kwargs)
 
 
 continuous_linear_equality_constraints = partial(

--- a/tests/hypothesis_strategies/constraints.py
+++ b/tests/hypothesis_strategies/constraints.py
@@ -12,8 +12,7 @@ from baybe.constraints.conditions import (
     _valid_logic_combiners,
 )
 from baybe.constraints.continuous import (
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
+    ContinuousLinearConstraint,
 )
 from baybe.constraints.discrete import (
     DiscreteDependenciesConstraint,
@@ -217,12 +216,9 @@ discrete_linked_parameters_constraints = partial(
 
 
 @st.composite
-def _continuous_linear_constraints(
+def continuous_linear_constraints(
     draw: st.DrawFn,
-    constraint_type: (
-        type[ContinuousLinearEqualityConstraint]
-        | type[ContinuousLinearInequalityConstraint]
-    ),
+    operators: list[str] | None = None,
     parameter_names: list[str] | None = None,
 ):
     """Generate continuous linear constraints."""  # noqa:E501
@@ -242,19 +238,18 @@ def _continuous_linear_constraints(
     rhs = draw(finite_floats())
 
     # Optionally add the operator
-    kwargs = {}
-    if constraint_type is ContinuousLinearInequalityConstraint:
-        kwargs["operator"] = draw(st.sampled_from([">=", "<="]))
+    operators = operators or ["=", ">=", "<="]
+    operator = draw(st.sampled_from(operators))
 
-    return constraint_type(parameter_names, coefficients, rhs, **kwargs)
+    return ContinuousLinearConstraint(parameter_names, coefficients, rhs, operator)
 
 
 continuous_linear_equality_constraints = partial(
-    _continuous_linear_constraints, ContinuousLinearEqualityConstraint
+    continuous_linear_constraints, operators=["="]
 )
-"""Generate :class:`baybe.constraints.continuous.ContinuousLinearEqualityConstraint`."""
+"""Generate linear equality constraints."""
 
 continuous_linear_inequality_constraints = partial(
-    _continuous_linear_constraints, ContinuousLinearInequalityConstraint
+    continuous_linear_constraints, operators=[">=", "<="]
 )
-"""Generate :class:`baybe.constraints.continuous.ContinuousLinearInequalityConstraint`."""  # noqa:E501
+"""Generate linear inequality constraints."""

--- a/tests/serialization/test_constraint_serialization.py
+++ b/tests/serialization/test_constraint_serialization.py
@@ -8,8 +8,7 @@ from pytest import param
 from baybe.constraints.base import Constraint
 
 from ..hypothesis_strategies.constraints import (
-    continuous_linear_equality_constraints,
-    continuous_linear_inequality_constraints,
+    continuous_linear_constraints,
     discrete_dependencies_constraints,
     discrete_excludes_constraints,
     discrete_linked_parameters_constraints,
@@ -40,12 +39,8 @@ from ..hypothesis_strategies.constraints import (
             id="DiscreteLinkedParametersConstraint",
         ),
         param(
-            continuous_linear_equality_constraints(),
-            id="ContinuousLinearEqualityConstraint",
-        ),
-        param(
-            continuous_linear_inequality_constraints(),
-            id="ContinuousLinearInequalityConstraint",
+            continuous_linear_constraints(),
+            id="ContinuousLinearonstraint",
         ),
     ],
 )

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -170,9 +170,9 @@ def test_constraint_config_deserialization(type_, op):
 
     expected = ContinuousLinearConstraint(
         parameters=["p1", "p2", "p3"],
+        operator=op,
         coefficients=[1.0, 2.0, 3.0],
         rhs=2.0,
-        operator=op,
     )
 
     with warnings.catch_warnings():

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -6,8 +6,7 @@ import pytest
 
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
-    ContinuousLinearEqualityConstraint,
-    ContinuousLinearInequalityConstraint,
+    ContinuousLinearConstraint,
     DiscreteSumConstraint,
     ThresholdCondition,
 )
@@ -154,7 +153,7 @@ def test_invalid_constraint_parameter_combos():
         SearchSpace.from_product(
             parameters=parameters,
             constraints=[
-                ContinuousLinearEqualityConstraint(
+                ContinuousLinearConstraint(
                     parameters=["c1", "c2", "d1"],
                 )
             ],
@@ -164,11 +163,7 @@ def test_invalid_constraint_parameter_combos():
     with pytest.raises(ValueError):
         SearchSpace.from_product(
             parameters=parameters,
-            constraints=[
-                ContinuousLinearInequalityConstraint(
-                    parameters=["c1", "c2", "d1"],
-                )
-            ],
+            constraints=[ContinuousLinearConstraint(parameters=["c1", "c2", "d1"])],
         )
 
     # Attempting discrete constraint over hybrid parameter set
@@ -199,11 +194,7 @@ def test_invalid_constraint_parameter_combos():
     with pytest.raises(ValueError):
         SearchSpace.from_product(
             parameters=parameters,
-            constraints=[
-                ContinuousLinearInequalityConstraint(
-                    parameters=["c1", "e7", "d1"],
-                )
-            ],
+            constraints=[ContinuousLinearConstraint(parameters=["c1", "e7", "d1"])],
         )
 
     # Attempting constraints over parameter sets containing non-numerical discrete

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -152,18 +152,14 @@ def test_invalid_constraint_parameter_combos():
     with pytest.raises(ValueError):
         SearchSpace.from_product(
             parameters=parameters,
-            constraints=[
-                ContinuousLinearConstraint(
-                    parameters=["c1", "c2", "d1"],
-                )
-            ],
+            constraints=[ContinuousLinearConstraint(["c1", "c2", "d1"], "=")],
         )
 
     # Attempting continuous constraint over hybrid parameter set
     with pytest.raises(ValueError):
         SearchSpace.from_product(
             parameters=parameters,
-            constraints=[ContinuousLinearConstraint(parameters=["c1", "c2", "d1"])],
+            constraints=[ContinuousLinearConstraint(["c1", "c2", "d1"], "=")],
         )
 
     # Attempting discrete constraint over hybrid parameter set
@@ -194,7 +190,7 @@ def test_invalid_constraint_parameter_combos():
     with pytest.raises(ValueError):
         SearchSpace.from_product(
             parameters=parameters,
-            constraints=[ContinuousLinearConstraint(parameters=["c1", "e7", "d1"])],
+            constraints=[ContinuousLinearConstraint(["c1", "e7", "d1"], "=")],
         )
 
     # Attempting constraints over parameter sets containing non-numerical discrete


### PR DESCRIPTION
This PR introduces unite the three previous linear continuous constraints in a new class called `ContinuousLinearConstraint`. The equation behavior (equality or one of the inequalities) is now ontrolled via the `operator` keyword


This is required for currently ongoing updates on BayChem, ideally we can publish this as part of a new version `0.11.1`