### PR TITLE
Improve GP Fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2025-01-31
+### Changed
+- More robust settings for the GP fitting
+
 ## [0.12.1] - 2025-01-29
 ### Changed
 - Default of `allow_recommending_already_recommended` is changed back to `False`

--- a/baybe/surrogates/naive.py
+++ b/baybe/surrogates/naive.py
@@ -37,7 +37,7 @@ class MeanPredictionSurrogate(IndependentGaussianSurrogate):
         import torch
 
         # TODO: use target value bounds for covariance scaling when explicitly provided
-        mean = self._model * torch.ones([len(candidates_comp_scaled)])
+        mean = self._model * torch.ones([len(candidates_comp_scaled)])  # type: ignore[operator]
         var = torch.ones(len(candidates_comp_scaled))
         return mean, var
 


### PR DESCRIPTION
- scipy fit is used for all cases now
- instead, the MLL type is switched based on whether TL is active or not