### PR TITLE
Xfail bugged SHAP plot tests

### DIFF
--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -157,9 +157,18 @@ def test_plots(ongoing_campaign: Campaign, use_comp_rep, plot_type):
     if use_comp_rep:
         df = ongoing_campaign.searchspace.transform(df)
 
-    with mock.patch("matplotlib.pyplot.show"):
-        shap_insight.plot(plot_type, df)
-        plt.close()
+    try:
+        with mock.patch("matplotlib.pyplot.show"):
+            shap_insight.plot(plot_type, df)
+            plt.close()
+    except AttributeError as e:
+        if "no attribute 'colors'" in str(e) and plot_type == "beeswarm":
+            pytest.xfail("SHAP bug")
+        raise e
+    except ValueError as e:
+        if "zero-size array to reduction" in str(e) and plot_type == "scatter":
+            pytest.xfail("SHAP bug")
+        raise e
 
 
 def test_updated_campaign_explanations(campaign, n_iterations, batch_size):


### PR DESCRIPTION
- catches exceptions due to current shap bugs and xfails the corresponding tests
- since not all of the issues are deterministic I went for exceptions catching rather than failing the test purely based on parameterization
- once there are no more xfails happening, we are sort of reminded that the issue might have been fixed on SHAP side