### PR TITLE
Drop `batch_quantity` keyword

### DIFF
--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -226,7 +226,6 @@ class Campaign(SerialMixin):
         self,
         batch_size: int,
         pending_experiments: pd.DataFrame | None = None,
-        batch_quantity: int = None,  # type: ignore[assignment]
     ) -> pd.DataFrame:
         """Provide the recommendations for the next batch of experiments.
 
@@ -234,7 +233,6 @@ class Campaign(SerialMixin):
             batch_size: Number of requested recommendations.
             pending_experiments: Parameter configurations specifying experiments
                 that are currently pending.
-            batch_quantity: Deprecated! Use ``batch_size`` instead.
 
         Returns:
             Dataframe containing the recommendations in experimental representation.


### PR DESCRIPTION
Was removed in PR #332 (commit 6371d976a07ffc0b44de9af87a71b6d5dc8d0bbe) but then mistakenly brought back in PR #319 (commit ac1fa4df16d4d278dcc12462fb61d24a4aa80376)