### PR TITLE
Increase timeout for benchmark test to 1440 minutes (24 hours)

### DIFF
--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -38,6 +38,7 @@ jobs:
   benchmark-test:
     needs: add-runner
     runs-on: self-hosted
+    timeout-minutes: 1440
     env:
       BAYBE_BENCHMARKING_PERSISTENCE_PATH: ${{ secrets.TEST_RESULT_S3_BUCKET }}
     steps:


### PR DESCRIPTION
Hi everyone, as one of the requested changes from #493, this PR sets the GitHub-side runtime limit for the container to 24 hours. This refers to the GITHUB_TOKEN generated per job, which expires after that time period. I've also tested longer runtimes and found that we should also be safe to go up to 35 days if necessary. Further changes regarding parallelization may follow once discussed.