### PR TITLE
Fix dtype in continuous comp rep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Rare bug arising from degenerate `SubstanceParameter.comp_df` rows that caused
   wrong number of recommendations being returned
+- `ContinuousConstraint`s can now be used in single point precision
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -30,6 +30,7 @@ from baybe.searchspace.validation import (
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.basic import to_tuple
 from baybe.utils.dataframe import get_transform_objects, pretty_print_df
+from baybe.utils.numerical import DTypeFloatNumpy
 from baybe.utils.plotting import to_string
 
 if TYPE_CHECKING:
@@ -277,8 +278,6 @@ class SubspaceContinuous(SerialMixin):
     @property
     def comp_rep_bounds(self) -> pd.DataFrame:
         """The minimum and maximum values of the computational representation."""
-        from baybe.utils.numerical import DTypeFloatNumpy
-
         return pd.DataFrame(
             {p.name: p.bounds.to_tuple() for p in self.parameters},
             index=["min", "max"],

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -277,9 +277,12 @@ class SubspaceContinuous(SerialMixin):
     @property
     def comp_rep_bounds(self) -> pd.DataFrame:
         """The minimum and maximum values of the computational representation."""
+        from baybe.utils.numerical import DTypeFloatNumpy
+
         return pd.DataFrame(
             {p.name: p.bounds.to_tuple() for p in self.parameters},
             index=["min", "max"],
+            dtype=DTypeFloatNumpy,
         )
 
     def _drop_parameters(self, parameter_names: Collection[str]) -> SubspaceContinuous:

--- a/docs/userguide/envvars.md
+++ b/docs/userguide/envvars.md
@@ -104,7 +104,7 @@ BAYBE_CACHE_DIR=""
 ```
 you can turn off disk caching entirely.
 
-## Floating Point Precision
+## EXPERIMENTAL: Floating Point Precision
 In general, double precision is recommended because numerical stability during optimization
 can be bad when single precision is used. This impacts gradient-based optimization,
 i.e. search spaces with continuous parameters, more than optimization without gradients.
@@ -113,10 +113,11 @@ If you still want to use single precision, you can set the following Boolean var
 - `BAYBE_NUMPY_USE_SINGLE_PRECISION` (defaults to `False`)
 - `BAYBE_TORCH_USE_SINGLE_PRECISION` (defaults to `False`)
 
-```{admonition} Continuous Constraints in Single Precision
+```{admonition} Experimental feature only!
 :class: warning
-Currently, due to explicit casting in BoTorch, 
-[`ContinuousConstraint`](baybe.constraints.base.ContinuousConstraint)s do not support
-single precision and cannot be used if the corresponding environment variables are
-activated.
+Currently, it cannot be guaranteed that all calculations will be performed in single precision,
+even when setting the aforementioned variables. The reason is that there are several code snippets
+within `BoTorch` that transform single precision variables to double precision variables.
+Consequently, this feature is currently only available as an *experimental* feature.
+We are however actively working on fully enabling single precision.
 ```


### PR DESCRIPTION
This PR fixes the DType used when calculating the computational representation in a continuous space.

Currently, the dtype is not using any of our flags but infers it from the provided data, always yielding a `float64` representation. This causes troubles down the line, specifically for continuous constraints: These then turn out to have bounds in `float64` while other parts are in `float32`, making them unusable.
