### PR TITLE
Unpin protobuf

### DIFF
--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -609,7 +609,6 @@ prompt-toolkit==3.0.47
     #   jupyter-console
 protobuf==3.20.3
     # via
-    #   baybe (pyproject.toml)
     #   googleapis-common-protos
     #   onnx
     #   onnxconverter-common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passing a dataframe via the `data` argument to `Target.transform` is no longer
   possible. The data must now be passed as a series as first positional argument.
 
+## [0.11.3] - 2024-11-06
+### Fixed
+- `protobuf` dependency issue, version pin was removed
+
 ## [0.11.2] - 2024-10-11
 ### Added
 - `n_restarts` and `n_raw_samples` keywords to configure continuous optimization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "ngboost>=0.3.12,<1",
     "numpy>=1.24.1,<2",
     "pandas>=1.4.2,<3",
-    "protobuf<=3.20.3,<4",
     "scikit-learn>=1.1.1,<2",
     "scikit-learn-extra>=0.3.0,<1",
     "scipy>=1.10.1,<2",


### PR DESCRIPTION
Fixes #419 
Was also pushed as hotfix in the form of release `0.11.3` (c92975f9b602b163d8b9a3ed954d5bea3a74e99f)