### PR TITLE
Fix empty constraints after dropping parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `qNIPV` not working with single `MIN` targets
 - Passing a `TargetTransformation` without passing `bounds` when createing a 
   `NumericalTarget` now raises an error
+- Crash when using ContinuousCardinalityConsraint caused by an unintended interplay
+  between constraints and dropped parameters
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `qNIPV` not working with single `MIN` targets
 - Passing a `TargetTransformation` without passing `bounds` when createing a 
   `NumericalTarget` now raises an error
-- Crash when using ContinuousCardinalityConsraint caused by an unintended interplay
-  between constraints and dropped parameters
+- Crash when using `ContinuousCardinalityConstraint` caused by an unintended interplay
+  between constraints and dropped parameters yielding empty parameter sets
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -300,12 +300,12 @@ class SubspaceContinuous(SerialMixin):
             constraints_lin_eq=[
                 c._drop_parameters(parameter_names)
                 for c in self.constraints_lin_eq
-                if [p for p in c.parameters if p not in parameter_names]
+                if set(c.parameters) - set(parameter_names)
             ],
             constraints_lin_ineq=[
                 c._drop_parameters(parameter_names)
                 for c in self.constraints_lin_ineq
-                if [p for p in c.parameters if p not in parameter_names]
+                if set(c.parameters) - set(parameter_names)
             ],
         )
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -298,10 +298,14 @@ class SubspaceContinuous(SerialMixin):
         return SubspaceContinuous(
             parameters=[p for p in self.parameters if p.name not in parameter_names],
             constraints_lin_eq=[
-                c._drop_parameters(parameter_names) for c in self.constraints_lin_eq
+                c._drop_parameters(parameter_names)
+                for c in self.constraints_lin_eq
+                if [p for p in c.parameters if p not in parameter_names]
             ],
             constraints_lin_ineq=[
-                c._drop_parameters(parameter_names) for c in self.constraints_lin_ineq
+                c._drop_parameters(parameter_names)
+                for c in self.constraints_lin_ineq
+                if [p for p in c.parameters if p not in parameter_names]
             ],
         )
 

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -169,3 +169,36 @@ def test_random_recommender_with_cardinality_constraint(
     _validate_samples(
         recommendations, max_cardinality=2, min_cardinality=1, batch_size=batch_size
     )
+
+
+def test_empty_constraints_after_cardinality_constraint():
+    """Constraints that have no more parameters left due to activated
+    cardinality constraints do not cause crashes."""  # noqa
+
+    N_PARAMETERS = 4
+
+    parameters = [
+        NumericalContinuousParameter(name=f"x_{i+1}", bounds=(0, 1))
+        for i in range(N_PARAMETERS)
+    ]
+    constraints = [
+        ContinuousLinearConstraint(
+            parameters=["x_1"],
+            operator="=",
+            coefficients=[1.0],
+            rhs=0.3,
+        ),
+        ContinuousLinearConstraint(
+            parameters=["x_2"],
+            operator="<=",
+            coefficients=[1.0],
+            rhs=0.6,
+        ),
+        ContinuousCardinalityConstraint(
+            parameters=["x_1", "x_2"],
+            max_cardinality=1,
+            min_cardinality=1,
+        ),
+    ]
+    searchspace = SearchSpace.from_product(parameters, constraints)
+    searchspace.continuous.sample_uniform(1)

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -175,7 +175,7 @@ def test_empty_constraints_after_cardinality_constraint():
     """Constraints that have no more parameters left due to activated
     cardinality constraints do not cause crashes."""  # noqa
 
-    N_PARAMETERS = 4
+    N_PARAMETERS = 2
 
     parameters = [
         NumericalContinuousParameter(name=f"x_{i+1}", bounds=(0, 1))
@@ -200,5 +200,5 @@ def test_empty_constraints_after_cardinality_constraint():
             min_cardinality=1,
         ),
     ]
-    searchspace = SearchSpace.from_product(parameters, constraints)
-    searchspace.continuous.sample_uniform(1)
+    subspace = SubspaceContinuous.from_product(parameters, constraints)
+    subspace.sample_uniform(1)


### PR DESCRIPTION
When dropping parameters due to the use of cardinality constraints, it can happen that an attempt is made to create a Constraint without any parameters, causing the code to crash.

This PR introduces an explicit test for this scenario as well as a fix by only including constraints that still have parameters after dropping them.

This was observed when working on #345 and is necessary for continuing working on that.