### PR TITLE
Bump Streamlit Requirement

### DIFF
--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -833,7 +833,7 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 stack-data==0.6.3
     # via ipython
-streamlit==1.36.0
+streamlit==1.39.0
     # via baybe (pyproject.toml)
 sympy==1.13.1
     # via
@@ -860,7 +860,7 @@ toml==0.10.2
     # via
     #   pip-audit
     #   streamlit
-tomli==2.0.1 ; python_full_version == '3.11'
+tomli==2.0.1 ; python_full_version <= '3.11'
     # via
     #   coverage
     #   jupyterlab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ examples = [
     "pillow>=10.0.1", # Necessary due to vulnerability
     "plotly>=5.10.0",
     "seaborn>=0.12.2",
-    "streamlit>=1.20.0",
+    "streamlit>=1.37.0", # Necessary due to vulnerability
     "tornado>=6.3.3", # see AUDIT NOTE, required by streamlit
 ]
 


### PR DESCRIPTION
to fix pip-audit vulnerabilities

```terminal
audit-py310: commands[1]> pip-audit
\ Auditing lifelinesFound 2 known vulnerabilities in 1 package
Name      Version ID                  Fix Versions
--------- ------- ------------------- ------------
streamlit 1.22.0  GHSA-8qw9-gf7w-42x5 1.30.0
streamlit 1.22.0  GHSA-rxff-vr5r-8cj5 1.37.0
```