### PR TITLE
Fix visual issue in documentation by reducing max_colwidth

### DIFF
--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -511,7 +511,7 @@ def pretty_print_df(
     df: pd.DataFrame,
     max_rows: int = 6,
     max_columns: int = 4,
-    max_colwidth: int = 16,
+    max_colwidth: int = 14,
     precision: int = 3,
 ) -> str:
     """Convert a dataframe into a pretty/readable format.


### PR DESCRIPTION
This PR fixes #432 by reducing the `max_colwidth` argument when pretty printing dataframes from 16 to 14.

The result can be seen on my fork: https://avhopp.github.io/baybe_dev/latest/examples/Serialization/basic_serialization.html