### PR TITLE
Add `Campaign.posterior_stats`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubstanceParameter`, `CustomDisreteParameter` and `CategoricalParameter` now also 
   support restricting the search space via `active_values`, while `values` continue to 
   identify allowed measurement inputs
-- `Campaign.posterior_stats` as convenience for providing statistical measures 
-  about the target predictions of a given set of candidates
+- `Campaign.posterior_stats` and `Surrogate.posterior_stats` as convenience methods for
+  providing statistical measures about the target predictions of a given set of
+  candidates
 
 ### Changed
 - Acquisition function indicator `is_mc` has been removed in favor of new indicators 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubstanceParameter`, `CustomDisreteParameter` and `CategoricalParameter` now also 
   support restricting the search space via `active_values`, while `values` continue to 
   identify allowed measurement inputs
+- `Campaign.posterior_statistics` as convenience for providing statistical measures 
+  about the target predictions of a given set of candidates
 
 ### Changed
 - Acquisition function indicator `is_mc` has been removed in favor of new indicators 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubstanceParameter`, `CustomDisreteParameter` and `CategoricalParameter` now also 
   support restricting the search space via `active_values`, while `values` continue to 
   identify allowed measurement inputs
-- `Campaign.posterior_statistics` as convenience for providing statistical measures 
+- `Campaign.posterior_stats` as convenience for providing statistical measures 
   about the target predictions of a given set of candidates
 
 ### Changed

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import gc
 import json
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Sequence
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Literal, Sequence, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import cattrs
 import numpy as np
@@ -576,8 +576,8 @@ class Campaign(SerialMixin):
                 targets = [t.name for t in self.objective.targets]
 
         result = pd.DataFrame(index=candidates.index)
-        for i, t in enumerate(targets):
-            for stat in stats:
+        for k, t in enumerate(targets):
+            for stat in stats:  # type: ignore[assignment]
                 stat_name = f"Q_{stat}" if isinstance(stat, float) else stat
 
                 try:
@@ -599,7 +599,7 @@ class Campaign(SerialMixin):
                     ) from e
 
                 vals = vals.cpu().numpy().reshape((len(result), len(targets)))
-                result[f"{t}_{stat_name}"] = vals[:, i]
+                result[f"{t}_{stat_name}"] = vals[:, k]
 
         return result
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -536,15 +536,15 @@ class Campaign(SerialMixin):
         with torch.no_grad():
             return surrogate.posterior(candidates)
 
-    def posterior_statistics(
-        self, candidates: pd.DataFrame, statistics: Sequence[Statistic] | None = None
+    def posterior_stats(
+        self, candidates: pd.DataFrame, stats: Sequence[Statistic] | None = None
     ) -> pd.DataFrame:
         """Return common posterior statistics for each target.
 
         Args:
             candidates: The candidate points in experimental representation.
                 For details, see :meth:`baybe.surrogates.base.Surrogate.posterior`.
-            statistics: Sequence indicating which statistics to compute. Also accepts
+            stats: Sequence indicating which statistics to compute. Also accepts
                 floats, for which the corresponding quantile point will be computed.
 
         Raises:
@@ -555,13 +555,13 @@ class Campaign(SerialMixin):
         Returns:
             Data frame with prediction statistics for each target for each candidate.
         """
-        statistics = statistics or ["mean", "std"]
-        for stat in (x for x in statistics if isinstance(x, float)):
+        stats = stats or ["mean", "std"]
+        for stat in (x for x in stats if isinstance(x, float)):
             if not 0 < stat < 1.0:
                 raise ValueError(
                     f"Posterior quantile statistics can only be computed for quantiles "
                     f"between 0 and 1 (non-inclusive). Provided value: '{stat}' as "
-                    f"part of {statistics=}'."
+                    f"part of {stats=}'."
                 )
         posterior = self.posterior(candidates)
 
@@ -577,7 +577,7 @@ class Campaign(SerialMixin):
 
         result = pd.DataFrame(index=candidates.index)
         for i, t in enumerate(targets):
-            for stat in statistics:
+            for stat in stats:
                 stat_name = f"Q_{stat}" if isinstance(stat, float) else stat
 
                 try:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -570,7 +570,7 @@ class Campaign(SerialMixin):
                 # TODO: Once desirability also supports posterior transforms this check
                 #  here will have to depend on the configuration of the obejctive and
                 #  whether it uses the transforms or not.
-                targets = ["desirability"]
+                targets = ["Desirability"]
             case _:
                 targets = [t.name for t in self.objective.targets]
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 import cattrs
 import numpy as np
 import pandas as pd
-import torch
 from attrs import Attribute, Factory, define, evolve, field, fields
 from attrs.converters import optional
 from attrs.validators import instance_of
@@ -533,6 +532,8 @@ class Campaign(SerialMixin):
                 f"provide a '{method_name}' method."
             )
 
+        import torch
+
         with torch.no_grad():
             return surrogate.posterior(candidates)
 
@@ -574,6 +575,8 @@ class Campaign(SerialMixin):
                 targets = ["Desirability"]
             case _:
                 targets = [t.name for t in self.objective.targets]
+
+        import torch
 
         result = pd.DataFrame(index=candidates.index)
         for k, t in enumerate(targets):

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -56,7 +56,7 @@ _MEASURED = "measured"
 _EXCLUDED = "excluded"
 _METADATA_COLUMNS = [_RECOMMENDED, _MEASURED, _EXCLUDED]
 
-Statistic: TypeAlias = float | Literal["mean", "std", "variance", "mode"]
+Statistic: TypeAlias = float | Literal["mean", "std", "var", "mode"]
 """Type alias for requestable posterior statistics.
 
 A float will result in the corresponding quantile points."""
@@ -602,7 +602,10 @@ class Campaign(SerialMixin):
                         vals = posterior.quantile(torch.tensor(stat))
                     else:
                         stat_name = stat
-                        vals = getattr(posterior, stat if stat != "std" else "variance")
+                        vals = getattr(
+                            posterior,
+                            stat if stat not in ["std", "var"] else "variance",
+                        )
                 except (AttributeError, NotImplementedError) as e:
                     # We could arrive here because an invalid statistics string has
                     # been requested or because a quantile point has been requested,

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -71,7 +71,7 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     # class variables
     numerical_only: ClassVar[bool] = True
-    # see base class.
+    # See base class.
 
     # object variables
     condition: ThresholdCondition = field()
@@ -99,7 +99,7 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
     # class variables
     numerical_only: ClassVar[bool] = True
-    # see base class.
+    # See base class.
 
     # object variables
     condition: ThresholdCondition = field()

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -46,9 +46,7 @@ if TYPE_CHECKING:
     from baybe.surrogates.composite import CompositeSurrogate
 
 PosteriorStatistic: TypeAlias = float | Literal["mean", "std", "var", "mode"]
-"""Type alias for requestable posterior statistics.
-
-A float will result in the corresponding quantile points."""
+"""Type alias for requestable statistics (a float yields the corresponding quantile)."""
 
 _ONNX_ENCODING = "latin-1"
 """Constant signifying the encoding for onnx byte strings in pretrained models.

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import gc
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from enum import Enum, auto
-from typing import TYPE_CHECKING, ClassVar, Protocol
+from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypeAlias
 
 import cattrs
 import pandas as pd
@@ -21,6 +22,7 @@ from joblib.hashing import hash
 from typing_extensions import override
 
 from baybe.exceptions import IncompatibleSurrogateError, ModelNotTrainedError
+from baybe.objectives import DesirabilityObjective
 from baybe.objectives.base import Objective
 from baybe.parameters.base import Parameter
 from baybe.searchspace import SearchSpace
@@ -42,6 +44,11 @@ if TYPE_CHECKING:
     from torch import Tensor
 
     from baybe.surrogates.composite import CompositeSurrogate
+
+PosteriorStatistic: TypeAlias = float | Literal["mean", "std", "var", "mode"]
+"""Type alias for requestable posterior statistics.
+
+A float will result in the corresponding quantile points."""
 
 _ONNX_ENCODING = "latin-1"
 """Constant signifying the encoding for onnx byte strings in pretrained models.
@@ -218,7 +225,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
         return scaler
 
-    def posterior(self, candidates: pd.DataFrame, /) -> Posterior:
+    def posterior(self, candidates: pd.DataFrame) -> Posterior:
         """Compute the posterior for candidates in experimental representation.
 
         Takes a dataframe of parameter configurations in **experimental representation**
@@ -305,6 +312,86 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             where the posterior is described on the scale dictated by the output scaler
             obtained via :meth:`baybe.surrogates.base.Surrogate._make_output_scaler`.
         """
+
+    def posterior_stats(
+        self,
+        candidates: pd.DataFrame,
+        stats: Sequence[PosteriorStatistic] = ("mean", "std"),
+    ) -> pd.DataFrame:
+        """Return posterior statistics for each target.
+
+        Args:
+            candidates: The candidate points in experimental representation.
+                For details, see :meth:`baybe.surrogates.base.Surrogate.posterior`.
+            stats: Sequence indicating which statistics to compute. Also accepts
+                floats, for which the corresponding quantile point will be computed.
+
+        Raises:
+            ModelNotTrainedError: When called before the model has been trained.
+            ValueError: If a requested quantile is outside the open interval (0,1).
+            TypeError: If the posterior utilized by the surrogate does not support
+                a requested statistic.
+
+        Returns:
+            A dataframe with posterior statistics for each target and candidate.
+        """
+        if self._objective is None:
+            raise ModelNotTrainedError(
+                "The surrogate must be trained before a posterior can be computed."
+            )
+
+        stat: PosteriorStatistic
+        for stat in (x for x in stats if isinstance(x, float)):
+            if not 0.0 < stat < 1.0:
+                raise ValueError(
+                    f"Posterior quantile statistics can only be computed for quantiles "
+                    f"between 0 and 1 (non-inclusive). Provided value: '{stat}' as "
+                    f"part of '{stats=}'."
+                )
+        posterior = self.posterior(candidates)
+
+        match self._objective:
+            case DesirabilityObjective():
+                # TODO: Once desirability also supports posterior transforms this check
+                #  here will have to depend on the configuration of the objective and
+                #  whether it uses the transforms or not.
+                targets = ["Desirability"]
+            case _:
+                targets = [t.name for t in self._objective.targets]
+
+        import torch
+
+        result = pd.DataFrame(index=candidates.index)
+        with torch.no_grad():
+            for k, target_name in enumerate(targets):
+                for stat in stats:
+                    try:
+                        if isinstance(stat, float):  # Calculate quantile statistic
+                            stat_name = f"Q_{stat}"
+                            vals = posterior.quantile(torch.tensor(stat))
+                        else:  # Calculate non-quantile statistic
+                            stat_name = stat
+                            vals = getattr(
+                                posterior,
+                                stat if stat not in ["std", "var"] else "variance",
+                            )
+                    except (AttributeError, NotImplementedError) as e:
+                        # We could arrive here because an invalid statistics string has
+                        # been requested or because a quantile point has been requested,
+                        # but the posterior type does not implement quantiles.
+                        raise TypeError(
+                            f"The utilized posterior of type "
+                            f"'{posterior.__class__.__name__}' does not support the "
+                            f"statistic associated with the requested input '{stat}'."
+                        ) from e
+
+                    if stat == "std":
+                        vals = torch.sqrt(vals)
+
+                    numpyvals = vals.cpu().numpy().reshape((len(result), len(targets)))
+                    result[f"{target_name}_{stat_name}"] = numpyvals[:, k]
+
+        return result
 
     @override
     def fit(

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -125,46 +125,6 @@ far. This is done by setting the following Boolean flags:
   `pending_experiments` can be recommended (see [asynchronous
   workflows](PENDING_EXPERIMENTS)).
 
-### Prediction Statistics
-You might be interested in statistics about the predicted target values for your 
-recommendations, or indeed for any set of possible candidate points. The 
-[`posterior`](baybe.campaign.Campaign.posterior) and 
-[`posterior_stats`](baybe.campaign.Campaign.posterior_stats) methods provide
-a simple interface for this:
-~~~python
-stats = campaign.posterior_stats(rec)
-~~~
-
-This will return a table with mean and standard deviation (and possibly other 
-statistics) of the target predictions for the provided candidates:
-
-|    | Yield_mean | Yield_std | Selectivity_mean |  Selectivity_std | ... |
-|---:|:-----------|:----------|:-----------------|:-----------------|-----|
-| 15 | 83.54      | 5.23      | 91.22            | 7.42             |.....|
-| 18 | 56.12      | 2.34      | 87.32            | 12.38            |.....|
-|  9 | 59.10      | 5.34      | 83.72            | 9.62             |.....|
-
-You can also provide an optional sequence of statistic names to compute other 
-statistics. If a float is provided, the corresponding quantile points will be 
-calculated:
-~~~python
-stats = campaign.posterior_stats(rec, stats=["mode", 0.5])
-~~~
-
-|    | Yield_mode | Yield_Q_0.5 | Selectivity_mode | Selectivity_Q_0.5 | ... |
-|---:|:-----------|:------------|:-----------------|:------------------|-----|
-| 15 | 83.54      | 83.54       | 91.22            | 91.22             |.....|
-| 18 | 56.12      | 56.12       | 87.32            | 87.32             |.....|
-|  9 | 59.10      | 59.10       | 83.72            | 83.72             |.....|
-
-```{admonition} Posterior Statistics with Desirability Objectives
-:class: note
-A [`DesirabilityObjective`](baybe.objectives.desirability.DesirabilityObjective) 
-scalarizes all targets into one single quantity called "Desirability". As a result, 
-the posterior statistics are only shown for this quantity, and not for individual 
-targets.
-```
-
 ### Caching of Recommendations
 
 The `Campaign` object caches the last batch of recommendations returned, in order to 
@@ -210,6 +170,45 @@ This requirement can be disabled using the method's
 `numerical_measurements_must_be_within_tolerance` flag.
 ```
 
+## Prediction Statistics
+You might be interested in statistics about the predicted target values for your 
+recommendations, or indeed for any set of possible candidate points. The 
+[`posterior`](baybe.campaign.Campaign.posterior) and 
+[`posterior_stats`](baybe.campaign.Campaign.posterior_stats) methods provide
+a simple interface for this:
+~~~python
+stats = campaign.posterior_stats(rec)
+~~~
+
+This will return a table with mean and standard deviation (and possibly other 
+statistics) of the target predictions for the provided candidates:
+
+|    | Yield_mean | Yield_std | Selectivity_mean |  Selectivity_std | ... |
+|---:|:-----------|:----------|:-----------------|:-----------------|-----|
+| 15 | 83.54      | 5.23      | 91.22            | 7.42             | ... |
+| 18 | 56.12      | 2.34      | 87.32            | 12.38            | ... |
+|  9 | 59.10      | 5.34      | 83.72            | 9.62             | ... |
+
+You can also provide an optional sequence of statistic names to compute other 
+statistics. If a float is provided, the corresponding quantile points will be 
+calculated:
+~~~python
+stats = campaign.posterior_stats(rec, stats=["mode", 0.5])
+~~~
+
+|    | Yield_mode | Yield_Q_0.5 | Selectivity_mode | Selectivity_Q_0.5 | ... |
+|---:|:-----------|:------------|:-----------------|:------------------|-----|
+| 15 | 83.54      | 83.54       | 91.22            | 91.22             | ... |
+| 18 | 56.12      | 56.12       | 87.32            | 87.32             | ... |
+|  9 | 59.10      | 59.10       | 83.72            | 83.72             | ... |
+
+```{admonition} Posterior Statistics with Desirability Objectives
+:class: note
+A [`DesirabilityObjective`](baybe.objectives.desirability.DesirabilityObjective) 
+scalarizes all targets into one single quantity called "Desirability". As a result, 
+the posterior statistics are only shown for this quantity, and not for individual 
+targets.
+```
 
 ## Serialization
 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -130,7 +130,7 @@ You might be interested in statistics about the predicted target values for your
 recommendations, or indeed for any set of possible candidate points. The 
 [`posterior`](baybe.campaign.Campaign.posterior) and 
 [`posterior_stats`](baybe.campaign.Campaign.posterior_stats) methods provide
-a simple interface to look at the resulting statistics:
+a simple interface for this:
 ~~~python
 stats = campaign.posterior_stats(rec)
 ~~~

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -129,10 +129,10 @@ far. This is done by setting the following Boolean flags:
 You might be interested in statistics about the predicted target values for your 
 recommendations, or indeed for any set of possible candidate points. The 
 [`posterior`](baybe.campaign.Campaign.posterior) and 
-[`posterior_statistics`](baybe.campaign.Campaign.posterior_statistics) methods provide
+[`posterior_stats`](baybe.campaign.Campaign.posterior_stats) methods provide
 a simple interface to look at the resulting statistics:
 ~~~python
-stats = campaign.posterior_statistics(rec)
+stats = campaign.posterior_stats(rec)
 ~~~
 
 This will return a table with mean and standard deviation (and possibly other 
@@ -148,7 +148,7 @@ You can also provide an optional sequence of statistic names to compute other
 statistics. If a float is provided, the corresponding quantile points will be 
 calculated:
 ~~~python
-stats = campaign.posterior_statistics(rec, statistics=["mode", 0.5])
+stats = campaign.posterior_stats(rec, stats=["mode", 0.5])
 ~~~
 
 |    | Yield_mode | Yield_Q_0.5 | Selectivity_mode | Selectivity_Q_0.5 | ... |

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -144,6 +144,19 @@ statistics) of the target predictions for the provided candidates:
 | 18 | 56.12      | 2.34      | 87.32            | 12.38            |.....|
 |  9 | 59.10      | 5.34      | 83.72            | 9.62             |.....|
 
+You can also provide an optional sequence of statistic names to compute other 
+statistics. If a float is provided, the corresponding quantile points will be 
+calculated:
+~~~python
+stats = campaign.posterior_statistics(rec, statistics=["mode", 0.5])
+~~~
+
+|    | Yield_mode | Yield_Q_0.5 | Selectivity_mode | Selectivity_Q_0.5 | ... |
+|---:|:-----------|:------------|:-----------------|:------------------|-----|
+| 15 | 83.54      | 83.54       | 91.22            | 91.22             |.....|
+| 18 | 56.12      | 56.12       | 87.32            | 87.32             |.....|
+|  9 | 59.10      | 59.10       | 83.72            | 83.72             |.....|
+
 ```{admonition} Posterior Statistics with Desirability Objectives
 :class: note
 A [`DesirabilityObjective`](baybe.objectives.desirability.DesirabilityObjective) 

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -13,9 +13,9 @@ It further serves as the primary interface for interacting with BayBE as a user
 since it is responsible for handling experimental data, making recommendations, adding
 measurements, and most other user-related tasks.
 
-## Creating a campaign
+## Creating a Campaign
 
-### Basic creation
+### Basic Creation
 
 Creating a campaign requires specifying at least two pieces of information that
 describe the underlying optimization problem at hand:
@@ -40,7 +40,7 @@ campaign = Campaign(
 )
 ~~~
 
-### Creation from a JSON config
+### Creation From a JSON Config
 Instead of using the default constructor, it is also possible to create a `Campaign` 
 from a JSON configuration string via 
 [`Campaign.from_config`](baybe.campaign.Campaign.from_config).
@@ -52,7 +52,7 @@ instantiating the object, which skips the potentially costly search space creati
 For more details and a full exemplary config, we refer to the corresponding
 [example](./../../examples/Serialization/create_from_config).
 
-## Getting recommendations
+## Getting Recommendations
 
 ### Basics
 
@@ -76,7 +76,7 @@ with the three parameters `Categorical_1`, `Categorical_2` and `Num_disc_1`:
 | 18 | C               | bad             |            1 |
 |  9 | B               | bad             |            1 |
 
-```{admonition} Batch optimization
+```{admonition} Batch Optimization
 :class: important
 In general, the parameter configurations in a recommended batch are **jointly**
 optimized and therefore tailored to the specific batch size requested. 
@@ -100,7 +100,7 @@ is not capable of joint optimization. Currently, the
 is the only recommender available that performs joint optimization.
 ```
 
-```{admonition} Sequential vs. parallel experimentation
+```{admonition} Sequential vs. Parallel Experimentation
 :class: note
 If you have a fixed experimental budget but the luxury of choosing 
 whether to run your experiments sequentially or in parallel, sequential 
@@ -125,7 +125,34 @@ far. This is done by setting the following Boolean flags:
   `pending_experiments` can be recommended (see [asynchronous
   workflows](PENDING_EXPERIMENTS)).
 
-### Caching of recommendations
+### Prediction Statistics
+You might be interested in statistics about the predicted target values for your 
+recommendations, or indeed for any set of possible candidate points. The 
+[`posterior`](baybe.campaign.Campaign.posterior) and 
+[`posterior_statistics`](baybe.campaign.Campaign.posterior_statistics) methods provide
+a simple interface to look at the resulting statistics:
+~~~python
+stats = campaign.posterior_statistics(rec)
+~~~
+
+This will return a table with mean and standard deviation (and possibly other 
+statistics) of the target predictions for the provided candidates:
+
+|    | Yield_mean | Yield_std | Selectivity_mean |  Selectivity_std | ... |
+|---:|:-----------|:----------|:-----------------|:-----------------|-----|
+| 15 | 83.54      | 5.23      | 91.22            | 7.42             |.....|
+| 18 | 56.12      | 2.34      | 87.32            | 12.38            |.....|
+|  9 | 59.10      | 5.34      | 83.72            | 9.62             |.....|
+
+```{admonition} Posterior Statistics with Desirability Objectives
+:class: note
+A [`DesirabilityObjective`](baybe.objectives.desirability.DesirabilityObjective) 
+scalarizes all targets into one single quantity called "Desirability". As a result, 
+the posterior statistics are only shown for this quantity, and not for individual 
+targets.
+```
+
+### Caching of Recommendations
 
 The `Campaign` object caches the last batch of recommendations returned, in order to 
 avoid unnecessary computations for subsequent queries between which the status
@@ -136,7 +163,7 @@ The latter is necessary because each batch is optimized for the specific number 
 experiments requested (see note above).
 
 (AM)=
-## Adding measurements
+## Adding Measurements
 
 Available experimental data can be added at any time during the campaign lifecycle using
 the [`add_measurements`](baybe.campaign.Campaign.add_measurements) method, 
@@ -200,7 +227,7 @@ experimentation at a later point in time:
 5. Run your (potentially lengthy) real-world experiments
 6. Repeat
 
-## Further information
+## Further Information
 
 Campaigns are created as a first step in most of our 
 [examples](./../../examples/examples).

--- a/docs/userguide/campaigns.md
+++ b/docs/userguide/campaigns.md
@@ -170,12 +170,12 @@ This requirement can be disabled using the method's
 `numerical_measurements_must_be_within_tolerance` flag.
 ```
 
-## Prediction Statistics
+## Predictive Statistics
 You might be interested in statistics about the predicted target values for your 
 recommendations, or indeed for any set of possible candidate points. The 
-[`posterior`](baybe.campaign.Campaign.posterior) and 
-[`posterior_stats`](baybe.campaign.Campaign.posterior_stats) methods provide
-a simple interface for this:
+[`Campaign.posterior_stats`](baybe.campaign.Campaign.posterior_stats) and 
+[`Surrogate.posterior_stats`](baybe.surrogates.base.Surrogate.posterior_stats) methods
+provide a simple interface for this:
 ~~~python
 stats = campaign.posterior_stats(rec)
 ~~~

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from tenacity import (
 from torch._C import _LinAlgError
 
 from baybe._optional.info import CHEM_INSTALLED
-from baybe.acquisition import qExpectedImprovement
+from baybe.acquisition import qLogExpectedImprovement
 from baybe.campaign import Campaign
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
@@ -700,7 +700,7 @@ def fixture_default_streaming_sequential_meta_recommender():
 @pytest.fixture(name="acqf")
 def fixture_default_acquisition_function():
     """The default acquisition function to be used if not specified differently."""
-    return qExpectedImprovement()
+    return qLogExpectedImprovement()
 
 
 @pytest.fixture(name="lengthscale_prior")

--- a/tests/docs/test_docs.py
+++ b/tests/docs/test_docs.py
@@ -7,7 +7,6 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from baybe._optional.info import CHEM_INSTALLED, LINT_INSTALLED
-from baybe.recommenders import RandomRecommender, TwoPhaseMetaRecommender
 
 from .utils import extract_code_blocks
 
@@ -42,20 +41,10 @@ def test_code_executability(file: Path, campaign):
 
 # TODO: Needs a refactoring (files codeblocks should be auto-detected)
 @pytest.mark.parametrize("file", doc_files_pseudocode, ids=doc_files_pseudocode)
-@pytest.mark.parametrize(
-    "recommender",
-    [
-        TwoPhaseMetaRecommender(
-            initial_recommender=RandomRecommender(), recommender=RandomRecommender()
-        )
-    ],
-)
 def test_pseudocode_executability(file: Path, searchspace, objective, recommender):
     """The pseudocode blocks in the file are a valid python script when using fixtures.
 
     Blocks surrounded with "triple-backticks" are included.
-    Due to a bug related to the serialization of the default recommender, this currently
-    uses a non-default recommender.
     """
     userguide_pseudocode = "\n".join(extract_code_blocks(file, include_tilde=True))
     exec(userguide_pseudocode)

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -168,17 +168,17 @@ def test_setting_allow_flags(flag, space_type, value):
     ],
 )
 @pytest.mark.parametrize("n_grid_points", [5], ids=["g5"])
-@pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
+@pytest.mark.parametrize("n_iterations", [2], ids=["i2"])
 def test_posterior_stats(ongoing_campaign, n_iterations, batch_size):
     """Posterior statistics have expected shape, index and columns."""
     objective = ongoing_campaign.objective
-    tested_stats = {"mean", "std"}
+    tested_stats = ["mean", "std"]
     test_quantiles = not (
         isinstance(objective, ParetoObjective)
         or isinstance(objective.targets[0], BinaryTarget)
     )
     if test_quantiles:
-        tested_stats |= {0.05, 0.95}
+        tested_stats += [0.05, 0.95]
 
     stats = ongoing_campaign.posterior_stats(
         ongoing_campaign.measurements, tested_stats

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -172,7 +172,7 @@ def test_setting_allow_flags(flag, space_type, value):
 def test_posterior_stats(ongoing_campaign, n_iterations, batch_size):
     """Posterior statistics have expected shape, index and columns."""
     objective = ongoing_campaign.objective
-    tested_stats = ["mean", "std"]
+    tested_stats = ["mean", "std", "var"]
     test_quantiles = not (
         isinstance(objective, ParetoObjective)
         or isinstance(objective.targets[0], BinaryTarget)

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -169,8 +169,8 @@ def test_setting_allow_flags(flag, space_type, value):
 )
 @pytest.mark.parametrize("n_grid_points", [5], ids=["g5"])
 @pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
-def test_posterior_statistics(ongoing_campaign, n_iterations, batch_size):
-    """Posterior statistics can have expected shape, index and columns."""
+def test_posterior_stats(ongoing_campaign, n_iterations, batch_size):
+    """Posterior statistics have expected shape, index and columns."""
     objective = ongoing_campaign.objective
     tested_stats = {"mean", "std"}
     test_quantiles = not (
@@ -180,7 +180,7 @@ def test_posterior_statistics(ongoing_campaign, n_iterations, batch_size):
     if test_quantiles:
         tested_stats |= {0.05, 0.95}
 
-    stats = ongoing_campaign.posterior_statistics(
+    stats = ongoing_campaign.posterior_stats(
         ongoing_campaign.measurements, tested_stats
     )
 
@@ -209,18 +209,16 @@ def test_posterior_statistics(ongoing_campaign, n_iterations, batch_size):
 
     # Assert correct error for unsupported statistics
     with pytest.raises(TypeError, match="does not support the statistic associated"):
-        ongoing_campaign.posterior_statistics(
-            ongoing_campaign.measurements, ["invalid"]
-        )
+        ongoing_campaign.posterior_stats(ongoing_campaign.measurements, ["invalid"])
 
     if test_quantiles:
         # Assert correct error for invalid quantiles
         with pytest.raises(ValueError, match="quantile statistics can only be"):
-            ongoing_campaign.posterior_statistics(ongoing_campaign.measurements, [-0.1])
-            ongoing_campaign.posterior_statistics(ongoing_campaign.measurements, [1.1])
+            ongoing_campaign.posterior_stats(ongoing_campaign.measurements, [-0.1])
+            ongoing_campaign.posterior_stats(ongoing_campaign.measurements, [1.1])
     else:
         # Assert correct error for unsupported quantile calculation
         with pytest.raises(
             TypeError, match="does not support the statistic associated"
         ):
-            ongoing_campaign.posterior_statistics(ongoing_campaign.measurements, [0.1])
+            ongoing_campaign.posterior_stats(ongoing_campaign.measurements, [0.1])

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -127,7 +127,7 @@ def test_setting_allow_flags(flag, space_type, value):
     ("parameter_names", "objective", "surrogate_model", "acqf", "batch_size"),
     [
         param(
-            ["Categorical_1", "Num_Disc_1", "Conti_finite1"],
+            ["Categorical_1", "Num_disc_1", "Conti_finite1"],
             NumericalTarget("t1", "MAX").to_objective(),
             GaussianProcessSurrogate(),
             qLogEI(),
@@ -135,7 +135,7 @@ def test_setting_allow_flags(flag, space_type, value):
             id="single_target",
         ),
         param(
-            ["Categorical_1", "Num_Disc_1", "Conti_finite1"],
+            ["Categorical_1", "Num_disc_1", "Conti_finite1"],
             DesirabilityObjective(
                 (
                     NumericalTarget("t1", "MAX", bounds=(0, 1)),
@@ -148,7 +148,7 @@ def test_setting_allow_flags(flag, space_type, value):
             id="desirability",
         ),
         param(
-            ["Categorical_1", "Num_Disc_1", "Conti_finite1"],
+            ["Categorical_1", "Num_disc_1", "Conti_finite1"],
             ParetoObjective(
                 (NumericalTarget("t1", "MAX"), NumericalTarget("t2", "MIN"))
             ),
@@ -168,15 +168,12 @@ def test_setting_allow_flags(flag, space_type, value):
     ],
 )
 @pytest.mark.parametrize("n_grid_points", [5], ids=["g5"])
-@pytest.mark.parametrize("n_iterations", [2], ids=["i2"])
+@pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
 def test_posterior_stats(ongoing_campaign, n_iterations, batch_size):
     """Posterior statistics have expected shape, index and columns."""
     objective = ongoing_campaign.objective
     tested_stats = ["mean", "std", "var"]
-    test_quantiles = not (
-        isinstance(objective, ParetoObjective)
-        or isinstance(objective.targets[0], BinaryTarget)
-    )
+    test_quantiles = not isinstance(objective.targets[0], BinaryTarget)
     if test_quantiles:
         tested_stats += [0.05, 0.95]
 


### PR DESCRIPTION
- Adds a convenience function `posterior_stats` to the `Campaign`, returning a data frame of statistics about the target predictions
- Adds a test for this
- Mentions it in the user guide
- Changed the default acqf in conftest (which was still the non-log version)

Currently, for desirability objectives it is hardcoded that the statistics are for a single target called "Desirability", consistent with what `transform` does. Once posterior transforms are available, this logic needs to be adapted and it is expected that there is a flag in `DesirabilityObjective` that decides between scalarization or posterior_transforms. The latter case can then be treated exactly like all other targets.