### PR TITLE
Fix rare degenerate `comp_df` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `allow_missing` and `allow_extra` keyword arguments to `Objective.transform`
 - Example for a traditional mixture
+- `df_add_noise_to_degenerate_rows` utility
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the
@@ -15,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example for slot-based mixtures has been revised and grouped together with the new 
   traditional mixture example
 - Memory caching is now non-verbose
+- `CustomDiscreteParameter` does not allow duplicated rows in `data` anymore
+
+### Fixed
+- Rare bug arising from degenerate `SubstanceParameter.comp_df` rows that caused
+  wrong number of recommendations being returned
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `allow_missing` and `allow_extra` keyword arguments to `Objective.transform`
 - Example for a traditional mixture
-- `df_add_noise_to_degenerate_rows` utility
+- `add_noise_to_perturb_degenerate_rows` utility
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -93,7 +93,7 @@ class CustomDiscreteParameter(DiscreteParameter):
         if value.duplicated().any():
             raise ValueError(
                 f"The custom dataframe for parameter {self.name} has duplicated rows."
-                f"This is not allowed because it creates problems with the "
+                f"This is not supported because it creates problems with the "
                 f"computational representation. Please ensure all labels have a unique "
                 f"numerical representation."
             )

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -58,6 +58,7 @@ class CustomDiscreteParameter(DiscreteParameter):
             ValueError: If the dataframe contains ``NaN``.
             ValueError: If the dataframe index contains duplicates.
             ValueError: If the dataframe contains columns with only one unique value.
+            ValueError: If the dataframe contains duplicated rows.
         """
         if value.select_dtypes("number").shape[1] != value.shape[1]:
             raise ValueError(
@@ -88,6 +89,13 @@ class CustomDiscreteParameter(DiscreteParameter):
             raise ValueError(
                 f"The custom dataframe for parameter {self.name} has columns "
                 "that contain only a single value and hence carry no information."
+            )
+        if value.duplicated().any():
+            raise ValueError(
+                f"The custom dataframe for parameter {self.name} has duplicated rows."
+                f"This is not allowed because it creates problems with the "
+                f"computational representation. Please ensure all labels have a unique "
+                f"numerical representation."
             )
 
     @override

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -92,10 +92,10 @@ class CustomDiscreteParameter(DiscreteParameter):
             )
         if value.duplicated().any():
             raise ValueError(
-                f"The custom dataframe for parameter {self.name} has duplicated rows."
-                f"This is not supported because it creates problems with the "
-                f"computational representation. Please ensure all labels have a unique "
-                f"numerical representation."
+                f"The custom dataframe for parameter {self.name} has duplicated rows. "
+                f"This is not supported because it can lead to ambiguous computational "
+                f"representations of candidate points. Please ensure all labels have a "
+                f"unique numerical representation."
             )
 
     @override

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -13,7 +13,11 @@ from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.validation import validate_decorrelation
 from baybe.utils.basic import group_duplicate_values
-from baybe.utils.dataframe import df_drop_single_value_columns, df_uncorrelated_features
+from baybe.utils.dataframe import (
+    df_add_noise_to_degenerate_rows,
+    df_drop_single_value_columns,
+    df_uncorrelated_features,
+)
 
 try:  # For python < 3.11, use the exceptiongroup backport
     ExceptionGroup
@@ -149,6 +153,10 @@ class SubstanceParameter(DiscreteParameter):
                 comp_df = df_uncorrelated_features(comp_df)
             else:
                 comp_df = df_uncorrelated_features(comp_df, threshold=self.decorrelate)
+
+        # Add noise to degenerate rows, if present
+        if comp_df.duplicated().any():
+            df_add_noise_to_degenerate_rows(comp_df)
 
         return comp_df
 

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -154,9 +154,8 @@ class SubstanceParameter(DiscreteParameter):
             else:
                 comp_df = df_uncorrelated_features(comp_df, threshold=self.decorrelate)
 
-        # Add noise to degenerate rows, if present
-        if comp_df.duplicated().any():
-            df_add_noise_to_degenerate_rows(comp_df)
+        # Add noise to degenerate rows if present
+        df_add_noise_to_degenerate_rows(comp_df)
 
         return comp_df
 

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -14,7 +14,7 @@ from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.validation import validate_decorrelation
 from baybe.utils.basic import group_duplicate_values
 from baybe.utils.dataframe import (
-    df_add_noise_to_degenerate_rows,
+    add_noise_to_perturb_degenerate_rows,
     df_drop_single_value_columns,
     df_uncorrelated_features,
 )
@@ -155,7 +155,7 @@ class SubstanceParameter(DiscreteParameter):
                 comp_df = df_uncorrelated_features(comp_df, threshold=self.decorrelate)
 
         # Add noise to degenerate rows if present
-        df_add_noise_to_degenerate_rows(comp_df)
+        add_noise_to_perturb_degenerate_rows(comp_df)
 
         return comp_df
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -365,6 +365,8 @@ def df_add_noise_to_degenerate_rows(
 ) -> pd.DataFrame:
     """Add noise to degenerate rows to being able to numerically distinguish them.
 
+    Note that the dataframe is changed in-place and also returned.
+
     Args:
         df: The dataframe to be modified.
         noise_level: The magnitude of noise relative to the min-max range of

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -361,7 +361,7 @@ def df_uncorrelated_features(
 
 
 def df_add_noise_to_degenerate_rows(
-    df: pd.DataFrame, noise_level: float = 0.001
+    df: pd.DataFrame, noise_ratio: float = 0.001
 ) -> pd.DataFrame:
     """Add noise to degenerate rows to make them numerically distinguishable.
 
@@ -370,8 +370,8 @@ def df_add_noise_to_degenerate_rows(
 
     Args:
         df: The dataframe to be modified.
-        noise_level: The magnitude of noise relative to the min-max range of
-            values for each column.
+        noise_ratio: The magnitude of generated uniform noise relative to the
+            min-max range of values for each column.
 
     Returns:
         The modified dataframe.
@@ -397,8 +397,8 @@ def df_add_noise_to_degenerate_rows(
     column_ranges = column_ranges.replace(0, 1)
 
     # Generate noise
-    noise = np.random.normal(
-        -noise_level, noise_level, size=(degen_rows.sum(), df.shape[1])
+    noise = np.random.uniform(
+        -noise_ratio, noise_ratio, size=(degen_rows.sum(), df.shape[1])
     )
     noise_df = pd.DataFrame(noise, columns=df.columns, index=df.index[degen_rows])
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -381,7 +381,7 @@ def df_add_noise_to_degenerate_rows(
     """
     # Find degenerate rows, exit if there are none
     degen_rows = df.duplicated(keep=False)
-    if degen_rows.sum() == 0:
+    if not degen_rows.any():
         return df
 
     # Assert that the input is purely numerical

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -360,7 +360,7 @@ def df_uncorrelated_features(
     return data
 
 
-def df_add_noise_to_degenerate_rows(
+def add_noise_to_perturb_degenerate_rows(
     df: pd.DataFrame, noise_ratio: float = 0.001
 ) -> pd.DataFrame:
     """Add noise to degenerate rows to make them numerically distinguishable.
@@ -387,7 +387,7 @@ def df_add_noise_to_degenerate_rows(
     # Assert that the input is purely numerical
     if any(df[col].dtype.kind not in "iufb" for col in df.columns):
         raise TypeError(
-            f"'{df_add_noise_to_degenerate_rows.__name__}' only supports purely "
+            f"'{add_noise_to_perturb_degenerate_rows.__name__}' only supports purely "
             f"numerical dataframes."
         )
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -365,7 +365,8 @@ def df_add_noise_to_degenerate_rows(
 ) -> pd.DataFrame:
     """Add noise to degenerate rows to make them numerically distinguishable.
 
-    Note that the dataframe is changed in-place and also returned.
+    Note that the dataframe is changed in-place and also returned. The dataframe is
+    left untouched if no rows are degenerate.
 
     Args:
         df: The dataframe to be modified.
@@ -378,6 +379,11 @@ def df_add_noise_to_degenerate_rows(
     Raises:
         TypeError: If the provided dataframe has non-numerical content.
     """
+    # Find degenerate rows, exit if there are none
+    degen_rows = df.duplicated(keep=False)
+    if degen_rows.sum() == 0:
+        return df
+
     # Assert that the input is purely numerical
     if any(df[col].dtype.kind not in "iufb" for col in df.columns):
         raise TypeError(
@@ -390,8 +396,7 @@ def df_add_noise_to_degenerate_rows(
     column_ranges = df.max() - df.min()
     column_ranges = column_ranges.replace(0, 1)
 
-    # Find degenerate rows and generate noise
-    degen_rows = df.duplicated(keep=False)
+    # Generate noise
     noise = np.random.normal(
         -noise_level, noise_level, size=(degen_rows.sum(), df.shape[1])
     )

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -363,7 +363,7 @@ def df_uncorrelated_features(
 def df_add_noise_to_degenerate_rows(
     df: pd.DataFrame, noise_level: float = 0.001
 ) -> pd.DataFrame:
-    """Add noise to degenerate rows to being able to numerically distinguish them.
+    """Add noise to degenerate rows to make them numerically distinguishable.
 
     Note that the dataframe is changed in-place and also returned.
 
@@ -381,7 +381,7 @@ def df_add_noise_to_degenerate_rows(
     # Assert that the input is purely numerical
     if any(df[col].dtype.kind not in "iufb" for col in df.columns):
         raise TypeError(
-            f"'{df_add_noise_to_degenerate_rows.__name__}' only supports purely"
+            f"'{df_add_noise_to_degenerate_rows.__name__}' only supports purely "
             f"numerical dataframes."
         )
 

--- a/tests/test_custom_parameter.py
+++ b/tests/test_custom_parameter.py
@@ -1,11 +1,6 @@
 """Tests for the custom parameter."""
 
-import numpy as np
-import pandas as pd
 import pytest
-from pytest import param
-
-from baybe.parameters import CustomDiscreteParameter
 
 from .conftest import run_iterations
 
@@ -14,54 +9,3 @@ from .conftest import run_iterations
 def test_run_iterations(campaign, n_iterations, batch_size):
     """Test if iterative loop runs with custom parameters."""
     run_iterations(campaign, n_iterations, batch_size)
-
-
-@pytest.mark.parametrize(
-    "data, msg",
-    [
-        param(
-            pd.DataFrame([[1, 2], [3, "A"]], index=["a", "b"]),
-            "contains non-numeric values",
-            id="non_numeric_values",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, 4]], index=["a", 1]),
-            "contains non-string index values",
-            id="non_string_index",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, 4]], index=["a", ""]),
-            "contains empty string index values",
-            id="empty_string_index",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, np.inf]], index=["a", "b"]),
-            "contains nan/infinity entries",
-            id="contains_inf",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, np.nan]], index=["a", "b"]),
-            "contains nan/infinity entries",
-            id="contains_nan",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, 4]], index=["a", "a"]),
-            "contains duplicated indices",
-            id="duplicate_indices",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [3, 2]], index=["a", "b"]),
-            "columns that contain only a single value",
-            id="constant_column",
-        ),
-        param(
-            pd.DataFrame([[1, 2], [1, 2], [3, 4]], index=["a", "b", "c"]),
-            "ensure all labels have a unique numerical representation",
-            id="duplicate_rows",
-        ),
-    ],
-)
-def test_invalid_input(data, msg):
-    """Test if invalid duplicated rows are detected."""
-    with pytest.raises(ValueError, match=msg):
-        CustomDiscreteParameter(name="p", data=data)

--- a/tests/test_custom_parameter.py
+++ b/tests/test_custom_parameter.py
@@ -1,11 +1,11 @@
-"""Test for initial simple input, recommendation and adding fake results.
+"""Tests for the custom parameter."""
 
-Fake target measurements are simulated for each round. Noise is added every second
-round. From the three recommendations only one is actually added to test the matching
-and metadata. Target objective is minimize to test computational transformation.
-"""
-
+import numpy as np
+import pandas as pd
 import pytest
+from pytest import param
+
+from baybe.parameters import CustomDiscreteParameter
 
 from .conftest import run_iterations
 
@@ -14,3 +14,54 @@ from .conftest import run_iterations
 def test_run_iterations(campaign, n_iterations, batch_size):
     """Test if iterative loop runs with custom parameters."""
     run_iterations(campaign, n_iterations, batch_size)
+
+
+@pytest.mark.parametrize(
+    "data, msg",
+    [
+        param(
+            pd.DataFrame([[1, 2], [3, "A"]], index=["a", "b"]),
+            "contains non-numeric values",
+            id="non_numeric_values",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, 4]], index=["a", 1]),
+            "contains non-string index values",
+            id="non_string_index",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, 4]], index=["a", ""]),
+            "contains empty string index values",
+            id="empty_string_index",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, np.inf]], index=["a", "b"]),
+            "contains nan/infinity entries",
+            id="contains_inf",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, np.nan]], index=["a", "b"]),
+            "contains nan/infinity entries",
+            id="contains_nan",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, 4]], index=["a", "a"]),
+            "contains duplicated indices",
+            id="duplicate_indices",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [3, 2]], index=["a", "b"]),
+            "columns that contain only a single value",
+            id="constant_column",
+        ),
+        param(
+            pd.DataFrame([[1, 2], [1, 2], [3, 4]], index=["a", "b", "c"]),
+            "ensure all labels have a unique numerical representation",
+            id="duplicate_rows",
+        ),
+    ],
+)
+def test_invalid_input(data, msg):
+    """Test if invalid duplicated rows are detected."""
+    with pytest.raises(ValueError, match=msg):
+        CustomDiscreteParameter(name="p", data=data)

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -19,3 +19,24 @@ from .conftest import run_iterations
 def test_run_iterations(campaign, batch_size, n_iterations):
     """Test running some iterations with fake results and a substance parameter."""
     run_iterations(campaign, n_iterations, batch_size)
+
+
+@pytest.mark.skipif(
+    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+)
+def test_degenerate_comp_df():
+    """Test a degenerate comp_df is detected and fixed numerically."""
+    from baybe.parameters import SubstanceParameter
+
+    # These molecules are know to cause a degenerate representation with rdkit fp's
+    dict_base = {
+        "Potassium acetate": r"O=C([O-])C.[K+]",
+        "Potassium pivalate": r"O=C([O-])C(C)(C)C.[K+]",
+        "Cesium acetate": r"O=C([O-])C.[Cs+]",
+        "Cesium pivalate": r"O=C([O-])C(C)(C)C.[Cs+]",
+    }
+    p = SubstanceParameter(name="p", data=dict_base, encoding="RDKITFINGERPRINT")
+
+    assert (
+        not p.comp_df.duplicated().any()
+    ), "A degenerate comp_df was not correctly treated."

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from baybe.utils.dataframe import df_add_noise_to_degenerate_rows
+from baybe.utils.dataframe import add_noise_to_perturb_degenerate_rows
 
 
 def test_degenerate_rows():
@@ -20,7 +20,7 @@ def test_degenerate_rows():
     df.iloc[:, -1] = 50.0  # Make last column constant to test the edge case
 
     # Add noise
-    df_add_noise_to_degenerate_rows(df)
+    add_noise_to_perturb_degenerate_rows(df)
 
     # Assert that the utility fixed the degenerate rows
     assert not df.duplicated().any(), "Degenerate rows were not fixed by the utility."
@@ -43,4 +43,4 @@ def test_degenerate_rows_invalid_input():
 
     # Add noise
     with pytest.raises(TypeError):
-        df_add_noise_to_degenerate_rows(df)
+        add_noise_to_perturb_degenerate_rows(df)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -1,0 +1,46 @@
+"""Tests for dataframe utilities."""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from baybe.utils.dataframe import df_add_noise_to_degenerate_rows
+
+
+def test_degenerate_rows():
+    """Test noise-based deduplication of degenerate rows."""
+    # Create random dataframe
+    df = pd.DataFrame(np.random.randint(0, 100, size=(5, 3))).astype(float)
+
+    # Manually create some degenerate rows
+    df.loc[1] = df.loc[0]  # Make row 1 identical to row 0
+    df.loc[3] = df.loc[2]  # Make row 3 identical to row 2
+    df.iloc[:, -1] = 50.0  # Make last column constant to test the edge case
+
+    # Add noise
+    df_add_noise_to_degenerate_rows(df)
+
+    # Assert that the utility fixed the degenerate rows
+    assert not df.duplicated().any(), "Degenerate rows were not fixed by the utility."
+
+
+def test_degenerate_rows_invalid_input():
+    """Test that the utility correctly handles invalid input."""
+    # Create random dataframe
+    df = pd.DataFrame(np.random.randint(0, 100, size=(5, 3))).astype(float)
+
+    # Manually create some degenerate rows
+    df.loc[1] = df.loc[0]  # Make row 1 identical to row 0
+    df.loc[3] = df.loc[2]  # Make row 3 identical to row 2
+
+    # Insert invalid data types
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        df.iloc[:, -1] = "A"
+        df.iloc[1, 2] = "B"
+
+    # Add noise
+    with pytest.raises(TypeError):
+        df_add_noise_to_degenerate_rows(df)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -1,7 +1,5 @@
 """Tests for dataframe utilities."""
 
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -36,10 +34,9 @@ def test_degenerate_rows_invalid_input():
     df.loc[3] = df.loc[2]  # Make row 3 identical to row 2
 
     # Insert invalid data types
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=FutureWarning)
-        df.iloc[:, -1] = "A"
-        df.iloc[1, 2] = "B"
+    df = df.astype(object)  # to avoid pandas column dtype warnings
+    df["invalid"] = "A"
+    df.iloc[1, 0] = "B"
 
     # Add noise
     with pytest.raises(TypeError):

--- a/tests/validation/test_parameter_validation.py
+++ b/tests/validation/test_parameter_validation.py
@@ -167,14 +167,18 @@ def test_invalid_encoding_substance_parameter():
 @pytest.mark.parametrize(
     "data",
     [
-        param(pd.DataFrame([[1, 2], [3, np.nan]], index=["A", "B"]), id="nan"),
-        param(pd.DataFrame([[1, 2], [3, np.inf]], index=["A", "B"]), id="infinity"),
-        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", "A"]), id="duplicates"),
-        param(pd.DataFrame([[1, 2]], index=["A"]), id="only_one_value"),
-        param(pd.DataFrame([[1, 2], [1, 2]], index=["A", "B"]), id="zero_variance"),
+        param(pd.DataFrame([[1, 2], [3, np.nan]], index=["A", "B"]), id="contains_nan"),
+        param(pd.DataFrame([[1, 2], [3, np.inf]], index=["A", "B"]), id="contains_inf"),
+        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", "A"]), id="duplicate_idxs"),
+        param(pd.DataFrame([[1, 2]], index=["A"]), id="wrong_label_number"),
+        param(pd.DataFrame([[1, 2], [1, 2]], index=["A", "B"]), id="zero_var_col"),
         param(pd.DataFrame([[1, 2], [3, "a"]], index=["A", "B"]), id="wrong_type"),
-        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", 1]), id="not_a_string"),
-        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", ""]), id="empty_string"),
+        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", 1]), id="non_string_idx"),
+        param(pd.DataFrame([[1, 2], [3, 4]], index=["A", ""]), id="empty_string_idx"),
+        param(
+            pd.DataFrame([[1, 2], [1, 2], [3, 4]], index=["A", "B", "C"]),
+            id="duplicate_rows",
+        ),
     ],
 )
 def test_invalid_data_custom_parameter(data):


### PR DESCRIPTION
- Adds a utility `df_add_noise_to_degenerate_rows` to add noise to
degenerate rows of a numerical dataframe
- Adds a test for the utility
- Disallows `CustomDiscreteParameter` accepting `data` that has
degenerate rows
- Adds input tests for `CustomDiscreteParameter`
- Adds the fix to the `comp_df` of `SubstanceParameter`
- End-to-end test for degenerate substance encoding