### PR TITLE
Return original series in transform if no bounds are present

### DIFF
--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -155,6 +155,11 @@ class NumericalTarget(Target, SerialMixin):
         assert isinstance(series, pd.Series)
         # <<<<<<<<<< Deprecation
 
+        # If no bounds are provided, then the transformation returns the original
+        # bounds
+        if not self.bounds.is_bounded:
+            return series.copy()
+
         # When a transformation is specified, apply it
         if self.transformation is not None:
             func = _get_target_transformation(


### PR DESCRIPTION
This PR implements a fix for #449 by returning the original series if a target transform without any bounds is attempted.

Note that this PR currently does not contain additional tests, I am currently trying to find the best way of testing.