### PR TITLE
Add manual benchmark workflow and S3 result persistence

### DIFF
--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -1,0 +1,57 @@
+name: Run Benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  add-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: Github_Add_Runner
+          aws-region: eu-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Execute Lambda function
+        run: |
+          aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "L", "repository": "${{ github.repository }}" }'  response.json
+          cat response.json
+          if ! grep -q '"statusCode": 200' response.json; then
+            echo "Lambda function failed. statusCode is not 200."
+            exit 1
+          fi
+
+  benchmark-test:
+    needs: add-runner
+    runs-on: self-hosted
+    env:
+      BAYBE_PERFORMANCE_PERSISTANCE_PATH: ${{ secrets.TEST_RESULT_S3_BUCKET }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        id: setup-python
+        with:
+          python-version: "3.10"
+      - name: Benchmark
+        run: |
+          pip install '.[benchmarking]'
+          python -m benchmarks

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -42,7 +42,7 @@ jobs:
     needs: add-runner
     runs-on: self-hosted
     env:
-      BAYBE_PERFORMANCE_PERSISTANCE_PATH: ${{ secrets.TEST_RESULT_S3_BUCKET }}
+      BAYBE_BENCHMARKING_PERSISTENCE_PATH: ${{ secrets.TEST_RESULT_S3_BUCKET }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -17,18 +17,15 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: Github_Add_Runner
           aws-region: eu-central-1
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
       - name: Execute Lambda function
         run: |
           aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "XL", "repository": "${{ github.repository }}" }'  response.json

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Execute Lambda function
         run: |
-          aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "L", "repository": "${{ github.repository }}" }'  response.json
+          aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "XL", "repository": "${{ github.repository }}" }'  response.json
           cat response.json
           if ! grep -q '"statusCode": 200' response.json; then
             echo "Lambda function failed. statusCode is not 200."

--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -47,6 +47,12 @@ blinker==1.8.2
     # via streamlit
 boolean-py==4.0
     # via license-expression
+boto3==1.35.68
+    # via baybe (pyproject.toml)
+botocore==1.35.68
+    # via
+    #   boto3
+    #   s3transfer
 botorch==0.11.3
     # via baybe (pyproject.toml)
 cachecontrol==0.14.0
@@ -264,6 +270,10 @@ jinja2==3.1.4
     #   pydeck
     #   sphinx
     #   torch
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 joblib==1.4.2
     # via
     #   baybe (pyproject.toml)
@@ -700,6 +710,7 @@ pytest-cov==5.0.0
 python-dateutil==2.9.0.post0
     # via
     #   arrow
+    #   botocore
     #   jupyter-client
     #   matplotlib
     #   pandas
@@ -768,6 +779,8 @@ rpds-py==0.19.0
     #   referencing
 ruff==0.5.2
     # via baybe (pyproject.toml)
+s3transfer==0.10.4
+    # via boto3
 scikit-fingerprints==1.9.0
     # via baybe (pyproject.toml)
 scikit-learn==1.5.1
@@ -985,7 +998,9 @@ tzdata==2024.1
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
-    # via requests
+    # via
+    #   botocore
+    #   requests
 uv==0.3.0
     # via
     #   baybe (pyproject.toml)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `benchmarks` subpackage for defining and running performance tests
 – `Campaign.toggle_discrete_candidates` to dynamically in-/exclude discrete candidates
 - `DiscreteConstraint.get_valid` to conveniently access valid candidates
+- Persistence capability for Benchmarking Results on a AWS S3 bucket from a manual pipeline run
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `benchmarks` subpackage for defining and running performance tests
 – `Campaign.toggle_discrete_candidates` to dynamically in-/exclude discrete candidates
 - `DiscreteConstraint.get_valid` to conveniently access valid candidates
-- Persistence capability for Benchmarking Results on a AWS S3 bucket from a manual pipeline run
+- Functionality for persisting benchmarking results on S3 from a manual pipeline run
 
 ### Changed
 - `SubstanceParameter` encodings are now computed exclusively with the

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,4 +29,4 @@
 - Karin Hrovatin (Merck KGaA, Darmstadt, Germany):\
   `scikit-fingerprints` support
 - Fabian Liebig (Merck KGaA, Darmstadt, Germany):\
-  Benchmarking structure
+  Benchmarking structure and persistence capabilities for benchmarking results

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,193 @@
+# Description
+
+This folder contains benchmark running scenarios and their resulting outputs continuously. If you want to execute them, you can do so by using the following command:
+
+```bash
+python -m benchmarks
+```
+
+The benchmarking module relies on callables that encapsulate the usage of BayBE code in general. The callables are defined in the domains folder, where each domain and every benchmark case has its own file. This file contains the complete definition and all components of a benchmark and is the place where benchmark-related objects, as well as BayBE-related code, are defined. The following components are relevant for a benchmark:
+
+## Benchmarking Structure
+
+The following describes the structure and logic of the benchmarking module, followed by an example of how to create a benchmark.
+
+### Benchmark
+
+```mermaid
+classDiagram
+    class Benchmark {
+        <<Generic, BenchmarkSerialization>>
+        +BenchmarkSettingsType settings
+        +Callable function
+        +str name
+        +float|None best_possible_result
+        +list<dict<str, Any>>|None optimal_function_inputs
+        +str description
+        +Result __call__()
+    }
+```
+
+The final benchmark object used for execution holds all relevant information based on the benchmark, covering human-readable information about the domain and the actual benchmarking function. It can be parameterized by the `BenchmarkSettingsType`, which is a generic type defined during runtime and is limited to being a subtype of `BenchmarkSettings` to ensure it covers the minimum necessary information within the added settings subtype class. The `Callable` object is the actual function that performs the benchmarking and contains the BayBE code. It receives an object of the `BenchmarkSettingsType` as input, meaning the input type for the provided function must match the type used for `BenchmarkSettingsType` during the respective benchmark object's creation. The name serves as the unique identifier of the benchmark, and the description is intended to be human-understandable. Note that this identifier is also used to store the results; therefore, any change will be considered a new benchmark. The `best_possible_result` and `optimal_function_inputs` are optional and can provide additional information about the benchmark's domain. The `best_possible_result` is the best achievable result based on the optimization problem, depending on the optimization goal, often referred to as the global minimum or maximum. The `optimal_function_inputs` are a list of input vectors that result in the `best_possible_result` when provided to the lookup function or selected from the DataFrame of the optimization process. The description is a human-readable representation of the benchmark's task, which can provide additional information without restrictions or coupling based on result persistence. Currently, the description is automatically generated based on the `__doc__` attribute of the `function` callable. The `__call__` method is used to execute the benchmark and return the result object. The structure of the result is described under [Result](#result).
+
+### BenchmarkSettings
+
+```mermaid
+classDiagram
+    class BenchmarkSettings {
+        <<ABC, BenchmarkSerialization>>
+        +int random_seed
+    }
+```
+
+The settings object is used to parameterize the benchmark. It is an abstract base class that can be extended by the user to provide additional information for the benchmark. The only required attribute is `random_seed`, which is used to seed the entire call of the benchmark function. A subtype of the class can be used to provide more information to the benchmark function and can be added as needed for a specific benchmarking task. Additional setting types can be added to reflect parameterization for the benchmarking callable. Currently, the following settings are available:
+
+#### ConvergenceExperimentSettings
+
+```mermaid
+classDiagram
+    class ConvergenceExperimentSettings {
+        +int batch_size
+        +int n_doe_iterations
+        +int n_mc_iterations
+    }
+```
+
+The settings object is used to parameterize the convergence experiment benchmarks and holds information about the batch size, the number of design of experiment iterations, and the number of Monte Carlo iterations, which can be used for BayBE scenario executions. Please refer to the BayBE documentation for more information about experiment simulations.
+
+### Result
+
+```mermaid
+classDiagram
+    class Result {
+        +str benchmark_identifier
+        +DataFrame data
+        +ResultMetadata metadata
+    }
+```
+
+The result object encapsulates all execution-relevant information of the benchmark and represents the result of the benchmark function, along with state information at the time of execution. The `benchmark_identifier` is a unique identifier for the benchmark and is used to store the results. The `data` attribute is a pandas DataFrame that holds the actual results of the benchmark function, which represents the optimization loop. The `metadata` attribute is a `ResultMetadata` object that contains additional information about the benchmark execution.
+
+#### ResultMetadata
+
+```mermaid
+classDiagram
+    class ResultMetadata {
+        +datetime start_datetime
+        +timedelta duration
+        +str commit_hash
+        +str latest_baybe_tag
+        +str branch
+    }
+```
+
+The metadata is the wrapper to hold the described information about the benchmark runtime. The `start_datetime` is the time when the benchmark was started, the `duration` is the time the benchmark took to execute, the `commit_hash` is the hash of the commit that was used to execute the benchmark, the `latest_baybe_tag` is the tag of the latest BayBE release from the checked out code state that was used to execute the benchmark and the `branch` is the branch of the BayBE repository that was used to execute the benchmark. A combination of the benchmark identifier and the metadata is meant to describe the conducted result uniquely under the assumption that equal benchmarked code states are also equally representative due to the fixed random seed.
+
+### Example
+
+Benchmarking definitions are stored in the `domains` folder.  If a new benchmark is to be created, a new file should be created in the `domains` folder with a reasonable name that describes the benchmark. We will illustrate the creation of the `synthetic_2C1D_1C` benchmark which can be found already in the `domains` folder. We will focus on every component of the code there and explain the structure and logic of the benchmarking module.
+The full code of the benchmark can be found in the `domains/synthetic_2C1D_1C.py` file.
+
+#### Callable
+
+The callable is the function meant to be containing BayBE code. Since we use the setting object `ConvergenceExperimentSettings` for this benchmark, the function got such a setting parameter as an input variable. The function should return a pandas DataFrame that contains the results of the benchmark. In this example we use the `simulate_scenarios` function to run the benchmark. The docstring is used as the description.  The function is defined as follows:
+
+```python
+def synthetic_2C1D_1C(settings: ConvergenceExperimentSettings) -> DataFrame:
+    """Hybrid synthetic test function.
+
+    Inputs:
+        z   discrete   {1,2,3,4}
+        x   continuous [-2*pi, 2*pi]
+        y   continuous [-2*pi, 2*pi]
+    Output: continuous
+    Objective: Maximization
+    Optimal Inputs:
+        {x: 1.610, y: 1.571, z: 3}
+        {x: 1.610, y: -4.712, z: 3}
+    Optimal Output: 4.09685
+    """
+    parameters = [
+        NumericalContinuousParameter("x", (-2 * pi, 2 * pi)),
+        NumericalContinuousParameter("y", (-2 * pi, 2 * pi)),
+        NumericalDiscreteParameter("z", (1, 2, 3, 4)),
+    ]
+
+    objective = NumericalTarget(name="target", mode=TargetMode.MAX).to_objective()
+    search_space = SearchSpace.from_product(parameters=parameters)
+
+    scenarios: dict[str, Campaign] = {
+        "Random Recommender": Campaign(
+            searchspace=search_space,
+            recommender=RandomRecommender(),
+            objective=objective,
+        ),
+        "Default Recommender": Campaign(
+            searchspace=search_space,
+            objective=objective,
+        ),
+    }
+
+    return simulate_scenarios(
+        scenarios,
+        _lookup,
+        batch_size=settings.batch_size,
+        n_doe_iterations=settings.n_doe_iterations,
+        n_mc_iterations=settings.n_mc_iterations,
+        impute_mode="error",
+    )
+```
+
+Where the lookup is another function in the same file. You are free to define the function as you like, as long as it gets the right input according to the benchmarks object definition which will be covered next and return a pandas DataFrame that contains the results of the benchmark.
+
+#### Benchmark Object Construction
+
+The benchmark gets the respective settings which is why the first object created is of type `ConvergenceExperimentSettings`. This will be add by the benchmark itself when calling your defined callable, which is why the `settings` parameter get the object `benchmark_config`. The `best_possible_result` and `optimal_function_inputs` are optional and can be used to provide additional information about the benchmarks domain. To link your defined callable with the benchmark code, the `function` parameter gets the callable object. The `name` of the function is set as the benchmarks unique identifier automatically.
+
+```python
+benchmark_config = ConvergenceExperimentSettings(
+    batch_size=5,
+    n_doe_iterations=30,
+    n_mc_iterations=50,
+)
+
+synthetic_2C1D_1C_benchmark = Benchmark(
+    function=synthetic_2C1D_1C,
+    best_possible_result=4.09685,
+    settings=benchmark_config,
+    optimal_function_inputs=[
+        {"x": 1.610, "y": 1.571, "z": 3},
+        {"x": 1.610, "y": -4.712, "z": 3},
+    ],
+)
+```
+
+`ConvergenceExperimentSettings` is just an example type and can be varied as needed.
+
+#### Add your benchmark to the benchmarking module
+
+In the last step, your benhcmark object has to be added to the benchmarking module. This is done by adding the object to the `BENCHMARKS` list in the `__init__.py` file in the `domains` folder. The `BENCHMARKS` list is a list of all benchmark objects that should be executed when running the benchmarking module. You can simply import your benchmark object (here it is `synthetic_2C1D_1C_benchmark`) and add it to the list. The `__init__.py` file should look like this:
+
+```python
+[...]
+from benchmarks.domains.synthetic_2C1D_1C import synthetic_2C1D_1C_benchmark
+
+BENCHMARKS: list[Benchmark] = [
+    synthetic_2C1D_1C_benchmark,
+]
+[...]
+```
+
+Then, the benchmark can be executed by the loop under `__main__` in the `benchmarks` module.
+
+## Persisting Results
+
+Results are stored automatically. Since multiple storage types are provided with different requirements and compatibilities, therefore the `PathConstructor` class is used to construct the identifier for the file. The path is automatically constructed and consists of data which describes the benchmarking result uniquely. For example `S3ObjectStorage` is used to store the results in an S3 bucket which separates the key by `/` (`<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_hash>/result.json`) but does not create real folders while the usual local persistence creates a file with a `_` so that folder creation is not necessary (`<benchmark_name>_<branch>_<latest_baybe_tag>_<execution-date>_<commit_hash>_result.json`). The class handling the storage of the resulting object get this `PathConstructor` and use it in the way it needs the identifier to be. There are currently two storage types available:
+
+### LocalFileObjectStorage
+
+Stores a file on the local file system and will automatically be chosen when calling the module if it does not run in the CI/CD pipeline. A prefix folder path can be provided when creating the object. The file will be stored in the current working directory if no prefix is provided. The file will be stored in the following format with the prefix: `<PREFIX_PATH>/<benchmark_name>_<branch>_<latest_baybe_tag>_<execution-date>_<commit_hash>_result.json`.
+
+### S3ObjectStorage
+
+Stores a file in an S3 bucket and will automatically be chosen when calling the module if it runs in the CI/CD pipeline. The credentials for boto3 are loaded automatically from the environment variables. For further information on how to set up the environment variables, please refer to the boto3 documentation. For locating the S3-Bucket to persist, the environment variable `BAYBE_BENCHMARKING_PERSISTENCE_PATH` must be set accordingly. For running the benchmarking module in the CI/CD pipeline, there must be also the possibility to assume a AWS role from a job call. This is done by providing the roles ARN in the secret `AWS_ROLE_TO_ASSUME`. For creating temporary credentials, a GitHub App will be used. To generated a token, the id of the GitHub App and its secret key must be provided in the secrets `APP_ID` and `APP_PRIVATE_KEY`. The file will be stored in the following format: `<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_hash>/result.json`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,193 +1,85 @@
-# Description
-
-This folder contains benchmark running scenarios and their resulting outputs continuously. If you want to execute them, you can do so by using the following command:
+This module contains benchmarks meant to test the performance of BayBE for
+pre-defined tasks. The benchmarks can be executed as a whole by executing
+the following command:
 
 ```bash
 python -m benchmarks
 ```
 
-The benchmarking module relies on callables that encapsulate the usage of BayBE code in general. The callables are defined in the domains folder, where each domain and every benchmark case has its own file. This file contains the complete definition and all components of a benchmark and is the place where benchmark-related objects, as well as BayBE-related code, are defined. The following components are relevant for a benchmark:
+# `Benchmark`
 
-## Benchmarking Structure
+The `Benchmark` object is the combination of all benchmark related data.
+At the heart is the callable `function`, used to perform and hide the
+benchmarked code. The `name` serves as the unique identifier of the benchmark. Note that
+this identifier is also used for storing a `Result`. Therefore, any change will be
+considered a new benchmark. The `function`s `__doc__` is used to
+automatically set the `description`. A full code example can be found in the
+`domains/synthetic_2C1D_1C.py` file.
 
-The following describes the structure and logic of the benchmarking module, followed by an example of how to create a benchmark.
+# `BenchmarkSettings`
 
-### Benchmark
+The `BenchmarkSettings` object is used to parameterize the benchmark `function`.
+It is an abstract base class that can be extended by the user to provide
+additional information. The only required attribute is
+`random_seed`, which is used to seed the entire call of the benchmark `function`.
+Currently, the following settings are available:
 
-```mermaid
-classDiagram
-    class Benchmark {
-        <<Generic, BenchmarkSerialization>>
-        +BenchmarkSettingsType settings
-        +Callable function
-        +str name
-        +float|None best_possible_result
-        +list<dict<str, Any>>|None optimal_function_inputs
-        +str description
-        +Result __call__()
-    }
-```
+## `ConvergenceExperimentSettings`
 
-The final benchmark object used for execution holds all relevant information based on the benchmark, covering human-readable information about the domain and the actual benchmarking function. It can be parameterized by the `BenchmarkSettingsType`, which is a generic type defined during runtime and is limited to being a subtype of `BenchmarkSettings` to ensure it covers the minimum necessary information within the added settings subtype class. The `Callable` object is the actual function that performs the benchmarking and contains the BayBE code. It receives an object of the `BenchmarkSettingsType` as input, meaning the input type for the provided function must match the type used for `BenchmarkSettingsType` during the respective benchmark object's creation. The name serves as the unique identifier of the benchmark, and the description is intended to be human-understandable. Note that this identifier is also used to store the results; therefore, any change will be considered a new benchmark. The `best_possible_result` and `optimal_function_inputs` are optional and can provide additional information about the benchmark's domain. The `best_possible_result` is the best achievable result based on the optimization problem, depending on the optimization goal, often referred to as the global minimum or maximum. The `optimal_function_inputs` are a list of input vectors that result in the `best_possible_result` when provided to the lookup function or selected from the DataFrame of the optimization process. The description is a human-readable representation of the benchmark's task, which can provide additional information without restrictions or coupling based on result persistence. Currently, the description is automatically generated based on the `__doc__` attribute of the `function` callable. The `__call__` method is used to execute the benchmark and return the result object. The structure of the result is described under [Result](#result).
+The `ConvergenceExperimentSettings` object is used to parameterize the
+convergence experiment benchmarks and holds information used for BayBE scenario
+executions. Please refer to the BayBE documentation for more information
+about the [simulations subpackage](baybe.simulation).
 
-### BenchmarkSettings
+# `Result`
 
-```mermaid
-classDiagram
-    class BenchmarkSettings {
-        <<ABC, BenchmarkSerialization>>
-        +int random_seed
-    }
-```
+The `Result` object encapsulates all execution-relevant information of the `Benchmark`
+and represents the `Result` of the benchmark `function`, along with state information
+at the time of execution.
 
-The settings object is used to parameterize the benchmark. It is an abstract base class that can be extended by the user to provide additional information for the benchmark. The only required attribute is `random_seed`, which is used to seed the entire call of the benchmark function. A subtype of the class can be used to provide more information to the benchmark function and can be added as needed for a specific benchmarking task. Additional setting types can be added to reflect parameterization for the benchmarking callable. Currently, the following settings are available:
+## `ResultMetadata`
 
-#### ConvergenceExperimentSettings
+The `ResultMetadata` is the wrapper to hold the described information about the
+`Benchmark` at runtime. A combination of the benchmark identifier and the metadata
+is meant to describe the conducted `Result` uniquely under the assumption that equal
+benchmarked code states are also equally representative due to the fixed random seed.
 
-```mermaid
-classDiagram
-    class ConvergenceExperimentSettings {
-        +int batch_size
-        +int n_doe_iterations
-        +int n_mc_iterations
-    }
-```
+# Add your benchmark to the benchmarking module
 
-The settings object is used to parameterize the convergence experiment benchmarks and holds information about the batch size, the number of design of experiment iterations, and the number of Monte Carlo iterations, which can be used for BayBE scenario executions. Please refer to the BayBE documentation for more information about experiment simulations.
+In the last step, your benchmark object has to be added to the
+`benchmarks module`. This is done by adding the object to the `BENCHMARKS`
+list in the `__init__.py` file in the `domains` folder. The `BENCHMARKS` contains all
+objects that should be called when running the `benchmarks module`.
 
-### Result
+# Persisting Results
 
-```mermaid
-classDiagram
-    class Result {
-        +str benchmark_identifier
-        +DataFrame data
-        +ResultMetadata metadata
-    }
-```
+`Result`s are stored automatically. Since multiple storage types are provided with
+different requirements and compatibilities, the `PathConstructor` class is used to
+construct the identifier for the file. For example `S3ObjectStorage` is used to
+store the `Result`s in an S3 bucket which separates the key by `/` but does not create
+real folders while the usual local persistence creates a file with a `_` so that folder
+creation is not necessary. The class handling the storage of the resulting object get
+this `PathConstructor` and use it in the way it needs the identifier to be.
+The following types of storage are available:
 
-The result object encapsulates all execution-relevant information of the benchmark and represents the result of the benchmark function, along with state information at the time of execution. The `benchmark_identifier` is a unique identifier for the benchmark and is used to store the results. The `data` attribute is a pandas DataFrame that holds the actual results of the benchmark function, which represents the optimization loop. The `metadata` attribute is a `ResultMetadata` object that contains additional information about the benchmark execution.
+## `LocalFileObjectStorage`
 
-#### ResultMetadata
+Stores a file on the local file system and will automatically be chosen when calling
+the `benchmarks module` if it does not run in the CI/CD pipeline. A prefix folder path can be
+provided when creating the object. The file will be stored in the current working
+directory if no prefix is provided. The file will be stored in the following format
+with the prefix:
+`<PREFIX_PATH>/<benchmark_name>_<branch>_<latest_baybe_tag>_<execution-date>_<commit_hash>_result.json`.
 
-```mermaid
-classDiagram
-    class ResultMetadata {
-        +datetime start_datetime
-        +timedelta duration
-        +str commit_hash
-        +str latest_baybe_tag
-        +str branch
-    }
-```
+## `S3ObjectStorage`
 
-The metadata is the wrapper to hold the described information about the benchmark runtime. The `start_datetime` is the time when the benchmark was started, the `duration` is the time the benchmark took to execute, the `commit_hash` is the hash of the commit that was used to execute the benchmark, the `latest_baybe_tag` is the tag of the latest BayBE release from the checked out code state that was used to execute the benchmark and the `branch` is the branch of the BayBE repository that was used to execute the benchmark. A combination of the benchmark identifier and the metadata is meant to describe the conducted result uniquely under the assumption that equal benchmarked code states are also equally representative due to the fixed random seed.
-
-### Example
-
-Benchmarking definitions are stored in the `domains` folder.  If a new benchmark is to be created, a new file should be created in the `domains` folder with a reasonable name that describes the benchmark. We will illustrate the creation of the `synthetic_2C1D_1C` benchmark which can be found already in the `domains` folder. We will focus on every component of the code there and explain the structure and logic of the benchmarking module.
-The full code of the benchmark can be found in the `domains/synthetic_2C1D_1C.py` file.
-
-#### Callable
-
-The callable is the function meant to be containing BayBE code. Since we use the setting object `ConvergenceExperimentSettings` for this benchmark, the function got such a setting parameter as an input variable. The function should return a pandas DataFrame that contains the results of the benchmark. In this example we use the `simulate_scenarios` function to run the benchmark. The docstring is used as the description.  The function is defined as follows:
-
-```python
-def synthetic_2C1D_1C(settings: ConvergenceExperimentSettings) -> DataFrame:
-    """Hybrid synthetic test function.
-
-    Inputs:
-        z   discrete   {1,2,3,4}
-        x   continuous [-2*pi, 2*pi]
-        y   continuous [-2*pi, 2*pi]
-    Output: continuous
-    Objective: Maximization
-    Optimal Inputs:
-        {x: 1.610, y: 1.571, z: 3}
-        {x: 1.610, y: -4.712, z: 3}
-    Optimal Output: 4.09685
-    """
-    parameters = [
-        NumericalContinuousParameter("x", (-2 * pi, 2 * pi)),
-        NumericalContinuousParameter("y", (-2 * pi, 2 * pi)),
-        NumericalDiscreteParameter("z", (1, 2, 3, 4)),
-    ]
-
-    objective = NumericalTarget(name="target", mode=TargetMode.MAX).to_objective()
-    search_space = SearchSpace.from_product(parameters=parameters)
-
-    scenarios: dict[str, Campaign] = {
-        "Random Recommender": Campaign(
-            searchspace=search_space,
-            recommender=RandomRecommender(),
-            objective=objective,
-        ),
-        "Default Recommender": Campaign(
-            searchspace=search_space,
-            objective=objective,
-        ),
-    }
-
-    return simulate_scenarios(
-        scenarios,
-        _lookup,
-        batch_size=settings.batch_size,
-        n_doe_iterations=settings.n_doe_iterations,
-        n_mc_iterations=settings.n_mc_iterations,
-        impute_mode="error",
-    )
-```
-
-Where the lookup is another function in the same file. You are free to define the function as you like, as long as it gets the right input according to the benchmarks object definition which will be covered next and return a pandas DataFrame that contains the results of the benchmark.
-
-#### Benchmark Object Construction
-
-The benchmark gets the respective settings which is why the first object created is of type `ConvergenceExperimentSettings`. This will be add by the benchmark itself when calling your defined callable, which is why the `settings` parameter get the object `benchmark_config`. The `best_possible_result` and `optimal_function_inputs` are optional and can be used to provide additional information about the benchmarks domain. To link your defined callable with the benchmark code, the `function` parameter gets the callable object. The `name` of the function is set as the benchmarks unique identifier automatically.
-
-```python
-benchmark_config = ConvergenceExperimentSettings(
-    batch_size=5,
-    n_doe_iterations=30,
-    n_mc_iterations=50,
-)
-
-synthetic_2C1D_1C_benchmark = Benchmark(
-    function=synthetic_2C1D_1C,
-    best_possible_result=4.09685,
-    settings=benchmark_config,
-    optimal_function_inputs=[
-        {"x": 1.610, "y": 1.571, "z": 3},
-        {"x": 1.610, "y": -4.712, "z": 3},
-    ],
-)
-```
-
-`ConvergenceExperimentSettings` is just an example type and can be varied as needed.
-
-#### Add your benchmark to the benchmarking module
-
-In the last step, your benhcmark object has to be added to the benchmarking module. This is done by adding the object to the `BENCHMARKS` list in the `__init__.py` file in the `domains` folder. The `BENCHMARKS` list is a list of all benchmark objects that should be executed when running the benchmarking module. You can simply import your benchmark object (here it is `synthetic_2C1D_1C_benchmark`) and add it to the list. The `__init__.py` file should look like this:
-
-```python
-[...]
-from benchmarks.domains.synthetic_2C1D_1C import synthetic_2C1D_1C_benchmark
-
-BENCHMARKS: list[Benchmark] = [
-    synthetic_2C1D_1C_benchmark,
-]
-[...]
-```
-
-Then, the benchmark can be executed by the loop under `__main__` in the `benchmarks` module.
-
-## Persisting Results
-
-Results are stored automatically. Since multiple storage types are provided with different requirements and compatibilities, therefore the `PathConstructor` class is used to construct the identifier for the file. The path is automatically constructed and consists of data which describes the benchmarking result uniquely. For example `S3ObjectStorage` is used to store the results in an S3 bucket which separates the key by `/` (`<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_hash>/result.json`) but does not create real folders while the usual local persistence creates a file with a `_` so that folder creation is not necessary (`<benchmark_name>_<branch>_<latest_baybe_tag>_<execution-date>_<commit_hash>_result.json`). The class handling the storage of the resulting object get this `PathConstructor` and use it in the way it needs the identifier to be. There are currently two storage types available:
-
-### LocalFileObjectStorage
-
-Stores a file on the local file system and will automatically be chosen when calling the module if it does not run in the CI/CD pipeline. A prefix folder path can be provided when creating the object. The file will be stored in the current working directory if no prefix is provided. The file will be stored in the following format with the prefix: `<PREFIX_PATH>/<benchmark_name>_<branch>_<latest_baybe_tag>_<execution-date>_<commit_hash>_result.json`.
-
-### S3ObjectStorage
-
-Stores a file in an S3 bucket and will automatically be chosen when calling the module if it runs in the CI/CD pipeline. The credentials for boto3 are loaded automatically from the environment variables. For further information on how to set up the environment variables, please refer to the boto3 documentation. For locating the S3-Bucket to persist, the environment variable `BAYBE_BENCHMARKING_PERSISTENCE_PATH` must be set accordingly. For running the benchmarking module in the CI/CD pipeline, there must be also the possibility to assume a AWS role from a job call. This is done by providing the roles ARN in the secret `AWS_ROLE_TO_ASSUME`. For creating temporary credentials, a GitHub App will be used. To generated a token, the id of the GitHub App and its secret key must be provided in the secrets `APP_ID` and `APP_PRIVATE_KEY`. The file will be stored in the following format: `<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_hash>/result.json`.
+Stores a file in an S3 bucket and will automatically be chosen when calling the
+`benchmarks module` if it runs in the CI/CD pipeline. For locating the S3-Bucket to
+persist, the environment variable `BAYBE_BENCHMARKING_PERSISTENCE_PATH` must be set
+with its name. For running the `benchmarks module` in the CI/CD pipeline,
+there must be also the possibility to assume a AWS role from a job call.
+This is done by providing the roles ARN in the secret `AWS_ROLE_TO_ASSUME`.
+For creating temporary credentials, a GitHub App will be used.
+To generated a token, the id of the GitHub App and its secret key must be provided in
+the secrets `APP_ID` and `APP_PRIVATE_KEY`. The file will be stored in the following
+format: `<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_hash>/result.json`.

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -2,18 +2,18 @@
 # Run this via 'python -m benchmarks' from the root directory.
 
 from benchmarks.domains import BENCHMARKS
-from benchmarks.persistence import persistence_object_factory, persister_factory
+from benchmarks.persistence import make_object_writer, make_path_constructor
 
 
 def main():
     """Run all benchmarks."""
-    persistence_handler = persister_factory()
+    persistence_handler = make_object_writer()
 
     for benchmark in BENCHMARKS:
         result = benchmark()
-        persistence_object = persistence_object_factory(benchmark, result)
+        path_constructor = make_path_constructor(benchmark, result)
         persist_dict = benchmark.to_dict() | result.to_dict()
-        persistence_handler.write_object(persistence_object, persist_dict)
+        persistence_handler.write_json(persist_dict, path_constructor)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -2,7 +2,7 @@
 # Run this via 'python -m benchmarks' from the root directory.
 
 from benchmarks.domains import BENCHMARKS
-from benchmarks.persistence import create_persistence_object, persister_factory
+from benchmarks.persistence import persistence_object_factory, persister_factory
 
 
 def main():
@@ -11,8 +11,9 @@ def main():
 
     for benchmark in BENCHMARKS:
         result = benchmark()
-        persistence_object = create_persistence_object(benchmark, result)
-        persistence_handler.write_object(persistence_object)
+        persistence_object = persistence_object_factory(benchmark, result)
+        persist_dict = benchmark.to_dict() | result.to_dict()
+        persistence_handler.write_object(persistence_object, persist_dict)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -17,7 +17,7 @@ def main():
     """Run all benchmarks."""
     for benchmark in BENCHMARKS:
         result = benchmark()
-        path_constructor = PathConstructor.from_benchmark_and_result(benchmark, result)
+        path_constructor = PathConstructor.from_result(result)
         persist_dict = benchmark.to_dict() | result.to_dict()
 
         object_storage = S3ObjectStorage() if RUNS_IN_CI else LocalFileObjectStorage()

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -2,12 +2,17 @@
 # Run this via 'python -m benchmarks' from the root directory.
 
 from benchmarks.domains import BENCHMARKS
+from benchmarks.persistence import create_persistence_object, persister_factory
 
 
 def main():
     """Run all benchmarks."""
+    persistence_handler = persister_factory()
+
     for benchmark in BENCHMARKS:
-        benchmark()
+        result = benchmark()
+        persistence_object = create_persistence_object(benchmark, result)
+        persistence_handler.write_object(persistence_object)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -1,19 +1,32 @@
 """Executes the benchmarking module."""
 # Run this via 'python -m benchmarks' from the root directory.
 
+import os
+
 from benchmarks.domains import BENCHMARKS
-from benchmarks.persistence import make_object_writer, make_path_constructor
+from benchmarks.persistence import (
+    LocalFileObjectStorage,
+    PathConstructor,
+    S3ObjectStorage,
+)
+
+VARNAME_GITHUB_CI = "CI"
+RUNS_ON_GITHUB_CI = VARNAME_GITHUB_CI in os.environ
 
 
 def main():
     """Run all benchmarks."""
-    persistence_handler = make_object_writer()
-
     for benchmark in BENCHMARKS:
         result = benchmark()
-        path_constructor = make_path_constructor(benchmark, result)
+        path_constructor = PathConstructor.from_benchmark_and_result(benchmark, result)
         persist_dict = benchmark.to_dict() | result.to_dict()
-        persistence_handler.write_json(persist_dict, path_constructor)
+
+        if not RUNS_ON_GITHUB_CI:
+            object_storage = LocalFileObjectStorage()
+        else:
+            object_storage = S3ObjectStorage()
+
+        object_storage.write_json(persist_dict, path_constructor)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -10,8 +10,7 @@ from benchmarks.persistence import (
     S3ObjectStorage,
 )
 
-VARNAME_GITHUB_CI = "CI"
-RUNS_ON_GITHUB_CI = VARNAME_GITHUB_CI in os.environ
+RUNS_IN_CI = "CI" in os.environ
 
 
 def main():
@@ -21,11 +20,7 @@ def main():
         path_constructor = PathConstructor.from_benchmark_and_result(benchmark, result)
         persist_dict = benchmark.to_dict() | result.to_dict()
 
-        if not RUNS_ON_GITHUB_CI:
-            object_storage = LocalFileObjectStorage()
-        else:
-            object_storage = S3ObjectStorage()
-
+        object_storage = S3ObjectStorage() if RUNS_IN_CI else LocalFileObjectStorage()
         object_storage.write_json(persist_dict, path_constructor)
 
 

--- a/benchmarks/definition/config.py
+++ b/benchmarks/definition/config.py
@@ -13,11 +13,11 @@ from pandas import DataFrame
 
 from baybe.utils.random import temporary_seed
 from benchmarks.result import Result, ResultMetadata
-from benchmarks.serialization import Serializable, converter
+from benchmarks.serialization import BenchmarkSerialization, converter
 
 
 @define(frozen=True)
-class BenchmarkSettings(ABC, Serializable):
+class BenchmarkSettings(ABC, BenchmarkSerialization):
     """Benchmark configuration for recommender analyses."""
 
     random_seed: int = field(validator=instance_of(int), kw_only=True, default=1337)
@@ -42,7 +42,7 @@ class ConvergenceExperimentSettings(BenchmarkSettings):
 
 
 @define(frozen=True)
-class Benchmark(Generic[BenchmarkSettingsType], Serializable):
+class Benchmark(Generic[BenchmarkSettingsType], BenchmarkSerialization):
     """The base class for a benchmark executable."""
 
     settings: BenchmarkSettingsType = field()

--- a/benchmarks/definition/config.py
+++ b/benchmarks/definition/config.py
@@ -10,6 +10,7 @@ from attrs import define, field
 from attrs.validators import instance_of
 from pandas import DataFrame
 
+from baybe.serialization.core import converter
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.random import temporary_seed
 from benchmarks.result import Result, ResultMetadata
@@ -41,7 +42,7 @@ class ConvergenceExperimentSettings(BenchmarkSettings):
 
 
 @define(frozen=True)
-class Benchmark(Generic[BenchmarkSettingsType]):
+class Benchmark(SerialMixin, Generic[BenchmarkSettingsType]):
     """The base class for a benchmark executable."""
 
     settings: BenchmarkSettingsType = field()
@@ -88,3 +89,17 @@ class Benchmark(Generic[BenchmarkSettingsType]):
         )
 
         return Result(self.name, result, metadata)
+
+    @staticmethod
+    def serialize(benchmark: "Benchmark") -> dict:
+        """Serialize the benchmark."""
+        return {
+            "name": benchmark.name,
+            "settings": benchmark.settings.to_dict(),
+            "best_possible_result": benchmark.best_possible_result,
+            "optimal_function_inputs": benchmark.optimal_function_inputs,
+            "description": benchmark.description,
+        }
+
+
+converter.register_unstructure_hook(Benchmark, Benchmark.serialize)

--- a/benchmarks/persistence/__init__.py
+++ b/benchmarks/persistence/__init__.py
@@ -1,8 +1,9 @@
 """Module for persisting benchmarking results."""
 
 from benchmarks.persistence.persistence import (
-    make_object_writer,
-    make_path_constructor,
+    LocalFileObjectStorage,
+    PathConstructor,
+    S3ObjectStorage,
 )
 
-__all__ = ["make_path_constructor", "make_object_writer"]
+__all__ = ["PathConstructor", "S3ObjectStorage", "LocalFileObjectStorage"]

--- a/benchmarks/persistence/__init__.py
+++ b/benchmarks/persistence/__init__.py
@@ -1,0 +1,8 @@
+"""Module for persisting benchmarking results."""
+
+from benchmarks.persistence.persistence import (
+    create_persistence_object,
+    persister_factory,
+)
+
+__all__ = ["persister_factory", "create_persistence_object"]

--- a/benchmarks/persistence/__init__.py
+++ b/benchmarks/persistence/__init__.py
@@ -1,8 +1,8 @@
 """Module for persisting benchmarking results."""
 
 from benchmarks.persistence.persistence import (
-    persistence_object_factory,
-    persister_factory,
+    make_object_writer,
+    make_path_constructor,
 )
 
-__all__ = ["persister_factory", "persistence_object_factory"]
+__all__ = ["make_path_constructor", "make_object_writer"]

--- a/benchmarks/persistence/__init__.py
+++ b/benchmarks/persistence/__init__.py
@@ -1,8 +1,8 @@
 """Module for persisting benchmarking results."""
 
 from benchmarks.persistence.persistence import (
-    create_persistence_object,
+    persistence_object_factory,
     persister_factory,
 )
 
-__all__ = ["persister_factory", "create_persistence_object"]
+__all__ = ["persister_factory", "persistence_object_factory"]

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -1,0 +1,229 @@
+"""Classes for persisting results to a S3-Bucket."""
+
+import json
+import os
+from typing import Protocol
+
+import boto3
+import boto3.session
+from attr import define, field
+from attrs.validators import instance_of
+from git import Repo
+
+from benchmarks import Benchmark, Result
+
+
+class PersistenceObjectInterface(Protocol):
+    """Interface for constructing the path of a result object."""
+
+    def get_full_file_path(self) -> str:
+        """Construct the path of a result object.
+
+        Returns:
+            The path of the result object.
+        """
+
+    def get_object(self) -> dict:
+        """Construct the object to be persisted.
+
+        Returns:
+            The object to be persisted.
+        """
+
+
+class PersistenceHandlingInterface(Protocol):
+    """Interface for persisting experiment results."""
+
+    def write_object(self, object: PersistenceObjectInterface) -> None:
+        """Store the result of a benchmark.
+
+        Args:
+            object: The object to be persisted.
+        """
+
+
+@define
+class S3PersistenceObjectCreator:
+    """Class for creating the path of a result object."""
+
+    _benchmark: Benchmark = field(validator=instance_of(Benchmark))
+    """The benchmark for which the result is stored."""
+
+    _result: Result = field(validator=instance_of(Result))
+    """The result of the benchmark."""
+
+    _branch: str = field(validator=instance_of(str), init=False)
+    """The branch of the BayBE library from which the workflow was started."""
+
+    _workflow_run_identifier: str = field(validator=instance_of(str), init=False)
+    """The identifier of the workflow run."""
+
+    @_branch.default
+    def _default_branch(self) -> str:
+        repo = Repo(search_parent_directories=True)
+        current_branch = repo.active_branch.name
+        S3_PATH_FORBIDDEN_CHARACTERS = ["/", "\\"]
+        sanitized_branch = ""
+        for char in S3_PATH_FORBIDDEN_CHARACTERS:
+            sanitized_branch = current_branch.replace(char, "-")
+        return sanitized_branch
+
+    @_workflow_run_identifier.default
+    def _default_workflow_id(self) -> str:
+        if "GITHUB_RUN_ID" not in os.environ:
+            raise ValueError("The environment variable GITHUB_RUN_ID is not set.")
+        return os.environ["GITHUB_RUN_ID"]
+
+    def get_full_file_path(self) -> str:
+        """Construct the path of a result object.
+
+        Returns:
+            The path of the result object.
+        """
+        experiment_identifier = self._benchmark.name
+        metadata = self._result.metadata
+        file_usable_date = metadata.start_datetime.strftime("%Y-%m-%d")
+        bucket_path_key = (
+            f"{experiment_identifier}/{self._branch}/{metadata.latest_baybe_tag}/"
+            + f"{file_usable_date}/"
+            + f"{metadata.commit_hash}/{self._workflow_run_identifier}/"
+            + "result.json"
+        )
+        return bucket_path_key
+
+    def get_object(self) -> dict:
+        """Construct the object to be persisted.
+
+        Returns:
+            The object to be persisted.
+        """
+        return self._result.to_dict() | self._benchmark.to_dict()
+
+
+@define
+class S3PersistenceHandler:
+    """Class for persisting experiment results in an S3 bucket."""
+
+    _bucket_name: str = field(validator=instance_of(str), init=False)
+    """The name of the S3 bucket where the results are stored."""
+
+    _object_session = boto3.session.Session()
+    """The boto3 session object. This will load the respective credentials
+    from the environment variables within the container."""
+
+    def write_object(self, object: PersistenceObjectInterface) -> None:
+        """Store the result of a benchmark.
+
+        This method will store the result of a benchmark in an S3 bucket.
+        The S3-key of the Java Script Notation Object will be the experiment identifier,
+        the branch, the BayBE-version, the start datetime, the commit hash and the
+        workflow run identifier.
+
+        Args:
+            object: The object to be persisted.
+        """
+        client = self._object_session.client("s3")
+
+        client.put_object(
+            Bucket=self._bucket_name,
+            Key=object.get_full_file_path(),
+            Body=json.dumps(object.get_object()),
+            ContentType="application/json",
+        )
+
+
+@define
+class LocalFileSystemObjectCreator:
+    """Class for creating the path of a result object."""
+
+    _benchmark: Benchmark = field(validator=instance_of(Benchmark))
+    """The benchmark for which the result is stored."""
+
+    _result: Result = field(validator=instance_of(Result))
+    """The result of the benchmark."""
+
+    _path: str = field(validator=instance_of(str))
+    """The path where the result is stored."""
+
+    _filename: str = field(validator=instance_of(str))
+    """The filename of the result object."""
+
+    @_path.default
+    def _default_bucket_name(self) -> str:
+        ENVIRONMENT_NOT_SET = "BAYBE_BENCHMARK_PERSISTENCE_PATH" not in os.environ
+        if ENVIRONMENT_NOT_SET:
+            return "./"
+        return os.environ["BAYBE_BENCHMARK_PERSISTENCE_PATH"]
+
+    @_filename.default
+    def _default_filename(self) -> str:
+        experiment_identifier = self._benchmark.name
+        metadata = self._result.metadata
+        file_usable_date = metadata.start_datetime.strftime("%Y-%m-%d")
+        return (
+            f"{experiment_identifier}_{metadata.latest_baybe_tag}"
+            + f"_{file_usable_date}_{metadata.commit_hash}.json"
+        )
+
+    def get_full_file_path(self) -> str:
+        """Construct the path of a result object.
+
+        Returns:
+            The path of the result object.
+        """
+        return f"{self._path}/{self._filename}"
+
+    def get_object(self) -> dict:
+        """Construct the object to be persisted.
+
+        Returns:
+            The object to be persisted.
+        """
+        return self._result.to_dict() | self._benchmark.to_dict()
+
+
+@define
+class LocalFileSystemPersistenceHandler:
+    """Class for persisting experiment results in an S3 bucket."""
+
+    def write_object(self, object: PersistenceObjectInterface) -> None:
+        """Store the result of a benchmark.
+
+        This method will store the result of a benchmark in an S3 bucket.
+        The key of the object will be the experiment identifier, the branch, the
+        BayBE-version, the start datetime, the commit hash and the workflow
+        run identifier.
+
+        Args:
+            object: The object to be persisted.
+        """
+        with open(object.get_full_file_path(), "w") as file:
+            json.dump(object.get_object(), file)
+
+
+def persister_factory() -> PersistenceHandlingInterface:
+    """Create a persistence handler based on the environment variables.
+
+    Returns:
+        The persistence handler.
+    """
+    if "GITHUB_RUN_ID" in os.environ:
+        return S3PersistenceHandler()
+    return LocalFileSystemPersistenceHandler()
+
+
+def create_persistence_object(
+    benchmark: Benchmark, result: Result
+) -> PersistenceObjectInterface:
+    """Create a persistence object.
+
+    Args:
+        benchmark: The benchmark for which the result is stored.
+        result: The result of the benchmark.
+
+    Returns:
+        The persistence object.
+    """
+    if "GITHUB_RUN_ID" in os.environ:
+        return S3PersistenceObjectCreator(benchmark, result)
+    return LocalFileSystemObjectCreator(benchmark, result)

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -1,5 +1,7 @@
 """Classes for persisting benchmark results."""
 
+from __future__ import annotations
+
 import json
 import os
 from datetime import datetime
@@ -75,8 +77,8 @@ class PathConstructor:
 
     @classmethod
     def from_benchmark_and_result(
-        cls: "PathConstructor", benchmark: Benchmark, result: Result
-    ) -> "PathConstructor":
+        cls, benchmark: Benchmark, result: Result
+    ) -> PathConstructor:
         """Create a path constructor from benchmark and result.
 
         Args:

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -116,7 +116,7 @@ class ObjectWriter(Protocol):
 
         Args:
             object: The object to be persisted.
-            path_constructor: The PathConstructor to create the path for the object.
+            path_constructor: The path constructor creating the path for the object.
         """
 
 
@@ -152,7 +152,7 @@ class S3ObjectWriter(ObjectWriter):
 
         Args:
             object: The object to be persisted.
-            path_constructor: The PathConstructor to create the path for the object.
+            path_constructor: The path constructor creating the path for the object.
 
         """
         client = self._object_session.client("s3")
@@ -185,7 +185,7 @@ class LocalFileSystemObjectWriter(ObjectWriter):
 
         Args:
             object: The object to be persisted.
-            path_constructor: The PathConstructor to create the path for the object.
+            path_constructor: The path constructor creating the path for the object.
 
 
         Raises:
@@ -214,14 +214,14 @@ def make_object_writer() -> ObjectWriter:
 
 
 def make_path_constructor(benchmark: Benchmark, result: Result) -> PathConstructor:
-    """Create a PathConstructor.
+    """Create a path constructor.
 
     Args:
         benchmark: The benchmark for which the result is stored.
         result: The result of the benchmark.
 
     Returns:
-        The persistence path builder.
+        The persistence path constructor.
     """
     benchmark_name = benchmark.name
     start_datetime = result.metadata.start_datetime

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -170,7 +170,7 @@ class S3ObjectWriter(ObjectWriter):
 class LocalFileSystemObjectWriter(ObjectWriter):
     """Class for persisting JSON serializable dicts locally."""
 
-    folder_path_prefix: Path = field(validator=instance_of(Path), default=Path("."))
+    folder_path_prefix: Path = field(converter=Path, default=Path("."))
     """The prefix of the folder path where the results are stored.
     The filename will be created automatically and create or override the
     file under this path. The file path must exist."""

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -17,7 +17,8 @@ from typing_extensions import override
 
 from benchmarks import Benchmark, Result
 
-PERSIST_DATA_TO_S3_BUCKET = "BAYBE_BENCHMARKING_PERSISTENCE_PATH" in os.environ
+VARNAME_BENCHMARKING_PERSISTENCE_PATH = "BAYBE_BENCHMARKING_PERSISTENCE_PATH"
+PERSIST_DATA_TO_S3_BUCKET = VARNAME_BENCHMARKING_PERSISTENCE_PATH in os.environ
 
 
 class PathStrategy(Enum):
@@ -135,11 +136,11 @@ class S3ObjectWriter(ObjectWriter):
         """Get the bucket name from the environment variables."""
         if not PERSIST_DATA_TO_S3_BUCKET:
             raise ValueError(
-                "No S3 bucket name provided. Please provide the "
-                + "bucket name by setting the environment variable "
-                + "BAYBE_BENCHMARKING_PERSISTENCE_PATH."
+                f"No S3 bucket name provided. Please provide the "
+                f"bucket name by setting the environment variable "
+                f"'{VARNAME_BENCHMARKING_PERSISTENCE_PATH}'."
             )
-        return os.environ["BAYBE_BENCHMARKING_PERSISTENCE_PATH"]
+        return os.environ[VARNAME_BENCHMARKING_PERSISTENCE_PATH]
 
     @override
     def write_json(self, object: dict, path_constructor: PathConstructor) -> None:

--- a/benchmarks/persistence/persistence.py
+++ b/benchmarks/persistence/persistence.py
@@ -37,7 +37,7 @@ class PathConstructor:
     This class is used to encapsulate the construction of a respective path depending
     on where the object should be stored. Since different storage backends have
     different requirements for the path, and some like the used S3 Bucket
-    not even support folders, the path uses its variables to construct the path
+    do not support folders, the path uses its variables to construct the path
     in the order of the variables with a separator depending on the strategy.
     For compatibility reasons, the path is sanitized to only contain the following
     allowed characters:

--- a/benchmarks/result/metadata.py
+++ b/benchmarks/result/metadata.py
@@ -7,12 +7,11 @@ from attrs import define, field
 from attrs.validators import instance_of
 from cattrs.gen import make_dict_unstructure_fn
 
-from baybe.serialization.core import converter
-from baybe.serialization.mixin import SerialMixin
+from benchmarks.serialization import Serializable, converter
 
 
 @define(frozen=True)
-class ResultMetadata(SerialMixin):
+class ResultMetadata(Serializable):
     """The metadata of a benchmark result."""
 
     start_datetime: datetime = field(validator=instance_of(datetime))

--- a/benchmarks/result/metadata.py
+++ b/benchmarks/result/metadata.py
@@ -7,11 +7,11 @@ from attrs import define, field
 from attrs.validators import instance_of
 from cattrs.gen import make_dict_unstructure_fn
 
-from benchmarks.serialization import Serializable, converter
+from benchmarks.serialization import BenchmarkSerialization, converter
 
 
 @define(frozen=True)
-class ResultMetadata(Serializable):
+class ResultMetadata(BenchmarkSerialization):
     """The metadata of a benchmark result."""
 
     start_datetime: datetime = field(validator=instance_of(datetime))

--- a/benchmarks/result/metadata.py
+++ b/benchmarks/result/metadata.py
@@ -26,6 +26,16 @@ class ResultMetadata(BenchmarkSerialization):
     latest_baybe_tag: str = field(validator=instance_of(str), init=False)
     """The latest BayBE tag reachable in the ancestor commit history."""
 
+    branch: str = field(validator=instance_of(str), init=False)
+    """The branch currently checked out."""
+
+    @branch.default
+    def _default_branch(self) -> str:
+        """Set the current checkout branch."""
+        repo = git.Repo(search_parent_directories=True)
+        current_branch = repo.active_branch.name
+        return current_branch
+
     @commit_hash.default
     def _default_commit_hash(self) -> str:
         """Extract the git commit hash."""

--- a/benchmarks/result/result.py
+++ b/benchmarks/result/result.py
@@ -7,11 +7,11 @@ from attrs.validators import instance_of
 from pandas import DataFrame
 
 from benchmarks.result import ResultMetadata
-from benchmarks.serialization import Serializable
+from benchmarks.serialization import BenchmarkSerialization
 
 
 @define(frozen=True)
-class Result(Serializable):
+class Result(BenchmarkSerialization):
     """A single result of the benchmarking."""
 
     benchmark_identifier: str = field(validator=instance_of(str))

--- a/benchmarks/result/result.py
+++ b/benchmarks/result/result.py
@@ -6,12 +6,12 @@ from attrs import define, field
 from attrs.validators import instance_of
 from pandas import DataFrame
 
-from baybe.serialization.mixin import SerialMixin
 from benchmarks.result import ResultMetadata
+from benchmarks.serialization import Serializable
 
 
 @define(frozen=True)
-class Result(SerialMixin):
+class Result(Serializable):
     """A single result of the benchmarking."""
 
     benchmark_identifier: str = field(validator=instance_of(str))

--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -25,7 +25,7 @@ converter.register_structure_hook(
 )
 
 
-class Serializable:
+class BenchmarkSerialization:
     """Mixin class providing serialization methods."""
 
     def to_dict(self) -> dict[str, Any]:

--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -1,0 +1,47 @@
+"""Serialization utilities for benchmarking objects."""
+
+import json
+from datetime import datetime, timedelta
+from typing import Any
+
+import cattrs
+import pandas as pd
+
+from baybe.serialization.core import (
+    _structure_dataframe_hook,
+    _unstructure_dataframe_hook,
+)
+
+benchmarking_converter = cattrs.GenConverter(unstruct_collection_overrides={set: list})
+"""The converter for benchmarking objects."""
+
+benchmarking_converter.register_unstructure_hook(
+    pd.DataFrame, _unstructure_dataframe_hook
+)
+benchmarking_converter.register_structure_hook(pd.DataFrame, _structure_dataframe_hook)
+benchmarking_converter.register_unstructure_hook(datetime, lambda x: x.isoformat())
+benchmarking_converter.register_structure_hook(
+    datetime, lambda x, _: datetime.fromisoformat(x)
+)
+benchmarking_converter.register_unstructure_hook(
+    timedelta, lambda x: f"{x.total_seconds()}s"
+)
+benchmarking_converter.register_structure_hook(
+    timedelta, lambda x, _: timedelta(seconds=float(x.removesuffix("s")))
+)
+
+
+class Serializable:
+    """Decorator to add serialization methods to a class."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Create an object's dictionary representation."""
+        return benchmarking_converter.unstructure(self)
+
+    def to_json(self) -> str:
+        """Create an object's JSON representation.
+
+        Returns:
+            The JSON representation as a string.
+        """
+        return json.dumps(self.to_dict())

--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -33,9 +33,5 @@ class Serializable:
         return converter.unstructure(self)
 
     def to_json(self) -> str:
-        """Create an object's JSON representation.
-
-        Returns:
-            The JSON representation as a string.
-        """
+        """Create an object's JSON representation."""
         return json.dumps(self.to_dict())

--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -12,31 +12,25 @@ from baybe.serialization.core import (
     _unstructure_dataframe_hook,
 )
 
-benchmarking_converter = cattrs.GenConverter(unstruct_collection_overrides={set: list})
+converter = cattrs.GenConverter(unstruct_collection_overrides={set: list})
 """The converter for benchmarking objects."""
 
-benchmarking_converter.register_unstructure_hook(
-    pd.DataFrame, _unstructure_dataframe_hook
-)
-benchmarking_converter.register_structure_hook(pd.DataFrame, _structure_dataframe_hook)
-benchmarking_converter.register_unstructure_hook(datetime, lambda x: x.isoformat())
-benchmarking_converter.register_structure_hook(
-    datetime, lambda x, _: datetime.fromisoformat(x)
-)
-benchmarking_converter.register_unstructure_hook(
-    timedelta, lambda x: f"{x.total_seconds()}s"
-)
-benchmarking_converter.register_structure_hook(
+converter.register_unstructure_hook(pd.DataFrame, _unstructure_dataframe_hook)
+converter.register_structure_hook(pd.DataFrame, _structure_dataframe_hook)
+converter.register_unstructure_hook(datetime, lambda x: x.isoformat())
+converter.register_structure_hook(datetime, lambda x, _: datetime.fromisoformat(x))
+converter.register_unstructure_hook(timedelta, lambda x: f"{x.total_seconds()}s")
+converter.register_structure_hook(
     timedelta, lambda x, _: timedelta(seconds=float(x.removesuffix("s")))
 )
 
 
 class Serializable:
-    """Decorator to add serialization methods to a class."""
+    """Mixin class providing serialization methods."""
 
     def to_dict(self) -> dict[str, Any]:
         """Create an object's dictionary representation."""
-        return benchmarking_converter.unstructure(self)
+        return converter.unstructure(self)
 
     def to_json(self) -> str:
         """Create an object's JSON representation.

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,6 +32,12 @@ ignore_missing_imports = True
 [mypy-mpl_toolkits.mplot3d]
 ignore_missing_imports = True
 
+[mypy-boto3.*]
+   ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
 [mypy-ngboost]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,8 @@ benchmarking = [
     "baybe[chem]",
     "baybe[onnx]",
     "baybe[simulation]",
-    "GitPython>=3.0.6", # GitPython<3.0.6 is necessary since older versions rely on a specific version of GitDB: https://github.com/gitpython-developers/GitPython/issues/983
+    "boto3>=1.0.0,<2",
+    "GitPython>=3.0.6,<4", # GitPython<3.0.6 is necessary since older versions rely on a specific version of GitDB: https://github.com/gitpython-developers/GitPython/issues/983
 ]
 
 test = [


### PR DESCRIPTION
Hi everyone,

This pull request introduces a class and a workflow designed to store the results of a benchmark run on an S3 bucket.

The key used for storage includes the identifier for the benchmark itself, the branch used, the release version, the current date and the commit hash in that order. Furthermore, boto3 package is added to interact with AWS components.

I look forward to your feedback.