### PR TITLE
Add logging to indicate currently running benchmark and its runtime

### DIFF
--- a/benchmarks/definition/base.py
+++ b/benchmarks/definition/base.py
@@ -80,8 +80,7 @@ class Benchmark(Generic[BenchmarkSettingsType], BenchmarkSerialization):
         duration = timedelta(seconds=stop_sec - start_sec)
 
         logger.info(
-            "=" * 80
-            + f"\nFinished benchmark '{self.name}' after {duration} "
+            f"\nFinished benchmark '{self.name}' after {duration} "
             + f"with random seed {self.settings.random_seed}.\n"
             + "=" * 80
         )

--- a/benchmarks/definition/base.py
+++ b/benchmarks/definition/base.py
@@ -1,5 +1,7 @@
 """Basic benchmark configuration."""
 
+import logging
+import sys
 import time
 from abc import ABC
 from collections.abc import Callable
@@ -15,6 +17,13 @@ from pandas import DataFrame
 from baybe.utils.random import temporary_seed
 from benchmarks.result import Result, ResultMetadata
 from benchmarks.serialization import BenchmarkSerialization, converter
+
+logger = logging.getLogger("baybe.benchmarks.definition.base")
+
+stdout = logging.StreamHandler(stream=sys.stdout)
+
+logger.addHandler(stdout)
+logger.setLevel(logging.INFO)
 
 
 @define(frozen=True, kw_only=True)
@@ -58,12 +67,25 @@ class Benchmark(Generic[BenchmarkSettingsType], BenchmarkSerialization):
         """Execute the benchmark and return the result."""
         start_datetime = datetime.now(timezone.utc)
 
+        logger.info(
+            "=" * 80
+            + f"\nRunning benchmark '{self.name}' with "
+            + f"random seed {self.settings.random_seed}.\n"
+            + "=" * 80
+        )
         with temporary_seed(self.settings.random_seed):
             start_sec = time.perf_counter()
             result = self.function(self.settings)
             stop_sec = time.perf_counter()
 
         duration = timedelta(seconds=stop_sec - start_sec)
+
+        logger.info(
+            "=" * 80
+            + f"\nFinished benchmark '{self.name}' after {duration} "
+            + f"with random seed {self.settings.random_seed}.\n"
+            + "=" * 80
+        )
 
         metadata = ResultMetadata(
             start_datetime=start_datetime,

--- a/benchmarks/definition/base.py
+++ b/benchmarks/definition/base.py
@@ -18,7 +18,7 @@ from baybe.utils.random import temporary_seed
 from benchmarks.result import Result, ResultMetadata
 from benchmarks.serialization import BenchmarkSerialization, converter
 
-logger = logging.getLogger("baybe.benchmarks.definition.base")
+logger = logging.getLogger(__name__)
 
 stdout = logging.StreamHandler(stream=sys.stdout)
 

--- a/benchmarks/definition/base.py
+++ b/benchmarks/definition/base.py
@@ -71,7 +71,6 @@ class Benchmark(Generic[BenchmarkSettingsType], BenchmarkSerialization):
             "=" * 80
             + f"\nRunning benchmark '{self.name}' with "
             + f"random seed {self.settings.random_seed}.\n"
-            + "=" * 80
         )
         with temporary_seed(self.settings.random_seed):
             start_sec = time.perf_counter()


### PR DESCRIPTION
This PR adds two lines for logging which benchmark is started and how long it took with regards to #493.
I think the name and random seed is sufficient, but feel free to suggest the more or less information. 
An exemplary log looks like this:
![image](https://github.com/user-attachments/assets/3e627acb-e585-44f7-8c84-930ce5644edd)@Hrovatin Kindly ask you to comment if that fits your needs. Thanks :)