### PR TITLE
Raise error when specifying transformation without bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search spaces are now stateless, preventing unintended side effects that could lead to
   incorrect candidate sets when reused in different optimization contexts
 - `qNIPV` not working with single `MIN` targets
+- Passing a `TargetTransformation` without passing `bounds` when createing a 
+  `NumericalTarget` now raises an error
 
 ### Deprecations
 - Passing a dataframe via the `data` argument to `Objective.transform` is no longer

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -113,7 +113,7 @@ class NumericalTarget(Target, SerialMixin):
     def _validate_transformation(  # noqa: DOC101, DOC103
         self, _: Any, value: TargetTransformation | None
     ) -> None:
-        """Validate that the given transformation is compatible with the specified mode.
+        """Validate compatability between transformation, bounds and the mode.
 
         Raises:
             ValueError: If a target transformation was provided for an unbounded

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -116,8 +116,15 @@ class NumericalTarget(Target, SerialMixin):
         """Validate that the given transformation is compatible with the specified mode.
 
         Raises:
+            ValueError: If a target transformation was provided for an unbounded
+                target.
             ValueError: If the target transformation and mode are not compatible.
         """
+        if (value is not None) and (not self.bounds.is_bounded):
+            raise ValueError(
+                f"You specified a transformation for target '{self.name}', but "
+                f"did not specify any bounds."
+            )
         if (value is not None) and (value not in _VALID_TRANSFORMATIONS[self.mode]):
             raise ValueError(
                 f"You specified bounds for target '{self.name}', but your "

--- a/tests/hypothesis_strategies/targets.py
+++ b/tests/hypothesis_strategies/targets.py
@@ -28,12 +28,14 @@ def numerical_targets(
     """
     name = draw(target_name)
     mode = draw(st.sampled_from(TargetMode))
+    transformation = draw(st.sampled_from(_VALID_TRANSFORMATIONS[mode]))
     if bounds_strategy is None:
         bounds_strategy = st_intervals(
-            exclude_half_bounded=True, exclude_fully_unbounded=mode is TargetMode.MATCH
+            exclude_half_bounded=True,
+            exclude_fully_unbounded=mode is TargetMode.MATCH
+            or transformation is not None,
         )
     bounds = draw(bounds_strategy)
-    transformation = draw(st.sampled_from(_VALID_TRANSFORMATIONS[mode]))
 
     return NumericalTarget(
         name=name, mode=mode, bounds=bounds, transformation=transformation

--- a/tests/validation/test_target_validation.py
+++ b/tests/validation/test_target_validation.py
@@ -58,8 +58,8 @@ def test_binary_target_invalid_values(choices, error, match):
 @pytest.mark.parametrize(
     ("mode", "transformation"),
     [
-        param("MIN", "LINEAR"),
-        param("MAX", "LINEAR"),
+        param("MIN", "LINEAR", id="linear_for_min"),
+        param("MAX", "LINEAR", id="linear_for_max"),
     ],
 )
 def test_providing_transformation_without_bounds(mode, transformation):

--- a/tests/validation/test_target_validation.py
+++ b/tests/validation/test_target_validation.py
@@ -53,3 +53,19 @@ def test_binary_target_invalid_values(choices, error, match):
             success_value=choices[0],
             failure_value=choices[1],
         )
+
+
+@pytest.mark.parametrize(
+    ("mode", "transformation"),
+    [
+        param("MIN", "LINEAR"),
+        param("MAX", "LINEAR"),
+    ],
+)
+def test_providing_transformation_without_bounds(mode, transformation):
+    with pytest.raises(ValueError, match="but did not specify any bounds."):
+        NumericalTarget(
+            name="transforamtion_without_bounds",
+            mode=mode,
+            transformation=transformation,
+        )

--- a/tests/validation/test_target_validation.py
+++ b/tests/validation/test_target_validation.py
@@ -56,16 +56,12 @@ def test_binary_target_invalid_values(choices, error, match):
 
 
 @pytest.mark.parametrize(
-    ("mode", "transformation"),
-    [
-        param("MIN", "LINEAR", id="linear_for_min"),
-        param("MAX", "LINEAR", id="linear_for_max"),
-    ],
+    "mode",
+    ["MIN", "MAX"],
 )
-def test_providing_transformation_without_bounds(mode, transformation):
+def test_providing_transformation_without_bounds(mode):
+    """Providing a transformation without bounds raises an error."""
     with pytest.raises(ValueError, match="but did not specify any bounds."):
         NumericalTarget(
-            name="transforamtion_without_bounds",
-            mode=mode,
-            transformation=transformation,
+            name="transformation_without_bounds", mode=mode, transformation="LINEAR"
         )


### PR DESCRIPTION
This PR fixes #449 by now checking whether a `NumericalTarget` has bounds if a transformation is provided.

Introduces a new step in the validation, raising a value error if the user provides a transformation but no bounds. Also adds an according test.