### PR TITLE
Maintain row order after cross join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compatible with `strtobool`
 - All arguments to `MetaRecommender.select_recommender` are now optional
 - `MetaRecommender`s can now be composed of other `MetaRecommender`s
+- For performance reasons, search space manipulation using `polars` is no longer
+  guaranteed to produce the same row order as the corresponding `pandas` operations
 
 ### Fixed
 - Rare bug arising from degenerate `SubstanceParameter.comp_df` rows that caused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SingleTargetObjective` no longer erroneously maximizes it
 - Improvement-based Monte Carlo acquisition functions now use the correct
   reference value in minimization mode
+- The `polars` cross join for the Cartesian product now explicitly maintains row order,
+  yielding an equivalent result to the `pandas` version and fixing tests for `>=1.19.0`
 
 ### Removed
 - `botorch_function_wrapper` utility for creating lookup callables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SingleTargetObjective` no longer erroneously maximizes it
 - Improvement-based Monte Carlo acquisition functions now use the correct
   reference value in minimization mode
-- The `polars` cross join for the Cartesian product now explicitly maintains row order,
-  yielding an equivalent result to the `pandas` version and fixing tests for `>=1.19.0`
 
 ### Removed
 - `botorch_function_wrapper` utility for creating lookup callables

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -792,7 +792,12 @@ def parameter_cartesian_prod_polars(parameters: Sequence[Parameter]) -> pl.LazyF
     # Cross-join parameters
     res = param_frames[0]
     for frame in param_frames[1:]:
-        res = res.join(frame, how="cross", force_parallel=True)
+        # Note: We enforce row order to be consistent with the pandas output,
+        #   which simplifies testing. If speed ever becomes problematic, this
+        #   restriction could be removed.
+        res = res.join(
+            frame, how="cross", force_parallel=True, maintain_order="left_right"
+        )
 
     return res
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -792,12 +792,7 @@ def parameter_cartesian_prod_polars(parameters: Sequence[Parameter]) -> pl.LazyF
     # Cross-join parameters
     res = param_frames[0]
     for frame in param_frames[1:]:
-        # Note: We enforce row order to be consistent with the pandas output,
-        #   which simplifies testing. If speed ever becomes problematic, this
-        #   restriction could be removed.
-        res = res.join(
-            frame, how="cross", force_parallel=True, maintain_order="left_right"
-        )
+        res = res.join(frame, how="cross", force_parallel=True)
 
     return res
 

--- a/docs/userguide/envvars.md
+++ b/docs/userguide/envvars.md
@@ -85,6 +85,12 @@ changing the Python environment. To do so, you can set the environment variable
 `BAYBE_DEACTIVATE_POLARS` to any truthy value accepted by
 [`strtobool`](baybe.utils.boolean.strtobool).
 
+```{admonition} Row Order
+:class: caution
+
+For performance reasons, search space manipulation using `polars` is not
+guaranteed to produce the same row order as the corresponding `pandas` operations.
+```
 
 ## Disk Caching
 For some components, such as the

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -189,7 +189,7 @@ def test_polars_product(constraints, parameters):
     # Do Pandas product
     df_pd = parameter_cartesian_prod_pandas(parameters)
 
-    # Assert equality of lengths before filtering
+    # Assert equality before filtering
     assert_frame_equal(df_pl.to_pandas(), df_pd)
 
     # Apply constraints
@@ -198,5 +198,9 @@ def test_polars_product(constraints, parameters):
         _apply_constraint_filter_polars(ldf, constraints)[0].collect().to_pandas()
     )
 
-    # Assert strict equality of two dataframes
-    assert_frame_equal(df_pl_filtered, df_pd_filtered)
+    # Assert order-agnostic equality of the two dataframes
+    cols = df_pd_filtered.columns.tolist()
+    assert_frame_equal(
+        df_pd_filtered.sort_values(cols).reset_index(drop=True),
+        df_pl_filtered.sort_values(cols).reset_index(drop=True),
+    )


### PR DESCRIPTION
Fixes the failing polars tests.

By default, `polars` gives no guarantees on the resulting row order of a join (see [here](https://github.com/pola-rs/polars/issues/20725)), meaning that our tests used to pass just by luck. This has changed since `polars==0.19.0`, which apparently included changes that affect the row order of our test dataframes. The PR fixes these tests by ignoring the row order during the equality check.

~~The current version of the polars cross join computing the Cartesian product currently makes no guarantees on the resulting row order (see [here](https://github.com/pola-rs/polars/issues/20725)). While strictly not a bug, this makes the behavior inconsistent with the corresponding pandas implementation and makes comparison more difficult. Accordingly, our tests started to fail since polars `0.19.0` which apparently included changes that affect the row order of our test dataframes.~~

~~Enforcing the pandas-equivalent row order seems like the best option for now, while potentially not exploiting the maximum possible speed of the polars join. In case speed really becomes a limitation, we can remove the restriction but then need to check that we don't rely on the order anywhere.~~