### PR TITLE
Fix SHAP Plot Tests

### DIFF
--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -7,6 +7,7 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib import pyplot as plt
 from pytest import mark
 
 from baybe._optional.info import INSIGHTS_INSTALLED
@@ -159,8 +160,10 @@ def test_plots(ongoing_campaign: Campaign, use_comp_rep, plot_type):
     df = ongoing_campaign.measurements[[p.name for p in ongoing_campaign.parameters]]
     if use_comp_rep:
         df = ongoing_campaign.searchspace.transform(df)
+
     with mock.patch("matplotlib.pyplot.show"):
         shap_insight.plot(plot_type, df)
+        plt.close()
 
 
 def test_updated_campaign_explanations(campaign, n_iterations, batch_size):


### PR DESCRIPTION
This is an attempt to fix the unrealiably failing SHAP plot tests.

The solution is motivated by this warning:
![image](https://github.com/user-attachments/assets/99a40969-5df4-41fe-8e0e-38dd6187d662)

So it seems despite the `show` method being mocked, some plot objects are created and sort of persist. I suspect that there is some form of interaction effect here that causes [this line](https://github.com/shap/shap/blob/f1808f5c660cee80a1c67470362d876f1ed31028/shap/plots/_bar.py#L352) in thee shap module to return an emtpy tick label list, causing the `IndexError`. I have no idea though why it happens undeterministically. I  also was not able to pull this error out of the pytest into a separate script - there it always worked. Anyway, the issue is fixed by using `plt.close()` as suggested by the warning.