### PR TITLE
XFail bugged test case

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import numpy as np
+import pytest
 import torch
 from attrs import asdict, has
 from hypothesis import given
@@ -67,6 +68,10 @@ def validate_gpytorch_kernel_components(obj: Any, mapped: Any, **kwargs) -> None
             assert component == mapped_component
 
 
+# Temporarily marked as xfail due to a bug for LinearKernel in the only available
+# GPyTorch version, see https://github.com/cornellius-gp/gpytorch/issues/2633. Awaiting
+# new gpytorch and botorch releases.
+@pytest.mark.xfail(reason="Bug in GPyTorch 0.14.0")
 @given(kernels())
 def test_kernel_assembly(kernel: Kernel):
     """Turning a BayBE kernel into a GPyTorch kernel raises no errors and all its


### PR DESCRIPTION
There is a GPyTorch bug which causes test failure in some test for `LinearKernel`, see https://github.com/cornellius-gp/gpytorch/issues/2633 . Since it could take a while until new versions are out, this PR aims to fix the CI failing due to this.

Awaiting new gpytorch and botorch versions. The entire test is marked as xfail which will automatically inform us once it is corrected.