### PR TITLE
Pipeline benchmark parallelization

### DIFF
--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -6,7 +6,7 @@ on:
       group_selection:
         description: "Select the group of benchmarks to run"
         required: true
-        default: "Manually selected benchmarks"
+        default: "All benchmarks"
         type: choice
         options:
           - "Manually selected benchmarks"

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -2,14 +2,85 @@ name: Run Benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      group_selection:
+        description: "Select the group of benchmarks to run"
+        required: true
+        default: "Manually selected benchmarks"
+        type: choice
+        options:
+          - "Manually selected benchmarks"
+          - "All benchmarks"
+          - "Default group"
+      synthetic_2C1D_1C:
+        description: "Run synthetic_2C1D_1C benchmark"
+        required: false
+        default: false
+        type: boolean
+
+env:
+  DEFAULT_BENCHMARKS: '["synthetic_2C1D_1C"]'
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  add-runner:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      benchmarks_to_execute: ${{ steps.set_benchmarks.outputs.benchmarks_to_execute }}
+    steps:
+      - name: Build matrix from inputs
+        if: ${{ github.event.inputs.group_selection == 'Manually selected benchmarks' || github.event.inputs.group_selection == 'All benchmarks' }}
+        id: build_matrix_from_inputs
+        run: |
+          benchmarks_to_execute='{"benchmark_list": ['
+          run_all_benchmarks=${{ github.event.inputs.group_selection == 'All benchmarks' }}
+
+          for key in $(echo '${{ toJson(github.event.inputs) }}' | jq -r 'keys_unsorted[]'); do
+            if [ "$key" != "group_selection" ]; then
+              value=$(echo '${{ toJson(github.event.inputs) }}' | jq -r --arg k "$key" '.[$k]')
+              if [ "$value" = "true" ] || [ "$run_all_benchmarks" = "true" ]; then
+                benchmarks_to_execute="$benchmarks_to_execute \"$key\","
+              fi
+            fi
+          done
+          benchmarks_to_execute=$(echo "$benchmarks_to_execute" | sed 's/,$//')
+          benchmarks_to_execute="$benchmarks_to_execute ]}"
+
+          echo "benchmarks_to_execute=$benchmarks_to_execute" >> "$GITHUB_ENV"
+
+      - name: Build matrix from group
+        if: ${{ github.event.inputs.group_selection != 'Manually selected benchmarks' && github.event.inputs.group_selection != 'All benchmarks' }}
+        id: build_matrix_from_group
+        run: |
+          benchmarks_to_execute='{"benchmark_list": []}'
+          run_all_benchmarks="${{ github.event.inputs.group_selection }}"
+
+          if [ "$run_all_benchmarks" = "Default group" ]; then
+            benchmarks_to_execute='{"benchmark_list": ${{ env.DEFAULT_BENCHMARKS }} }'
+          fi
+
+          echo "benchmarks_to_execute=$benchmarks_to_execute" >> "$GITHUB_ENV"
+
+      - name: Set benchmarks output
+        id: set_benchmarks
+        run: |
+          echo 'benchmarks_to_execute=${{ env.benchmarks_to_execute }}' >> "$GITHUB_OUTPUT"
+          number_of_tasks=$(echo '${{ env.benchmarks_to_execute }}' | jq '.benchmark_list | length')
+          echo "$number_of_tasks"
+          if [ "$number_of_tasks" -le 0 ]; then
+            echo "Please run at least one benchmark"
+            exit 1
+          fi
+
+  add-runner:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJson(needs.prepare.outputs.benchmarks_to_execute) }}
     steps:
       - name: Generate a token
         id: generate-token
@@ -28,7 +99,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Execute Lambda function
         run: |
-          aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "XL", "repository": "${{ github.repository }}" }'  response.json
+          aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "M", "repository": "${{ github.repository }}" }'  response.json
           cat response.json
           if ! grep -q '"statusCode": 200' response.json; then
             echo "Lambda function failed. statusCode is not 200."
@@ -36,8 +107,11 @@ jobs:
           fi
 
   benchmark-test:
-    needs: add-runner
+    needs: [prepare, add-runner]
     runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.benchmarks_to_execute) }}
     timeout-minutes: 1440
     env:
       BAYBE_BENCHMARKING_PERSISTENCE_PATH: ${{ secrets.TEST_RESULT_S3_BUCKET }}
@@ -52,4 +126,4 @@ jobs:
       - name: Benchmark
         run: |
           pip install '.[benchmarking]'
-          python -m benchmarks
+          python -m benchmarks --benchmark-list "${{ matrix.benchmark_list }}"

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -6,7 +6,7 @@ on:
       group_selection:
         description: "Group of Benchmarks to Run:"
         required: true
-        default: "All benchmarks"
+        default: "All"
         type: choice
         options:
           - "Manually Selected"
@@ -32,11 +32,11 @@ jobs:
       benchmarks_to_execute: ${{ steps.set_benchmarks.outputs.benchmarks_to_execute }}
     steps:
       - name: Build matrix from inputs
-        if: ${{ github.event.inputs.group_selection == 'Manually selected benchmarks' || github.event.inputs.group_selection == 'All benchmarks' }}
+        if: ${{ github.event.inputs.group_selection == 'Manually Selected' || github.event.inputs.group_selection == 'All' }}
         id: build_matrix_from_inputs
         run: |
           benchmarks_to_execute='{"benchmark_list": ['
-          run_all_benchmarks=${{ github.event.inputs.group_selection == 'All benchmarks' }}
+          run_all_benchmarks=${{ github.event.inputs.group_selection == 'All' }}
 
           for key in $(echo '${{ toJson(github.event.inputs) }}' | jq -r 'keys_unsorted[]'); do
             if [ "$key" != "group_selection" ]; then
@@ -52,13 +52,13 @@ jobs:
           echo "benchmarks_to_execute=$benchmarks_to_execute" >> "$GITHUB_ENV"
 
       - name: Build matrix from group
-        if: ${{ github.event.inputs.group_selection != 'Manually selected benchmarks' && github.event.inputs.group_selection != 'All benchmarks' }}
+        if: ${{ github.event.inputs.group_selection != 'Manually Selected' && github.event.inputs.group_selection != 'All' }}
         id: build_matrix_from_group
         run: |
           benchmarks_to_execute='{"benchmark_list": []}'
           run_all_benchmarks="${{ github.event.inputs.group_selection }}"
 
-          if [ "$run_all_benchmarks" = "Default group" ]; then
+          if [ "$run_all_benchmarks" = "Default" ]; then
             benchmarks_to_execute='{"benchmark_list": ${{ env.DEFAULT_BENCHMARKS }} }'
           fi
 
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo 'benchmarks_to_execute=${{ env.benchmarks_to_execute }}' >> "$GITHUB_OUTPUT"
           number_of_tasks=$(echo '${{ env.benchmarks_to_execute }}' | jq '.benchmark_list | length')
-          echo "$number_of_tasks"
+
           if [ "$number_of_tasks" -le 0 ]; then
             echo "Please run at least one benchmark"
             exit 1
@@ -100,7 +100,7 @@ jobs:
       - name: Execute Lambda function
         run: |
           aws lambda invoke --function-name jit_runner_register_and_create_runner_container  --cli-binary-format raw-in-base64-out --payload '{"github_api_secret": "${{ steps.generate-token.outputs.token }}", "count_container":  1, "container_compute": "M", "repository": "${{ github.repository }}" }'  response.json
-          cat response.json
+
           if ! grep -q '"statusCode": 200' response.json; then
             echo "Lambda function failed. statusCode is not 200."
             exit 1

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       group_selection:
-        description: "Select the group of benchmarks to run"
+        description: "Group of Benchmarks to Run:"
         required: true
         default: "All benchmarks"
         type: choice
         options:
-          - "Manually selected benchmarks"
-          - "All benchmarks"
-          - "Default group"
+          - "Manually Selected"
+          - "All"
+          - "Default"
       synthetic_2C1D_1C:
-        description: "Run synthetic_2C1D_1C benchmark"
+        description: "synthetic_2C1D_1C benchmark"
         required: false
         default: false
         type: boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For label-like parameters, `SubspaceDiscrete` now only includes parameter values 
   that are in `active_values`
 - Model scaling now uses the parameter bounds instead of the search space bounds
+- `benchmarks` module now accepts a list of domains to be executed
 
 ### Fixed
 - Incorrect optimization direction with `PSTD` with a single minimization target

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,7 +16,7 @@ A subset of benchmarks where the benchmark `synthetic_2C1D_1C` would be the firs
 the list can be called with:
 
 ```bash
-python -m benchmarks --benchmark-list synthetic_2C1D_1C <key2> <key3>
+python -m benchmarks --benchmark-list synthetic_2C1D_1C
 ```
 
 Please find instruction on how to add the benchmarks to the CI/CD pipeline in the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -104,7 +104,7 @@ format: `<benchmark_name>/<branch>/<latest_baybe_tag>/<execution-date>/<commit_h
 
 The benchmarks will not automatically be executed in the CI/CD pipeline.
 You have to provide them as clickable inputs in the GitHub Actions workflow.
-To do this, a new boolean checkbox needs to be added to the workflow file
+To do this, a new Boolean checkbox needs to be added to the workflow file
 `manual_benchmark.yml` in the`.github/workflows` folder. The checkbox name must exactly
 match the benchmark name. The benchmark `synthetic_2C1D_1C.py` with the callable
 `synthetic_2C1D_1C` (which is named after the callable NOT the file) would look
@@ -118,7 +118,7 @@ like this:
         type: boolean
 ```
 
-Which can just be copied below the existing checkboxes. If we would add a benchmark
+which can just be copied below the existing checkboxes. If we would add a benchmark
 called `foo` with the callable `bar` the checkbox would look like this:
 
 ```yaml
@@ -130,19 +130,19 @@ on:
       group_selection:
         description: "Select the group of benchmarks to run"
         required: true
-        default: "All benchmarks"
+        default: "All"
         type: choice
         options:
-          - "Manually selected benchmarks"
-          - "All benchmarks"
-          - "Default group"
+          - "Manually Selected"
+          - "All"
+          - "Default"
       synthetic_2C1D_1C:
-        description: "Run synthetic_2C1D_1C benchmark"
+        description: "Synthetic_2C1D_1C benchmark"
         required: false
         default: false
         type: boolean
       bar:
-        description: "Run foo benchmark"
+        description: "Foo benchmark"
         required: false
         default: false
         type: boolean
@@ -150,7 +150,7 @@ on:
 
 ### Add benchmark group
 
-There are also groups that can be definer in the workflow file. The benchmarks in the
+There are also groups that can be defined in the workflow file. The benchmarks in the
 groups are jointly executed when the group is selected. Groups are defined as env variables
 in the workflow file. If you want to add `bar` to the `DEFAULT_BENCHMARKS` group, you
 can just write it behind the existing entities separated by a comma:
@@ -167,28 +167,28 @@ env:
     FOO_BAR: '["foo"]'
 ```
 
-And you also have to add it to the dropdown menu in the workflow file:
+You also have to add it to the dropdown menu in the workflow file:
 
 ```yaml
       group_selection:
         description: "Select the group of benchmarks to run"
         required: true
-        default: "Manually selected benchmarks"
+        default: "All"
         type: choice
         options:
-          - "Manually selected benchmarks"
-          - "All benchmarks"
-          - "Default group"
-          - "Foo bar group"                       #<-- Add this line
+          - "Manually Selected"
+          - "All"
+          - "Default"
+          - "Foo bar"             #<-- Add this line
 ```
 
-So that the selected group can be checked in the step `build_matrix_from_group`, where
+so that the selected group can be checked in the step `build_matrix_from_group`, where
 you have to add:
 
 ```yaml
-          if [ "$run_all_benchmarks" = "Default group" ]; then
+          if [ "$run_all_benchmarks" = "Default" ]; then
             benchmarks_to_execute='{"benchmark_list": ${{ env.DEFAULT_BENCHMARKS }} }'
-          elif [ "$run_all_benchmarks" = "Foo bar group" ]; then             #<-- Add this line
+          elif [ "$run_all_benchmarks" = "Foo bar" ]; then                   #<-- Add this line
             benchmarks_to_execute='{"benchmark_list": ${{ env.FOO_BAR }} }'  #<-- Add this line
           fi
 ``` 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,7 +130,7 @@ on:
       group_selection:
         description: "Select the group of benchmarks to run"
         required: true
-        default: "Manually selected benchmarks"
+        default: "All benchmarks"
         type: choice
         options:
           - "Manually selected benchmarks"

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -1,27 +1,60 @@
 """Executes the benchmarking module."""
 # Run this via 'python -m benchmarks' from the root directory.
 
+import argparse
 import os
 
+from benchmarks.definition import Benchmark
 from benchmarks.domains import BENCHMARKS
 from benchmarks.persistence import (
     LocalFileObjectStorage,
     PathConstructor,
     S3ObjectStorage,
 )
+from benchmarks.result import Result
 
 RUNS_IN_CI = "CI" in os.environ
 
 
-def main():
+def save_benchmark_data(benchmark: Benchmark, result: Result):
+    """Save the benchmark data to the object storage."""
+    path_constructor = PathConstructor.from_result(result)
+    persist_dict = benchmark.to_dict() | result.to_dict()
+
+    object_storage = S3ObjectStorage() if RUNS_IN_CI else LocalFileObjectStorage()
+    object_storage.write_json(persist_dict, path_constructor)
+
+
+def run_all_benchmarks():
     """Run all benchmarks."""
     for benchmark in BENCHMARKS:
         result = benchmark()
-        path_constructor = PathConstructor.from_result(result)
-        persist_dict = benchmark.to_dict() | result.to_dict()
+        save_benchmark_data(benchmark, result)
 
-        object_storage = S3ObjectStorage() if RUNS_IN_CI else LocalFileObjectStorage()
-        object_storage.write_json(persist_dict, path_constructor)
+
+def run_specific_benchmarks(benchmark_subset_names: set[str]):
+    """Run a subset based on the benchmark name."""
+    for benchmark in BENCHMARKS:
+        if benchmark.name not in benchmark_subset_names:
+            continue
+
+        result = benchmark()
+        save_benchmark_data(benchmark, result)
+
+
+def main():
+    """Execute the benchmarking module."""
+    parser = argparse.ArgumentParser(description="Executes the benchmarking module.")
+    parser.add_argument(
+        "--benchmark-list", nargs="+", help="List of benchmarks to run", default=None
+    )
+    args = parser.parse_args()
+    if not args.benchmark_list:
+        run_all_benchmarks()
+        return
+
+    benchmark_execute_set = set(args.benchmark_list)
+    run_specific_benchmarks(benchmark_execute_set)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+from collections.abc import Collection
 
 from benchmarks.definition import Benchmark
 from benchmarks.domains import BENCHMARKS
@@ -32,10 +33,10 @@ def run_all_benchmarks() -> None:
         save_benchmark_data(benchmark, result)
 
 
-def run_specific_benchmarks(benchmark_subset_names: set[str]) -> None:
+def run_benchmarks(benchmark_names: Collection[str]) -> None:
     """Run a subset based on the benchmark name."""
     for benchmark in BENCHMARKS:
-        if benchmark.name not in benchmark_subset_names:
+        if benchmark.name not in benchmark_names:
             continue
 
         result = benchmark()
@@ -54,7 +55,7 @@ def main() -> None:
         return
 
     benchmark_execute_set = set(args.benchmark_list)
-    run_specific_benchmarks(benchmark_execute_set)
+    run_benchmarks(benchmark_execute_set)
 
 
 if __name__ == "__main__":

--- a/benchmarks/__main__.py
+++ b/benchmarks/__main__.py
@@ -16,7 +16,7 @@ from benchmarks.result import Result
 RUNS_IN_CI = "CI" in os.environ
 
 
-def save_benchmark_data(benchmark: Benchmark, result: Result):
+def save_benchmark_data(benchmark: Benchmark, result: Result) -> None:
     """Save the benchmark data to the object storage."""
     path_constructor = PathConstructor.from_result(result)
     persist_dict = benchmark.to_dict() | result.to_dict()
@@ -25,14 +25,14 @@ def save_benchmark_data(benchmark: Benchmark, result: Result):
     object_storage.write_json(persist_dict, path_constructor)
 
 
-def run_all_benchmarks():
+def run_all_benchmarks() -> None:
     """Run all benchmarks."""
     for benchmark in BENCHMARKS:
         result = benchmark()
         save_benchmark_data(benchmark, result)
 
 
-def run_specific_benchmarks(benchmark_subset_names: set[str]):
+def run_specific_benchmarks(benchmark_subset_names: set[str]) -> None:
     """Run a subset based on the benchmark name."""
     for benchmark in BENCHMARKS:
         if benchmark.name not in benchmark_subset_names:
@@ -42,7 +42,7 @@ def run_specific_benchmarks(benchmark_subset_names: set[str]):
         save_benchmark_data(benchmark, result)
 
 
-def main():
+def main() -> None:
     """Execute the benchmarking module."""
     parser = argparse.ArgumentParser(description="Executes the benchmarking module.")
     parser.add_argument(

--- a/benchmarks/domains/__init__.py
+++ b/benchmarks/domains/__init__.py
@@ -7,4 +7,5 @@ BENCHMARKS: list[Benchmark] = [
     synthetic_2C1D_1C_benchmark,
 ]
 
+
 __all__ = ["BENCHMARKS"]


### PR DESCRIPTION
Hi everyone, this PR adds benchmark parallelization as requested in #493 by using a matrix in the workflow. The container still needs to be deployed separately, so two matrixes are added. To start only a subset, the `__main__.py` was altered to take a CMD line argument so that existing domains don't have to be changed. The selection of different benchmarks was a bit tricky, so the separation of groups may be removed if it overcomplicates stuff.
![image](https://github.com/user-attachments/assets/1f83bb81-7c52-47f2-acaa-775ae99f5964)
I also noticed that the average CPU utilization was at about 48% for the 15 H benchmarks which ran recently:
![image](https://github.com/user-attachments/assets/e2e67e46-120d-463c-994a-c68dec10bd08)
So I changed CPUs requested compute from 16 vCPUs to 8.
