### PR TITLE
Enable Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
   fulltest:
     needs: [typecheck]
     strategy:
+      fail-fast: false  # Remove once we have solved the regular "LinAlgErrors"
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'}, {semantic: '3.13', tox: 'py313'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,3 @@
-# NOTES:
-# - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.12, except the fulltest which is also run in 3.10
-# - Only coretest and fulltest environments are cached due to space limit
-
 name: Continuous Integration
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        py-version: [ {semantic: '3.12', tox: 'py312'} ]
+        py-version: [ {semantic: '3.13', tox: 'py313'} ]
     name: Lint ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -113,7 +113,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.12', tox: 'py312'} ]
+        py-version: [ {semantic: '3.13', tox: 'py313'} ]
     name: Type Check ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -131,7 +131,7 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.12', tox: 'py312'} ]
+        py-version: [ {semantic: '3.13', tox: 'py313'} ]
     name: Audit ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -171,7 +171,7 @@ jobs:
     needs: [typecheck]
     strategy:
       matrix:
-        py-version: [ {semantic: '3.10', tox: 'py310'}, {semantic: '3.12', tox: 'py312'} ]
+        py-version: [ {semantic: '3.10', tox: 'py310'}, {semantic: '3.13', tox: 'py313'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -53,7 +53,8 @@ jobs:
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
-                      {semantic: '3.12', tox: 'py312'} ]
+                      {semantic: '3.12', tox: 'py312'},
+                      {semantic: '3.13', tox: 'py313'} ]
     name: Lint ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +75,8 @@ jobs:
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
-                      {semantic: '3.12', tox: 'py312'} ]
+                      {semantic: '3.12', tox: 'py312'},
+                      {semantic: '3.13', tox: 'py313'} ]
     name: Type Check ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -95,7 +97,8 @@ jobs:
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
-                      {semantic: '3.12', tox: 'py312'} ]
+                      {semantic: '3.12', tox: 'py312'},
+                      {semantic: '3.13', tox: 'py313'} ]
     name: Audit ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +119,8 @@ jobs:
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
-                      {semantic: '3.12', tox: 'py312'} ]
+                      {semantic: '3.12', tox: 'py312'},
+                      {semantic: '3.13', tox: 'py313'} ]
     name: Core Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +141,8 @@ jobs:
       matrix:
         py-version: [ {semantic: '3.10', tox: 'py310'},
                       {semantic: '3.11', tox: 'py311'},
-                      {semantic: '3.12', tox: 'py312'} ]
+                      {semantic: '3.12', tox: 'py312'},
+                      {semantic: '3.13', tox: 'py313'} ]
     name: Full Tests ${{ matrix.py-version.semantic }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -1,9 +1,3 @@
-# NOTES:
-# - The map syntax used for matrix is flagged red but actually works
-# - This runs everything in Python 3.10, 3.11 and 3.12
-# - Environments are **not** cached in order to perform a full end-to-end test
-#   (and due to space limit)
-
 name: Regular Checks
 on:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Clean
         run: |
           python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist")]'
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install test-package
         run: |
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ baybe==${{  github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for Python 3.13
 - `random_tie_break` flag to `farthest_point_sampling` to toggle between 
   random or deterministic sampling for equidistant cases
 - `random_tie_break` and `initialization` attributes to `FPSRecommender` to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ we recommend the following workflow:
 1. Clone a [fork](https://github.com/emdgroup/BayBE/fork) of the repository to 
    your local machine.
 
-1. Create and activate a virtual python environment using one of the supported 
-   python versions.
+1. Create and activate a virtual Python environment using one of the supported 
+   Python versions.
 
 1. Change into the root folder of the cloned repository and install an editable version
    including all development dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,13 @@ we recommend the following workflow:
    You can retrieve all available environments via `tox list`.
    For more information, see our [README about tests](https://github.com/emdgroup/baybe/blob/main/tests/README.md).
    
-   For instance, running all code tests in Python 3.12 can be achieved via:
+   For instance, running all code tests in Python 3.13 can be achieved via:
    ```console
-   tox -e fulltest-py312
+   tox -e fulltest-py313
    ```
 
-   Other tox tests that are useful to verify your work locally are `tox -e lint-py312`,
-   `tox -e mypy-py312` and `tox -e coretest-py312`.
+   Other tox tests that are useful to verify your work locally are `tox -e lint-py313`,
+   `tox -e mypy-py313` and `tox -e coretest-py313`.
 
    If you want to challenge your machine, you can run all checks in all Python versions
    in parallel via:

--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -1,23 +1,9 @@
 """Optional ONNX import."""
 
-from packaging.version import Version
-
 from baybe.exceptions import OptionalImportError
 
 try:
-    import onnx
     import onnxruntime
-
-    # NOTE: In version 1.18.0, the function `onnx.helper.split_complex_to_pairs` was
-    # replaced by the "private" function `_split_complex_to_pairs`.
-    # Not all dependencies, in particulat "skl2onnx" have been updated to use the
-    # new function.
-    # This is a temporary fix until all dependencies are updated.
-    onnx_version = onnx.__version__
-    if Version(onnx_version) >= Version("1.18.0"):
-        from onnx.helper import _split_complex_to_pairs
-
-        onnx.helper.split_complex_to_pairs = _split_complex_to_pairs
 except ModuleNotFoundError as ex:
     raise OptionalImportError(name="onnxruntime", group="onnx") from ex
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,6 +73,3 @@ ignore_missing_imports = True
 
 [mypy-shap.*]
 ignore_missing_imports = True
-
-[mypy-onnx.*]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,13 +68,13 @@ tox -e fulltest-py310
 ``` 
 will run pytest on baybe with all optional features in python 3.10, while 
 ```bash
-tox -e coretest-py312
+tox -e coretest-py313
 ```
-will run pytest on baybe without additional features in python 3.12.
+will run pytest on baybe without additional features in python 3.13.
 ```bash
-tox -e lint-py312
+tox -e lint-py313
 ```
-will run the linters with python 3.12.
+will run the linters with python 3.13.
 
 For a full overview of all available environments, type:
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,12 @@ if strtobool(os.getenv("CI", "false")):
 # https://docs.pytest.org/en/stable/reference/reference.html#pytest-fixture
 
 
+_onnx_issue = (
+    "Breaking change in onnx 0.18.0, which causes skl2onnx to fail. "
+    "Fix is already on the way: https://github.com/onnx/sklearn-onnx/pull/1181"
+)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def disable_telemetry():
     """Disables telemetry during pytesting via fixture."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,16 +888,6 @@ def fixture_default_simplex_config():
 @pytest.fixture(name="onnx_str")
 def fixture_default_onnx_str() -> bytes:
     """The default ONNX model string to be used if not specified differently."""
-    # NOTE: In version 1.18.0 of `onnx`, the function
-    # `onnx.helper.split_complex_to_pairs` was removed.
-    # This requires us to do some monkeypatching in the baybe._optional.onnx, and we
-    # refer to this place if you are interested in the details.
-    # Since using this fixture imports "skl2onnx", we need to ensure that this
-    # monkeypatching is done before this import, hence we do the additional import here.
-    # Note that this is only a temporary fix until all dependencies are updated to use
-    # the new function.
-    import baybe._optional.onnx  # noqa: F401, I001
-
     from skl2onnx import convert_sklearn
     from skl2onnx.common.data_types import FloatTensorType
     from sklearn.linear_model import BayesianRidge

--- a/tests/docs/test_examples.py
+++ b/tests/docs/test_examples.py
@@ -8,6 +8,8 @@ import pytest
 
 from baybe._optional.info import CHEM_INSTALLED, ONNX_INSTALLED
 
+from ..conftest import _onnx_issue
+
 # Run these tests in reduced settings
 _SMOKE_TEST_CACHE = os.environ.get("SMOKE_TEST", None)
 os.environ["SMOKE_TEST"] = "true"
@@ -20,7 +22,19 @@ paths = [str(x) for x in Path("examples/").rglob("*.py")]
 @pytest.mark.skipif(
     not (CHEM_INSTALLED and ONNX_INSTALLED), reason="skipped for core tests"
 )
-@pytest.mark.parametrize("example", paths, ids=paths)
+@pytest.mark.parametrize(
+    "example",
+    [
+        pytest.param(
+            p,
+            marks=[pytest.mark.xfail(reason=_onnx_issue, strict=True)]
+            if "custom_pretrained" in p
+            else [],
+        )
+        for p in paths
+    ],
+    ids=paths,
+)
 def test_example(example: str):
     """Test an individual example by running it.
 

--- a/tests/serialization/test_surrogate_serialization.py
+++ b/tests/serialization/test_surrogate_serialization.py
@@ -11,8 +11,21 @@ from baybe.surrogates.ngboost import NGBoostSurrogate
 from baybe.surrogates.random_forest import RandomForestSurrogate
 from baybe.utils.basic import get_subclasses
 
+from ..conftest import _onnx_issue
 
-@pytest.mark.parametrize("surrogate_cls", get_subclasses(Surrogate))
+
+@pytest.mark.parametrize(
+    "surrogate_cls",
+    [
+        pytest.param(
+            s,
+            marks=[pytest.mark.xfail(reason=_onnx_issue, strict=True)]
+            if issubclass(s, CustomONNXSurrogate)
+            else [],
+        )
+        for s in get_subclasses(Surrogate)
+    ],
+)
 def test_surrogate_serialization(request, surrogate_cls):
     """A serialization roundtrip yields an equivalent object."""
     if issubclass(surrogate_cls, CustomONNXSurrogate):

--- a/tests/test_custom_surrogate.py
+++ b/tests/test_custom_surrogate.py
@@ -9,7 +9,10 @@ from baybe._optional.info import ONNX_INSTALLED
 from baybe.surrogates import CustomONNXSurrogate
 from tests.conftest import run_iterations
 
+from .conftest import _onnx_issue
 
+
+@pytest.mark.xfail(reason=_onnx_issue, strict=True)
 @pytest.mark.skipif(
     not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
 )
@@ -37,6 +40,7 @@ def test_invalid_onnx_str():
         CustomONNXSurrogate(onnx_input_name="input", onnx_str=b"onnx_str")
 
 
+@pytest.mark.xfail(reason=_onnx_issue, strict=True)
 @pytest.mark.skipif(
     not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 min_version = 4.9
-env_list = {fulltest,coretest,lint,mypy,audit}-py{310,311,312}
+env_list = {fulltest,coretest,lint,mypy,audit}-py{310,311,312,313}
 isolated_build = True
 
-[testenv:fulltest,fulltest-py{310,311,312}]
+[testenv:fulltest,fulltest-py{310,311,312,313}]
 description = Run PyTest with all extra functionality
 extras = chem,examples,lint,onnx,polars,insights,simulation,test
 passenv =
@@ -18,7 +18,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:coretest,coretest-py{310,311,312}]
+[testenv:coretest,coretest-py{310,311,312,313}]
 description = Run PyTest with core functionality
 extras = test
 passenv =
@@ -33,7 +33,7 @@ commands =
     python --version
     pytest -p no:warnings --cov=baybe --durations=5 {posargs}
 
-[testenv:lint,lint-py{310,311,312}]
+[testenv:lint,lint-py{310,311,312,313}]
 description = Run linters and format checkers
 extras = lint,examples
 skip_install = True
@@ -42,7 +42,7 @@ commands =
     python --version
     pre-commit run --all-files {posargs:--show-diff-on-failure}
 
-[testenv:mypy,mypy-py{310,311,312}]
+[testenv:mypy,mypy-py{310,311,312,313}]
 description = Run mypy
 extras = mypy
 setenv =
@@ -51,7 +51,7 @@ commands =
     python --version
     mypy
 
-[testenv:audit,audit-py{310,311,312}]
+[testenv:audit,audit-py{310,311,312,313}]
 description = Run pip-audit
 extras = dev # audit entire environment
 setenv =


### PR DESCRIPTION
Enables Python 3.13 and reverts the ONNX monkeypatch from #555 since a fix is now on the way from the `skl2onnx` side.