### PR TITLE
Fix: qNIPV not working with single MIN target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrong number of recommendations being returned
 - `ContinuousConstraint`s can now be used in single point precision
 - Search spaces are now stateless, preventing unintended side effects that could lead to
-  incorrect candidate sets when reused in different optimization contexts 
+  incorrect candidate sets when reused in different optimization contexts
+- `qNIPV` not working with single `MIN` targets
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -118,6 +118,9 @@ class AcquisitionFunction(ABC, SerialMixin):
                     additional_params["objective"] = LinearMCObjective(
                         torch.tensor([-1.0])
                     )
+                elif issubclass(acqf_cls, bo_acqf.qNegIntegratedPosteriorVariance):
+                    # qNIPV is valid but does not require any adjusted params
+                    pass
                 else:
                     raise ValueError(
                         f"Unsupported acquisition function type: {acqf_cls}."


### PR DESCRIPTION
The `qNIPV` acquisition function (despite starting with `q`) does not seem to be derived from either `MCAcquisitionFunction` nor `AnalyticAcquisitionFunction`. This causes an issue in [this block](https://github.com/emdgroup/baybe/blob/98cb4ea06ab3cc678f6fb94c3084801c1b7be3d0/baybe/acquisition/base.py#L115-L124) because it is automatically put into the error block as a results. However, `qNIPV` is a valid choice. It does not require adjustment of any arguments (it has neither `maximize` nor `objective`), hence it is handled with `pass`.