### PR TITLE
Vectorize `fuzzy_row_match`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `supports_batching` and `supports_pending_experiments`
 - `SHAPInsight` now allows explanation input that has additional columns compared to 
   the background data (will be ignored)
+- `fuzzy_row_match` now uses vectorized operations, resulting in a speedup of matching 
+  measurements to the search space between 4x and 40x
 
 ### Fixed
 - Incorrect optimization direction with `PSTD` with a single minimization target

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -1,5 +1,9 @@
 """Custom exceptions and warnings."""
 
+import pandas as pd
+from attr.validators import instance_of
+from attrs import define, field
+from typing_extensions import override
 
 ##### Warnings #####
 
@@ -11,11 +15,22 @@ class UnusedObjectWarning(UserWarning):
     """
 
 
+@define
 class SearchSpaceMatchWarning(UserWarning):
     """
-    When trying to match datapoints to entries in the search space, something
-    unexpected happened.
+    When trying to match data to entries in the search space, something unexpected
+    happened.
     """
+
+    message: str = field(validator=instance_of(str))
+    data: pd.DataFrame = field(validator=instance_of(pd.DataFrame))
+
+    def __attrs_pre_init(self):
+        super().__init__(self.message)
+
+    @override
+    def __str__(self):
+        return self.message
 
 
 ##### Exceptions #####

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -11,6 +11,13 @@ class UnusedObjectWarning(UserWarning):
     """
 
 
+class SearchSpaceMatchWarning(UserWarning):
+    """
+    When trying to match datapoints to entries in the search space, something
+    unexpected happened.
+    """
+
+
 ##### Exceptions #####
 
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -542,22 +542,22 @@ def fuzzy_row_match(
 
     # Warn if there are multiple or no matches
     if no_match_indices := right_df.index[mask_no_match].tolist():
-        warnings.warn(
-            f"Some input rows could not be matched to the search space. This could "
-            f"indicate that something went wrong or measurements are very noisy. "
-            f"Indices with no matches: {no_match_indices}",
-            SearchSpaceMatchWarning,
+        w = SearchSpaceMatchWarning(
+            f"Some input rows could not be matched to the search space. Indices with "
+            f"no matches: {no_match_indices}",
+            right_df.loc[no_match_indices],
         )
+        warnings.warn(w)
 
     mask_multiple_matches = match_matrix.sum(axis=1) > 1
     if multiple_match_indices := right_df.index[mask_multiple_matches].tolist():
-        warnings.warn(
+        w = SearchSpaceMatchWarning(
             f"Some input rows have multiple matches with the search space. "
-            f"This could indicate that something went wrong. Matching only "
-            f"first occurrence for these rows. Indices with multiple matches: "
-            f"{multiple_match_indices}",
-            SearchSpaceMatchWarning,
+            f"Matching only first occurrence for these rows. Indices with multiple "
+            f"matches: {multiple_match_indices}",
+            right_df.loc[multiple_match_indices],
         )
+        warnings.warn(w)
 
     return matched_indices
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -485,18 +485,24 @@ def fuzzy_row_match(
         The index of the matching rows in ``left_df``.
 
     Raises:
-        ValueError: If some rows are present in the right but not in the left dataframe.
+        ValueError: If either left_df or right_df does not contain columns for each
+            entry in parameters.
     """
-    # Assert that all parameters appear in the given dataframe
-    if not set(right_df.columns).issubset(set(left_df.columns)):
-        raise ValueError(
-            "For fuzzy row matching all columns of the right dataframe need to be "
-            "present in the left dataframe."
-        )
-
     # Separate categorical and numerical columns
     cat_cols = [p.name for p in parameters if not p.is_numerical]
     num_cols = [p.name for p in parameters if (p.is_numerical and p.is_discrete)]
+
+    # Assert that all parameters appear in the given dataframes
+    if diff := set(cat_cols + num_cols).difference(set(left_df.columns)):
+        raise ValueError(
+            f"For fuzzy row matching all parameters need to have a corresponding "
+            f"column in the left dataframe. Parameters not found: {diff})"
+        )
+    if diff := set(cat_cols + num_cols).difference(set(right_df.columns)):
+        raise ValueError(
+            f"For fuzzy row matching all parameters need to have a corresponding "
+            f"column in the right dataframe. Parameters not found: {diff})"
+        )
 
     # Initialize the match matrix. We will later filter it down via applying other
     # matrices (representing the matching for each relevant column) via logical 'and'.

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 import numpy as np
 import pandas as pd
 
+from baybe.exceptions import SearchSpaceMatchWarning
 from baybe.targets.base import Target
 from baybe.targets.binary import BinaryTarget
 from baybe.targets.enum import TargetMode
@@ -535,7 +536,8 @@ def fuzzy_row_match(
         warnings.warn(
             f"Some input rows could not be matched to the search space. This could "
             f"indicate that something went wrong or measurements are very noisy. "
-            f"Indices with no matches: {no_match_indices}"
+            f"Indices with no matches: {no_match_indices}",
+            SearchSpaceMatchWarning,
         )
 
     mask_multiple_matches = match_matrix.sum(axis=1) > 1
@@ -544,7 +546,8 @@ def fuzzy_row_match(
             f"Some input rows have multiple matches with the search space. "
             f"This could indicate that something went wrong. Matching only "
             f"first occurrence for these rows. Indices with multiple matches: "
-            f"{multiple_match_indices}"
+            f"{multiple_match_indices}",
+            SearchSpaceMatchWarning,
         )
 
     return matched_indices

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -477,14 +477,15 @@ def fuzzy_row_match(
     Args:
         left_df: The data that serves as lookup reference.
         right_df: The data that is checked for matching rows in the left dataframe.
-        parameters: Parameter objects that identify relevant column names.
+        parameters: Parameter objects that identify the relevant column names and how
+            matching is performed.
 
     Returns:
         The index of the matching rows in ``left_df``.
 
     Raises:
-        ValueError: If either left_df or right_df does not contain columns for each
-            entry in parameters.
+        ValueError: If either ``left_df`` or ``right_df`` does not contain columns for
+            each entry in parameters.
     """
     # Separate categorical and numerical columns
     cat_cols = [p.name for p in parameters if not p.is_numerical]
@@ -502,22 +503,22 @@ def fuzzy_row_match(
             f"column in the right dataframe. Parameters not found: {diff})"
         )
 
-    # Initialize the match matrix. We will later filter it down via applying other
-    # matrices (representing the matching for each relevant column) via logical 'and'.
+    # Initialize the match matrix. We will later filter it down using other
+    # matrices (representing the matches for individual parameters) via logical 'and'.
     match_matrix = pd.DataFrame(
         True, index=right_df.index, columns=left_df.index, dtype=bool
     )
 
     # Match categorical parameters
     for col in cat_cols:
-        # Per categorical parameter, this calculates the match between all elements of
-        # left and right and stores it as a matrix.
+        # Per categorical parameter, this identifies matches between all elements of
+        # left and right and stores them in a matrix.
         match_matrix &= right_df[col].values[:, None] == left_df[col].values[None, :]
 
     # Match numerical parameters
     for col in num_cols:
         # Per numerical parameter, this identifies the rows with the smallest absolute
-        # difference and stores it as a matrix.
+        # difference and records them in a matrix.
         abs_diff = np.abs(right_df[col].values[:, None] - left_df[col].values[None, :])
         min_diff = abs_diff.min(axis=1, keepdims=True)
         match_matrix &= abs_diff == min_diff

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -504,6 +504,10 @@ def fuzzy_row_match(
             f"column in the right dataframe. Parameters not found: {diff})"
         )
 
+    assert (set(cat_cols) | set(num_cols)) == {
+        p.name for p in parameters
+    }, "There are parameter types that would be silently ignored."
+
     # Initialize the match matrix. We will later filter it down using other
     # matrices (representing the matches for individual parameters) via logical 'and'.
     match_matrix = pd.DataFrame(

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -135,13 +135,16 @@ def test_fuzzy_row_match(searchspace, noise, duplicated):
     with context as c:
         matched = fuzzy_row_match(left_df, right_df, searchspace.parameters)
 
-    # Assert correct identification of problematic df parts
-    if c is not None:
+    if duplicated:
+        # Assert correct identification of problematic df parts
         w = next(x for x in c if isinstance(x.message, SearchSpaceMatchWarning)).message
         assert_frame_equal(right_df.loc[[0]], w.data)
 
-    if not duplicated:
-        assert set(selected) == set(matched), (selected, matched)
+        # Ignore problematic indices for subsequent equality check
+        selected = selected[1:]
+        matched = matched[1:]
+
+    assert set(selected) == set(matched), (selected, matched)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -145,7 +145,7 @@ def test_fuzzy_row_match(searchspace, noise, duplicated):
         param(["Categorical_1", "Num_disc_1", "Conti_finite1"], id="hybrid"),
     ],
 )
-@pytest.mark.parametrize("invalid", ["left_invalid", "right_invalid"])
+@pytest.mark.parametrize("invalid", ["left", "right"])
 def test_invalid_fuzzy_row_match(searchspace, invalid):
     """Returns expected errors when dataframes don't contain all expected columns."""
     left_df = searchspace.discrete.exp_rep.copy()
@@ -153,13 +153,11 @@ def test_invalid_fuzzy_row_match(searchspace, invalid):
     right_df = left_df.loc[selected].copy()
 
     # Drop first column
-    if invalid == "left_invalid":
+    if invalid == "left":
         left_df = left_df.iloc[:, 1:]
-        side = "left"
     else:
         right_df = right_df.iloc[:, 1:]
-        side = "right"
 
-    match = f"corresponding column in the {side} dataframe."
+    match = f"corresponding column in the {invalid} dataframe."
     with pytest.raises(ValueError, match=match):
         fuzzy_row_match(left_df, right_df, searchspace.parameters)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 from pytest import param
 
 from baybe.exceptions import SearchSpaceMatchWarning
@@ -131,8 +132,13 @@ def test_fuzzy_row_match(searchspace, noise, duplicated):
             noise_level=0.1,
         )
 
-    with context:
+    with context as c:
         matched = fuzzy_row_match(left_df, right_df, searchspace.parameters)
+
+    # Assert correct identification of problematic df parts
+    if c is not None:
+        w = next(x for x in c if isinstance(x.message, SearchSpaceMatchWarning)).message
+        assert_frame_equal(right_df.loc[[0]], w.data)
 
     if not duplicated:
         assert set(selected) == set(matched), (selected, matched)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -88,7 +88,7 @@ def test_fuzzy_row_match(searchspace, noise):
 )
 @pytest.mark.parametrize("invalid", ["left_invalid", "right_invalid"])
 def test_invalid_fuzzy_row_match(searchspace, invalid):
-    """Fuzzy row matching returns expected errors."""
+    """Returns expected errors when dataframes don't contain all expected columns."""
     left_df = searchspace.discrete.exp_rep.copy()
     selected = np.random.choice(left_df.index, 4, replace=False)
     right_df = left_df.loc[selected].copy()
@@ -96,8 +96,11 @@ def test_invalid_fuzzy_row_match(searchspace, invalid):
     # Drop first column
     if invalid == "left_invalid":
         left_df = left_df.iloc[:, 1:]
+        side = "left"
     else:
         right_df = right_df.iloc[:, 1:]
+        side = "right"
 
-    with pytest.raises(ValueError):
+    match = f"corresponding column in the {side} dataframe."
+    with pytest.raises(ValueError, match=match):
         fuzzy_row_match(left_df, right_df, searchspace.parameters)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -62,7 +62,7 @@ def test_degenerate_rows_invalid_input():
 )
 @pytest.mark.parametrize("noise", [True, False], ids=["exact", "noisy"])
 def test_fuzzy_row_match(searchspace, noise):
-    """Test whether fuzzy row matching returns expected indices."""
+    """Fuzzy row matching returns expected indices."""
     left_df = searchspace.discrete.exp_rep.copy()
     selected = np.random.choice(left_df.index, 4, replace=False)
     right_df = left_df.loc[selected].copy()
@@ -87,8 +87,8 @@ def test_fuzzy_row_match(searchspace, noise):
     ],
 )
 @pytest.mark.parametrize("invalid", ["left_invalid", "right_invalid"])
-def test_invalid_fuzzy_row_match(searchspace, invalid, n_grid_points):
-    """Test whether fuzzy row matching returns expected errors."""
+def test_invalid_fuzzy_row_match(searchspace, invalid):
+    """Fuzzy row matching returns expected errors."""
     left_df = searchspace.discrete.exp_rep.copy()
     selected = np.random.choice(left_df.index, 4, replace=False)
     right_df = left_df.loc[selected].copy()

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -3,8 +3,18 @@
 import numpy as np
 import pandas as pd
 import pytest
+from pytest import param
 
-from baybe.utils.dataframe import add_noise_to_perturb_degenerate_rows
+from baybe.utils.dataframe import (
+    add_noise_to_perturb_degenerate_rows,
+    add_parameter_noise,
+    fuzzy_row_match,
+)
+
+
+@pytest.fixture()
+def n_grid_points():
+    return 5
 
 
 def test_degenerate_rows():
@@ -41,3 +51,53 @@ def test_degenerate_rows_invalid_input():
     # Add noise
     with pytest.raises(TypeError):
         add_noise_to_perturb_degenerate_rows(df)
+
+
+@pytest.mark.parametrize(
+    "parameter_names",
+    [
+        param(["Categorical_1", "Categorical_2", "Switch_1"], id="discrete"),
+        param(["Categorical_1", "Num_disc_1", "Conti_finite1"], id="hybrid"),
+    ],
+)
+@pytest.mark.parametrize("noise", [True, False], ids=["exact", "noisy"])
+def test_fuzzy_row_match(searchspace, noise):
+    """Test whether fuzzy row matching returns expected indices."""
+    left_df = searchspace.discrete.exp_rep.copy()
+    selected = np.random.choice(left_df.index, 4, replace=False)
+    right_df = left_df.loc[selected].copy()
+
+    if noise:
+        add_parameter_noise(
+            right_df,
+            searchspace.discrete.parameters,
+            noise_type="relative_percent",
+            noise_level=0.1,
+        )
+    matched = fuzzy_row_match(left_df, right_df, searchspace.parameters)
+
+    assert set(selected) == set(matched), (selected, matched)
+
+
+@pytest.mark.parametrize(
+    "parameter_names",
+    [
+        param(["Categorical_1", "Categorical_2", "Switch_1"], id="discrete"),
+        param(["Categorical_1", "Num_disc_1", "Conti_finite1"], id="hybrid"),
+    ],
+)
+@pytest.mark.parametrize("invalid", ["left_invalid", "right_invalid"])
+def test_invalid_fuzzy_row_match(searchspace, invalid, n_grid_points):
+    """Test whether fuzzy row matching returns expected errors."""
+    left_df = searchspace.discrete.exp_rep.copy()
+    selected = np.random.choice(left_df.index, 4, replace=False)
+    right_df = left_df.loc[selected].copy()
+
+    # Drop first column
+    if invalid == "left_invalid":
+        left_df = left_df.iloc[:, 1:]
+    else:
+        right_df = right_df.iloc[:, 1:]
+
+    with pytest.raises(ValueError):
+        fuzzy_row_match(left_df, right_df, searchspace.parameters)


### PR DESCRIPTION
- use vectorized operations instead of the for loop
- fixed column validations
- I tested that the result of the new version is always exactly equal to the old version
- added some basic pytests for the utility
- related to #344 

Here a resulting test looking at the speedup:
<img width="815" alt="image" src="https://github.com/user-attachments/assets/094bd96c-1e0f-4c4b-a10e-fdd5d680eb16" />
- speedup for the most realistic cases (`left_df` large versus `right_df`) approaches 4x from above
- for less relevant cases (`left_df` and `right_df` comparable in size or overall very small) the speedup can even be 40x