### PR TITLE
Use correct precision in botorch wrapper

### DIFF
--- a/baybe/utils/botorch_wrapper.py
+++ b/baybe/utils/botorch_wrapper.py
@@ -3,6 +3,8 @@
 import torch
 from botorch.test_functions import SyntheticTestFunction
 
+from baybe.utils.torch import DTypeFloatTorch
+
 
 def botorch_function_wrapper(test_function: SyntheticTestFunction):
     """Turn a BoTorch test function into a format accepted by lookup in simulations.
@@ -19,7 +21,7 @@ def botorch_function_wrapper(test_function: SyntheticTestFunction):
 
     def wrapper(*x: float) -> float:
         # Cast the provided list of floats to a tensor.
-        x_tensor = torch.tensor(x)
+        x_tensor = torch.tensor(x, dtype=DTypeFloatTorch)
         result = test_function.forward(x_tensor)
         # We do not need to return a tuple here.
         return float(result)


### PR DESCRIPTION
This PR enables the use of `DTypeFloatTorch` in the BoTorch Wrapper.

Previously, this wrapper converted anything into `float64` precision. This can cause troubles an imprecision during the corresponding `forward` call in that function.

Note that this is one of the fixes required for GPU support, but since it is an issue on its own, I decided to already create this mini PR.