### PR TITLE
Require truthy/falsy values for `BAYBE_DEACTIVATE_POLARS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   traditional mixture example
 - Memory caching is now non-verbose
 - `CustomDiscreteParameter` does not allow duplicated rows in `data` anymore
+- De-/activating Polars via `BAYBE_DEACTIVATE_POLARS` now requires passing values
+  compatible with `strtobool`
 
 ### Fixed
 - Rare bug arising from degenerate `SubstanceParameter.comp_df` rows that caused

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -32,7 +32,7 @@ from baybe.searchspace.validation import (
 )
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.basic import to_tuple
-from baybe.utils.boolean import eq_dataframe
+from baybe.utils.boolean import eq_dataframe, strtobool
 from baybe.utils.dataframe import (
     df_drop_single_value_columns,
     fuzzy_row_match,
@@ -296,7 +296,7 @@ class SubspaceDiscrete(SerialMixin):
 
         try:
             # Check for manual deactivation of polars
-            if os.environ.get("BAYBE_DEACTIVATE_POLARS", None) is not None:
+            if not strtobool(os.environ.get("BAYBE_DEACTIVATE_POLARS", "False")):
                 raise OptionalImportError(
                     "Polars was deactivated manually via environment variable."
                 )

--- a/docs/userguide/envvars.md
+++ b/docs/userguide/envvars.md
@@ -82,7 +82,8 @@ during this process, and thus might be beneficial for very large search spaces.
 
 Since this is still somewhat experimental, you might want to deactivate Polars without
 changing the Python environment. To do so, you can set the environment variable 
-`BAYBE_DEACTIVATE_POLARS` to any value.
+`BAYBE_DEACTIVATE_POLARS` to any truthy value accepted by
+[`strtobool`](baybe.utils.boolean.strtobool).
 
 
 ## Disk Caching


### PR DESCRIPTION
Fixes #425 by requiring truthy/falsy values for `BAYBE_DEACTIVATE_POLARS` instead of accepting *any* value.