### PR TITLE
Fix Substance Encodings

### DIFF
--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -111,8 +111,6 @@ cyclonedx-python-lib==7.5.1
     # via pip-audit
 dask==2024.7.1
     # via xyzpy
-datasketch==1.6.5
-    # via scikit-fingerprints
 debugpy==1.8.2
     # via ipykernel
 decorator==5.1.1
@@ -374,7 +372,7 @@ markupsafe==2.1.5
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.9.1
+matplotlib==3.10.0
     # via
     #   baybe (pyproject.toml)
     #   lifelines
@@ -456,7 +454,6 @@ numpy==1.26.4
     #   autograd
     #   botorch
     #   contourpy
-    #   datasketch
     #   descriptastorus
     #   e3fp
     #   formulaic
@@ -805,7 +802,7 @@ ruff==0.5.2
     # via baybe (pyproject.toml)
 s3transfer==0.10.4
     # via boto3
-scikit-fingerprints==1.9.0
+scikit-fingerprints==1.13.1
     # via baybe (pyproject.toml)
 scikit-image==0.25.0
     # via lime
@@ -826,7 +823,6 @@ scipy==1.14.0
     #   baybe (pyproject.toml)
     #   autograd-gamma
     #   botorch
-    #   datasketch
     #   descriptastorus
     #   e3fp
     #   formulaic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `BCUT2D` encoding for `SubstanceParameter`
+
 ## [0.12.2] - 2025-01-31
 ### Changed
 - More robust settings for the GP fitting

--- a/baybe/constraints/continuous.py
+++ b/baybe/constraints/continuous.py
@@ -103,7 +103,7 @@ class ContinuousLinearConstraint(ContinuousConstraint):
         """Cast the constraint in a format required by botorch.
 
         Used in calling ``optimize_acqf_*`` functions, for details see
-        https://botorch.org/api/optim.html#botorch.optim.optimize.optimize_acqf
+        :func:`botorch.optim.optimize.optimize_acqf`
 
         Args:
             parameters: The parameter objects of the continuous space.

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -39,6 +39,9 @@ class SubstanceEncoding(ParameterEncoding):
     AVALON = "AVALON"
     """:class:`skfp.fingerprints.AvalonFingerprint`"""
 
+    BCUT2D = "BCUT2D"
+    """:class:`skfp.fingerprints.BCUT2DFingerprint`"""
+
     E3FP = "E3FP"
     """:class:`skfp.fingerprints.E3FPFingerprint`"""
 

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -1,6 +1,7 @@
 """Substance parameters."""
 
 import gc
+import warnings
 from functools import cached_property
 from typing import Any, ClassVar
 
@@ -140,8 +141,16 @@ class SubstanceParameter(DiscreteParameter):
             kwargs_fingerprint=self.kwargs_fingerprint,
         )
 
-        # Drop NaN and constant columns
+        # Drop NaN, constant columns and columns with duplicated names
         comp_df = comp_df.loc[:, ~comp_df.isna().any(axis=0)]
+        if any(mask_duplicated_columns := comp_df.columns.duplicated()):
+            warnings.warn(
+                f"There were duplicated column names for the substance parameter "
+                f"{self.name} with encoding {self.encoding.name}. This could indicate "
+                f"bugs with the encoding computation. The duplicated columns will be "
+                f"dropped."
+            )
+            comp_df = comp_df.loc[:, ~mask_duplicated_columns]
         comp_df = df_drop_single_value_columns(comp_df)
 
         # Label the rows with the molecule names

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -1,7 +1,6 @@
 """Substance parameters."""
 
 import gc
-import warnings
 from functools import cached_property
 from typing import Any, ClassVar
 
@@ -141,16 +140,8 @@ class SubstanceParameter(DiscreteParameter):
             kwargs_fingerprint=self.kwargs_fingerprint,
         )
 
-        # Drop NaN, constant columns and columns with duplicated names
+        # Drop NaN and constant columns
         comp_df = comp_df.loc[:, ~comp_df.isna().any(axis=0)]
-        if any(mask_duplicated_columns := comp_df.columns.duplicated()):
-            warnings.warn(
-                f"There were duplicated column names for the substance parameter "
-                f"{self.name} with encoding {self.encoding.name}. This could indicate "
-                f"bugs with the encoding computation. The duplicated columns will be "
-                f"dropped."
-            )
-            comp_df = comp_df.loc[:, ~mask_duplicated_columns]
         comp_df = df_drop_single_value_columns(comp_df)
 
         # Label the rows with the molecule names

--- a/baybe/utils/chemistry.py
+++ b/baybe/utils/chemistry.py
@@ -152,7 +152,7 @@ def smiles_to_fingerprint_features(
     feature_names_out = fingerprint_encoder.get_feature_names_out()
     no_descriptor_names = all("fingerprint" in f for f in feature_names_out)
     suffixes = [
-        f.split("fingerprint")[1] if no_descriptor_names else f
+        f.split("fingerprint")[1] if no_descriptor_names else f.replace(" ", "_")
         for f in feature_names_out
     ]
     col_names = [prefix + name + suffix for suffix in suffixes]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -247,6 +247,7 @@ modindex_common_prefix = ["baybe."]
 
 # Mappings to all external packages that we want to have clickable links to
 intersphinx_mapping = {
+    "botorch": ("https://botorch.readthedocs.io/en/latest", None),
     "python": ("https://docs.python.org/3", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
     "polars": ("https://docs.pola.rs/api/python/stable/", None),
@@ -256,7 +257,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "torch": ("https://pytorch.org/docs/main/", None),
     "rdkit": ("https://rdkit.org/docs/", None),
-    "shap": ("https://shap.readthedocs.io/en/latest/", None),
+    "shap": ("https://shap.readthedocs.io/en/stable/", None),
 }
 
 # --- Options for autodoc typehints and autodoc -------------------------------

--- a/examples/Transfer_Learning/backtesting.py
+++ b/examples/Transfer_Learning/backtesting.py
@@ -49,7 +49,7 @@ objective = target.to_objective()
 
 ### Creating the Search Space
 
-# This example uses the [Hartmann Function](https://botorch.org/api/test_functions.html#botorch.test_functions.synthetic.Hartmann)
+# This example uses the [Hartmann Function](botorch.test_functions.synthetic.Hartmann)
 # as implemented by `botorch`.
 # The bounds of the search space are dictated by the test function and can be extracted
 # from the function itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ Issues = "https://github.com/emdgroup/baybe/issues/"
 
 [project.optional-dependencies]
 chem = [
-    "scikit-fingerprints>=1.7.0",
+    "scikit-fingerprints>=1.13.1",
 ]
 
 onnx = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ examples = [
     "baybe[chem]", # Required for some of the examples
     "baybe[onnx]", # Required for some of the examples
     "baybe[simulation]", # Required for some of the examples
-    "matplotlib>=3.7.3",
+    "matplotlib>=3.7.3,!=3.9.1",
     "openpyxl>=3.0.9",
     "pillow>=10.0.1", # Necessary due to vulnerability
     "plotly>=5.10.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,7 @@ def fixture_parameters(
             ],
             *[
                 SubstanceParameter(
-                    name=f"Substance_1_{encoding}",
+                    name=f"Substance_1_{encoding.name}",
                     data=mock_substances,
                     encoding=encoding,
                 )

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -13,9 +13,11 @@ from .conftest import run_iterations
 )
 @pytest.mark.parametrize(
     "parameter_names",
-    [["Categorical_1", f"Substance_1_{enc}"] for enc in SubstanceEncoding],
+    [["Categorical_1", f"Substance_1_{enc.name}"] for enc in SubstanceEncoding],
     ids=[enc.name for enc in SubstanceEncoding],
 )
+@pytest.mark.parametrize("n_grid_points", [8], ids=["g8"])
+@pytest.mark.parametrize("batch_size", [1], ids=["b3"])
 def test_run_iterations(campaign, batch_size, n_iterations):
     """Test running some iterations with fake results and a substance parameter."""
     run_iterations(campaign, n_iterations, batch_size)


### PR DESCRIPTION
`scikit-fingerprints` has updated to `1.13.0`. This broke our tests. This is caused by some of the new feature names having duplicates.

- bumped skfp version requirement to `>=0.13.1`
- excluded yanked matplotlib version
- Opened an [issue](https://github.com/scikit-fingerprints/scikit-fingerprints/issues/389) with scikit-fingerprints which triggered a fixed release
- Added support for the new `BCUT2D` fingerprint
- Also: the docs fail due to botorch links, which seems to have moved host location. Those were also fixed.