### PR TITLE
Typing overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `n_restarts` and `n_raw_samples` keywords to configure continuous optimization
   behavior for `BotorchRecommender`
 - User guide for utilities
+- `mypy` rule expecting explicit `override` markers for method overrides
 
 ### Changed
 - Utility `add_fake_results` renamed to `add_fake_measurements`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,9 @@ Apart from that, we generally recommend adhering to the following guideline:
 
 - Use double backticks for literals like in ``` ``MyString`` ```.
 
-## Writing `attrs` classes 
+## Writing classes 
+
+### Conventions for `attrs` classes
 
 - Place attribute docstrings below the attribute declaration, not in the class 
   docstring.
@@ -205,3 +207,31 @@ Apart from that, we generally recommend adhering to the following guideline:
   section if applicable. Linter warnings regarding missing attribute docstrings can be 
   silenced using `# noqa: DOC101, DOC103`.
   
+### Method overrides
+
+When overriding methods in subclasses, decorate them with `@typing_extensions.override`
+to make the relationship explicit:
+```python
+from typing_extensions import override
+
+class Parent:
+
+   def le_method():
+      """The method of the parent class."""
+      ...
+
+class Child:
+
+   @override
+   def le_method():
+      """Overridden method of the child class."""
+      ...
+```
+Using the decorator provides a type-safe approach for defining inheritance structures
+that eliminates two potential sources of unintended class design:
+* An intended override is does not occur because the method names differ between
+  the parent and child classes (e.g. if the parent method is renamed)
+* An unintended override occurs because a method name that exists in the parent class
+  is used in the child class by mistake.
+In both cases, `mypy` will complain and force you to fix the problem.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,10 +160,6 @@ Apart from that, we generally recommend adhering to the following guideline:
     * an optional extended summary or description below and
     * all relevant sections (`Args`, `Raises`, ...).
   
-  Potential exceptions are functions whose docstring is to be fully inherited from a 
-  parent class.
-  In this case, use `# noqa: D102` to disable the automatic checks locally.
-
 - Use type hints (for variables/constants, attributes, function/method signatures, ...).
   Avoid repeating type hints in docstrings.
 

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -9,6 +9,7 @@ from attr.converters import optional as optional_c
 from attr.validators import optional as optional_v
 from attrs import define, field, fields
 from attrs.validators import ge, gt, instance_of, le
+from typing_extensions import override
 
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.searchspace import SearchSpace
@@ -67,6 +68,7 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
                 f"be specified at the same time."
             )
 
+    @override
     @classproperty
     def _non_botorch_attrs(cls) -> tuple[str, ...]:
         flds = fields(qNegIntegratedPosteriorVariance)
@@ -299,6 +301,7 @@ class qThompsonSampling(qSimpleRegret):
     Thompson sampling using the regular acquisition function machinery.
     """
 
+    @override
     @classproperty
     def _non_botorch_attrs(cls) -> tuple[str, ...]:
         flds = fields(qThompsonSampling)

--- a/baybe/acquisition/partial.py
+++ b/baybe/acquisition/partial.py
@@ -3,7 +3,7 @@
 import gc
 
 import torch
-from attr import define
+from attrs import define
 from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
 from torch import Tensor
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -12,6 +12,7 @@ import pandas as pd
 from attrs import define, field
 from attrs.converters import optional
 from attrs.validators import instance_of
+from typing_extensions import override
 
 from baybe.exceptions import IncompatibilityError
 from baybe.objectives.base import Objective, to_objective
@@ -93,6 +94,7 @@ class Campaign(SerialMixin):
     )
     """The cached recommendations."""
 
+    @override
     def __str__(self) -> str:
         metadata_fields = [
             to_string("Batches done", self.n_batches_done, single_line=True),

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -7,8 +7,8 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pandas as pd
-from attr import define, field
-from attr.validators import ge, instance_of, min_len
+from attrs import define, field
+from attrs.validators import ge, instance_of, min_len
 
 from baybe.constraints.deprecation import structure_constraints
 from baybe.serialization import (

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -17,6 +17,7 @@ from attr.validators import in_
 from attrs.validators import min_len
 from funcy import rpartial
 from numpy.typing import ArrayLike
+from typing_extensions import override
 
 from baybe.parameters.validation import validate_unique_values
 from baybe.serialization import (
@@ -171,8 +172,8 @@ class ThresholdCondition(Condition):
             func = rpartial(func, atol=self.tolerance)
         return func
 
+    @override
     def evaluate(self, data: pd.Series) -> pd.Series:  # noqa: D102
-        # See base class.
         if data.dtype.kind not in "iufb":
             raise ValueError(
                 "You tried to apply a threshold condition to non-numeric data. "
@@ -182,8 +183,8 @@ class ThresholdCondition(Condition):
         func = self._make_operator_function()
         return data.apply(func)
 
+    @override
     def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
-        # See base class.
         op = self._make_operator_function()
         return op(expr)
 
@@ -211,12 +212,12 @@ class SubSelectionCondition(Condition):
             for itm in self._selection
         )
 
+    @override
     def evaluate(self, data: pd.Series) -> pd.Series:  # noqa: D102
-        # See base class.
         return data.isin(self.selection)
 
+    @override
     def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
-        # See base class.
         return expr.is_in(self.selection)
 
 

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -9,12 +9,12 @@ from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
+import cattrs
 import numpy as np
 import pandas as pd
 from attr import define, field
 from attr.validators import in_
 from attrs.validators import min_len
-from cattrs.gen import override
 from funcy import rpartial
 from numpy.typing import ArrayLike
 
@@ -222,7 +222,7 @@ class SubSelectionCondition(Condition):
 
 # Register (un-)structure hooks
 _overrides = {
-    "_selection": override(rename="selection"),
+    "_selection": cattrs.override(rename="selection"),
 }
 # FIXME[typing]: https://github.com/python/mypy/issues/4717
 converter.register_structure_hook(

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -172,7 +172,7 @@ class ThresholdCondition(Condition):
         return func
 
     @override
-    def evaluate(self, data: pd.Series) -> pd.Series:  # noqa: D102
+    def evaluate(self, data: pd.Series) -> pd.Series:
         if data.dtype.kind not in "iufb":
             raise ValueError(
                 "You tried to apply a threshold condition to non-numeric data. "
@@ -183,7 +183,7 @@ class ThresholdCondition(Condition):
         return data.apply(func)
 
     @override
-    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
+    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:
         op = self._make_operator_function()
         return op(expr)
 
@@ -204,7 +204,7 @@ class SubSelectionCondition(Condition):
     """The internal list of items which are considered valid."""
 
     @property
-    def selection(self) -> tuple:  # noqa: D102
+    def selection(self) -> tuple:
         """The list of items which are considered valid."""
         return tuple(
             DTypeFloatNumpy(itm) if isinstance(itm, (float, int, bool)) else itm
@@ -212,11 +212,11 @@ class SubSelectionCondition(Condition):
         )
 
     @override
-    def evaluate(self, data: pd.Series) -> pd.Series:  # noqa: D102
+    def evaluate(self, data: pd.Series) -> pd.Series:
         return data.isin(self.selection)
 
     @override
-    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:  # noqa: D102
+    def to_polars(self, expr: pl.Expr, /) -> pl.Expr:
         return expr.is_in(self.selection)
 
 

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -12,9 +12,8 @@ from typing import TYPE_CHECKING, Any
 import cattrs
 import numpy as np
 import pandas as pd
-from attr import define, field
-from attr.validators import in_
-from attrs.validators import min_len
+from attrs import define, field
+from attrs.validators import in_, min_len
 from funcy import rpartial
 from numpy.typing import ArrayLike
 from typing_extensions import override

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -8,8 +8,8 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import pandas as pd
-from attr import define, field
-from attr.validators import in_, min_len
+from attrs import define, field
+from attrs.validators import in_, min_len
 from typing_extensions import override
 
 from baybe.constraints.base import CardinalityConstraint, DiscreteConstraint

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -42,7 +42,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
     """Operator encoding how to combine the individual conditions."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         satisfied = [
             cond.evaluate(data[self.parameters[k]])
             for k, cond in enumerate(self.conditions)
@@ -51,7 +51,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         return data.index[res]
 
     @override
-    def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
+    def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
         satisfied = []
@@ -78,14 +78,14 @@ class DiscreteSumConstraint(DiscreteConstraint):
     """The condition modeled by this constraint."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         evaluate_data = data[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
         return data.index[mask_bad]
 
     @override
-    def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
+    def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
         return self.condition.to_polars(pl.sum_horizontal(self.parameters)).not_()
@@ -106,14 +106,14 @@ class DiscreteProductConstraint(DiscreteConstraint):
     """The condition that is used for this constraint."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         evaluate_data = data[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
         return data.index[mask_bad]
 
     @override
-    def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
+    def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
         op = _threshold_operators[self.condition.operator]
@@ -140,13 +140,13 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
     """
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         mask_bad = data[self.parameters].nunique(axis=1) != len(self.parameters)
 
         return data.index[mask_bad]
 
     @override
-    def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
+    def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
         expr = (
@@ -168,13 +168,13 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
     """
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         mask_bad = data[self.parameters].nunique(axis=1) != 1
 
         return data.index[mask_bad]
 
     @override
-    def get_invalid_polars(self) -> pl.Expr:  # noqa: D102
+    def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
         expr = (
@@ -229,7 +229,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
             )
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
@@ -295,7 +295,7 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
     """Dependencies connected with the invariant parameters."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         # Get indices of entries with duplicate label entries. These will also be
         # dropped by this constraint.
         mask_duplicate_labels = pd.Series(False, index=data.index)
@@ -350,7 +350,7 @@ class DiscreteCustomConstraint(DiscreteConstraint):
     you want to keep/remove."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         mask_bad = ~self.validator(data[self.parameters])
 
         return data.index[mask_bad]
@@ -365,7 +365,7 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
     # See base class.
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:  # noqa: D102
+    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         non_zeros = (data[self.parameters] != 0.0).sum(axis=1)
         mask_bad = non_zeros > self.max_cardinality
         mask_bad |= non_zeros < self.min_cardinality

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -31,7 +31,7 @@ class LinearKernel(BasicKernel):
     """An optional initial value for the kernel variance parameter."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -98,7 +98,7 @@ class PeriodicKernel(BasicKernel):
     """An optional initial value for the kernel period length."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -153,7 +153,7 @@ class PolynomialKernel(BasicKernel):
     """An optional initial value for the kernel offset."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -6,6 +6,7 @@ from attrs import define, field
 from attrs.converters import optional as optional_c
 from attrs.validators import ge, gt, in_, instance_of
 from attrs.validators import optional as optional_v
+from typing_extensions import override
 
 from baybe.kernels.base import BasicKernel
 from baybe.priors.base import Prior
@@ -29,8 +30,8 @@ class LinearKernel(BasicKernel):
     )
     """An optional initial value for the kernel variance parameter."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -96,8 +97,8 @@ class PeriodicKernel(BasicKernel):
     )
     """An optional initial value for the kernel period length."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -151,8 +152,8 @@ class PolynomialKernel(BasicKernel):
     )
     """An optional initial value for the kernel offset."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -8,6 +8,7 @@ from attrs import define, field
 from attrs.converters import optional as optional_c
 from attrs.validators import deep_iterable, gt, instance_of, min_len
 from attrs.validators import optional as optional_v
+from typing_extensions import override
 
 from baybe.kernels.base import CompositeKernel, Kernel
 from baybe.priors.base import Prior
@@ -33,8 +34,8 @@ class ScaleKernel(CompositeKernel):
     )
     """An optional initial value for the output scale."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -59,9 +60,8 @@ class AdditiveKernel(CompositeKernel):
     )
     """The individual kernels to be summed."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
-
         return reduce(add, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
 
@@ -77,9 +77,8 @@ class ProductKernel(CompositeKernel):
     )
     """The individual kernels to be multiplied."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
-        # See base class.
-
         return reduce(mul, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
 

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -35,7 +35,7 @@ class ScaleKernel(CompositeKernel):
     """An optional initial value for the output scale."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         import torch
 
         from baybe.utils.torch import DTypeFloatTorch
@@ -61,7 +61,7 @@ class AdditiveKernel(CompositeKernel):
     """The individual kernels to be summed."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         return reduce(add, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
 
@@ -78,7 +78,7 @@ class ProductKernel(CompositeKernel):
     """The individual kernels to be multiplied."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         return reduce(mul, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
 

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -3,9 +3,9 @@
 import gc
 from abc import ABC, abstractmethod
 
+import cattrs
 import pandas as pd
 from attrs import define
-from cattrs import override
 
 from baybe.objectives.deprecation import structure_objective
 from baybe.serialization.core import (
@@ -53,8 +53,8 @@ converter.register_unstructure_hook(
     lambda x: unstructure_base(
         x,
         overrides=dict(
-            _target=override(rename="target"),
-            _targets=override(rename="targets"),
+            _target=cattrs.override(rename="target"),
+            _targets=cattrs.override(rename="targets"),
         ),
     ),
 )

--- a/baybe/objectives/deprecation.py
+++ b/baybe/objectives/deprecation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING
 
-from cattrs import override
+import cattrs
 from cattrs.gen import make_dict_structure_fn
 
 from baybe.serialization import converter
@@ -40,8 +40,8 @@ def structure_objective(val: dict, cls: type) -> Objective:
             cls,
             converter,
             _cattrs_forbid_extra_keys=True,
-            _target=override(rename="target"),
-            _targets=override(rename="targets"),
+            _target=cattrs.override(rename="target"),
+            _targets=cattrs.override(rename="targets"),
         )  # type: ignore
         return fun(val, cls)
 

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -11,6 +11,7 @@ import numpy.typing as npt
 import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_iterable, gt, instance_of, min_len
+from typing_extensions import override
 
 from baybe.objectives.base import Objective
 from baybe.objectives.enum import Scalarizer
@@ -114,9 +115,9 @@ class DesirabilityObjective(Objective):
                 f"Specified number of targets: {lt}. Specified number of weights: {lw}."
             )
 
+    @override
     @property
     def targets(self) -> tuple[Target, ...]:  # noqa: D102
-        # See base class.
         return self._targets
 
     @cached_property
@@ -137,9 +138,8 @@ class DesirabilityObjective(Objective):
 
         return to_string("Objective", *fields)
 
+    @override
     def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
-        # See base class.
-
         # Transform all targets individually
         transformed = data[[t.name for t in self.targets]].copy()
         for target in self.targets:

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -117,7 +117,7 @@ class DesirabilityObjective(Objective):
 
     @override
     @property
-    def targets(self) -> tuple[Target, ...]:  # noqa: D102
+    def targets(self) -> tuple[Target, ...]:
         return self._targets
 
     @cached_property
@@ -140,7 +140,7 @@ class DesirabilityObjective(Objective):
         return to_string("Objective", *fields)
 
     @override
-    def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
         # Transform all targets individually
         transformed = data[[t.name for t in self.targets]].copy()
         for target in self.targets:

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -125,6 +125,7 @@ class DesirabilityObjective(Objective):
         """The normalized target weights."""
         return np.asarray(self.weights) / np.sum(self.weights)
 
+    @override
     def __str__(self) -> str:
         targets_list = [target.summary() for target in self.targets]
         targets_df = pd.DataFrame(targets_list)

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -3,8 +3,8 @@
 import gc
 
 import pandas as pd
-from attr import define, field
-from attr.validators import instance_of
+from attrs import define, field
+from attrs.validators import instance_of
 from typing_extensions import override
 
 from baybe.objectives.base import Objective

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -20,6 +20,7 @@ class SingleTargetObjective(Objective):
     _target: Target = field(validator=instance_of(Target), alias="target")
     """The single target considered by the objective."""
 
+    @override
     def __str__(self) -> str:
         targets_list = [target.summary() for target in self.targets]
         targets_df = pd.DataFrame(targets_list)

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -34,11 +34,11 @@ class SingleTargetObjective(Objective):
 
     @override
     @property
-    def targets(self) -> tuple[Target, ...]:  # noqa: D102
+    def targets(self) -> tuple[Target, ...]:
         return (self._target,)
 
     @override
-    def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
         target_data = data[[self._target.name]].copy()
         return self._target.transform(target_data)
 

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -5,6 +5,7 @@ import gc
 import pandas as pd
 from attr import define, field
 from attr.validators import instance_of
+from typing_extensions import override
 
 from baybe.objectives.base import Objective
 from baybe.targets.base import Target
@@ -30,13 +31,13 @@ class SingleTargetObjective(Objective):
 
         return to_string("Objective", *fields)
 
+    @override
     @property
     def targets(self) -> tuple[Target, ...]:  # noqa: D102
-        # See base class.
         return (self._target,)
 
+    @override
     def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
-        # See base class.
         target_data = data[[self._target.name]].copy()
         return self._target.transform(target_data)
 

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -110,7 +110,7 @@ class DiscreteParameter(Parameter, ABC):
 
     @override
     @property
-    def comp_rep_columns(self) -> tuple[str, ...]:  # noqa: D102
+    def comp_rep_columns(self) -> tuple[str, ...]:
         return tuple(self.comp_df.columns)
 
     def to_subspace(self) -> SubspaceDiscrete:
@@ -120,7 +120,7 @@ class DiscreteParameter(Parameter, ABC):
         return SubspaceDiscrete.from_parameter(self)
 
     @override
-    def is_in_range(self, item: Any) -> bool:  # noqa: D102
+    def is_in_range(self, item: Any) -> bool:
         return item in self.values
 
     def transform(self, series: pd.Series, /) -> pd.DataFrame:
@@ -147,7 +147,7 @@ class DiscreteParameter(Parameter, ABC):
         return transformed
 
     @override
-    def summary(self) -> dict:  # noqa: D102
+    def summary(self) -> dict:
         param_dict = dict(
             Name=self.name,
             Type=self.__class__.__name__,

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -11,6 +11,7 @@ import cattrs
 import pandas as pd
 from attrs import define, field
 from attrs.validators import instance_of, min_len
+from typing_extensions import override
 
 from baybe.parameters.enum import ParameterEncoding
 from baybe.serialization import (
@@ -106,9 +107,9 @@ class DiscreteParameter(Parameter, ABC):
         # TODO: Should be renamed to `comp_rep`
         """Return the computational representation of the parameter."""
 
+    @override
     @property
     def comp_rep_columns(self) -> tuple[str, ...]:  # noqa: D102
-        # See base class.
         return tuple(self.comp_df.columns)
 
     def to_subspace(self) -> SubspaceDiscrete:
@@ -117,8 +118,8 @@ class DiscreteParameter(Parameter, ABC):
 
         return SubspaceDiscrete.from_parameter(self)
 
+    @override
     def is_in_range(self, item: Any) -> bool:  # noqa: D102
-        # See base class.
         return item in self.values
 
     def transform(self, series: pd.Series, /) -> pd.DataFrame:
@@ -144,8 +145,8 @@ class DiscreteParameter(Parameter, ABC):
 
         return transformed
 
+    @override
     def summary(self) -> dict:  # noqa: D102
-        # See base class.
         param_dict = dict(
             Name=self.name,
             Type=self.__class__.__name__,

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -7,10 +7,10 @@ from abc import ABC, abstractmethod
 from functools import cached_property, partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import cattrs
 import pandas as pd
 from attrs import define, field
 from attrs.validators import instance_of, min_len
-from cattrs.gen import override
 
 from baybe.parameters.enum import ParameterEncoding
 from baybe.serialization import (
@@ -167,7 +167,7 @@ class ContinuousParameter(Parameter):
 
 
 # Register (un-)structure hooks
-_overrides = {"_values": override(rename="values")}
+_overrides = {"_values": cattrs.override(rename="values")}
 # FIXME[typing]: https://github.com/python/mypy/issues/4717
 converter.register_structure_hook(
     Parameter,

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -57,6 +57,7 @@ class Parameter(ABC, SerialMixin):
             ``True`` if the item is within the parameter range, ``False`` otherwise.
         """
 
+    @override
     def __str__(self) -> str:
         return str(self.summary())
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from attrs import Converter, define, field
 from attrs.validators import deep_iterable, instance_of, min_len
+from typing_extensions import override
 
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.enum import CategoricalEncoding
@@ -52,9 +53,9 @@ class CategoricalParameter(DiscreteParameter):
         """The values of the parameter."""
         return self._values
 
+    @override
     @cached_property
     def comp_df(self) -> pd.DataFrame:  # noqa: D102
-        # See base class.
         if self.encoding is CategoricalEncoding.OHE:
             cols = [f"{self.name}_{val}" for val in self.values]
             comp_df = pd.DataFrame(

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -56,7 +56,7 @@ class CategoricalParameter(DiscreteParameter):
 
     @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:  # noqa: D102
+    def comp_df(self) -> pd.DataFrame:
         if self.encoding is CategoricalEncoding.OHE:
             cols = [f"{self.name}_{val}" for val in self.values]
             comp_df = pd.DataFrame(

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -48,6 +48,7 @@ class CategoricalParameter(DiscreteParameter):
     )
     # See base class.
 
+    @override
     @property
     def values(self) -> tuple:
         """The values of the parameter."""

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -98,7 +98,7 @@ class CustomDiscreteParameter(DiscreteParameter):
 
     @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:  # noqa: D102
+    def comp_df(self) -> pd.DataFrame:
         # The encoding is directly provided by the user
         # We prepend the parameter name to the columns names to avoid potential
         # conflicts with other parameters

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -90,6 +90,7 @@ class CustomDiscreteParameter(DiscreteParameter):
                 "that contain only a single value and hence carry no information."
             )
 
+    @override
     @property
     def values(self) -> tuple:
         """Returns the representing labels of the parameter."""

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 from attrs.validators import min_len
+from typing_extensions import override
 
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.enum import CustomEncoding
@@ -94,9 +95,9 @@ class CustomDiscreteParameter(DiscreteParameter):
         """Returns the representing labels of the parameter."""
         return tuple(self.data.index)
 
+    @override
     @cached_property
     def comp_df(self) -> pd.DataFrame:  # noqa: D102
-        # See base class.
         # The encoding is directly provided by the user
         # We prepend the parameter name to the columns names to avoid potential
         # conflicts with other parameters

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -81,19 +81,19 @@ class NumericalDiscreteParameter(DiscreteParameter):
 
     @override
     @property
-    def values(self) -> tuple:  # noqa: D102
+    def values(self) -> tuple:
         return tuple(DTypeFloatNumpy(itm) for itm in self._values)
 
     @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:  # noqa: D102
+    def comp_df(self) -> pd.DataFrame:
         comp_df = pd.DataFrame(
             {self.name: self.values}, index=self.values, dtype=DTypeFloatNumpy
         )
         return comp_df
 
     @override
-    def is_in_range(self, item: float) -> bool:  # noqa: D102
+    def is_in_range(self, item: float) -> bool:
         differences_acceptable = [
             np.abs(val - item) <= self.tolerance for val in self.values
         ]
@@ -131,16 +131,16 @@ class NumericalContinuousParameter(ContinuousParameter):
             )
 
     @override
-    def is_in_range(self, item: float) -> bool:  # noqa: D102
+    def is_in_range(self, item: float) -> bool:
         return self.bounds.contains(item)
 
     @override
     @property
-    def comp_rep_columns(self) -> tuple[str, ...]:  # noqa: D102
+    def comp_rep_columns(self) -> tuple[str, ...]:
         return (self.name,)
 
     @override
-    def summary(self) -> dict:  # noqa: D102
+    def summary(self) -> dict:
         param_dict = dict(
             Name=self.name,
             Type=self.__class__.__name__,

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 from attrs.validators import min_len
+from typing_extensions import override
 
 from baybe.exceptions import NumericalUnderflowError
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter
@@ -78,21 +79,21 @@ class NumericalDiscreteParameter(DiscreteParameter):
                 f"tolerance must be smaller than {max_tol} to avoid ambiguity."
             )
 
+    @override
     @property
     def values(self) -> tuple:  # noqa: D102
-        # See base class.
         return tuple(DTypeFloatNumpy(itm) for itm in self._values)
 
+    @override
     @cached_property
     def comp_df(self) -> pd.DataFrame:  # noqa: D102
-        # See base class.
         comp_df = pd.DataFrame(
             {self.name: self.values}, index=self.values, dtype=DTypeFloatNumpy
         )
         return comp_df
 
+    @override
     def is_in_range(self, item: float) -> bool:  # noqa: D102
-        # See base class.
         differences_acceptable = [
             np.abs(val - item) <= self.tolerance for val in self.values
         ]
@@ -129,18 +130,17 @@ class NumericalContinuousParameter(ContinuousParameter):
                 "The interval specified by the parameter bounds cannot be degenerate."
             )
 
+    @override
     def is_in_range(self, item: float) -> bool:  # noqa: D102
-        # See base class.
-
         return self.bounds.contains(item)
 
+    @override
     @property
     def comp_rep_columns(self) -> tuple[str, ...]:  # noqa: D102
-        # See base class.
         return (self.name,)
 
+    @override
     def summary(self) -> dict:  # noqa: D102
-        # See base class.
         param_dict = dict(
             Name=self.name,
             Type=self.__class__.__name__,

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -114,7 +114,7 @@ class SubstanceParameter(DiscreteParameter):
 
     @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:  # noqa: D102
+    def comp_df(self) -> pd.DataFrame:
         from baybe.utils import chemistry
 
         vals = list(self.data.values())

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -106,6 +106,7 @@ class SubstanceParameter(DiscreteParameter):
                 )
             raise ExceptionGroup("duplicate substances", exceptions)
 
+    @override
     @property
     def values(self) -> tuple:
         """Returns the labels of the given set of molecules."""

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar
 import pandas as pd
 from attrs import define, field
 from attrs.validators import and_, deep_mapping, instance_of, min_len
+from typing_extensions import override
 
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.enum import SubstanceEncoding
@@ -110,10 +111,9 @@ class SubstanceParameter(DiscreteParameter):
         """Returns the labels of the given set of molecules."""
         return tuple(self.data.keys())
 
+    @override
     @cached_property
     def comp_df(self) -> pd.DataFrame:  # noqa: D102
-        # See base class.
-
         from baybe.utils import chemistry
 
         vals = list(self.data.values())

--- a/baybe/priors/basic.py
+++ b/baybe/priors/basic.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from attrs import define, field
 from attrs.validators import gt
+from typing_extensions import override
 
 from baybe.priors.base import Prior
 from baybe.utils.validation import finite_float
@@ -100,6 +101,7 @@ class BetaPrior(Prior):
     beta: float = field(converter=float, validator=gt(0.0))
     """Beta concentration parameter. Controls mass accumulated toward one."""
 
+    @override
     def to_gpytorch(self, *args, **kwargs):  # noqa: D102
         raise NotImplementedError(
             f"'{self.__class__.__name__}' does not have a gpytorch analog."

--- a/baybe/priors/basic.py
+++ b/baybe/priors/basic.py
@@ -102,7 +102,7 @@ class BetaPrior(Prior):
     """Beta concentration parameter. Controls mass accumulated toward one."""
 
     @override
-    def to_gpytorch(self, *args, **kwargs):  # noqa: D102
+    def to_gpytorch(self, *args, **kwargs):
         raise NotImplementedError(
             f"'{self.__class__.__name__}' does not have a gpytorch analog."
         )

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -4,7 +4,6 @@ from typing import Protocol, runtime_checkable
 
 import cattrs
 import pandas as pd
-from cattrs import override
 
 from baybe.objectives.base import Objective
 from baybe.searchspace import SearchSpace
@@ -66,9 +65,9 @@ converter.register_unstructure_hook(
         overrides=dict(
             acquisition_function_cls=cattrs.override(omit=True),
             # Temporary workaround (see TODO note above)
-            _surrogate_model=override(rename="surrogate_model"),
-            _current_recommender=override(omit=False),
-            _used_recommender_ids=override(omit=False),
+            _surrogate_model=cattrs.override(rename="surrogate_model"),
+            _current_recommender=cattrs.override(omit=False),
+            _used_recommender_ids=cattrs.override(omit=False),
         ),
     ),
 )
@@ -78,9 +77,9 @@ converter.register_structure_hook(
         RecommenderProtocol,
         # Temporary workaround (see TODO note above)
         overrides=dict(
-            _surrogate_model=override(rename="surrogate_model"),
-            _current_recommender=override(omit=False),
-            _used_recommender_ids=override(omit=False),
+            _surrogate_model=cattrs.override(rename="surrogate_model"),
+            _current_recommender=cattrs.override(omit=False),
+            _used_recommender_ids=cattrs.override(omit=False),
         ),
     ),
 )

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -7,6 +7,7 @@ from typing import Any
 import cattrs
 import pandas as pd
 from attrs import define, field
+from typing_extensions import override
 
 from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
@@ -92,6 +93,7 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
 
         return recommender
 
+    @override
     def recommend(
         self,
         batch_size: int,

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -10,6 +10,7 @@ from typing import Literal
 import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_iterable, in_, instance_of
+from typing_extensions import override
 
 from baybe.exceptions import NoRecommendersLeftError
 from baybe.objectives.base import Objective
@@ -51,6 +52,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
     """The number of experiments after which the recommender is switched for the next
     requested batch."""
 
+    @override
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
@@ -59,8 +61,6 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> PureRecommender:
-        # See base class.
-
         return (
             self.recommender
             if (measurements is not None) and (len(measurements) >= self.switch_after)
@@ -131,6 +131,7 @@ class SequentialMetaRecommender(MetaRecommender):
     _n_last_measurements: int = field(default=-1, alias="_n_last_measurements")
     """The number of measurements that were available at the last call."""
 
+    @override
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
@@ -139,8 +140,6 @@ class SequentialMetaRecommender(MetaRecommender):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> PureRecommender:
-        # See base class.
-
         n_data = len(measurements) if measurements is not None else 0
 
         # If the training dataset size has increased, move to the next recommender
@@ -221,6 +220,7 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
         """Initialize the recommender iterator."""
         return iter(self.recommenders)
 
+    @override
     def select_recommender(  # noqa: D102
         self,
         batch_size: int,
@@ -229,8 +229,6 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> PureRecommender:
-        # See base class.
-
         use_last = True
         n_data = len(measurements) if measurements is not None else 0
 

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -67,6 +67,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
             else self.initial_recommender
         )
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Initial recommender", self.initial_recommender),
@@ -175,6 +176,7 @@ class SequentialMetaRecommender(MetaRecommender):
 
         return recommender
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Recommenders", self.recommenders),
@@ -260,6 +262,7 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
 
         return self._last_recommender  # type: ignore[return-value]
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Recommenders", self.recommenders),

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -53,7 +53,7 @@ class TwoPhaseMetaRecommender(MetaRecommender):
     requested batch."""
 
     @override
-    def select_recommender(  # noqa: D102
+    def select_recommender(
         self,
         batch_size: int,
         searchspace: SearchSpace | None = None,
@@ -133,7 +133,7 @@ class SequentialMetaRecommender(MetaRecommender):
     """The number of measurements that were available at the last call."""
 
     @override
-    def select_recommender(  # noqa: D102
+    def select_recommender(
         self,
         batch_size: int,
         searchspace: SearchSpace | None = None,
@@ -223,7 +223,7 @@ class StreamingSequentialMetaRecommender(MetaRecommender):
         return iter(self.recommenders)
 
     @override
-    def select_recommender(  # noqa: D102
+    def select_recommender(
         self,
         batch_size: int,
         searchspace: SearchSpace | None = None,

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 import pandas as pd
 from attrs import define, evolve, field, fields
+from typing_extensions import override
 
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
@@ -77,6 +78,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
                 allow_repeated_recommendations=flag,
             )
 
+    @override
     def recommend(  # noqa: D102
         self,
         batch_size: int,
@@ -85,8 +87,6 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        # See base class.
-
         from baybe.acquisition.partial import PartialAcquisitionFunction
 
         if (not isinstance(self.disc_recommender, BayesianRecommender)) and (

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -79,7 +79,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
             )
 
     @override
-    def recommend(  # noqa: D102
+    def recommend(
         self,
         batch_size: int,
         searchspace: SearchSpace,

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 import pandas as pd
 from attrs import define, field
+from typing_extensions import override
 
 from baybe.exceptions import NotEnoughPointsLeftError
 from baybe.objectives.base import Objective
@@ -41,6 +42,7 @@ class PureRecommender(ABC, RecommenderProtocol):
     the corresponding points will be removed from the candidates. This only has an
     influence in discrete search spaces."""
 
+    @override
     def recommend(  # noqa: D102
         self,
         batch_size: int,
@@ -49,7 +51,6 @@ class PureRecommender(ABC, RecommenderProtocol):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        # See base class
         if searchspace.type is SearchSpaceType.CONTINUOUS:
             return self._recommend_continuous(
                 subspace_continuous=searchspace.continuous, batch_size=batch_size

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -43,7 +43,7 @@ class PureRecommender(ABC, RecommenderProtocol):
     influence in discrete search spaces."""
 
     @override
-    def recommend(  # noqa: D102
+    def recommend(
         self,
         batch_size: int,
         searchspace: SearchSpace,

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -90,7 +90,7 @@ class BayesianRecommender(PureRecommender, ABC):
         )
 
     @override
-    def recommend(  # noqa: D102
+    def recommend(
         self,
         batch_size: int,
         searchspace: SearchSpace,

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -6,6 +6,7 @@ from abc import ABC
 
 import pandas as pd
 from attrs import define, field, fields
+from typing_extensions import override
 
 from baybe.acquisition.acqfs import qLogExpectedImprovement
 from baybe.acquisition.base import AcquisitionFunction
@@ -88,6 +89,7 @@ class BayesianRecommender(PureRecommender, ABC):
             pending_experiments,
         )
 
+    @override
     def recommend(  # noqa: D102
         self,
         batch_size: int,
@@ -96,8 +98,6 @@ class BayesianRecommender(PureRecommender, ABC):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        # See base class.
-
         if objective is None:
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' require "

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -8,6 +8,7 @@ import pandas as pd
 from attrs import define, field
 from attrs.converters import optional as optional_c
 from attrs.validators import gt, instance_of
+from typing_extensions import override
 
 from baybe.acquisition.acqfs import qThompsonSampling
 from baybe.exceptions import (
@@ -89,6 +90,7 @@ class BotorchRecommender(BayesianRecommender):
                 f"Hybrid sampling percentage needs to be between 0 and 1 but is {value}"
             )
 
+    @override
     def _recommend_discrete(
         self,
         subspace_discrete: SubspaceDiscrete,
@@ -146,6 +148,7 @@ class BotorchRecommender(BayesianRecommender):
 
         return idxs
 
+    @override
     def _recommend_continuous(
         self,
         subspace_continuous: SubspaceContinuous,
@@ -198,6 +201,7 @@ class BotorchRecommender(BayesianRecommender):
         rec = pd.DataFrame(points, columns=subspace_continuous.parameter_names)
         return rec
 
+    @override
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
@@ -310,6 +314,7 @@ class BotorchRecommender(BayesianRecommender):
 
         return rec_exp
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Surrogate", self._surrogate_model),

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -7,6 +7,7 @@ from abc import ABC
 import pandas as pd
 from attr import fields
 from attrs import define
+from typing_extensions import override
 
 from baybe.exceptions import UnusedObjectWarning
 from baybe.objectives.base import Objective
@@ -18,6 +19,7 @@ from baybe.searchspace.core import SearchSpace, SearchSpaceType
 class NonPredictiveRecommender(PureRecommender, ABC):
     """Abstract base class for all nonpredictive recommenders."""
 
+    @override
     def recommend(  # noqa: D102
         self,
         batch_size: int,
@@ -26,8 +28,6 @@ class NonPredictiveRecommender(PureRecommender, ABC):
         measurements: pd.DataFrame | None = None,
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
-        # See base class.
-
         if (measurements is not None) and (len(measurements) != 0):
             warnings.warn(
                 f"'{self.recommend.__name__}' was called with a non-empty "

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -19,7 +19,7 @@ class NonPredictiveRecommender(PureRecommender, ABC):
     """Abstract base class for all nonpredictive recommenders."""
 
     @override
-    def recommend(  # noqa: D102
+    def recommend(
         self,
         batch_size: int,
         searchspace: SearchSpace,

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -5,8 +5,7 @@ import warnings
 from abc import ABC
 
 import pandas as pd
-from attr import fields
-from attrs import define
+from attrs import define, fields
 from typing_extensions import override
 
 from baybe.exceptions import UnusedObjectWarning

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -11,6 +11,7 @@ from scipy.stats import multivariate_normal
 from sklearn.base import ClusterMixin
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import StandardScaler
+from typing_extensions import override
 
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType, SubspaceDiscrete
@@ -95,14 +96,13 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         """
         raise NotImplementedError("This line in the code should be unreachable. Sry.")
 
+    @override
     def _recommend_discrete(
         self,
         subspace_discrete: SubspaceDiscrete,
         candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.Index:
-        # See base class.
-
         # Fit scaler on entire search space
         # TODO [Scaling]: scaling should be handled by search space object
         scaler = StandardScaler()
@@ -160,9 +160,9 @@ class PAMClusteringRecommender(SKLearnClusteringRecommender):
         """Create the default model parameters."""
         return {"max_iter": 100, "init": "k-medoids++"}
 
+    @override
     @staticmethod
     def _get_model_cls() -> type[ClusterMixin]:
-        # See base class.
         from sklearn_extra.cluster import KMedoids
 
         return KMedoids
@@ -208,9 +208,9 @@ class KMeansClusteringRecommender(SKLearnClusteringRecommender):
         """Create the default model parameters."""
         return {"max_iter": 1000, "n_init": 50}
 
+    @override
     @staticmethod
     def _get_model_cls() -> type[ClusterMixin]:
-        # See base class.
         from sklearn.cluster import KMeans
 
         return KMeans
@@ -252,9 +252,9 @@ class GaussianMixtureClusteringRecommender(SKLearnClusteringRecommender):
     model_cluster_num_parameter_name: ClassVar[str] = "n_components"
     # See base class.
 
+    @override
     @staticmethod
     def _get_model_cls() -> type[ClusterMixin]:
-        # See base class.
         from sklearn.mixture import GaussianMixture
 
         return GaussianMixture

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -128,6 +128,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         # Convert positional indices into DataFrame indices and return result
         return candidates_comp.index[selection]
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Compatibility", self.compatibility, single_line=True),
@@ -167,6 +168,7 @@ class PAMClusteringRecommender(SKLearnClusteringRecommender):
 
         return KMedoids
 
+    @override
     def _make_selection_custom(
         self,
         model: ClusterMixin,
@@ -215,6 +217,7 @@ class KMeansClusteringRecommender(SKLearnClusteringRecommender):
 
         return KMeans
 
+    @override
     def _make_selection_custom(
         self,
         model: ClusterMixin,
@@ -259,6 +262,7 @@ class GaussianMixtureClusteringRecommender(SKLearnClusteringRecommender):
 
         return GaussianMixture
 
+    @override
     def _make_selection_custom(
         self,
         model: ClusterMixin,

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
+from typing_extensions import override
 
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType, SubspaceDiscrete
@@ -19,14 +20,13 @@ class RandomRecommender(NonPredictiveRecommender):
     compatibility: ClassVar[SearchSpaceType] = SearchSpaceType.HYBRID
     # See base class.
 
+    @override
     def _recommend_hybrid(
         self,
         searchspace: SearchSpace,
         candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.DataFrame:
-        # See base class.
-
         if searchspace.type == SearchSpaceType.DISCRETE:
             return candidates_exp.sample(batch_size)
 
@@ -58,14 +58,13 @@ class FPSRecommender(NonPredictiveRecommender):
     compatibility: ClassVar[SearchSpaceType] = SearchSpaceType.DISCRETE
     # See base class.
 
+    @override
     def _recommend_discrete(
         self,
         subspace_discrete: SubspaceDiscrete,
         candidates_exp: pd.DataFrame,
         batch_size: int,
     ) -> pd.Index:
-        # See base class.
-
         # Fit scaler on entire search space
         # TODO [Scaling]: scaling should be handled by search space object
         scaler = StandardScaler()

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -46,6 +46,7 @@ class RandomRecommender(NonPredictiveRecommender):
         cont_random.index = disc_random.index
         return pd.concat([disc_random, cont_random], axis=1)
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Compatibility", self.compatibility, single_line=True)]
         return to_string(self.__class__.__name__, *fields)
@@ -76,6 +77,7 @@ class FPSRecommender(NonPredictiveRecommender):
         ilocs = farthest_point_sampling(candidates_scaled, batch_size)
         return candidates_comp.index[ilocs]
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Compatibility", self.compatibility, single_line=True)]
         return to_string(self.__class__.__name__, *fields)

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import pandas as pd
 from attrs import define, field, fields
+from typing_extensions import override
 
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
@@ -68,6 +69,7 @@ class SubspaceContinuous(SerialMixin):
     )
     """Nonlinear constraints."""
 
+    @override
     def __str__(self) -> str:
         if self.is_empty:
             return ""

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import pandas as pd
 from attr import define, field
+from typing_extensions import override
 
 from baybe.constraints import (
     validate_constraints,
@@ -67,6 +68,7 @@ class SearchSpace(SerialMixin):
     continuous: SubspaceContinuous = field(factory=SubspaceContinuous.empty)
     """The (potentially empty) continuous subspace of the overall search space."""
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Search Space Type", self.type.name, single_line=True),

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import cast
 
 import pandas as pd
-from attr import define, field
+from attrs import define, field
 from typing_extensions import override
 
 from baybe.constraints import (

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from attr import define, field
 from cattrs import IterableValidationError
+from typing_extensions import override
 
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
 from baybe.constraints.base import DiscreteConstraint
@@ -118,6 +119,7 @@ class SubspaceDiscrete(SerialMixin):
     and thereby speed up construction. If not provided, the default hook will derive it
     from ``exp_rep``."""
 
+    @override
     def __str__(self) -> str:
         if self.is_empty:
             return ""

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
-from attr import define, field
+from attrs import define, field
 from cattrs import IterableValidationError
 from typing_extensions import override
 

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -25,11 +25,11 @@ class AdapterModel(Model):
         self._surrogate = surrogate
 
     @property
-    def num_outputs(self) -> int:  # noqa: D102
+    def num_outputs(self) -> int:
         # TODO: So far, the usage is limited to single-output models.
         return 1
 
-    def posterior(  # noqa: D102
+    def posterior(
         self,
         X: Tensor,
         output_indices: list[int] | None = None,

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -6,7 +6,6 @@ from typing import Any
 from botorch.models.gpytorch import Model
 from botorch.posteriors import Posterior
 from torch import Tensor
-from typing_extensions import override
 
 from baybe.surrogates.base import Surrogate
 
@@ -25,13 +24,11 @@ class AdapterModel(Model):
         super().__init__()
         self._surrogate = surrogate
 
-    @override
     @property
     def num_outputs(self) -> int:  # noqa: D102
         # TODO: So far, the usage is limited to single-output models.
         return 1
 
-    @override
     def posterior(  # noqa: D102
         self,
         X: Tensor,

--- a/baybe/surrogates/_adapter.py
+++ b/baybe/surrogates/_adapter.py
@@ -6,6 +6,7 @@ from typing import Any
 from botorch.models.gpytorch import Model
 from botorch.posteriors import Posterior
 from torch import Tensor
+from typing_extensions import override
 
 from baybe.surrogates.base import Surrogate
 
@@ -24,12 +25,13 @@ class AdapterModel(Model):
         super().__init__()
         self._surrogate = surrogate
 
+    @override
     @property
     def num_outputs(self) -> int:  # noqa: D102
-        # See base class.
         # TODO: So far, the usage is limited to single-output models.
         return 1
 
+    @override
     def posterior(  # noqa: D102
         self,
         X: Tensor,
@@ -38,7 +40,6 @@ class AdapterModel(Model):
         posterior_transform: Callable[[Posterior], Posterior] | None = None,
         **kwargs: Any,
     ) -> Posterior:
-        # See base class.
         if (
             (output_indices is not None)
             or observation_noise

--- a/baybe/surrogates/bandit.py
+++ b/baybe/surrogates/bandit.py
@@ -85,7 +85,7 @@ class BetaBernoulliMultiArmedBanditSurrogate(Surrogate):
         ).unsqueeze(-1)
 
     @override
-    def to_botorch(self) -> Model:  # noqa: D102
+    def to_botorch(self) -> Model:
         # We register the sampler on the fly to avoid eager loading of torch
 
         from botorch.sampling.base import MCSampler

--- a/baybe/surrogates/bandit.py
+++ b/baybe/surrogates/bandit.py
@@ -159,6 +159,7 @@ class BetaBernoulliMultiArmedBanditSurrogate(Surrogate):
         losses = (train_x * (train_y == float(_FAILURE_VALUE_COMP))).sum(dim=0)
         self._win_lose_counts = torch.vstack([wins, losses]).to(torch.int)
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Prior", self.prior, single_line=True)]
         return to_string(super().__str__(), *fields)

--- a/baybe/surrogates/bandit.py
+++ b/baybe/surrogates/bandit.py
@@ -6,6 +6,7 @@ import gc
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from attrs import define, field
+from typing_extensions import override
 
 from baybe.exceptions import IncompatibleSearchSpaceError, ModelNotTrainedError
 from baybe.parameters.categorical import CategoricalParameter
@@ -83,9 +84,8 @@ class BetaBernoulliMultiArmedBanditSurrogate(Surrogate):
             [self.prior.alpha, self.prior.beta]
         ).unsqueeze(-1)
 
+    @override
     def to_botorch(self) -> Model:  # noqa: D102
-        # See base class.
-
         # We register the sampler on the fly to avoid eager loading of torch
 
         from botorch.sampling.base import MCSampler
@@ -108,23 +108,20 @@ class BetaBernoulliMultiArmedBanditSurrogate(Surrogate):
 
         return super().to_botorch()
 
+    @override
     @staticmethod
     def _make_input_scaler_factory():
-        # See base class.
-        #
         # Due to enforced one-hot encoding, no input scaling is needed.
         return None
 
+    @override
     @staticmethod
     def _make_target_scaler_factory():
-        # See base class.
-        #
         # We directly use the binary computational representation from the target.
         return None
 
+    @override
     def _posterior(self, candidates: Tensor, /) -> TorchPosterior:
-        # See base class.
-
         from botorch.posteriors import TorchPosterior
         from torch.distributions import Beta
 
@@ -133,9 +130,8 @@ class BetaBernoulliMultiArmedBanditSurrogate(Surrogate):
         ]
         return TorchPosterior(Beta(*beta_params_for_candidates.split(1, -1)))
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor, _: Any = None) -> None:
-        # See base class.
-
         # TODO: Fix requirement of OHE encoding. This is likely a long-term goal since
         #   probably requires decoupling parameter from encodings and associating the
         #   latter with the surrogate.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -280,6 +280,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             obtained via :meth:`baybe.surrogates.base.Surrogate._make_output_scaler`.
         """
 
+    @override
     def fit(
         self,
         searchspace: SearchSpace,
@@ -349,6 +350,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
         """Perform the actual fitting logic."""
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string(

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -18,6 +18,7 @@ from cattrs.dispatch import (
     UnstructureHook,
 )
 from joblib.hashing import hash
+from typing_extensions import override
 
 from baybe.exceptions import ModelNotTrainedError
 from baybe.objectives.base import Objective
@@ -128,8 +129,8 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     Scales a tensor containing target measurements in computational representation
     to make them digestible for the model-specific, scale-agnostic posterior logic."""
 
+    @override
     def to_botorch(self) -> Model:  # noqa: D102
-        # See base class.
         from baybe.surrogates._adapter import AdapterModel
 
         return AdapterModel(self)
@@ -363,9 +364,8 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 class IndependentGaussianSurrogate(Surrogate, ABC):
     """A surrogate base class providing independent Gaussian posteriors."""
 
+    @override
     def _posterior(self, candidates_comp_scaled: Tensor, /) -> GPyTorchPosterior:
-        # See base class.
-
         import torch
         from botorch.posteriors import GPyTorchPosterior
         from gpytorch.distributions import MultivariateNormal

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -130,7 +130,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     to make them digestible for the model-specific, scale-agnostic posterior logic."""
 
     @override
-    def to_botorch(self) -> Model:  # noqa: D102
+    def to_botorch(self) -> Model:
         from baybe.surrogates._adapter import AdapterModel
 
         return AdapterModel(self)

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -7,9 +7,9 @@ from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
+import cattrs
 import pandas as pd
 from attrs import define, field
-from cattrs import override
 from cattrs.dispatch import (
     StructuredValue,
     StructureHook,
@@ -441,7 +441,7 @@ def _block_serialize_custom_architecture(
 #   existing hooks of the concrete subclasses.
 _unstructure_hook = _make_hook_decode_onnx_str(
     _block_serialize_custom_architecture(
-        lambda x: unstructure_base(x, overrides={"_model": override(omit=True)})
+        lambda x: unstructure_base(x, overrides={"_model": cattrs.override(omit=True)})
     )
 )
 converter.register_unstructure_hook(Surrogate, _unstructure_hook)

--- a/baybe/surrogates/custom.py
+++ b/baybe/surrogates/custom.py
@@ -14,6 +14,7 @@ import gc
 from typing import TYPE_CHECKING, ClassVar, NoReturn
 
 from attrs import define, field, validators
+from typing_extensions import override
 
 from baybe.exceptions import DeprecationError
 from baybe.parameters import (
@@ -75,6 +76,7 @@ class CustomONNXSurrogate(IndependentGaussianSurrogate):
         except Exception as exc:
             raise ValueError("Invalid ONNX string") from exc
 
+    @override
     @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
@@ -97,6 +99,7 @@ class CustomONNXSurrogate(IndependentGaussianSurrogate):
             torch.from_numpy(results[1]).pow(2).to(DTypeFloatTorch),
         )
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
         # TODO: This method actually needs to raise a NotImplementedError because
         #   ONNX surrogate models cannot be retrained. However, this would currently
@@ -140,6 +143,7 @@ class CustomONNXSurrogate(IndependentGaussianSurrogate):
                 f"{CustomDiscreteParameter.__name__}."
             )
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("ONNX input name", self.onnx_input_name, single_line=True)]
         return to_string(super().__str__(), *fields)

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -211,6 +211,7 @@ class GaussianProcessSurrogate(Surrogate):
         else:
             botorch.fit.fit_gpytorch_mll(mll)
 
+    @override
     def __str__(self) -> str:
         fields = [
             to_string("Kernel factory", self.kernel_factory, single_line=True),

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -117,7 +117,7 @@ class GaussianProcessSurrogate(Surrogate):
         return make_gp_from_preset(preset)
 
     @override
-    def to_botorch(self) -> Model:  # noqa: D102
+    def to_botorch(self) -> Model:
         return self._model
 
     @override

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from attrs import define, field
 from attrs.validators import instance_of
+from typing_extensions import override
 
 from baybe.parameters.base import Parameter
 from baybe.searchspace.core import SearchSpace
@@ -115,34 +116,30 @@ class GaussianProcessSurrogate(Surrogate):
         """Create a Gaussian process surrogate from one of the defined presets."""
         return make_gp_from_preset(preset)
 
+    @override
     def to_botorch(self) -> Model:  # noqa: D102
-        # See base class.
-
         return self._model
 
+    @override
     @staticmethod
     def _make_parameter_scaler_factory(
         parameter: Parameter,
     ) -> type[InputTransform] | None:
-        # See base class.
-
         # For GPs, we let botorch handle the scaling. See [Scaling Workaround] above.
         return None
 
+    @override
     @staticmethod
     def _make_target_scaler_factory() -> type[OutcomeTransform] | None:
-        # See base class.
-
         # For GPs, we let botorch handle the scaling. See [Scaling Workaround] above.
         return None
 
+    @override
     def _posterior(self, candidates_comp_scaled: Tensor, /) -> Posterior:
-        # See base class.
         return self._model.posterior(candidates_comp_scaled)
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
-        # See base class.
-
         import botorch
         import gpytorch
         import torch

--- a/baybe/surrogates/gaussian_process/kernel_factory.py
+++ b/baybe/surrogates/gaussian_process/kernel_factory.py
@@ -45,7 +45,7 @@ class PlainKernelFactory(KernelFactory, SerialMixin):
     """The fixed kernel to be returned by the factory."""
 
     @override
-    def __call__(  # noqa: D102
+    def __call__(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         return self.kernel

--- a/baybe/surrogates/gaussian_process/kernel_factory.py
+++ b/baybe/surrogates/gaussian_process/kernel_factory.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from attrs import define, field
 from attrs.validators import instance_of
+from typing_extensions import override
 
 from baybe.kernels.base import Kernel
 from baybe.searchspace import SearchSpace
@@ -43,11 +44,10 @@ class PlainKernelFactory(KernelFactory, SerialMixin):
     kernel: Kernel = field(validator=instance_of(Kernel))
     """The fixed kernel to be returned by the factory."""
 
+    @override
     def __call__(  # noqa: D102
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        # See base class.
-
         return self.kernel
 
 

--- a/baybe/surrogates/gaussian_process/presets/default.py
+++ b/baybe/surrogates/gaussian_process/presets/default.py
@@ -35,7 +35,7 @@ class DefaultKernelFactory(KernelFactory):
     """
 
     @override
-    def __call__(  # noqa: D102
+    def __call__(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         effective_dims = train_x.shape[-1] - len(

--- a/baybe/surrogates/gaussian_process/presets/default.py
+++ b/baybe/surrogates/gaussian_process/presets/default.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import define
+from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
@@ -33,10 +34,10 @@ class DefaultKernelFactory(KernelFactory):
     and interpolates the prior moments linearly between them.
     """
 
+    @override
     def __call__(  # noqa: D102
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        # See base class.
         effective_dims = train_x.shape[-1] - len(
             [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
         )

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -6,6 +6,7 @@ import gc
 from typing import TYPE_CHECKING
 
 from attrs import define
+from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
@@ -29,10 +30,10 @@ class EDBOKernelFactory(KernelFactory):
         * https://doi.org/10.1038/s41586-021-03213-y
     """
 
+    @override
     def __call__(  # noqa: D102
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        # See base class.
         effective_dims = train_x.shape[-1] - len(
             [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
         )

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -31,7 +31,7 @@ class EDBOKernelFactory(KernelFactory):
     """
 
     @override
-    def __call__(  # noqa: D102
+    def __call__(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         effective_dims = train_x.shape[-1] - len(

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from attr import define, field
+from attrs import define, field
 from sklearn.linear_model import ARDRegression
 from typing_extensions import override
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import define, field
 from sklearn.linear_model import ARDRegression
+from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
@@ -35,12 +36,11 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     _model: ARDRegression | None = field(init=False, default=None, eq=False)
     """The actual model."""
 
+    @override
     @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:
-        # See base class.
-
         # FIXME[typing]: It seems there is currently no better way to inform the type
         #   checker that the attribute is available at the time of the function call
         assert self._model is not None
@@ -56,8 +56,8 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
 
         return mean, var
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
-        # See base class.
         self._model = ARDRegression(**(self.model_params))
         self._model.fit(train_x, train_y.ravel())
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -61,6 +61,7 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
         self._model = ARDRegression(**(self.model_params))
         self._model.fit(train_x, train_y.ravel())
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Model Params", self.model_params, single_line=True)]
         return to_string(super().__str__(), *fields)

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 from typing import TYPE_CHECKING, ClassVar
 
-from attr import define, field
+from attrs import define, field
 from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -6,6 +6,7 @@ import gc
 from typing import TYPE_CHECKING, ClassVar
 
 from attr import define, field
+from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction
@@ -28,12 +29,11 @@ class MeanPredictionSurrogate(IndependentGaussianSurrogate):
     _model: float | None = field(init=False, default=None, eq=False)
     """The estimated posterior mean value of the training targets."""
 
+    @override
     @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:
-        # See base class.
-
         import torch
 
         # TODO: use target value bounds for covariance scaling when explicitly provided
@@ -41,8 +41,8 @@ class MeanPredictionSurrogate(IndependentGaussianSurrogate):
         var = torch.ones(len(candidates_comp_scaled))
         return mean, var
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
-        # See base class.
         self._model = train_y.mean().item()
 
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from attr import define, field
 from ngboost import NGBRegressor
+from typing_extensions import override
 
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import IndependentGaussianSurrogate
@@ -43,28 +44,25 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
     def __attrs_post_init__(self):
         self.model_params = {**self._default_model_params, **self.model_params}
 
+    @override
     @staticmethod
     def _make_parameter_scaler_factory(
         parameter: Parameter,
     ) -> type[InputTransform] | None:
-        # See base class.
-
         # Tree-like models do not require any input scaling
         return None
 
+    @override
     @staticmethod
     def _make_target_scaler_factory() -> type[OutcomeTransform] | None:
-        # See base class.
-
         # Tree-like models do not require any output scaling
         return None
 
+    @override
     @batchify_mean_var_prediction
     def _estimate_moments(
         self, candidates_comp_scaled: Tensor, /
     ) -> tuple[Tensor, Tensor]:
-        # See base class.
-
         # FIXME[typing]: It seems there is currently no better way to inform the type
         #   checker that the attribute is available at the time of the function call
         assert self._model is not None
@@ -80,8 +78,8 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
 
         return mean, var
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
-        # See base class.
         self._model = NGBRegressor(**(self.model_params)).fit(train_x, train_y.ravel())
 
     def __str__(self) -> str:

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from attr import define, field
+from attrs import define, field
 from ngboost import NGBRegressor
 from typing_extensions import override
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -82,6 +82,7 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
         self._model = NGBRegressor(**(self.model_params)).fit(train_x, train_y.ravel())
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Model Params", self.model_params, single_line=True)]
         return to_string(super().__str__(), *fields)

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -104,6 +104,7 @@ class RandomForestSurrogate(Surrogate):
         self._model = RandomForestRegressor(**(self.model_params))
         self._model.fit(train_x.numpy(), train_y.numpy().ravel())
 
+    @override
     def __str__(self) -> str:
         fields = [to_string("Model Params", self.model_params, single_line=True)]
         return to_string(super().__str__(), *fields)

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -6,7 +6,7 @@ from collections.abc import Collection
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 import numpy as np
-from attr import define, field
+from attrs import define, field
 from sklearn.ensemble import RandomForestRegressor
 from typing_extensions import override
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 import numpy as np
 from attr import define, field
 from sklearn.ensemble import RandomForestRegressor
+from typing_extensions import override
 
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import Surrogate
@@ -46,25 +47,22 @@ class RandomForestSurrogate(Surrogate):
     _model: RandomForestRegressor | None = field(init=False, default=None, eq=False)
     """The actual model."""
 
+    @override
     @staticmethod
     def _make_parameter_scaler_factory(
         parameter: Parameter,
     ) -> type[InputTransform] | None:
-        # See base class.
-
         # Tree-like models do not require any input scaling
         return None
 
+    @override
     @staticmethod
     def _make_target_scaler_factory() -> type[OutcomeTransform] | None:
-        # See base class.
-
         # Tree-like models do not require any output scaling
         return None
 
+    @override
     def _posterior(self, candidates_comp_scaled: Tensor, /) -> EnsemblePosterior:
-        # See base class.
-
         from botorch.models.ensemble import EnsemblePosterior
 
         @batchify_ensemble_predictor
@@ -101,8 +99,8 @@ class RandomForestSurrogate(Surrogate):
 
         return predictions
 
+    @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
-        # See base class.
         self._model = RandomForestRegressor(**(self.model_params))
         self._model.fit(train_x.numpy(), train_y.numpy().ravel())
 

--- a/baybe/targets/base.py
+++ b/baybe/targets/base.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 from attrs import define, field
+from typing_extensions import override
 
 from baybe.serialization import (
     SerialMixin,
@@ -54,6 +55,7 @@ class Target(ABC, SerialMixin):
     def summary(self) -> dict:
         """Return a custom summarization of the target."""
 
+    @override
     def __str__(self) -> str:
         return str(self.summary())
 

--- a/baybe/targets/binary.py
+++ b/baybe/targets/binary.py
@@ -54,6 +54,7 @@ class BinaryTarget(Target, SerialMixin):
                 f"target '{self.name}': {value}"
             )
 
+    @override
     def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
         # TODO: The method (signature) needs to be refactored, potentially when
         #   enabling multi-target settings. The current input type suggests that passing

--- a/baybe/targets/binary.py
+++ b/baybe/targets/binary.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 from attrs.validators import instance_of
+from typing_extensions import override
 
 from baybe.exceptions import InvalidTargetValueError
 from baybe.serialization import SerialMixin
@@ -78,8 +79,8 @@ class BinaryTarget(Target, SerialMixin):
             columns=data.columns,
         )
 
+    @override
     def summary(self) -> dict:  # noqa: D102
-        # See base class.
         return dict(
             Type=self.__class__.__name__,
             Name=self.name,

--- a/baybe/targets/binary.py
+++ b/baybe/targets/binary.py
@@ -55,7 +55,7 @@ class BinaryTarget(Target, SerialMixin):
             )
 
     @override
-    def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
         # TODO: The method (signature) needs to be refactored, potentially when
         #   enabling multi-target settings. The current input type suggests that passing
         #   dataframes is allowed, but the code was designed for single targets and
@@ -81,7 +81,7 @@ class BinaryTarget(Target, SerialMixin):
         )
 
     @override
-    def summary(self) -> dict:  # noqa: D102
+    def summary(self) -> dict:
         return dict(
             Type=self.__class__.__name__,
             Name=self.name,

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 from numpy.typing import ArrayLike
+from typing_extensions import override
 
 from baybe.serialization import SerialMixin
 from baybe.targets.base import Target
@@ -130,9 +131,8 @@ class NumericalTarget(Target, SerialMixin):
         """Indicate if the computational transformation maps to the unit interval."""
         return (self.bounds.is_bounded) and (self.transformation is not None)
 
+    @override
     def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
-        # See base class.
-
         # TODO: The method (signature) needs to be refactored, potentially when
         #   enabling multi-target settings. The current input type suggests that passing
         #   dataframes is allowed, but the code was designed for single targets and
@@ -156,8 +156,8 @@ class NumericalTarget(Target, SerialMixin):
 
         return transformed
 
+    @override
     def summary(self) -> dict:  # noqa: D102
-        # See base class.
         target_dict = dict(
             Type=self.__class__.__name__,
             Name=self.name,

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -132,7 +132,7 @@ class NumericalTarget(Target, SerialMixin):
         return (self.bounds.is_bounded) and (self.transformation is not None)
 
     @override
-    def transform(self, data: pd.DataFrame) -> pd.DataFrame:  # noqa: D102
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
         # TODO: The method (signature) needs to be refactored, potentially when
         #   enabling multi-target settings. The current input type suggests that passing
         #   dataframes is allowed, but the code was designed for single targets and
@@ -157,7 +157,7 @@ class NumericalTarget(Target, SerialMixin):
         return transformed
 
     @override
-    def summary(self) -> dict:  # noqa: D102
+    def summary(self) -> dict:
         target_dict = dict(
             Type=self.__class__.__name__,
             Name=self.name,

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, TypeVar
 
 from attrs import asdict, has
+from typing_extensions import override
 
 from baybe.exceptions import UnidentifiedSubclassError, UnmatchedAttributeError
 
@@ -22,6 +23,7 @@ class Dummy:
     Useful e.g. for detecting duplicates in constraints.
     """
 
+    @override
     def __repr__(self):
         """Return a representation of the placeholder."""
         return "<dummy>"

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,8 @@ packages = baybe
 ; * https://github.com/python/mypy/issues/4717
 disable_error_code = type-abstract
 
+enable_error_code = explicit-override
+
 ; at some point, these excludes should all be gone ...
 exclude = (?x)(
           baybe/serialization

--- a/tests/validation/test_acqf_validation.py
+++ b/tests/validation/test_acqf_validation.py
@@ -3,7 +3,7 @@
 from contextlib import nullcontext
 
 import pytest
-from attr import NOTHING as N
+from attrs import NOTHING as N
 from pytest import param
 
 from baybe.acquisition import UCB, qLogNEI, qNEI, qNIPV, qUCB


### PR DESCRIPTION
Let's replace our `See base class` hints with a more modern variant that actually uses the type system, as now enabled via [PEP 698](https://peps.python.org/pep-0698/). Until we drop Python 3.11, this is achieved via the `typing_extensions` backport.