### PR TITLE
Add BoTorch kernel preset, which uses dimensions-scaled prior

### DIFF
--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -8,6 +8,8 @@ from attrs.validators import ge, gt, in_, instance_of
 from attrs.validators import optional as optional_v
 from typing_extensions import override
 
+from gpytorch.constraints import Interval
+
 from baybe.kernels.base import BasicKernel
 from baybe.priors.base import Prior
 from baybe.utils.conversion import fraction_to_float
@@ -179,6 +181,12 @@ class RBFKernel(BasicKernel):
         validator=optional_v([finite_float, gt(0.0)]),
     )
     """An optional initial value for the kernel lengthscale."""
+
+    # TODO replace with baybe constraint if possible
+    lengthscale_constraint: Interval | None = field(
+        default=None, validator=optional_v(instance_of(Interval))
+    )
+    """An optional prior on the kernel lengthscale constraint."""
 
 
 @define(frozen=True)

--- a/baybe/surrogates/gaussian_process/presets/__init__.py
+++ b/baybe/surrogates/gaussian_process/presets/__init__.py
@@ -6,10 +6,12 @@ from baybe.surrogates.gaussian_process.presets.core import (
 )
 from baybe.surrogates.gaussian_process.presets.default import DefaultKernelFactory
 from baybe.surrogates.gaussian_process.presets.edbo import EDBOKernelFactory
+from baybe.surrogates.gaussian_process.presets.botorch import BotorchKernelFactory
 
 __all__ = [
     "DefaultKernelFactory",
     "EDBOKernelFactory",
+    "BotorchKernelFactory",
     "make_gp_from_preset",
     "GaussianProcessPreset",
 ]

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing_extensions import override
+from attrs import define
+
+from math import log, sqrt
+
+from gpytorch.constraints import GreaterThan
+
+from baybe.kernels.basic import RBFKernel
+from baybe.parameters import TaskParameter
+from baybe.priors.basic import LogNormalPrior
+from baybe.searchspace import SearchSpace
+from baybe.surrogates.gaussian_process.kernel_factory import KernelFactory
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+    from baybe.kernels.base import Kernel
+
+
+@define
+class BotorchKernelFactory(KernelFactory):
+    """A factory providing the kernel for Gaussian process surrogates adapted from BoTorch.
+
+    References:
+        * https://github.com/pytorch/botorch/blob/a018a5ffbcbface6229d6c39f7ac6ef9baf5765e/botorch/models/multitask.py#L220
+        * https://github.com/pytorch/botorch/blob/a018a5ffbcbface6229d6c39f7ac6ef9baf5765e/botorch/models/utils/gpytorch_modules.py#L100
+
+    """
+
+    @override
+    def __call__(
+            self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> Kernel:
+        ard_num_dims = train_x.shape[-1] - len([
+            param for param in searchspace.discrete.parameters if isinstance(param, TaskParameter)])
+        lengthscale_prior = LogNormalPrior(loc=sqrt(2) + log(ard_num_dims) * 0.5, scale=sqrt(3))
+
+        return RBFKernel(
+            lengthscale_prior=lengthscale_prior,
+            lengthscale_constraint=GreaterThan(
+                2.5e-2, transform=None, initial_value=lengthscale_prior.to_gpytorch().mode
+            ),
+        )

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -46,6 +46,7 @@ from baybe.surrogates.custom import CustomONNXSurrogate
 from baybe.surrogates.gaussian_process.presets import (
     DefaultKernelFactory,
     EDBOKernelFactory,
+    BotorchKernelFactory,
 )
 from baybe.utils.basic import get_subclasses
 
@@ -204,6 +205,7 @@ valid_kernels = valid_base_kernels + valid_scale_kernels + valid_composite_kerne
 valid_kernel_factories = [
     param(DefaultKernelFactory(), id="Default"),
     param(EDBOKernelFactory(), id="EDBO"),
+    param(BotorchKernelFactory(), id="BoTorch"),
 ]
 
 test_targets = [


### PR DESCRIPTION
This can stay a draft until it is validated that the performance improves with this preset and that we even want to use it.