### PR TITLE
Acquisition function builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that are in `active_values`
 - Model scaling now uses the parameter bounds instead of the search space bounds
 - `benchmarks` module now accepts a list of domains to be executed
+- Construction of BoTorch acquisition functions has been redesigned from ground up
 
 ### Fixed
 - Incorrect optimization direction with `PSTD` with a single minimization target

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -104,23 +104,28 @@ class BotorchAcquisitionFunctionBuilder:
 
     @cached_property
     def _botorch_surrogate(self) -> Model:
+        """The botorch surrogate object."""
         return self.surrogate.to_botorch()
 
     @property
     def _maximize_flags(self) -> list[bool]:
+        """Booleans indicating which target is to be minimized/maximized."""
         assert is_all_instance(self.objective.targets, NumericalTarget)
         return [t.mode is TargetMode.MAX for t in self.objective.targets]
 
     @property
     def _multiplier(self) -> list[float]:
+        """Signs indicating which target is to be minimized/maximized."""
         return [1.0 if m else -1.0 for m in self._maximize_flags]
 
     @cached_property
     def _train_x(self) -> pd.DataFrame:
+        """The training parameter values."""
         return self.searchspace.transform(self.measurements, allow_extra=True)
 
     @cached_property
     def _train_y(self) -> pd.DataFrame:
+        """The training target values."""
         return self.measurements[[t.name for t in self.objective.targets]]
 
     def build(self) -> BotorchAcquisitionFunction:

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -11,8 +11,8 @@ import pandas as pd
 import torch
 from attrs import asdict, define, field, fields
 from attrs.validators import instance_of, optional
-from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
-from botorch.acquisition.monte_carlo import MCAcquisitionObjective as BObjective
+from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
+from botorch.acquisition.monte_carlo import MCAcquisitionObjective as BoObjective
 from botorch.acquisition.multi_objective import WeightedMCMultiOutputObjective
 from botorch.acquisition.objective import LinearMCObjective
 from botorch.models.model import Model
@@ -53,7 +53,7 @@ class BotorchAcquisitionArgs:
     beta: float | None = field(default=None, validator=opt_v(float))
     maximize: bool | None = field(default=None, validator=opt_v(bool))
     mc_points: Tensor | None = field(default=None, validator=opt_v(Tensor))
-    objective: BObjective | None = field(default=None, validator=opt_v(BObjective))
+    objective: BoObjective | None = field(default=None, validator=opt_v(BoObjective))
     prune_baseline: bool | None = field(default=None, validator=opt_v(bool))
     ref_point: Tensor | None = field(default=None, validator=opt_v(Tensor))
     X_baseline: Tensor | None = field(default=None, validator=opt_v(Tensor))
@@ -84,7 +84,7 @@ class BotorchAcquisitionFunctionBuilder:
 
     # Context shared across building methods
     _args: BotorchAcquisitionArgs = field(init=False)
-    _botorch_acqf_cls: BotorchAcquisitionFunction = field(init=False)
+    _botorch_acqf_cls: BoAcquisitionFunction = field(init=False)
     _signature: MappingProxyType = field(init=False)
     _set_best_f_called: bool = field(init=False, default=False)
 
@@ -128,7 +128,7 @@ class BotorchAcquisitionFunctionBuilder:
         """The training target values."""
         return self.measurements[[t.name for t in self.objective.targets]]
 
-    def build(self) -> BotorchAcquisitionFunction:
+    def build(self) -> BoAcquisitionFunction:
         """Build the BoTorch acquisition function object."""
         # Set context-specific parameters
         self._set_best_f()
@@ -194,7 +194,7 @@ class BotorchAcquisitionFunctionBuilder:
             case SingleTargetObjective() | DesirabilityObjective():
                 self._args.best_f = post_mean.max().item()
 
-    def set_default_sample_shape(self, acqf: BotorchAcquisitionFunction, /):
+    def set_default_sample_shape(self, acqf: BoAcquisitionFunction, /):
         """Apply temporary workaround for Thompson sampling."""
         if not isinstance(self.acqf, qThompsonSampling):
             return

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -33,7 +33,7 @@ from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.base import SurrogateProtocol
 from baybe.targets.enum import TargetMode
 from baybe.targets.numerical import NumericalTarget
-from baybe.utils.basic import match_attributes
+from baybe.utils.basic import is_all_instance, match_attributes
 from baybe.utils.dataframe import to_tensor
 
 
@@ -105,6 +105,7 @@ class BotorchAcquisitionFunctionBuilder:
 
     @property
     def _maximize_flags(self) -> list[bool]:
+        assert is_all_instance(self.objective.targets, NumericalTarget)
         return [t.mode is TargetMode.MAX for t in self.objective.targets]
 
     @property

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -226,18 +226,18 @@ class BotorchAcquisitionFunctionBuilder:
 
         assert isinstance(self.acqf, qLogNoisyExpectedHypervolumeImprovement)
 
-        if isinstance(ref_point := self._args.ref_point, Iterable):
-            point = [p * m for p, m in zip(ref_point, self._multiplier, strict=True)]
+        if isinstance(ref_point := self.acqf.reference_point, Iterable):
+            self._args.ref_point = torch.tensor(
+                [p * m for p, m in zip(ref_point, self._multiplier, strict=True)]
+            )
         else:
-            kwargs = {"factor": ref_point} if ref_point is not None else {}
-            point = (
+            kwargs = {} if ref_point is None else {"factor": ref_point}
+            self._args.ref_point = torch.tensor(
                 self.acqf.compute_ref_point(
                     self._train_y, self._maximize_flags, **kwargs
                 )
                 * self._multiplier
             )
-
-        self._args.ref_point = torch.tensor(point)
 
     def set_default_sample_shape(self, acqf: BotorchAcquisitionFunction, /):
         """Apply temporary workaround for Thompson sampling."""

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -1,0 +1,250 @@
+"""Functionality for building BoTorch acquisition functions."""
+
+from collections.abc import Callable, Iterable
+from functools import cached_property
+from inspect import signature
+from types import MappingProxyType
+from typing import Any
+
+import botorch.acquisition as bo_acqf
+import numpy as np
+import pandas as pd
+import torch
+from attrs import asdict, define, field, fields
+from attrs.validators import instance_of, optional
+from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
+from botorch.acquisition.monte_carlo import MCAcquisitionObjective as BObjective
+from botorch.acquisition.multi_objective import WeightedMCMultiOutputObjective
+from botorch.acquisition.objective import LinearMCObjective
+from botorch.models.model import Model
+from torch import Tensor
+
+from baybe.acquisition.acqfs import (
+    qLogNoisyExpectedHypervolumeImprovement,
+    qNegIntegratedPosteriorVariance,
+    qThompsonSampling,
+)
+from baybe.acquisition.base import AcquisitionFunction, _get_botorch_acqf_class
+from baybe.objectives.base import Objective
+from baybe.objectives.desirability import DesirabilityObjective
+from baybe.objectives.pareto import ParetoObjective
+from baybe.objectives.single import SingleTargetObjective
+from baybe.searchspace.core import SearchSpace
+from baybe.surrogates.base import SurrogateProtocol
+from baybe.targets.enum import TargetMode
+from baybe.targets.numerical import NumericalTarget
+from baybe.utils.basic import match_attributes
+from baybe.utils.dataframe import to_tensor
+
+
+def opt_v(x: Any, /) -> Callable:
+    """Shorthand for an optional attrs isinstance validator."""  # noqa: D401
+    return optional(instance_of(x))
+
+
+@define
+class BotorchAcquisitionArgs:
+    """The collection of (optional) arguments for BoTorch acquisition functions."""
+
+    # Always required
+    model: Model = field(validator=instance_of(Model))
+
+    # Optional, depending on the specific acquisition function being used
+    best_f: float | None = field(default=None, validator=opt_v(float))
+    beta: float | None = field(default=None, validator=opt_v(float))
+    maximize: bool | None = field(default=None, validator=opt_v(bool))
+    objective: BObjective | None = field(default=None, validator=opt_v(BObjective))
+    prune_baseline: bool | None = field(default=None, validator=opt_v(bool))
+    X_baseline: Tensor | None = field(default=None, validator=opt_v(Tensor))
+    X_pending: Tensor | None = field(default=None, validator=opt_v(Tensor))
+    mc_points: Tensor | None = field(default=None, validator=opt_v(Tensor))
+    ref_point: Tensor | None = field(default=None, validator=opt_v(Tensor))
+
+    def collect(self) -> dict[str, Any]:
+        """Collect the assigned arguments into a dictionary."""
+        return asdict(self, filter=lambda _, x: x is not None)
+
+
+flds = fields(BotorchAcquisitionArgs)
+"""Shorthand for the argument field references."""
+
+
+@define
+class BotorchAcquisitionFunctionBuilder:
+    """A class for building BoTorch acquisition functions from BayBE objects."""
+
+    # The (pre-validated) BayBE objects
+    surrogate: SurrogateProtocol = field()
+    searchspace: SearchSpace = field()
+    objective: Objective = field()
+    measurements: pd.DataFrame = field()
+    pending_experiments: pd.DataFrame | None = field(default=None)
+
+    # Context shared across building methods
+    _args: BotorchAcquisitionArgs | None = field(init=False)
+    _acqf: AcquisitionFunction | None = field(init=False)
+    _botorch_acqf_cls: BotorchAcquisitionFunction | None = field(init=False)
+    _signature: MappingProxyType | None = field(init=False)
+    _set_best_f_called: bool = field(init=False, default=False)
+
+    @cached_property
+    def _train_x(self) -> Tensor:
+        return to_tensor(
+            self.searchspace.transform(self.measurements, allow_extra=True)
+        )
+
+    @cached_property
+    def _train_y(self) -> np.ndarray:
+        return self.measurements[[t.name for t in self.objective.targets]].to_numpy()
+
+    @cached_property
+    def _botorch_surrogate(self) -> Model:
+        return self.surrogate.to_botorch()
+
+    @property
+    def _maximize_flags(self) -> list[bool]:
+        return [t.mode is TargetMode.MAX for t in self.objective.targets]
+
+    @property
+    def _multiplier(self) -> list[float]:
+        return [1.0 if m else -1.0 for m in self._maximize_flags]
+
+    def build(self, acqf: AcquisitionFunction, /) -> BotorchAcquisitionFunction:
+        """Build the BoTorch acquisition function object."""
+        self._initialize(acqf)
+
+        # Set context-specific parameters
+        self._set_X_baseline()
+        self._set_mc_points()
+        self._set_X_pending()
+        self._set_best_f()
+        self._invert_optimization_direction()
+        self._set_X_baseline()
+        self._set_X_pending()
+        self._set_mc_points()
+        self._set_ref_point()
+
+        botorch_acqf = self._botorch_acqf_cls(**self._args.collect())
+        self.set_default_sample_shape(botorch_acqf)
+
+        return botorch_acqf
+
+    def _initialize(self, acqf: AcquisitionFunction, /) -> None:
+        """Initialize the building process."""
+        self._acqf = acqf
+
+        # Retrieve botorch acquisition function class and match attributes
+        self._botorch_acqf_cls = _get_botorch_acqf_class(type(acqf))
+        self._signature = signature(self._botorch_acqf_cls).parameters
+        args, _ = match_attributes(
+            acqf, self._botorch_acqf_cls.__init__, ignore=acqf._non_botorch_attrs
+        )
+
+        # Pre-populate the acqf arguments with the content of the BayBE acqf
+        self._args = BotorchAcquisitionArgs(self.surrogate.to_botorch(), **args)
+
+    def _set_X_baseline(self) -> None:
+        """Set BoTorch's ``X_baseline`` argument."""
+        if flds.X_baseline.name not in self._signature:
+            return
+
+        self._args.X_baseline = self._train_x
+
+    def _set_mc_points(self) -> None:
+        """Set BoTorch's ``mc_points`` argument."""
+        if flds.mc_points.name not in self._signature:
+            return
+
+        assert isinstance(self._acqf, qNegIntegratedPosteriorVariance)
+        self._args.mc_points = to_tensor(
+            self._acqf.get_integration_points(self.searchspace)
+        )
+
+    def _set_X_pending(self) -> None:
+        """Set BoTorch's ``X_pending`` argument."""
+        if self.pending_experiments is None:
+            return
+
+        pending_x = self.searchspace.transform(
+            self.pending_experiments, allow_extra=True
+        )
+        self._args.X_pending = to_tensor(pending_x)
+
+    def _set_best_f(self) -> None:
+        """Set BoTorch's ``best_f`` argument."""
+        self._set_best_f_called = True
+
+        if flds.best_f.name not in self._signature:
+            return
+
+        posterior_mean = self._botorch_surrogate.posterior(self._train_x).mean
+
+        match self.objective:
+            case SingleTargetObjective(NumericalTarget(mode=TargetMode.MIN)):
+                self._args.best_f = posterior_mean.min().item()
+            case SingleTargetObjective() | DesirabilityObjective():
+                self._args.best_f = posterior_mean.max().item()
+
+    def _invert_optimization_direction(self) -> None:
+        """Invert optimization direction for minimization targets."""
+        # ``best_f`` must have been already set (for the inversion below to work)
+        assert self._set_best_f_called
+
+        if issubclass(
+            type(self._acqf),
+            (
+                bo_acqf.qNegIntegratedPosteriorVariance,
+                bo_acqf.PosteriorStandardDeviation,
+                bo_acqf.qPosteriorStandardDeviation,
+            ),
+        ):
+            # No action needed for the active learning acquisition functions:
+            # - PSTD: Minimization happens by setting `maximize=False`, which is
+            #   already take care of by auto-matching attributes
+            # - qPSTD and qNIPV do not support minimization yet
+            # In both cases, the setting is independent of the target mode.
+            return
+
+        match self.objective:
+            case SingleTargetObjective(NumericalTarget(mode=TargetMode.MIN)):
+                if issubclass(self._botorch_acqf_cls, bo_acqf.MCAcquisitionFunction):
+                    if self._args.best_f is not None:
+                        self._args.best_f *= -1.0
+                    self._args.objective = LinearMCObjective(torch.tensor([-1.0]))
+                elif issubclass(
+                    self._botorch_acqf_cls, bo_acqf.AnalyticAcquisitionFunction
+                ):
+                    self._args.maximize = False
+
+            case ParetoObjective():
+                self._args.objective = WeightedMCMultiOutputObjective(
+                    torch.tensor(self._multiplier)
+                )
+
+    def _set_ref_point(self) -> None:
+        """Set BoTorch's ``ref_point`` argument."""
+        if flds.ref_point.name not in self._signature:
+            return
+
+        assert isinstance(self._acqf, qLogNoisyExpectedHypervolumeImprovement)
+
+        if isinstance(ref_point := self._args.ref_point, Iterable):
+            point = [p * m for p, m in zip(ref_point, self._multiplier, strict=True)]
+        else:
+            kwargs = {"factor": ref_point} if ref_point is not None else {}
+            point = (
+                self._acqf.compute_ref_point(
+                    self._train_y, self._maximize_flags, **kwargs
+                )
+                * self._multiplier
+            )
+
+        self._args.ref_point = torch.tensor(point)
+
+    def set_default_sample_shape(self, acqf: BotorchAcquisitionFunction, /):
+        """Apply temporary workaround for Thompson sampling."""
+        if not isinstance(self._acqf, qThompsonSampling):
+            return
+
+        assert hasattr(acqf, "_default_sample_shape")
+        acqf._default_sample_shape = torch.Size([self._acqf.n_mc_samples])

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -53,6 +53,7 @@ class BotorchAcquisitionArgs:
     beta: float | None = field(default=None, validator=opt_v(float))
     maximize: bool | None = field(default=None, validator=opt_v(bool))
     mc_points: Tensor | None = field(default=None, validator=opt_v(Tensor))
+    num_fantasies: int | None = field(default=None, validator=opt_v(int))
     objective: BoObjective | None = field(default=None, validator=opt_v(BoObjective))
     prune_baseline: bool | None = field(default=None, validator=opt_v(bool))
     ref_point: Tensor | None = field(default=None, validator=opt_v(Tensor))

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -326,7 +326,7 @@ class qLogNoisyExpectedHypervolumeImprovement(AcquisitionFunction):
 
     abbreviation: ClassVar[str] = "qLogNEHVI"
 
-    ref_point: float | tuple[float, ...] | None = field(
+    reference_point: float | tuple[float, ...] | None = field(
         default=None, converter=optional_c(convert_to_float)
     )
     """The reference point for computing the hypervolume improvement.
@@ -341,6 +341,15 @@ class qLogNoisyExpectedHypervolumeImprovement(AcquisitionFunction):
 
     prune_baseline: bool = field(default=True, validator=instance_of(bool))
     """Auto-prune candidates that are unlikely to be the best."""
+
+    @override
+    @classproperty
+    def _non_botorch_attrs(cls) -> tuple[str, ...]:
+        # While BoTorch's acquisition function also expects a `ref_point` argument,
+        # the attribute defined here is more general and can hence not be directly
+        # matched. Thus, we bypass the auto-matching mechanism and handle it manually.
+        flds = fields(qLogNoisyExpectedHypervolumeImprovement)
+        return (flds.reference_point.name,)
 
     @staticmethod
     def compute_ref_point(

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -11,6 +11,7 @@ import pandas as pd
 from attrs import define
 
 from baybe.exceptions import (
+    IncompatibleAcquisitionFunctionError,
     UnidentifiedSubclassError,
 )
 from baybe.objectives.base import Objective
@@ -73,6 +74,12 @@ class AcquisitionFunction(ABC, SerialMixin):
         :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`.
         """
         from baybe.acquisition._builder import BotorchAcquisitionFunctionBuilder
+
+        if pending_experiments is not None and not self.supports_pending_experiments:
+            raise IncompatibleAcquisitionFunctionError(
+                f"The chosen acquisition function of type '{self.__class__.__name__}' "
+                f"does not support pending experiments."
+            )
 
         return BotorchAcquisitionFunctionBuilder(
             self, surrogate, searchspace, objective, measurements, pending_experiments

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -75,8 +75,8 @@ class AcquisitionFunction(ABC, SerialMixin):
         from baybe.acquisition._builder import BotorchAcquisitionFunctionBuilder
 
         return BotorchAcquisitionFunctionBuilder(
-            surrogate, searchspace, objective, measurements, pending_experiments
-        ).build(self)
+            self, surrogate, searchspace, objective, measurements, pending_experiments
+        ).build()
 
 
 def _get_botorch_acqf_class(

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -5,21 +5,15 @@ from __future__ import annotations
 import gc
 import warnings
 from abc import ABC
-from collections.abc import Iterable
-from inspect import signature
 from typing import TYPE_CHECKING, ClassVar
 
 import pandas as pd
 from attrs import define
 
 from baybe.exceptions import (
-    IncompatibleAcquisitionFunctionError,
     UnidentifiedSubclassError,
 )
 from baybe.objectives.base import Objective
-from baybe.objectives.desirability import DesirabilityObjective
-from baybe.objectives.pareto import ParetoObjective
-from baybe.objectives.single import SingleTargetObjective
 from baybe.searchspace.core import SearchSpace
 from baybe.serialization.core import (
     converter,
@@ -28,11 +22,8 @@ from baybe.serialization.core import (
 )
 from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import SurrogateProtocol
-from baybe.targets.enum import TargetMode
-from baybe.targets.numerical import NumericalTarget
-from baybe.utils.basic import classproperty, match_attributes
+from baybe.utils.basic import classproperty
 from baybe.utils.boolean import is_abstract
-from baybe.utils.dataframe import to_tensor
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
@@ -81,132 +72,11 @@ class AcquisitionFunction(ABC, SerialMixin):
         The required structure of `measurements` is specified in
         :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`.
         """
-        import botorch.acquisition as bo_acqf
-        import torch
-        from botorch.acquisition.multi_objective import WeightedMCMultiOutputObjective
-        from botorch.acquisition.objective import LinearMCObjective
+        from baybe.acquisition._builder import BotorchAcquisitionFunctionBuilder
 
-        from baybe.acquisition.acqfs import (
-            qLogNoisyExpectedHypervolumeImprovement,
-            qThompsonSampling,
-        )
-
-        # Retrieve botorch acquisition function class and match attributes
-        acqf_cls = _get_botorch_acqf_class(type(self))
-        params_dict = match_attributes(
-            self, acqf_cls.__init__, ignore=self._non_botorch_attrs
-        )[0]
-
-        # Create botorch surrogate model
-        bo_surrogate = surrogate.to_botorch()
-
-        # Get computational data representation
-        train_x = to_tensor(searchspace.transform(measurements, allow_extra=True))
-
-        # Collect remaining (context-specific) parameters
-        signature_params = signature(acqf_cls).parameters
-        additional_params = {}
-        additional_params["model"] = bo_surrogate
-        if "X_baseline" in signature_params:
-            additional_params["X_baseline"] = train_x
-        if "mc_points" in signature_params:
-            additional_params["mc_points"] = to_tensor(
-                self.get_integration_points(searchspace)  # type: ignore[attr-defined]
-            )
-        if pending_experiments is not None:
-            if self.supports_pending_experiments:
-                pending_x = searchspace.transform(pending_experiments, allow_extra=True)
-                additional_params["X_pending"] = to_tensor(pending_x)
-            else:
-                raise IncompatibleAcquisitionFunctionError(
-                    f"Pending experiments were provided but the chosen acquisition "
-                    f"function '{self.__class__.__name__}' does not support this."
-                )
-
-        # Add acquisition objective / best observed value
-        match objective:
-            case SingleTargetObjective(NumericalTarget(mode=TargetMode.MIN)):
-                # Adjust best_f
-                if "best_f" in signature_params:
-                    additional_params["best_f"] = (
-                        bo_surrogate.posterior(train_x).mean.min().item()
-                    )
-                    if issubclass(acqf_cls, bo_acqf.MCAcquisitionFunction):
-                        additional_params["best_f"] *= -1.0
-
-                # Adjust objective
-                if issubclass(
-                    acqf_cls,
-                    (
-                        bo_acqf.qNegIntegratedPosteriorVariance,
-                        bo_acqf.PosteriorStandardDeviation,
-                        bo_acqf.qPosteriorStandardDeviation,
-                    ),
-                ):
-                    # The active learning acqfs are valid but no changes based on the
-                    # target direction are required.
-                    pass
-                elif issubclass(acqf_cls, bo_acqf.AnalyticAcquisitionFunction):
-                    # Minimize acqfs in case the target should be minimized.
-                    additional_params["maximize"] = False
-                elif issubclass(acqf_cls, bo_acqf.MCAcquisitionFunction):
-                    additional_params["objective"] = LinearMCObjective(
-                        torch.tensor([-1.0])
-                    )
-                else:
-                    raise ValueError(
-                        f"Unsupported acquisition function type: {acqf_cls}."
-                    )
-            case SingleTargetObjective() | DesirabilityObjective():
-                if "best_f" in signature_params:
-                    additional_params["best_f"] = (
-                        bo_surrogate.posterior(train_x).mean.max().item()
-                    )
-            case ParetoObjective():
-                if not isinstance(self, qLogNoisyExpectedHypervolumeImprovement):
-                    raise IncompatibleAcquisitionFunctionError(
-                        f"Pareto optimization currently supports the "
-                        f"'{qLogNoisyExpectedHypervolumeImprovement.__name__}' "
-                        f"acquisition function only."
-                    )
-                if not all(
-                    isinstance(t, NumericalTarget)
-                    and t.mode in (TargetMode.MAX, TargetMode.MIN)
-                    for t in objective.targets
-                ):
-                    raise NotImplementedError(
-                        "Pareto optimization currently supports "
-                        "maximization/minimization targets only."
-                    )
-                maximize = [t.mode is TargetMode.MAX for t in objective.targets]  # type: ignore[attr-defined]
-                multiplier = [1.0 if m else -1.0 for m in maximize]
-                additional_params["objective"] = WeightedMCMultiOutputObjective(
-                    torch.tensor(multiplier)
-                )
-                train_y = measurements[[t.name for t in objective.targets]].to_numpy()
-                if isinstance(ref_point := params_dict["ref_point"], Iterable):
-                    ref_point = [
-                        p * m for p, m in zip(ref_point, multiplier, strict=True)
-                    ]
-                else:
-                    kwargs = {"factor": ref_point} if ref_point is not None else {}
-                    ref_point = (
-                        self.compute_ref_point(train_y, maximize, **kwargs) * multiplier
-                    )
-                params_dict["ref_point"] = ref_point
-
-            case _:
-                raise ValueError(f"Unsupported objective type: {objective}")
-
-        params_dict.update(additional_params)
-
-        acqf = acqf_cls(**params_dict)
-
-        if isinstance(self, qThompsonSampling):
-            assert hasattr(acqf, "_default_sample_shape")
-            acqf._default_sample_shape = torch.Size([self.n_mc_samples])
-
-        return acqf
+        return BotorchAcquisitionFunctionBuilder(
+            surrogate, searchspace, objective, measurements, pending_experiments
+        ).build(self)
 
 
 def _get_botorch_acqf_class(

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -75,7 +75,7 @@ class AcquisitionFunction(ABC, SerialMixin):
         objective: Objective,
         measurements: pd.DataFrame,
         pending_experiments: pd.DataFrame | None = None,
-    ):
+    ) -> BotorchAcquisitionFunction:
         """Create the botorch-ready representation of the function.
 
         The required structure of `measurements` is specified in

--- a/tests/hypothesis_strategies/acquisition.py
+++ b/tests/hypothesis_strategies/acquisition.py
@@ -47,7 +47,7 @@ def _qNIPV_strategy(draw: st.DrawFn):
 
 
 @st.composite
-def _ref_points(draw: st.DrawFn):
+def _reference_points(draw: st.DrawFn):
     """Draw reference points for hypervolume improvement acquisition functions."""
     if draw(st.booleans()):
         return draw(st.lists(finite_floats(), min_size=1))
@@ -77,6 +77,6 @@ acquisition_functions = st.one_of(
     st.builds(
         qLogNoisyExpectedHypervolumeImprovement,
         prune_baseline=st.booleans(),
-        ref_point=_ref_points(),
+        reference_point=_reference_points(),
     ),
 )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -59,6 +59,7 @@ def test_imports(module: str):
 WHITELISTS = {
     "torch": [
         "baybe.acquisition.partial",
+        "baybe.acquisition._builder",
         "baybe.surrogates._adapter",
         "baybe.utils.torch",
     ],


### PR DESCRIPTION
This PR refactors the translation of BayBE acquisition functions into BoTorch acquisition functions, adopting concepts from the builder software pattern.

Rationale / Goals / Problems Addressed:
* No more monolithic spaghetti logic --> instead small isolated methods per attribute/concept
* No more partially overlapping if-conditions (which were the source of many bugs in the past)
* No more "string-based" logic
* Clear overview of existing arguments and (validation of) their types via the `BotorchAcquisitionArgs` class
* No more need to think about where/when to compute potentially costly intermediate quantities that are only needed in some cases --> (cached) properties instead