### PR TITLE
Immutable searchspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubstanceEncoding` value `MORGAN_FP`. As a replacement, `ECFP` with 1024 bits and
   radius of 4 can be used.
 - `SubstanceEncoding` value `RDKIT`. As a replacement, `RDKIT2DDESCRIPTORS` can be used.
+- The `metadata` attribute of `SubspaceDiscrete` no longer exists. Metadata is now
+  exclusively handled by the `Campaign` class.
 
 ## [0.11.3] - 2024-11-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example for a traditional mixture
 - `add_noise_to_perturb_degenerate_rows` utility
 - `benchmarks` subpackage for defining and running performance tests
+– `Campaign.exclude_discrete_candidates` for dynamically un-/excluding discrete
+  candidates from recommendation
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `add_noise_to_perturb_degenerate_rows` utility
 - `benchmarks` subpackage for defining and running performance tests
 – `Campaign.toggle_discrete_candidates` to dynamically in-/exclude discrete candidates
+- `DiscreteConstraint.get_valid` to conveniently access valid candidates
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example for a traditional mixture
 - `add_noise_to_perturb_degenerate_rows` utility
 - `benchmarks` subpackage for defining and running performance tests
-– `Campaign.toggle_discrete_candidates` for dynamically un-/excluding discrete
-  candidates from recommendation
+– `Campaign.toggle_discrete_candidates` to dynamically in-/exclude discrete candidates
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example for a traditional mixture
 - `add_noise_to_perturb_degenerate_rows` utility
 - `benchmarks` subpackage for defining and running performance tests
-– `Campaign.exclude_discrete_candidates` for dynamically un-/excluding discrete
+– `Campaign.toggle_discrete_candidates` for dynamically un-/excluding discrete
   candidates from recommendation
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rare bug arising from degenerate `SubstanceParameter.comp_df` rows that caused
   wrong number of recommendations being returned
 - `ContinuousConstraint`s can now be used in single point precision
+- Search spaces are now stateless, preventing unintended side effects that could lead to
+  incorrect candidate sets when reused in different optimization contexts 
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,7 +304,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simulation no longer fails for targets in `MATCH` mode
 - `closest_element` now works for array-like input of all kinds
 - Structuring concrete subclasses no longer requires providing an explicit `type` field
-- `_target(s)` attributes of `Objectives` are now de-/serialized without leading
+- `_target(s)` attributes of `Objectives` are now (de-)serialized without leading
   underscore to support user-friendly serialization strings
 - Telemetry does not execute any code if it was disabled
 - Running simulations no longer alters the states of the global random number generators
@@ -442,7 +442,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mypy` for targets and intervals
 - Tests for code blocks in README and user guides
 - `hypothesis` strategies and roundtrip tests for targets, intervals, and dataframes
-- De-/serialization of target subclasses via base class
+- (De-)serialization of target subclasses via base class
 - Docs building check now part of CI
 - Automatic formatting checks for code examples in documentation
 - Deserialization of classes with classmethod constructors can now be customized
@@ -467,7 +467,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use pydoclint as flake8 plugin and not as a stand-alone linter
 - Margins in documentation for desktop and mobile version
 - `Interval`s can now also be deserialized from a bounds iterable
-- `SubspaceDiscrete` and `SubspaceContinuous` now have de-/serialization methods
+- `SubspaceDiscrete` and `SubspaceContinuous` now have (de-)serialization methods
 
 ### Removed
 - Conda install instructions and version badge

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Besides functionality to perform a typical recommend-measure loop, BayBE's highl
 - ⚙️ Custom surrogate models: Enhance your predictions through mechanistic understanding
 - 📈 Comprehensive backtest, simulation and imputation utilities: Benchmark and find your best settings
 - 📝 Fully typed and hypothesis-tested: Robust code base
-- 🔄 All objects are fully de-/serializable: Useful for storing results in databases or use in wrappers like APIs
+- 🔄 All objects are fully (de-)serializable: Useful for storing results in databases or use in wrappers like APIs
 
 
 ## ⚡ Quick Start

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -159,7 +159,7 @@ def _get_botorch_acqf_class(
     )
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 def _add_deprecation_hook(hook):
     """Add deprecation warnings to the default hook.
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import cattrs
 import numpy as np
 import pandas as pd
-from attrs import Factory, define, evolve, field
+from attrs import define, evolve, field
 from attrs.converters import optional
 from attrs.validators import instance_of
 from typing_extensions import override
@@ -85,18 +85,7 @@ class Campaign(SerialMixin):
     """The employed recommender"""
 
     # Metadata
-    _searchspace_metadata: pd.DataFrame = field(
-        init=False,
-        default=Factory(
-            lambda self: pd.DataFrame(
-                False,
-                index=self.searchspace.discrete.exp_rep.index,
-                columns=_METADATA_COLUMNS,
-            ),
-            takes_self=True,
-        ),
-        eq=eq_dataframe,
-    )
+    _searchspace_metadata: pd.DataFrame = field(init=False, eq=eq_dataframe)
     """Metadata tracking the experimentation status of the search space."""
 
     n_batches_done: int = field(default=0, init=False)
@@ -115,6 +104,17 @@ class Campaign(SerialMixin):
         factory=pd.DataFrame, eq=eq_dataframe, init=False
     )
     """The cached recommendations."""
+
+    @_searchspace_metadata.default
+    def _default_searchspace_metadata(self) -> pd.DataFrame:
+        """Create a fresh metadata object."""
+        df = pd.DataFrame(
+            False,
+            index=self.searchspace.discrete.exp_rep.index,
+            columns=_METADATA_COLUMNS,
+        )
+        df.loc[:, _EXCLUDED] = self.searchspace.discrete._excluded
+        return df
 
     @override
     def __str__(self) -> str:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -307,10 +307,9 @@ class Campaign(SerialMixin):
                 for details.
             exclude: If ``True``, the specified candidates are excluded.
                 If ``False``, the candidates are considered for recommendation.
-            complement: If ``False``, the filtering mechanism is used as is.
-                If ``True``, the filtering mechanism is inverted so that
-                the complement of the subset specified by the filter is toggled.
-                For details, see :func:`~baybe.utils.dataframe.filter_df`.
+            complement: If ``True``, the filtering mechanism is inverted so that
+                the complement of the candidate subset specified by the filter is
+                toggled. For details, see :func:`~baybe.utils.dataframe.filter_df`.
             dry_run: If ``True``, the target subset is only extracted but not
                 affected. If ``False``, the candidate set is updated correspondingly.
                 Useful for setting up the correct filtering mechanism.

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -314,7 +314,8 @@ class Campaign(SerialMixin):
                 Useful for setting up the correct filtering mechanism.
 
         Returns:
-            The discrete candidate set passing through the specified filter.
+            A new dataframe containing the  discrete candidate set passing through the
+            specified filter.
         """
         raise NotImplementedError(
             f"Candidate toggling is not implemented for constraint specifications of "
@@ -334,7 +335,7 @@ class Campaign(SerialMixin):
         idx = constraint.get_valid(df)
 
         # Determine the candidate subset to be toggled
-        points = df.drop(index=idx) if anti else df.loc[idx]
+        points = df.drop(index=idx) if anti else df.loc[idx].copy()
 
         if not dry_run:
             self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -264,6 +264,31 @@ class Campaign(SerialMixin):
         )
         self._searchspace_metadata.loc[idxs_matched, _WAS_MEASURED] = True
 
+    def exclude_discrete_candidates(
+        self, filter: pd.DataFrame, value: bool, dry_run: bool = False
+    ) -> pd.DataFrame:
+        """Un-/exclude a certain set of discrete candidate points.
+
+        Args:
+            filter: A dataframe defining the candidates to be un-/excluded.
+                The subset is determined via an inner merge with the discrete space.
+            value: If True, the specified set of candidates are excluded.
+                If False, the candidates are re-considered for recommendation.
+            dry_run: If True, the matching candidate set is only extracted but not
+                affected. Useful for setting up the correct filtering mechanism.
+
+        Returns:
+            The discrete candidate set passing through the specified filter.
+        """
+        points = pd.merge(
+            self.searchspace.discrete.exp_rep.reset_index(names="_df_index"),
+            filter,
+            how="inner",
+        ).set_index("_df_index")
+        if not dry_run:
+            self._searchspace_metadata.loc[points.index, _DONT_RECOMMEND] = value
+        return points
+
     def recommend(
         self,
         batch_size: int,

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -310,6 +310,9 @@ class Campaign(SerialMixin):
         elif isinstance(constraints, Collection) and is_all_instance(
             constraints, DiscreteConstraint
         ):
+            # TODO: Should be taken over by upcoming `SubspaceDiscrete.filter` method,
+            #   automatically choosing the appropriate backend (polars/pandas/...)
+
             # Filter the search space dataframe according to the given constraint
             idx = reduce(
                 lambda x, y: x.intersection(y), (c.get_valid(df) for c in constraints)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -280,11 +280,12 @@ class Campaign(SerialMixin):
         Returns:
             The discrete candidate set passing through the specified filter.
         """
+        exp_rep = self.searchspace.discrete.exp_rep
+        index_name = exp_rep.index.name
         points = pd.merge(
-            self.searchspace.discrete.exp_rep.reset_index(names="_df_index"),
-            filter,
-            how="inner",
+            exp_rep.reset_index(names="_df_index"), filter, how="inner"
         ).set_index("_df_index")
+        points.index.name = index_name
         if not dry_run:
             self._searchspace_metadata.loc[points.index, _EXCLUDED] = value
         return points

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -331,11 +331,10 @@ class Campaign(SerialMixin):
     ) -> pd.DataFrame:
         # Filter search space dataframe according to the given constraint
         df = self.searchspace.discrete.exp_rep
-        idx = constraint.get_invalid(df)
-        filtered = df.drop(index=idx)
+        idx = constraint.get_valid(df)
 
         # Determine the candidate subset to be toggled
-        points = df.drop(index=filtered.index) if anti else filtered
+        points = df.drop(index=idx) if anti else df.loc[idx]
 
         if not dry_run:
             self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -314,11 +314,15 @@ class Campaign(SerialMixin):
         """
         exp_rep = self.searchspace.discrete.exp_rep
         index_name = exp_rep.index.name
+
+        # Identify points to be dropped
         points = pd.merge(
             exp_rep.reset_index(names="_df_index"), filter, how="left", indicator=True
         ).set_index("_df_index")
-        selector = "left_only" if anti else "both"
-        points = points[points["_merge"] == selector]
+        to_drop = points["_merge"] == ("both" if anti else "left_only")
+
+        # Drop the points
+        points.drop(index=points[to_drop].index, inplace=True)
         points.drop("_merge", axis=1, inplace=True)
         points.index.name = index_name
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -264,26 +264,26 @@ class Campaign(SerialMixin):
         )
         self._searchspace_metadata.loc[idxs_matched, _MEASURED] = True
 
-    def exclude_discrete_candidates(
+    def toggle_discrete_candidates(
         self,
         filter: pd.DataFrame,
-        value: bool,
+        exclude: bool,
         anti: bool = False,
         dry_run: bool = False,
     ) -> pd.DataFrame:
-        """Un-/exclude a certain set of discrete candidate points.
+        """Un-/exclude certain discrete points from the candidate set.
 
         Args:
-            filter: A dataframe defining the candidates subset to be un-/excluded.
-                The subset is determined via a join (see ``anti`` argument) with the
-                discrete space.
-            value: If ``True``, the specified set of candidates are excluded.
+            filter: A dataframe specifying the filtering mechanism to determine the
+                candidates subset to be un-/excluded. The subset is determined via a
+                join (see ``anti`` argument for details) with the discrete space.
+            exclude: If ``True``, the specified candidates are excluded.
                 If ``False``, the candidates are considered for recommendation.
             anti: If ``False``, the filter determines the points to be affected (i.e.
-                selection using a regular join). If ``True``, the filtering mechanism is
+                selection via regular join). If ``True``, the filtering mechanism is
                 inverted in that only the points passing the filter are unaffected (i.e.
-                selection using an anti-join).
-            dry_run: If ``True``, the matching subset is only extracted but not
+                selection via anti-join).
+            dry_run: If ``True``, the target subset is only extracted but not
                 affected. If ``False``, the candidate set is updated correspondingly.
                 Useful for setting up the correct filtering mechanism.
 
@@ -301,7 +301,7 @@ class Campaign(SerialMixin):
         points.index.name = index_name
 
         if not dry_run:
-            self._searchspace_metadata.loc[points.index, _EXCLUDED] = value
+            self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude
 
         return points
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -23,7 +23,6 @@ from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.searchspace.core import (
     SearchSpace,
-    SearchSpaceType,
     to_searchspace,
     validate_searchspace_from_config,
 )
@@ -195,13 +194,6 @@ class Campaign(SerialMixin):
                     f"The numerical parameter '{param.name}' has non-numeric entries in"
                     f" the provided dataframe."
                 )
-
-        # Update meta data
-        # TODO: refactor responsibilities
-        if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            self.searchspace.discrete.mark_as_measured(
-                data, numerical_measurements_must_be_within_tolerance
-            )
 
         # Read in measurements and add them to the database
         self.n_batches_done += 1

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -39,6 +39,7 @@ from baybe.telemetry import (
     telemetry_record_recommended_measurement_percentage,
     telemetry_record_value,
 )
+from baybe.utils.basic import is_all_instance
 from baybe.utils.boolean import eq_dataframe
 from baybe.utils.dataframe import filter_df, fuzzy_row_match
 from baybe.utils.plotting import to_string
@@ -324,7 +325,9 @@ class Campaign(SerialMixin):
             # Determine the candidate subset to be toggled
             points = filter_df(df, constraints, complement)
 
-        elif isinstance(constraints, Collection):
+        elif isinstance(constraints, Collection) and is_all_instance(
+            constraints, DiscreteConstraint
+        ):
             # Filter the search space dataframe according to the given constraint
             idx = reduce(
                 lambda x, y: x.intersection(y), (c.get_valid(df) for c in constraints)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -44,10 +44,10 @@ if TYPE_CHECKING:
     from botorch.posteriors import Posterior
 
 # Metadata columns
-_WAS_RECOMMENDED = "was_recommended"
-_WAS_MEASURED = "was_measured"
-_DONT_RECOMMEND = "dont_recommend"
-_METADATA_COLUMNS = [_WAS_RECOMMENDED, _WAS_MEASURED, _DONT_RECOMMEND]
+_RECOMMENDED = "recommended"
+_MEASURED = "measured"
+_EXCLUDED = "excluded"
+_METADATA_COLUMNS = [_RECOMMENDED, _MEASURED, _EXCLUDED]
 
 
 @define
@@ -262,7 +262,7 @@ class Campaign(SerialMixin):
             self.parameters,
             numerical_measurements_must_be_within_tolerance,
         )
-        self._searchspace_metadata.loc[idxs_matched, _WAS_MEASURED] = True
+        self._searchspace_metadata.loc[idxs_matched, _MEASURED] = True
 
     def exclude_discrete_candidates(
         self, filter: pd.DataFrame, value: bool, dry_run: bool = False
@@ -286,7 +286,7 @@ class Campaign(SerialMixin):
             how="inner",
         ).set_index("_df_index")
         if not dry_run:
-            self._searchspace_metadata.loc[points.index, _DONT_RECOMMEND] = value
+            self._searchspace_metadata.loc[points.index, _EXCLUDED] = value
         return points
 
     def recommend(
@@ -349,7 +349,7 @@ class Campaign(SerialMixin):
 
         # Update metadata
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            self._searchspace_metadata.loc[rec.index, _WAS_RECOMMENDED] = True
+            self._searchspace_metadata.loc[rec.index, _RECOMMENDED] = True
 
         # Telemetry
         telemetry_record_value(TELEM_LABELS["COUNT_RECOMMEND"], 1)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -293,11 +293,11 @@ class Campaign(SerialMixin):
         anti: bool = False,
         dry_run: bool = False,
     ) -> pd.DataFrame:
-        """Un-/exclude certain discrete points from the candidate set.
+        """In-/exclude certain discrete points in/from the candidate set.
 
         Args:
             filter: A dataframe specifying the filtering mechanism to determine the
-                candidates subset to be un-/excluded. The subset is determined via a
+                candidates subset to be in-/excluded. The subset is determined via a
                 join (see ``anti`` argument for details) with the discrete space.
             exclude: If ``True``, the specified candidates are excluded.
                 If ``False``, the candidates are considered for recommendation.

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -322,6 +322,10 @@ class Campaign(SerialMixin):
         # Cache the recommendations
         self._cached_recommendation = rec.copy()
 
+        # Update metadata
+        if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
+            self.searchspace_metadata.loc[rec.index, _WAS_RECOMMENDED] = True
+
         # Telemetry
         telemetry_record_value(TELEM_LABELS["COUNT_RECOMMEND"], 1)
         telemetry_record_value(TELEM_LABELS["BATCH_SIZE"], batch_size)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -85,7 +85,7 @@ class Campaign(SerialMixin):
     """The employed recommender"""
 
     # Metadata
-    searchspace_metadata: pd.DataFrame = field(
+    _searchspace_metadata: pd.DataFrame = field(
         init=False,
         default=Factory(
             lambda self: pd.DataFrame(
@@ -262,7 +262,7 @@ class Campaign(SerialMixin):
             self.parameters,
             numerical_measurements_must_be_within_tolerance,
         )
-        self.searchspace_metadata.loc[idxs_matched, _WAS_MEASURED] = True
+        self._searchspace_metadata.loc[idxs_matched, _WAS_MEASURED] = True
 
     def recommend(
         self,
@@ -306,7 +306,7 @@ class Campaign(SerialMixin):
         annotated_searchspace = evolve(
             self.searchspace,
             discrete=AnnotatedSubspaceDiscrete.from_subspace(
-                self.searchspace.discrete, self.searchspace_metadata
+                self.searchspace.discrete, self._searchspace_metadata
             ),
         )
 
@@ -324,7 +324,7 @@ class Campaign(SerialMixin):
 
         # Update metadata
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            self.searchspace_metadata.loc[rec.index, _WAS_RECOMMENDED] = True
+            self._searchspace_metadata.loc[rec.index, _WAS_RECOMMENDED] = True
 
         # Telemetry
         telemetry_record_value(TELEM_LABELS["COUNT_RECOMMEND"], 1)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -293,7 +293,7 @@ class Campaign(SerialMixin):
         self,
         constraint: DiscreteConstraint | pd.DataFrame,
         exclude: bool,
-        anti: bool = False,
+        complement: bool = False,
         dry_run: bool = False,
     ) -> pd.DataFrame:
         """In-/exclude certain discrete points in/from the candidate set.
@@ -306,9 +306,10 @@ class Campaign(SerialMixin):
                 for details.
             exclude: If ``True``, the specified candidates are excluded.
                 If ``False``, the candidates are considered for recommendation.
-            anti: Boolean flag deciding if the points specified by the filter or their
-                complement is to be kept. For details, see
-                :func:`~baybe.utils.dataframe.filter_df`.
+            complement: If ``False``, the filtering mechanism is used as is.
+                If ``True``, the filtering mechanism is inverted so that
+                the complement of the subset specified by the filter is toggled.
+                For details, see :func:`~baybe.utils.dataframe.filter_df`.
             dry_run: If ``True``, the target subset is only extracted but not
                 affected. If ``False``, the candidate set is updated correspondingly.
                 Useful for setting up the correct filtering mechanism.
@@ -327,7 +328,7 @@ class Campaign(SerialMixin):
         self,
         constraint: DiscreteConstraint,
         exclude: bool,
-        anti: bool = False,
+        complement: bool = False,
         dry_run: bool = False,
     ) -> pd.DataFrame:
         # Filter search space dataframe according to the given constraint
@@ -335,7 +336,7 @@ class Campaign(SerialMixin):
         idx = constraint.get_valid(df)
 
         # Determine the candidate subset to be toggled
-        points = df.drop(index=idx) if anti else df.loc[idx].copy()
+        points = df.drop(index=idx) if complement else df.loc[idx].copy()
 
         if not dry_run:
             self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude
@@ -347,11 +348,11 @@ class Campaign(SerialMixin):
         self,
         constraint: pd.DataFrame,
         exclude: bool,
-        anti: bool = False,
+        complement: bool = False,
         dry_run: bool = False,
     ) -> pd.DataFrame:
         # Determine the candidate subset to be toggled
-        points = filter_df(self.searchspace.discrete.exp_rep, constraint, anti)
+        points = filter_df(self.searchspace.discrete.exp_rep, constraint, complement)
 
         if not dry_run:
             self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -248,7 +248,7 @@ class Campaign(SerialMixin):
         measurements: pd.DataFrame,
         numerical_measurements_must_be_within_tolerance: bool,
     ) -> None:
-        """Mark the given elements of the space as measured.
+        """Mark the given elements of the discrete subspace as measured.
 
         Args:
             measurements: A dataframe containing parameter configurations to be

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -118,9 +118,31 @@ class Campaign(SerialMixin):
 
     @override
     def __str__(self) -> str:
+        recommended_count = sum(self._searchspace_metadata[_RECOMMENDED])
+        measured_count = sum(self._searchspace_metadata[_MEASURED])
+        excluded_count = sum(self._searchspace_metadata[_EXCLUDED])
+        n_elements = len(self._searchspace_metadata)
+        searchspace_fields = [
+            to_string(
+                "Recommended:",
+                f"{recommended_count}/{n_elements}",
+                single_line=True,
+            ),
+            to_string(
+                "Measured:",
+                f"{measured_count}/{n_elements}",
+                single_line=True,
+            ),
+            to_string(
+                "Excluded:",
+                f"{excluded_count}/{n_elements}",
+                single_line=True,
+            ),
+        ]
         metadata_fields = [
             to_string("Batches done", self.n_batches_done, single_line=True),
             to_string("Fits done", self.n_fits_done, single_line=True),
+            to_string("Discrete Subspace Meta Data", *searchspace_fields),
         ]
         metadata = to_string("Meta Data", *metadata_fields)
         fields = [metadata, self.searchspace, self.objective, self.recommender]

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -256,9 +256,13 @@ class Campaign(SerialMixin):
 
         # Update metadata
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            self._mark_as_measured(
-                data, numerical_measurements_must_be_within_tolerance
+            idxs_matched = fuzzy_row_match(
+                self.searchspace.discrete.exp_rep,
+                data,
+                self.parameters,
+                numerical_measurements_must_be_within_tolerance,
             )
+            self._searchspace_metadata.loc[idxs_matched, _MEASURED] = True
 
         # Telemetry
         telemetry_record_value(TELEM_LABELS["COUNT_ADD_RESULTS"], 1)
@@ -268,27 +272,6 @@ class Campaign(SerialMixin):
             self.parameters,
             numerical_measurements_must_be_within_tolerance,
         )
-
-    def _mark_as_measured(
-        self,
-        measurements: pd.DataFrame,
-        numerical_measurements_must_be_within_tolerance: bool,
-    ) -> None:
-        """Mark the given elements of the discrete subspace as measured.
-
-        Args:
-            measurements: A dataframe containing parameter configurations to be
-                marked as measured.
-            numerical_measurements_must_be_within_tolerance: See
-                :func:`baybe.utils.dataframe.fuzzy_row_match`.
-        """
-        idxs_matched = fuzzy_row_match(
-            self.searchspace.discrete.exp_rep,
-            measurements,
-            self.parameters,
-            numerical_measurements_must_be_within_tolerance,
-        )
-        self._searchspace_metadata.loc[idxs_matched, _MEASURED] = True
 
     def toggle_discrete_candidates(  # noqa: DOC501
         self,

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -482,7 +482,7 @@ def _drop_version(dict_: dict) -> dict:
     return dict_
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 unstructure_hook = cattrs.gen.make_dict_unstructure_fn(
     Campaign, converter, _cattrs_include_init_false=True
 )

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -302,7 +302,7 @@ class Campaign(SerialMixin):
         Args:
             constraints: A filtering mechanism determining the candidates subset to be
                 in-/excluded. Can be either a collection of
-                :class:`~baybe.constraints.base.DiscreteConstraint`s or a dataframe.
+                :class:`~baybe.constraints.base.DiscreteConstraint` or a dataframe.
                 For the latter, see :func:`~baybe.utils.dataframe.filter_df`
                 for details.
             exclude: If ``True``, the specified candidates are excluded.

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -93,16 +93,27 @@ class DiscreteConstraint(Constraint, ABC):
     eval_during_modeling: ClassVar[bool] = False
     # See base class.
 
+    def get_valid(self, df: pd.DataFrame, /) -> pd.Index:
+        """Get the indices of dataframe entries that are valid under the constraint.
+
+        Args:
+            df: A dataframe where each row represents a parameter configuration.
+
+        Returns:
+            The dataframe indices of rows that fulfill the constraint.
+        """
+        invalid = self.get_invalid(df)
+        return df.index.drop(invalid)
+
     @abstractmethod
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         """Get the indices of dataframe entries that are invalid under the constraint.
 
         Args:
-            data: A dataframe where each row represents a particular parameter
-                combination.
+            data: A dataframe where each row represents a parameter configuration.
 
         Returns:
-            The dataframe indices of rows where the constraint is violated.
+            The dataframe indices of rows that violate the constraint.
         """
 
     def get_invalid_polars(self) -> pl.Expr:

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -115,6 +115,7 @@ class DiscreteConstraint(Constraint, ABC):
         Returns:
             The dataframe indices of rows that violate the constraint.
         """
+        # TODO: Should switch backends (pandas/polars/...) behind the scenes
 
     def get_invalid_polars(self) -> pl.Expr:
         """Translate the constraint to Polars expression identifying undesired rows.

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -125,7 +125,7 @@ class CompositeKernel(Kernel, ABC):
     """Abstract base class for all composite kernels."""
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 converter.register_structure_hook(Kernel, get_base_structure_hook(Kernel))
 converter.register_unstructure_hook(Kernel, unstructure_base)
 

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -60,7 +60,7 @@ def to_objective(x: Target | Objective, /) -> Objective:
     return x if isinstance(x, Objective) else x.to_objective()
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 converter.register_structure_hook(Objective, structure_objective)
 converter.register_unstructure_hook(
     Objective,

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -4,7 +4,6 @@ import gc
 import warnings
 from collections.abc import Callable
 from functools import cached_property, partial
-from typing import TypeGuard
 
 import cattrs
 import numpy as np
@@ -18,18 +17,11 @@ from baybe.objectives.base import Objective
 from baybe.objectives.enum import Scalarizer
 from baybe.targets.base import Target
 from baybe.targets.numerical import NumericalTarget
-from baybe.utils.basic import to_tuple
+from baybe.utils.basic import is_all_instance, to_tuple
 from baybe.utils.dataframe import get_transform_objects, pretty_print_df
 from baybe.utils.numerical import geom_mean
 from baybe.utils.plotting import to_string
 from baybe.utils.validation import finite_float
-
-
-def _is_all_numerical_targets(
-    x: tuple[Target, ...], /
-) -> TypeGuard[tuple[NumericalTarget, ...]]:
-    """Typeguard helper function."""
-    return all(isinstance(y, NumericalTarget) for y in x)
 
 
 def scalarize(
@@ -94,7 +86,7 @@ class DesirabilityObjective(Objective):
 
     @_targets.validator
     def _validate_targets(self, _, targets) -> None:  # noqa: DOC101, DOC103
-        if not _is_all_numerical_targets(targets):
+        if not is_all_instance(targets, NumericalTarget):
             raise TypeError(
                 f"'{self.__class__.__name__}' currently only supports targets "
                 f"of type '{NumericalTarget.__name__}'."

--- a/baybe/priors/base.py
+++ b/baybe/priors/base.py
@@ -39,7 +39,7 @@ class Prior(ABC, SerialMixin):
         return prior_cls(*args, **kwargs)
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 converter.register_structure_hook(Prior, get_base_structure_hook(Prior))
 converter.register_unstructure_hook(Prior, unstructure_base)
 

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -222,15 +222,11 @@ class PureRecommender(ABC, RecommenderProtocol):
         # Get recommendations
         if is_hybrid_space:
             rec = self._recommend_hybrid(searchspace, candidates_exp, batch_size)
-            idxs = rec.index
         else:
             idxs = self._recommend_discrete(
                 searchspace.discrete, candidates_exp, batch_size
             )
             rec = searchspace.discrete.exp_rep.loc[idxs, :]
-
-        # Update metadata
-        searchspace.discrete.metadata.loc[idxs, "was_recommended"] = True
 
         # Return recommendations
         return rec

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -212,11 +212,10 @@ class PureRecommender(ABC, RecommenderProtocol):
         if (not is_hybrid_space) and (len(candidates_exp) < batch_size):
             raise NotEnoughPointsLeftError(
                 f"Using the current settings, there are fewer than {batch_size} "
-                "possible data points left to recommend. This can be "
-                "either because all data points have been measured at some point "
-                "(while 'allow_repeated_recommendations' or "
-                "'allow_recommending_already_measured' being False) "
-                "or because all data points are marked as 'dont_recommend'."
+                "possible data points left to recommend. This can happen "
+                "when all candidates have already been measured/recommended while "
+                "`allow_repeated_recommendations'/'allow_recommending_already_measured' "  # noqa: E501
+                "are set to `False`."
             )
 
         # Get recommendations

--- a/baybe/searchspace/_annotated.py
+++ b/baybe/searchspace/_annotated.py
@@ -30,14 +30,14 @@ class AnnotatedSubspaceDiscrete(SubspaceDiscrete):
         allow_recommending_already_measured: bool = False,
         exclude: pd.DataFrame | None = None,
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        from baybe.campaign import _DONT_RECOMMEND, _WAS_MEASURED, _WAS_RECOMMENDED
+        from baybe.campaign import _EXCLUDED, _MEASURED, _RECOMMENDED
 
         # Exclude parts marked by metadata
-        mask_todrop = self.metadata[_DONT_RECOMMEND].copy()
+        mask_todrop = self.metadata[_EXCLUDED].copy()
         if not allow_repeated_recommendations:
-            mask_todrop |= self.metadata[_WAS_RECOMMENDED]
+            mask_todrop |= self.metadata[_RECOMMENDED]
         if not allow_recommending_already_measured:
-            mask_todrop |= self.metadata[_WAS_MEASURED]
+            mask_todrop |= self.metadata[_MEASURED]
 
         # Remove additional excludes
         if exclude is not None:

--- a/baybe/searchspace/_annotated.py
+++ b/baybe/searchspace/_annotated.py
@@ -1,0 +1,48 @@
+"""Search spaces with metadata."""
+
+import pandas as pd
+from attrs import asdict, define, field
+from typing_extensions import Self, override
+
+from baybe.searchspace import SubspaceDiscrete
+from baybe.utils.boolean import eq_dataframe
+
+
+@define
+class AnnotatedSubspaceDiscrete(SubspaceDiscrete):
+    """An annotated search space carrying additional metadata."""
+
+    metadata: pd.DataFrame = field(kw_only=True, eq=eq_dataframe)
+    """The metadata."""
+
+    @classmethod
+    def from_subspace(cls, subspace: SubspaceDiscrete, metadata: pd.DataFrame) -> Self:
+        """Annotate an existing subspace with metadata."""
+        return cls(
+            **asdict(subspace, filter=lambda attr, _: attr.init, recurse=False),
+            metadata=metadata,
+        )
+
+    @override
+    def get_candidates(
+        self,
+        allow_repeated_recommendations: bool = False,
+        allow_recommending_already_measured: bool = False,
+        exclude: pd.DataFrame | None = None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        from baybe.campaign import _DONT_RECOMMEND, _WAS_MEASURED, _WAS_RECOMMENDED
+
+        # Exclude parts marked by metadata
+        mask_todrop = self.metadata[_DONT_RECOMMEND].copy()
+        if not allow_repeated_recommendations:
+            mask_todrop |= self.metadata[_WAS_RECOMMENDED]
+        if not allow_recommending_already_measured:
+            mask_todrop |= self.metadata[_WAS_MEASURED]
+
+        # Remove additional excludes
+        if exclude is not None:
+            mask_todrop |= pd.merge(self.exp_rep, exclude, indicator=True, how="left")[
+                "_merge"
+            ].eq("both")
+
+        return self.exp_rep.loc[~mask_todrop], self.comp_rep.loc[~mask_todrop]

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -89,7 +89,9 @@ class SubspaceContinuous(SerialMixin):
         nonlinear_df = pd.DataFrame(nonlin_constraints_list)
 
         fields = [
-            to_string("Continuous Parameters", pretty_print_df(param_df)),
+            to_string(
+                "Continuous Parameters", pretty_print_df(param_df, max_colwidth=None)
+            ),
             to_string("Linear Equality Constraints", pretty_print_df(lin_eq_df)),
             to_string("Linear Inequality Constraints", pretty_print_df(lin_ineq_df)),
             to_string("Non-linear Constraints", pretty_print_df(nonlinear_df)),

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -129,7 +129,10 @@ class SubspaceDiscrete(SerialMixin):
         constraints_df = pd.DataFrame(constraints_list)
 
         fields = [
-            to_string("Discrete Parameters", pretty_print_df(param_df)),
+            to_string(
+                "Discrete Parameters",
+                pretty_print_df(param_df, max_colwidth=None),
+            ),
             to_string("Experimental Representation", pretty_print_df(self.exp_rep)),
             to_string("Constraints", pretty_print_df(constraints_df)),
             to_string("Computational Representation", pretty_print_df(self.comp_rep)),

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -99,6 +99,7 @@ class SubspaceDiscrete(SerialMixin):
     exp_rep: pd.DataFrame = field(eq=eq_dataframe)
     """The experimental representation of the subspace."""
 
+    # TODO: remove when refactoring active values mechanism
     _excluded: pd.Series = field(init=False, eq=eq_dataframe)
     """Temporary workaround for handling inactive ``TaskParameter`` values."""
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -525,7 +525,7 @@ class SubspaceDiscrete(SerialMixin):
             f"Search spaces no longer carry any metadata to avoid stateful behavior. "
             f"Metadata is now exclusively tracked by the `{Campaign.__name__}` class. "
             f"To dynamically exclude discrete candidates from the search space, "
-            f"use its `{Campaign.exclude_discrete_candidates.__name__}` method."
+            f"use its `{Campaign.toggle_discrete_candidates.__name__}` method."
         )
 
     @property

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -18,7 +18,7 @@ from typing_extensions import override
 
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
 from baybe.constraints.base import DiscreteConstraint
-from baybe.exceptions import OptionalImportError
+from baybe.exceptions import DeprecationError, OptionalImportError
 from baybe.parameters import (
     CategoricalParameter,
     NumericalDiscreteParameter,
@@ -514,6 +514,18 @@ class SubspaceDiscrete(SerialMixin):
             parameters=[*simplex_parameters, *product_parameters],
             exp_rep=exp_rep,
             constraints=constraints,
+        )
+
+    @property
+    def metadata(self) -> pd.DataFrame:
+        """Deprecated!"""
+        from baybe.campaign import Campaign
+
+        raise DeprecationError(
+            f"Search spaces no longer carry any metadata to avoid stateful behavior. "
+            f"Metadata is now exclusively tracked by the `{Campaign.__name__}` class. "
+            f"To dynamically exclude discrete candidates from the search space, "
+            f"use its `{Campaign.exclude_discrete_candidates.__name__}` method."
         )
 
     @property

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -35,7 +35,6 @@ from baybe.utils.basic import to_tuple
 from baybe.utils.boolean import eq_dataframe, strtobool
 from baybe.utils.dataframe import (
     df_drop_single_value_columns,
-    fuzzy_row_match,
     get_transform_objects,
     pretty_print_df,
 )
@@ -47,8 +46,6 @@ if TYPE_CHECKING:
     import polars as pl
 
     from baybe.searchspace.core import SearchSpace
-
-_METADATA_COLUMNS = ["was_recommended", "was_measured", "dont_recommend"]
 
 
 @define(kw_only=True)
@@ -102,8 +99,8 @@ class SubspaceDiscrete(SerialMixin):
     exp_rep: pd.DataFrame = field(eq=eq_dataframe)
     """The experimental representation of the subspace."""
 
-    metadata: pd.DataFrame = field(eq=eq_dataframe)
-    """The metadata."""
+    _excluded: pd.Series = field(init=False, eq=eq_dataframe)
+    """Temporary workaround for handling inactive ``TaskParameter`` values."""
 
     empty_encoding: bool = field(default=False)
     """Flag encoding whether an empty encoding is used."""
@@ -130,33 +127,9 @@ class SubspaceDiscrete(SerialMixin):
         param_df = pd.DataFrame(param_list)
         constraints_df = pd.DataFrame(constraints_list)
 
-        # Get summary information from metadata
-        was_recommended_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[0]]])
-        was_measured_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[1]]])
-        dont_recommend_count = len(self.metadata[self.metadata[_METADATA_COLUMNS[2]]])
-        metadata_count = len(self.metadata)
-
-        metadata_fields = [
-            to_string(
-                f"{_METADATA_COLUMNS[0]}",
-                f"{was_recommended_count}/{metadata_count}",
-                single_line=True,
-            ),
-            to_string(
-                f"{_METADATA_COLUMNS[1]}",
-                f"{was_measured_count}/{metadata_count}",
-                single_line=True,
-            ),
-            to_string(
-                f"{_METADATA_COLUMNS[2]}",
-                f"{dont_recommend_count}/{metadata_count}",
-                single_line=True,
-            ),
-        ]
         fields = [
             to_string("Discrete Parameters", pretty_print_df(param_df)),
             to_string("Experimental Representation", pretty_print_df(self.exp_rep)),
-            to_string("Meta Data", *metadata_fields),
             to_string("Constraints", pretty_print_df(constraints_df)),
             to_string("Computational Representation", pretty_print_df(self.comp_rep)),
         ]
@@ -177,45 +150,10 @@ class SubspaceDiscrete(SerialMixin):
                 "This is not allowed, as it can lead to hard-to-detect bugs."
             )
 
-    @metadata.default
-    def _default_metadata(self) -> pd.DataFrame:
-        """Create the default metadata."""
-        # If the discrete search space is empty, explicitly return an empty dataframe
-        # instead of simply using a zero-length index. Otherwise, the Boolean dtype
-        # would be lost during a serialization roundtrip as there would be no
-        # data available that allows to determine the type, causing subsequent
-        # equality checks to fail.
-        # TODO: verify if this is still required
-        if self.is_empty:
-            return pd.DataFrame(columns=_METADATA_COLUMNS)
-
-        # TODO [16605]: Redesign metadata handling
-        # Exclude inactive tasks from search
-        df = pd.DataFrame(False, columns=_METADATA_COLUMNS, index=self.exp_rep.index)
-        off_task_idxs = ~self._on_task_configurations()
-        df.loc[off_task_idxs.values, "dont_recommend"] = True  # type: ignore
-        return df
-
-    @metadata.validator
-    def _validate_metadata(  # noqa: DOC101, DOC103
-        self, _: Any, metadata: pd.DataFrame
-    ) -> None:
-        """Validate the metadata.
-
-        Raises:
-            ValueError: If the provided metadata allows testing parameter configurations
-                for inactive tasks.
-        """
-        # We first check whether there are actually any parameters that need to be
-        # checked.
-        if self.is_empty:
-            return
-        off_task_idxs = ~self._on_task_configurations()
-        if not metadata.loc[off_task_idxs.values, "dont_recommend"].all():  # type: ignore
-            raise ValueError(
-                "Inconsistent instructions given: The provided metadata allows "
-                "testing parameter configurations for inactive tasks."
-            )
+    @_excluded.default
+    def _default_excluded(self) -> pd.Series:
+        """Exclude inactive tasks from search."""
+        return ~self._on_task_configurations()
 
     @comp_rep.default
     def _default_comp_rep(self) -> pd.DataFrame:
@@ -233,13 +171,6 @@ class SubspaceDiscrete(SerialMixin):
         )
 
         return comp_rep
-
-    def __attrs_post_init__(self) -> None:
-        # TODO [16605]: Redesign metadata handling
-        if self.is_empty:
-            return
-        off_task_idxs = ~self._on_task_configurations()
-        self.metadata.loc[off_task_idxs.values, "dont_recommend"] = True  # type: ignore
 
     def to_searchspace(self) -> SearchSpace:
         """Turn the subspace into a search space with no continuous part."""
@@ -264,7 +195,6 @@ class SubspaceDiscrete(SerialMixin):
         return SubspaceDiscrete(
             parameters=[],
             exp_rep=pd.DataFrame(),
-            metadata=pd.DataFrame(columns=_METADATA_COLUMNS),
         )
 
     @classmethod
@@ -652,27 +582,6 @@ class SubspaceDiscrete(SerialMixin):
             comp_rep_shape=(n_rows, n_cols_comp),
         )
 
-    def mark_as_measured(
-        self,
-        measurements: pd.DataFrame,
-        numerical_measurements_must_be_within_tolerance: bool,
-    ) -> None:
-        """Mark the given elements of the space as measured.
-
-        Args:
-            measurements: A dataframe containing parameter settings that should be
-                marked as measured.
-            numerical_measurements_must_be_within_tolerance: See
-                :func:`baybe.utils.dataframe.fuzzy_row_match`.
-        """
-        idxs_matched = fuzzy_row_match(
-            self.exp_rep,
-            measurements,
-            self.parameters,
-            numerical_measurements_must_be_within_tolerance,
-        )
-        self.metadata.loc[idxs_matched, "was_measured"] = True
-
     def get_candidates(
         self,
         allow_repeated_recommendations: bool = False,
@@ -698,11 +607,7 @@ class SubspaceDiscrete(SerialMixin):
             representation.
         """
         # Filter the search space down to the candidates
-        mask_todrop = self.metadata["dont_recommend"].copy()
-        if not allow_repeated_recommendations:
-            mask_todrop |= self.metadata["was_recommended"]
-        if not allow_recommending_already_measured:
-            mask_todrop |= self.metadata["was_measured"]
+        mask_todrop = self._excluded.copy()
 
         # Remove additional excludes
         if exclude is not None:

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -161,7 +161,7 @@ def select_constructor_hook(specs: dict, cls: type[_T]) -> _T:
     return converter.structure_attrs_fromdict(specs, cls)
 
 
-# Register custom un-/structure hooks
+# Register custom (un-)structure hooks
 converter.register_unstructure_hook(pd.DataFrame, _unstructure_dataframe_hook)
 converter.register_structure_hook(pd.DataFrame, _structure_dataframe_hook)
 converter.register_unstructure_hook(datetime, lambda x: x.isoformat())

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -127,7 +127,9 @@ def simulate_experiment(
         # available in the lookup
         if impute_mode == "ignore":
             campaign.toggle_discrete_candidates(
-                lookup[[p.name for p in campaign.parameters]], exclude=True, anti=True
+                lookup[[p.name for p in campaign.parameters]],
+                exclude=True,
+                complement=True,
             )
 
         # Run the DOE loop

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -125,21 +125,10 @@ def simulate_experiment(
 
         # For impute_mode 'ignore', do not recommend space entries that are not
         # available in the lookup
-        # TODO [16605]: Avoid direct manipulation of metadata
         if impute_mode == "ignore":
-            exp_rep = campaign.searchspace.discrete.exp_rep
-            lookup_configurations = lookup[
-                [p.name for p in campaign.parameters]
-            ].drop_duplicates()
-            missing_inds = exp_rep.index[
-                exp_rep.merge(lookup_configurations, how="left", indicator=True)[
-                    "_merge"
-                ]
-                == "left_only"
-            ]
-            campaign.searchspace.discrete.metadata.loc[
-                missing_inds, "dont_recommend"
-            ] = True
+            campaign.toggle_discrete_candidates(
+                lookup[[p.name for p in campaign.parameters]], exclude=True, anti=True
+            )
 
         # Run the DOE loop
         limit = n_doe_iterations or np.inf

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-import numpy as np
 import pandas as pd
 
 from baybe.campaign import Campaign
@@ -222,15 +221,12 @@ def _simulate_groupby(
         # off-group configurations from the candidates list
         # TODO: Reconsider if deepcopies are required once [16605] is resolved
         campaign_group = deepcopy(campaign)
-        # TODO: Implement SubspaceDiscrete.__len__
-        off_group_idx = np.full(
-            len(campaign.searchspace.discrete.exp_rep), fill_value=True, dtype=bool
-        )
-        off_group_idx[group.index.values] = False
-        # TODO [16605]: Avoid direct manipulation of metadata
-        campaign_group.searchspace.discrete.metadata.loc[
-            off_group_idx, "dont_recommend"
-        ] = True
+        cols = [
+            c
+            for c in group.columns
+            if c in campaign.searchspace.discrete.parameter_names
+        ]
+        campaign_group.toggle_discrete_candidates(group[cols], exclude=True, anti=True)
 
         # Run the group simulation
         try:

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -226,7 +226,9 @@ def _simulate_groupby(
             for c in group.columns
             if c in campaign.searchspace.discrete.parameter_names
         ]
-        campaign_group.toggle_discrete_candidates(group[cols], exclude=True, anti=True)
+        campaign_group.toggle_discrete_candidates(
+            group[cols], exclude=True, complement=True
+        )
 
         # Run the group simulation
         try:

--- a/baybe/simulation/transfer_learning.py
+++ b/baybe/simulation/transfer_learning.py
@@ -76,7 +76,7 @@ def simulate_transfer_learning(
         # off-task configurations from the candidates list
         # TODO: Reconsider if deepcopies are required once [16605] is resolved
         campaign_task = deepcopy(campaign)
-        campaign.toggle_discrete_candidates(
+        campaign_task.toggle_discrete_candidates(
             pd.DataFrame({task_param.name: [task]}), exclude=True, anti=True
         )
 

--- a/baybe/simulation/transfer_learning.py
+++ b/baybe/simulation/transfer_learning.py
@@ -76,11 +76,9 @@ def simulate_transfer_learning(
         # off-task configurations from the candidates list
         # TODO: Reconsider if deepcopies are required once [16605] is resolved
         campaign_task = deepcopy(campaign)
-        off_task_mask = campaign.searchspace.discrete.exp_rep[task_param.name] != task
-        # TODO [16605]: Avoid direct manipulation of metadata
-        campaign_task.searchspace.discrete.metadata.loc[
-            off_task_mask.values, "dont_recommend"
-        ] = True
+        campaign.toggle_discrete_candidates(
+            pd.DataFrame({task_param.name: [task]}), exclude=True, anti=True
+        )
 
         # Use all off-task data as training data
         df_train = lookup[lookup[task_param.name] != task]

--- a/baybe/simulation/transfer_learning.py
+++ b/baybe/simulation/transfer_learning.py
@@ -77,7 +77,7 @@ def simulate_transfer_learning(
         # TODO: Reconsider if deepcopies are required once [16605] is resolved
         campaign_task = deepcopy(campaign)
         campaign_task.toggle_discrete_candidates(
-            pd.DataFrame({task_param.name: [task]}), exclude=True, anti=True
+            pd.DataFrame({task_param.name: [task]}), exclude=True, complement=True
         )
 
         # Use all off-task data as training data

--- a/baybe/surrogates/gaussian_process/kernel_factory.py
+++ b/baybe/surrogates/gaussian_process/kernel_factory.py
@@ -32,7 +32,7 @@ class KernelFactory(Protocol):
         ...
 
 
-# Register de-/serialization hooks
+# Register (un-)structure hooks
 converter.register_structure_hook(KernelFactory, get_base_structure_hook(KernelFactory))
 converter.register_unstructure_hook(KernelFactory, unstructure_base)
 

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 from collections.abc import Callable, Collection, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any, TypeGuard, TypeVar
 
 from attrs import asdict, has
 from typing_extensions import override
@@ -27,6 +27,13 @@ class Dummy:
     def __repr__(self):
         """Return a representation of the placeholder."""
         return "<dummy>"
+
+
+def is_all_instance(x: Collection[Any], t: type[_T], /) -> TypeGuard[Collection[_T]]:
+    """Typeguard to check if all elements in a collection are of a certain type."""
+    # IMPROVE: Ideally, the collection type should itself be abstracted away using a
+    #   generic container type, but unclear how to achieve this with the typing system.
+    return all(isinstance(y, t) for y in x)
 
 
 def get_subclasses(cls: _C, recursive: bool = True, abstract: bool = False) -> list[_C]:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -604,17 +604,17 @@ def get_transform_objects(
 
 
 def filter_df(
-    df: pd.DataFrame, filter: pd.DataFrame, anti: bool = False
+    df: pd.DataFrame, filter: pd.DataFrame, complement: bool = False
 ) -> pd.DataFrame:
     """Filter a dataframe based on a second dataframe defining filtering conditions.
 
-    Filtering is done via a join (see ``anti`` argument for details) between the
+    Filtering is done via a join (see ``complement`` argument for details) between the
     input dataframe and the filter dataframe.
 
     Args:
         df: The dataframe to be filtered.
         filter: The dataframe defining the filtering conditions.
-        anti: If ``False``, the filter dataframe determines the rows to be kept
+        complement: If ``False``, the filter dataframe determines the rows to be kept
             (i.e. selection via regular join). If ``True``, the filtering mechanism is
             inverted so that the complement set of rows is kept (i.e. selection
             via anti-join).
@@ -634,12 +634,12 @@ def filter_df(
         2    1   a
         3    1   b
 
-        >>> filter_df(df, pd.DataFrame([0], columns=["num"]), anti=False)
+        >>> filter_df(df, pd.DataFrame([0], columns=["num"]), complement=False)
            num cat
         0    0   a
         1    0   b
 
-        >>> filter_df(df, pd.DataFrame([0], columns=["num"]), anti=True)
+        >>> filter_df(df, pd.DataFrame([0], columns=["num"]), complement=True)
            num cat
         2    1   a
         3    1   b
@@ -651,7 +651,7 @@ def filter_df(
     out = pd.merge(
         df.reset_index(names="_df_index"), filter, how="left", indicator=True
     ).set_index("_df_index")
-    to_drop = out["_merge"] == ("both" if anti else "left_only")
+    to_drop = out["_merge"] == ("both" if complement else "left_only")
 
     # Drop the points
     out.drop(index=out[to_drop].index, inplace=True)

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -509,9 +509,9 @@ def fuzzy_row_match(
 
 def pretty_print_df(
     df: pd.DataFrame,
-    max_rows: int = 6,
-    max_columns: int = 4,
-    max_colwidth: int = 16,
+    max_rows: int | None = 6,
+    max_columns: int | None = 4,
+    max_colwidth: int | None = 16,
     precision: int = 3,
 ) -> str:
     """Convert a dataframe into a pretty/readable format.

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -161,7 +161,7 @@ This requirement can be disabled using the method's
 
 ## Serialization
 
-Like other BayBE objects, [`Campaigns`](baybe.campaign.Campaign) can be de-/serialized 
+Like other BayBE objects, [`Campaigns`](baybe.campaign.Campaign) can be (de-)serialized 
 using their [`from_json`](baybe.serialization.mixin.SerialMixin.from_json)/
 [`to_json`](baybe.serialization.mixin.SerialMixin.to_json) methods, which 
 allow to convert between Python objects and their corresponding representation in JSON 

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -402,7 +402,7 @@ Find a detailed example [here](../../examples/Constraints_Discrete/custom_constr
 
 ```{warning}
 Due to the arbitrary nature of code and dependencies that can be used in the
-`DiscreteCustomConstraint`, de-/serializability cannot be guaranteed. As a consequence,
+`DiscreteCustomConstraint`, (de-)serializability cannot be guaranteed. As a consequence,
 using a `DiscreteCustomConstraint` results in an error if you attempt to serialize
 the corresponding object or higher-level objects containing it.
 ```

--- a/docs/userguide/recommenders.md
+++ b/docs/userguide/recommenders.md
@@ -125,7 +125,7 @@ recommender = TwoPhaseMetaRecommender(
   enables the utilization of *arbitrary* iterables to select recommender.
 
   ```{warning}
-  Due to the arbitrary nature of iterables that can be used, de-/serializability cannot
+  Due to the arbitrary nature of iterables that can be used, (de-)serializability cannot
   be guaranteed. As a consequence, using a `StreamingSequentialMetaRecommender` results
   in an error if you attempt to serialize the corresponding object or higher-level
   objects containing it.

--- a/docs/userguide/searchspace.md
+++ b/docs/userguide/searchspace.md
@@ -149,16 +149,6 @@ subspace = SubspaceDiscrete.from_product(parameters=[speed, temperature])
   5           0             0           1        105.0
 ~~~
 
-### Metadata
-
-```{warning}
-Although possible, it is not intended to manually change the metadata. The metadata is maintained internally, and there is a risk involved with manipulating it manually.
-Consequently, we advise to only change the metadata manually if you are certain about it.
-```
-
-Discrete subspaces keep track of the recommendations that were made during a campaign.
-The information is stored in a [`metadata`](baybe.searchspace.discrete.SubspaceDiscrete.metadata) field, and it is possible to manually modify `metadata` to influence the behavior of the corresponding `campaign` exploring the space. In particular, by manually changing the values of `metadata["dont_recommend"]`, it is possible to prevent certain points of the subspace from being recommended.
-
 ## Continuous Subspaces
 
 The `SubspaceContinuous` contains all the continuous parameters of a `SearchSpace`. There are different ways of constructing this subspace.

--- a/docs/userguide/searchspace.md
+++ b/docs/userguide/searchspace.md
@@ -222,78 +222,16 @@ The function [`SearchSpace.from_product`](baybe.searchspace.core.SearchSpace.fro
 ### Constructing from a Dataframe
 
 [`SearchSpace.from_dataframe`](baybe.searchspace.core.SearchSpace.from_dataframe) constructs a search space from a given dataframe.
-Due to the ambiguity between discrete and numerical parameter choices, this function requires a parameters list with pre-defined parameter objects, unlike its subspace counterparts, where this list is optional.
+Due to the ambiguity between discrete and continuous parameter representations when identifying parameter ranges based only on data, this function requires that the appropriate parameter definitions be explicitly provided. This is different for its subspace counterparts [`SubspaceDiscrete.from_dataframe`](baybe.searchspace.discrete.SubspaceDiscrete.from_dataframe) and [`SubspaceContinuous.from_dataframe`](baybe.searchspace.continuous.SubspaceContinuous.from_dataframe), where a fallback mechanism can automatically infer minimal parameter specifications if omitted.
 
 ```python
 from baybe.searchspace import SearchSpace
 
-params = [
-    NumericalDiscreteParameter(name="x0", values=[1, 2, 3]),
-    NumericalDiscreteParameter(name="x1", values=[4, 5, 6]),
-    NumericalContinuousParameter(name="x2", bounds=(6, 9)),
-]
-
-df = pd.DataFrame(
-    {
-        "x0": [2, 3],
-        "x1": [5, 4],
-        "x2": [9, 7],
-    }
-)
-searchspace = SearchSpace.from_dataframe(df=df, parameters=params)
+p_cont = NumericalContinuousParameter(name="c", bounds=[0, 1])
+p_disc = NumericalDiscreteParameter(name="d", values=[1, 2, 3])
+df = pd.DataFrame({"c": [0.3, 0.7], "d": [2, 3]})
+searchspace = SearchSpace.from_dataframe(df=df, parameters=[p_cont, p_disc])
 ```
-
-Since one of the provided parameters is continuous, this creates a hybrid space.
-The following shows *all* information that are available to the user for this space:
-
-~~~
-Search Space
-         
- Search Space Type: HYBRID
-         
- Discrete Search Space
-              
-  Discrete Parameters
-    Name                        Type  Num_Values Encoding
-  0   x0  NumericalDiscreteParameter           3     None
-  1   x1  NumericalDiscreteParameter           3     None
-              
-  Experimental Representation
-     x0  x1   
-  0   2   5
-  1   3   4
-  
-  Metadata:
-  was_recommended: 0/2
-  was_measured: 0/2
-  dont_recommend: 0/2
-              
-  Constraints
-  Empty DataFrame
-  Columns: []
-  Index: []
-              
-  Computational Representation
-     x0  x1   
-  0   2   5
-  1   3   4
-         
- Continuous Search Space
-              
-  Continuous Parameters
-    Name                          Type  Lower_Bound  Upper_Bound
-  0   x2  NumericalContinuousParameter          6.0          9.0
-              
-  List of Linear Equality Constraints
-  Empty DataFrame
-  Columns: []
-  Index: []
-              
-  List of Linear Inequality Constraints
-  Empty DataFrame
-  Columns: []
-  Index: []
-~~~
 
 ## Restricting Search Spaces Using Constraints
 

--- a/docs/userguide/searchspace.md
+++ b/docs/userguide/searchspace.md
@@ -231,7 +231,45 @@ p_cont = NumericalContinuousParameter(name="c", bounds=[0, 1])
 p_disc = NumericalDiscreteParameter(name="d", values=[1, 2, 3])
 df = pd.DataFrame({"c": [0.3, 0.7], "d": [2, 3]})
 searchspace = SearchSpace.from_dataframe(df=df, parameters=[p_cont, p_disc])
+print(searchspace)
 ```
+
+~~~
+SearchSpace
+   Search Space Type: HYBRID
+   SubspaceDiscrete
+      Discrete Parameters
+           Name                        Type  Num_Values Encoding
+         0    d  NumericalDiscreteParameter           3     None
+      Experimental Representation
+            d
+         0  2
+         1  3
+      Constraints
+         Empty DataFrame
+         Columns: []
+         Index: []
+      Computational Representation
+            d
+         0  2
+         1  3
+   SubspaceContinuous
+      Continuous Parameters
+           Name                          Type  Lower_Bound  Upper_Bound
+         0    c  NumericalContinuousParameter          0.0          1.0
+      Linear Equality Constraints
+         Empty DataFrame
+         Columns: []
+         Index: []
+      Linear Inequality Constraints
+         Empty DataFrame
+         Columns: []
+         Index: []
+      Non-linear Constraints
+         Empty DataFrame
+         Columns: []
+         Index: []
+~~~
 
 ## Restricting Search Spaces Using Constraints
 

--- a/docs/userguide/serialization.md
+++ b/docs/userguide/serialization.md
@@ -22,7 +22,7 @@ i.e., reassembling the corresponding Python object from its serialization string
 ```
 
 (JSON_SERIALIZATION)=
-## JSON de-/serialization
+## JSON (de-)serialization
 Most BayBE objects can be conveniently serialized into an equivalent JSON 
 representation by calling their
 {meth}`to_json <baybe.serialization.mixin.SerialMixin.to_json>` method.

--- a/examples/Serialization/Serialization_Header.md
+++ b/examples/Serialization/Serialization_Header.md
@@ -1,3 +1,3 @@
 # Serialization
 
-These examples demonstrate BayBE's de-/serialization capabilities.
+These examples demonstrate BayBE's (de-)serialization capabilities.

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -2,7 +2,6 @@
 
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
 from pytest import param
 
 from baybe.campaign import _EXCLUDED, Campaign
@@ -37,25 +36,10 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
     assert model is not None, "Something went wrong during surrogate model extraction."
 
 
-@pytest.mark.parametrize(
-    ("anti", "expected"),
-    [
-        (
-            False,
-            pd.DataFrame(columns=["a", "b"], data=[[0.0, 3.0], [0.0, 4.0], [0.0, 5.0]]),
-        ),
-        (
-            True,
-            pd.DataFrame(columns=["a", "b"], data=[[1.0, 3.0], [1.0, 4.0], [1.0, 5.0]]),
-        ),
-    ],
-    ids=["regular", "anti"],
-)
+@pytest.mark.parametrize("anti", [False, True], ids=["regular", "anti"])
 @pytest.mark.parametrize("exclude", [True, False], ids=["exclude", "include"])
-def test_candidate_filter(exclude, anti, expected):
-    """The candidate filter extracts the correct subset of points and the campaign
-    metadata is updated accordingly."""  # noqa
-
+def test_candidate_toggling(exclude, anti):
+    """Toggling discrete candidates updates the campaign metadata accordingly."""
     subspace = SubspaceDiscrete.from_product(
         [
             NumericalDiscreteParameter("a", [0, 1]),
@@ -68,16 +52,14 @@ def test_candidate_filter(exclude, anti, expected):
     campaign._searchspace_metadata[_EXCLUDED] = not exclude
 
     # Toggle the candidates
-    df = campaign.toggle_discrete_candidates(
-        pd.DataFrame({"a": [0]}), exclude, anti=anti
-    )
+    campaign.toggle_discrete_candidates(pd.DataFrame({"a": [0]}), exclude, anti=anti)
 
-    # Assert that the filtering is correct
-    rows = pd.merge(df.reset_index(), expected).set_index("index")
-    assert_frame_equal(df, rows, check_names=False)
+    # Extract row indices of candidates whose metadata should have been toggled
+    matches = campaign.searchspace.discrete.exp_rep["a"] == 0
+    idx = matches.index[~matches] if anti else matches.index[matches]
 
     # Assert that metadata is set correctly
-    target = campaign._searchspace_metadata.loc[rows.index, _EXCLUDED]
-    other = campaign._searchspace_metadata[_EXCLUDED].drop(index=rows.index)
+    target = campaign._searchspace_metadata.loc[idx, _EXCLUDED]
+    other = campaign._searchspace_metadata[_EXCLUDED].drop(index=idx)
     assert all(target == exclude)  # must contain the updated values
     assert all(other != exclude)  # must contain the original values

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -41,14 +41,14 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
 @pytest.mark.parametrize("complement", [False, True], ids=["regular", "complement"])
 @pytest.mark.parametrize("exclude", [True, False], ids=["exclude", "include"])
 @pytest.mark.parametrize(
-    "constraint",
+    "constraints",
     [
         pd.DataFrame({"a": [0]}),
-        DiscreteExcludeConstraint(["a"], [SubSelectionCondition([1])]),
+        [DiscreteExcludeConstraint(["a"], [SubSelectionCondition([1])])],
     ],
     ids=["dataframe", "constraints"],
 )
-def test_candidate_toggling(constraint, exclude, complement):
+def test_candidate_toggling(constraints, exclude, complement):
     """Toggling discrete candidates updates the campaign metadata accordingly."""
     subspace = SubspaceDiscrete.from_product(
         [
@@ -62,7 +62,7 @@ def test_candidate_toggling(constraint, exclude, complement):
     campaign._searchspace_metadata[_EXCLUDED] = not exclude
 
     # Toggle the candidates
-    campaign.toggle_discrete_candidates(constraint, exclude, complement=complement)
+    campaign.toggle_discrete_candidates(constraints, exclude, complement=complement)
 
     # Extract row indices of candidates whose metadata should have been toggled
     matches = campaign.searchspace.discrete.exp_rep["a"] == 0

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -66,7 +66,7 @@ def test_candidate_toggling(constraints, exclude, complement):
 
     # Extract row indices of candidates whose metadata should have been toggled
     matches = campaign.searchspace.discrete.exp_rep["a"] == 0
-    idx = matches.index[~matches] if complement else matches.index[matches]
+    idx = matches.index[~matches if complement else matches]
 
     # Assert that metadata is set correctly
     target = campaign._searchspace_metadata.loc[idx, _EXCLUDED]

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -5,7 +5,7 @@ import pytest
 from pandas.testing import assert_frame_equal
 from pytest import param
 
-from baybe.campaign import Campaign
+from baybe.campaign import _EXCLUDED, Campaign
 from baybe.parameters.numerical import NumericalDiscreteParameter
 from baybe.searchspace.discrete import SubspaceDiscrete
 
@@ -51,8 +51,11 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
     ],
     ids=["regular", "anti"],
 )
-def test_candidate_filter(anti, expected):
-    """The candidate filter extracts the correct subset of points."""
+@pytest.mark.parametrize("exclude", [True, False], ids=["exclude", "include"])
+def test_candidate_filter(exclude, anti, expected):
+    """The candidate filter extracts the correct subset of points and the campaign
+    metadata is updated accordingly."""  # noqa
+
     subspace = SubspaceDiscrete.from_product(
         [
             NumericalDiscreteParameter("a", [0, 1]),
@@ -60,7 +63,21 @@ def test_candidate_filter(anti, expected):
         ]
     )
     campaign = Campaign(subspace)
-    df = campaign.toggle_discrete_candidates(pd.DataFrame({"a": [0]}), False, anti=anti)
-    assert_frame_equal(
-        df, pd.merge(df.reset_index(), expected).set_index("index"), check_names=False
+
+    # Set metadata to opposite of targeted value so that we can verify the effect later
+    campaign._searchspace_metadata[_EXCLUDED] = not exclude
+
+    # Toggle the candidates
+    df = campaign.toggle_discrete_candidates(
+        pd.DataFrame({"a": [0]}), exclude, anti=anti
     )
+
+    # Assert that the filtering is correct
+    rows = pd.merge(df.reset_index(), expected).set_index("index")
+    assert_frame_equal(df, rows, check_names=False)
+
+    # Assert that metadata is set correctly
+    target = campaign._searchspace_metadata.loc[rows.index, _EXCLUDED]
+    other = campaign._searchspace_metadata[_EXCLUDED].drop(index=rows.index)
+    assert all(target == exclude)  # must contain the updated values
+    assert all(other != exclude)  # must contain the original values

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -38,7 +38,7 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
     assert model is not None, "Something went wrong during surrogate model extraction."
 
 
-@pytest.mark.parametrize("anti", [False, True], ids=["regular", "anti"])
+@pytest.mark.parametrize("complement", [False, True], ids=["regular", "complement"])
 @pytest.mark.parametrize("exclude", [True, False], ids=["exclude", "include"])
 @pytest.mark.parametrize(
     "constraint",
@@ -48,7 +48,7 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
     ],
     ids=["dataframe", "constraints"],
 )
-def test_candidate_toggling(constraint, exclude, anti):
+def test_candidate_toggling(constraint, exclude, complement):
     """Toggling discrete candidates updates the campaign metadata accordingly."""
     subspace = SubspaceDiscrete.from_product(
         [
@@ -62,11 +62,11 @@ def test_candidate_toggling(constraint, exclude, anti):
     campaign._searchspace_metadata[_EXCLUDED] = not exclude
 
     # Toggle the candidates
-    campaign.toggle_discrete_candidates(constraint, exclude, anti=anti)
+    campaign.toggle_discrete_candidates(constraint, exclude, complement=complement)
 
     # Extract row indices of candidates whose metadata should have been toggled
     matches = campaign.searchspace.discrete.exp_rep["a"] == 0
-    idx = matches.index[~matches] if anti else matches.index[matches]
+    idx = matches.index[~matches] if complement else matches.index[matches]
 
     # Assert that metadata is set correctly
     target = campaign._searchspace_metadata.loc[idx, _EXCLUDED]

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -21,12 +21,16 @@ from baybe.objectives.base import Objective
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.single import SingleTargetObjective
 from baybe.parameters.enum import SubstanceEncoding
-from baybe.parameters.numerical import NumericalContinuousParameter
+from baybe.parameters.numerical import (
+    NumericalContinuousParameter,
+    NumericalDiscreteParameter,
+)
 from baybe.recommenders.pure.bayesian import (
     BotorchRecommender,
     SequentialGreedyRecommender,
 )
 from baybe.searchspace.continuous import SubspaceContinuous
+from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.searchspace.validation import get_transform_parameters
 from baybe.targets.binary import BinaryTarget
 from baybe.targets.numerical import NumericalTarget
@@ -271,3 +275,12 @@ def test_deprecated_encodings(deprecated, replacement):
             patched.assert_called_once_with(**{"fp_size": 1024, "radius": 4})
         else:
             patched.assert_called_once()
+
+
+def test_migrated_metadata_attribue():
+    """Accessing the migrated metadata search space attribute raises an error."""
+    with pytest.raises(DeprecationError, match="no longer carry any metadata"):
+        subspace = SubspaceDiscrete.from_parameter(
+            NumericalDiscreteParameter("p", [0, 1])
+        )
+        subspace.metadata()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -277,10 +277,10 @@ def test_deprecated_encodings(deprecated, replacement):
             patched.assert_called_once()
 
 
-def test_migrated_metadata_attribue():
+def test_migrated_metadata_attribute():
     """Accessing the migrated metadata search space attribute raises an error."""
     with pytest.raises(DeprecationError, match="no longer carry any metadata"):
         subspace = SubspaceDiscrete.from_parameter(
             NumericalDiscreteParameter("p", [0, 1])
         )
-        subspace.metadata()
+        subspace.metadata


### PR DESCRIPTION
Fixes #371 by making `SubspaceDiscrete` stateless.

### Current Approach
* The `SubspaceDiscrete.metadata` attribute gets deprecated and the responsibility of metadata handling is shifted to `Campaign`
* The new mechanism is not yet final (see out of scope below) but designed in a way that allows to implement upcoming changes in a non-breaking manner. In particular:
  * The metadata handling mechanism is redesigned in that the actual metadata representation is completely hidden from the user, i.e. campaign manages the data in form of private attributes. This is to avoid further lock-in into `pandas` as our search space backend and prepares for future search space improvements by abstracting away the specific implementation details, enabling us to easily offer other backends (polars, databases, etc) in the future.
  * The `allow_*` flags are not yet migrated to the `Campaign` class, but the `AnnotatedSubspaceDiscrete` allows to migrate them in a follow-up PR (#423) without causing much friction
* A new user-facing method `Campaign.toggle_discrete_candidates` now allows convenient and dynamic control over the discrete candidate set, avoiding any fiddling with the backend dataframes and index manipulations. The positive effect can be seen in the much cleaner code parts of the simulation package.

### Out of scope / (potentially) coming next
* Migration of `allow_*` flags in order to make `Campaign` the unique place where the concept of metadata exists, i.e. campaigns will be the only stateful objects. A PR taking care of this should follow soon because the `get_candidates` signature of `SubspaceDiscrete` currently makes not much sense, as it expects these flags in a context where metadata does not exist.
* Once the flags are migrated, the `AnnotatedSubspaceDiscrete` might become obsolete since the `Campaign` class can then theoretically filter down the space before passing it to the recommender. This however requires an efficient implementation that does not cause unnecessary dataframe copies. 
* Actually turning the state space classes `frozen`. There a few other things that should be addressed at the same time (i.e. general cleanup of the classes).