### PR TITLE
Enable Partial Measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from candidates in experimental representation
 - `acquisition_values` and `joint_acquisition_value` convenience methods to
   `Campaign` and `BayesianRecommender` for computing acquisition values
+- Composite surrogates now drop rows containing NaNs (separately for each target), 
+  effectively enabling partial measurements
 
 ### Changed
 - Acquisition function indicator `is_mc` has been removed in favor of new indicators 
@@ -65,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ngboost` and `scikit-learn-extra` are now optional dependencies
 - `setuptools-scm` is now an optional dependency, used for improved version inference
 - `create_example_plots`, `to_string` and `indent` have been relocated within utils
+- Targets are now allowed to contain NaN, deferring potential failure to attempted 
+  recommendation instead of data ingestion
 
 ### Fixed
 - Incorrect optimization direction with `PSTD` with a single minimization target

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following provides a non-comprehensive overview:
 - 🚀 Transfer learning: Mix data from multiple campaigns and accelerate optimization
 - 🎰 Bandit models: Efficiently find the best among many options in noisy environments (e.g. A/B Testing)
 - 🔢 Cardinality constraints: Control the number of active factors in your design
-- 🌎 Distributed workflows: Run campaigns asynchronously with pending experiments
+- 🌎 Distributed workflows: Run campaigns asynchronously with pending experiments and partial measurements
 - 🎓 Active learning: Perform smart data acquisition campaigns
 - ⚙️ Custom surrogate models: Enhance your predictions through mechanistic understanding
 - 📈 Comprehensive backtest, simulation and imputation utilities: Benchmark and find your best settings

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -137,11 +137,8 @@ class BotorchAcquisitionFunctionBuilder:
         Raises:
             ValueError: If no complete measurement exists.
         """
-        transformed = self.objective.transform(
-            self.measurements[[t.name for t in self.objective.targets]]
-        )
         configurations = handle_missing_values(
-            transformed,
+            self.measurements[[t.name for t in self.objective.targets]],
             [t.name for t in self.objective.targets],
             drop=True,
         )
@@ -155,10 +152,10 @@ class BotorchAcquisitionFunctionBuilder:
                 f"configuration must have a measured value for all targets. You can "
                 f"fix this by setting the "
                 f"'{fields(_ExpectedHypervolumeImprovement).reference_point.name}' "
-                f"argument of {self.acqf.__class__.__name__} explicitly."
+                f"argument of '{self.acqf.__class__.__name__}' explicitly."
             )
 
-        return configurations
+        return self.objective.transform(configurations)
 
     def build(self) -> BoAcquisitionFunction:
         """Build the BoTorch acquisition function object."""

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -33,7 +33,7 @@ from baybe.surrogates.base import SurrogateProtocol
 from baybe.targets.enum import TargetMode
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import is_all_instance, match_attributes
-from baybe.utils.dataframe import handle_invalid_column_values, to_tensor
+from baybe.utils.dataframe import handle_missing_values, to_tensor
 
 
 def opt_v(x: Any, /) -> Callable:
@@ -133,7 +133,7 @@ class BotorchAcquisitionFunctionBuilder:
         transformed = self.objective.transform(
             self.measurements[[t.name for t in self.objective.targets]]
         )
-        return handle_invalid_column_values(
+        return handle_missing_values(
             transformed,
             [t.name for t in self.objective.targets],
             drop=True,

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -33,7 +33,7 @@ from baybe.surrogates.base import SurrogateProtocol
 from baybe.targets.enum import TargetMode
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import is_all_instance, match_attributes
-from baybe.utils.dataframe import handle_invalid_target_values, to_tensor
+from baybe.utils.dataframe import handle_invalid_column_values, to_tensor
 
 
 def opt_v(x: Any, /) -> Callable:
@@ -133,9 +133,9 @@ class BotorchAcquisitionFunctionBuilder:
         transformed = self.objective.transform(
             self.measurements[[t.name for t in self.objective.targets]]
         )
-        return handle_invalid_target_values(
+        return handle_invalid_column_values(
             transformed,
-            self.objective.targets,
+            [t.name for t in self.objective.targets],
             drop=True,
         )
 

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -371,7 +371,7 @@ class _ExpectedHypervolumeImprovement(AcquisitionFunction, ABC):
     def compute_ref_point(
         array: npt.ArrayLike, maximize: npt.ArrayLike, factor: float = 0.1
     ) -> np.ndarray:
-        """Compute a reference point for a given set of of target configurations.
+        """Compute a reference point for a given set of target configurations.
 
         The reference point is positioned relative to the worst point in the direction
         coming from the best point:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -359,13 +359,10 @@ class Campaign(SerialMixin):
 
         # Perform the update
         cols = [p.name for p in self.parameters] + [t.name for t in self.targets]
-        matching_idxs = [
-            idx for idx in data.index if idx in self._measurements_exp.index
-        ]
-        self._measurements_exp.loc[matching_idxs, cols] = data.loc[matching_idxs, cols]
+        self._measurements_exp.loc[data.index, cols] = data[cols]
 
         # Reset fit number and cached recommendations
-        self._measurements_exp.loc[matching_idxs, "FitNr"] = np.nan
+        self._measurements_exp.loc[data.index, "FitNr"] = np.nan
         self._cached_recommendation = pd.DataFrame()
 
     def toggle_discrete_candidates(  # noqa: DOC501

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -330,8 +330,9 @@ class Campaign(SerialMixin):
                 numerical parameters need to be within their tolerances.
 
         Raises:
-            ValueError: If data contains duplicated indices.
-            ValueError: If data contains indices not present in existing measurements.
+            ValueError: If the given data contains duplicated indices.
+            ValueError: If the given data contains indices not present in existing
+                measurements.
         """
         # Validate target and parameter input values
         validate_target_input(data, self.targets)
@@ -341,7 +342,7 @@ class Campaign(SerialMixin):
         data.__class__ = _ValidatedDataFrame
 
         # Block duplicate input indices
-        if len(set(data.index)) != len(data.index):
+        if data.index.has_duplicates:
             raise ValueError(
                 "The input dataframe containing the measurement updates has duplicated "
                 "indices. Please ensure that all updates for a given measurement are "

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -95,6 +95,10 @@ class NoMeasurementsError(Exception):
     """A context expected measurements but none were available."""
 
 
+class IncompleteMeasurementsError(Exception):
+    """A context expected complete measurements but none were available."""
+
+
 class NothingToSimulateError(Exception):
     """There is nothing to simulate because there are no testable configurations."""
 

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -33,7 +33,7 @@ from baybe.serialization.core import (
 )
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import handle_invalid_target_values, to_tensor
+from baybe.utils.dataframe import handle_invalid_column_values, to_tensor
 from baybe.utils.plotting import to_string
 from baybe.utils.scaling import ColumnTransformer
 
@@ -447,7 +447,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             )
 
         # Block partial measurements
-        handle_invalid_target_values(measurements, objective.targets)
+        handle_invalid_column_values(measurements, [t.name for t in objective.targets])
 
         # Remember the training context
         self._searchspace = searchspace

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -33,7 +33,7 @@ from baybe.serialization.core import (
 )
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import handle_invalid_column_values, to_tensor
+from baybe.utils.dataframe import handle_missing_values, to_tensor
 from baybe.utils.scaling import ColumnTransformer
 
 if TYPE_CHECKING:
@@ -446,7 +446,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             )
 
         # Block partial measurements
-        handle_invalid_column_values(measurements, [t.name for t in objective.targets])
+        handle_missing_values(measurements, [t.name for t in objective.targets])
 
         # Remember the training context
         self._searchspace = searchspace

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -34,7 +34,6 @@ from baybe.serialization.core import (
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.conversion import to_string
 from baybe.utils.dataframe import handle_invalid_column_values, to_tensor
-from baybe.utils.plotting import to_string
 from baybe.utils.scaling import ColumnTransformer
 
 if TYPE_CHECKING:

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -33,7 +33,8 @@ from baybe.serialization.core import (
 )
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import to_tensor
+from baybe.utils.dataframe import handle_invalid_target_values, to_tensor
+from baybe.utils.plotting import to_string
 from baybe.utils.scaling import ColumnTransformer
 
 if TYPE_CHECKING:
@@ -444,6 +445,9 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             raise NotImplementedError(
                 "Continuous search spaces are currently only supported by GPs."
             )
+
+        # Block partial measurements
+        handle_invalid_target_values(measurements, objective.targets)
 
         # Remember the training context
         self._searchspace = searchspace

--- a/baybe/surrogates/composite.py
+++ b/baybe/surrogates/composite.py
@@ -18,6 +18,7 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import PosteriorStatistic, SurrogateProtocol
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.utils.basic import is_all_instance
+from baybe.utils.dataframe import handle_invalid_target_values
 
 if TYPE_CHECKING:
     from botorch.models.model import ModelList
@@ -97,8 +98,13 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
         measurements: pd.DataFrame,
     ) -> None:
         for target in objective.targets:
+            # Drop impartial measurements for the respective target
+            measurements_filtered = handle_invalid_target_values(
+                measurements, [target], drop=True
+            )
+
             self.surrogates[target.name].fit(
-                searchspace, target.to_objective(), measurements
+                searchspace, target.to_objective(), measurements_filtered
             )
         self._target_names = tuple(t.name for t in objective.targets)
 

--- a/baybe/surrogates/composite.py
+++ b/baybe/surrogates/composite.py
@@ -18,7 +18,7 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import PosteriorStatistic, SurrogateProtocol
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.utils.basic import is_all_instance
-from baybe.utils.dataframe import handle_invalid_column_values
+from baybe.utils.dataframe import handle_missing_values
 
 if TYPE_CHECKING:
     from botorch.models.model import ModelList
@@ -99,7 +99,7 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
     ) -> None:
         for target in objective.targets:
             # Drop partial measurements for the respective target
-            measurements_filtered = handle_invalid_column_values(
+            measurements_filtered = handle_missing_values(
                 measurements, [target.name], drop=True
             )
 

--- a/baybe/surrogates/composite.py
+++ b/baybe/surrogates/composite.py
@@ -18,7 +18,7 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import PosteriorStatistic, SurrogateProtocol
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.utils.basic import is_all_instance
-from baybe.utils.dataframe import handle_invalid_target_values
+from baybe.utils.dataframe import handle_invalid_column_values
 
 if TYPE_CHECKING:
     from botorch.models.model import ModelList
@@ -99,8 +99,8 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
     ) -> None:
         for target in objective.targets:
             # Drop partial measurements for the respective target
-            measurements_filtered = handle_invalid_target_values(
-                measurements, [target], drop=True
+            measurements_filtered = handle_invalid_column_values(
+                measurements, [target.name], drop=True
             )
 
             self.surrogates[target.name].fit(

--- a/baybe/surrogates/composite.py
+++ b/baybe/surrogates/composite.py
@@ -98,7 +98,7 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
         measurements: pd.DataFrame,
     ) -> None:
         for target in objective.targets:
-            # Drop impartial measurements for the respective target
+            # Drop partial measurements for the respective target
             measurements_filtered = handle_invalid_target_values(
                 measurements, [target], drop=True
             )

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -807,7 +807,7 @@ class _ValidatedDataFrame(pd.DataFrame):
     """Wrapper indicating the underlying experimental data was already validated."""
 
 
-def handle_invalid_column_values(
+def handle_missing_values(
     data: pd.DataFrame, cols: Collection[str], drop: bool = False
 ) -> pd.DataFrame:
     """Handle invalid inputs by dropping corresponding rows or raising an error.

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -805,3 +805,32 @@ def arrays_to_dataframes(
 
 class _ValidatedDataFrame(pd.DataFrame):
     """Wrapper indicating the underlying experimental data was already validated."""
+
+
+def handle_invalid_target_values(
+    data: pd.DataFrame, targets: Iterable[Target], drop: bool = False
+) -> pd.DataFrame:
+    """Handle invalid target inputs by dropping corresponding rows or raising an error.
+
+    Args:
+        data: Measurements in experimental representation.
+        targets: The targets to check.
+        drop: Whether to drop the corresponding rows and not raise an error.
+
+    Raises:
+        ValueError: If any row contains a MeasurementStatus in the target columns.
+
+    Returns:
+        If drop=True this returns the modified dataframe.
+    """
+    cols = [t.name for t in targets]
+    mask = data[cols].isna().any(axis=1)
+
+    if (not drop) and mask.any():
+        raise ValueError(
+            f"Incomplete measurements identified by NaN were found in the input, "
+            f"but are not supported. Bad input in the rows with these "
+            f"indices: {data.index[mask].tolist()}"
+        )
+
+    return data.loc[~mask]

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 import warnings
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 import numpy as np
@@ -807,14 +807,14 @@ class _ValidatedDataFrame(pd.DataFrame):
     """Wrapper indicating the underlying experimental data was already validated."""
 
 
-def handle_invalid_target_values(
-    data: pd.DataFrame, targets: Iterable[Target], drop: bool = False
+def handle_invalid_column_values(
+    data: pd.DataFrame, cols: Collection[str], drop: bool = False
 ) -> pd.DataFrame:
-    """Handle invalid target inputs by dropping corresponding rows or raising an error.
+    """Handle invalid inputs by dropping corresponding rows or raising an error.
 
     Args:
         data: Measurements in experimental representation.
-        targets: The targets to check.
+        cols: The column names to check.
         drop: Whether to drop the corresponding rows instead of raising an error.
 
     Raises:
@@ -822,9 +822,8 @@ def handle_invalid_target_values(
             if ``drop=False``.
 
     Returns:
-        If drop=True this returns the modified dataframe.
+        If ``drop=True`` this returns the original (potentially modified) dataframe.
     """
-    cols = [t.name for t in targets]
     mask = data[cols].isna().any(axis=1)
 
     if (not drop) and mask.any():

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -822,8 +822,7 @@ def handle_missing_values(
             if ``drop=False``.
 
     Returns:
-        In case of no errors or if ``drop=True``, this returns the original
-        (potentially modified) dataframe.
+        A new dataframe with the rows containing NaN dropped.
     """
     mask = data[columns].isna().any(axis=1)
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -815,10 +815,11 @@ def handle_invalid_target_values(
     Args:
         data: Measurements in experimental representation.
         targets: The targets to check.
-        drop: Whether to drop the corresponding rows and not raise an error.
+        drop: Whether to drop the corresponding rows instead of raising an error.
 
     Raises:
-        ValueError: If any row contains a MeasurementStatus in the target columns.
+        ValueError: If any row contains NaN in the target columns. Only relevant
+            if ``drop=False``.
 
     Returns:
         If drop=True this returns the modified dataframe.

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -808,13 +808,13 @@ class _ValidatedDataFrame(pd.DataFrame):
 
 
 def handle_missing_values(
-    data: pd.DataFrame, cols: Collection[str], drop: bool = False
+    data: pd.DataFrame, columns: Collection[str], drop: bool = False
 ) -> pd.DataFrame:
-    """Handle invalid inputs by dropping corresponding rows or raising an error.
+    """Handle missing inputs by dropping corresponding rows or raising an error.
 
     Args:
-        data: Measurements in experimental representation.
-        cols: The column names to check.
+        data: Data to be checked.
+        columns: The column names to check.
         drop: Whether to drop the corresponding rows instead of raising an error.
 
     Raises:
@@ -822,9 +822,10 @@ def handle_missing_values(
             if ``drop=False``.
 
     Returns:
-        If ``drop=True`` this returns the original (potentially modified) dataframe.
+        In case of no errors or if ``drop=True``, this returns the original
+        (potentially modified) dataframe.
     """
-    mask = data[cols].isna().any(axis=1)
+    mask = data[columns].isna().any(axis=1)
 
     if (not drop) and mask.any():
         raise ValueError(

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -84,8 +84,8 @@ def validate_target_input(data: pd.DataFrame, targets: Iterable[Target]) -> None
         targets: The allowed targets.
 
     Raises:
-        ValueError: If data is empty.
-        ValueError: If data misses columns for a target.
+        ValueError: If the data is empty.
+        ValueError: If the data misses columns for a target.
         TypeError: If any numerical target data contain non-numeric values.
         ValueError: If any binary target data contain values not part of the targets'
             allowed values or NaN.
@@ -132,8 +132,8 @@ def validate_parameter_input(
             parameter-specific tolerance.
 
     Raises:
-        ValueError: If data is empty.
-        ValueError: If data misses columns for a parameter.
+        ValueError: If the data is empty.
+        ValueError: If the data misses columns for a parameter.
         ValueError: If a parameter contains NaN.
         TypeError: If a parameter contains non-numeric values.
     """

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -83,7 +83,8 @@ def validate_target_input(data: pd.DataFrame, targets: Iterable[Target]) -> None
         targets: The allowed targets.
 
     Raises:
-        ValueError: If the input dataframe is empty.
+        ValueError: If data is empty.
+        ValueError: If data misses columns for a target.
         ValueError: If any target data contain NaN.
         TypeError: If any numerical target data contain non-numeric values.
         ValueError: If any binary target data contain values not part of the targets'
@@ -93,6 +94,12 @@ def validate_target_input(data: pd.DataFrame, targets: Iterable[Target]) -> None
 
     if data.empty:
         raise ValueError("The provided input dataframe cannot be empty.")
+
+    if missing := {t.name for t in targets}.difference(data.columns):
+        raise ValueError(
+            f"The input dataframe is missing columns for the following targets: "
+            f"{missing}"
+        )
 
     for t in targets:
         if data[t.name].isna().any():
@@ -130,12 +137,19 @@ def validate_parameter_input(
             parameter-specific tolerance.
 
     Raises:
-        ValueError: If the input dataframe is empty.
+        ValueError: If data is empty.
+        ValueError: If data misses columns for a parameter.
         ValueError: If a parameter contains NaN.
         TypeError: If a parameter contains non-numeric values.
     """
     if data.empty:
         raise ValueError("The provided input dataframe cannot be empty.")
+
+    if missing := {p.name for p in parameters}.difference(data.columns):
+        raise ValueError(
+            f"The input dataframe is missing columns for the following parameters: "
+            f"{missing}"
+        )
 
     for p in parameters:
         if data[p.name].isna().any():

--- a/docs/userguide/async.md
+++ b/docs/userguide/async.md
@@ -92,19 +92,26 @@ As a simple example, consider a campaign with medical background aimed at creati
 drug formulation. Typically, there are quick initial analytics performed on the 
 formulation, followed by *in vitro* experiments followed by mouse *in vivo* experiments.
 Without the ability to use partial measurements, you would have to wait until the slow 
-mouse experiment for a given recommendation is measured until you could utilize it as 
-measurement in the recommendation loop. Furthermore, if the fast measurements are 
-already unpromising, the slower target measurements are possibly never performed at all.
+mouse experiment for a given recommendation is measured until you could utilize any of 
+the other (faster) experimental outcomes for that recommendation. Furthermore, if the fast 
+measurements are already unpromising, the slower target measurements are possibly never 
+performed at all.
 
 In BayBE, you can leverage results even if they are only partial. This is indicated 
-by setting the corresponding target measurement value to NaN (by using 
-[`numpy.nan`](numpy.nan)). Let us consider this 3-batch of recommendations, assuming 
+by setting the corresponding target measurement value to NaN. There are several ways to indicate this, e.g.:
+* [`numpy.nan`](numpy.nan)
+* [`pandas.NA`](pandas.NA)
+* `None`
+* `float("nan")`
+
+Let us consider this 3-batch of recommendations, assuming 
 we need to measure "Target_1", "Target_2" and "Target_3":
 ```python
 import numpy as np
+import pandas as pd
 
 rec = campaign.recommend(batch_size=3)
-# resetting the index to have easier access via .loc later
+# Resetting the index to have easier access via .loc later
 measurements = rec.reset_index(drop=True)
 
 # Add measurement results
@@ -117,12 +124,12 @@ measurements.loc[1, "Target_2"] = np.nan  # not measured yet
 measurements.loc[1, "Target_3"] = 12.2
 
 measurements.loc[2, "Target_1"] = 11.4
-measurements.loc[2, "Target_2"] = np.nan  # not measured yet
-measurements.loc[2, "Target_3"] = np.nan  # not measured yet
+measurements.loc[2, "Target_2"] = pd.NA  # not measured yet
+measurements.loc[2, "Target_3"] = None  # not measured yet
 
 measurements
 
-# proceed with campaign.add_measurements ...
+# Proceed with campaign.add_measurements ...
 ```
 
 | Param_1 | Param_2 | ...  | Target_1 | Target_2 | Target_3 |

--- a/docs/userguide/objectives.md
+++ b/docs/userguide/objectives.md
@@ -25,7 +25,7 @@ in the optimization problem.
 Because this fairly trivial conversion step requires no additional user configuration,
 we provide a convenience constructor for it:
 
-````{admonition} Convenience construction and implicit conversion
+````{admonition} Convenience Construction and Implicit Conversion
 :class: tip
 * The conversion from a single [`Target`](baybe.targets.base.Target) to a
 [`SingleTargetObjective`](baybe.objectives.single.SingleTargetObjective) describes a
@@ -47,7 +47,7 @@ enables the combination of multiple targets via scalarization into a single nume
 value (commonly referred to as the *overall desirability*), a method also utilized in
 classical DOE.
 
-```{admonition} Mandatory target bounds
+```{admonition} Mandatory Target Bounds
 :class: attention
 Since measurements of different targets can vary arbitrarily in scale, all targets
 passed to a
@@ -109,7 +109,7 @@ multiple conflicting targets. Unlike the
 targets into a single scalar value but instead seeks to identify the Pareto front – the
 set of *non-dominated* target configurations.
 
-```{admonition} Non-dominated Configurations
+```{admonition} Non-Dominated Configurations
 :class: tip
 A target configuration is considered non-dominated (or Pareto-optimal) if no other
 configuration is better in *all* targets.
@@ -138,3 +138,10 @@ target_2 = NumericalTarget(name="t_2", mode="MAX")
 objective = ParetoObjective(targets=[target_1, target_2])
 ```
 
+```{admonition} Convenience Multi-Output Casting
+:class: tip
+`ParetoObjective` requires a [multi-output surrogate model](multi_output_modeling). 
+If you attempt to use a  single-output model, BayBE will automatically turn it into a 
+[`CompositeSurrogate`](baybe.surrogates.composite.CompositeSurrogate) 
+using [independent replicates](auto_replication).
+```

--- a/docs/userguide/objectives.md
+++ b/docs/userguide/objectives.md
@@ -140,7 +140,8 @@ objective = ParetoObjective(targets=[target_1, target_2])
 
 ```{admonition} Convenience Multi-Output Casting
 :class: tip
-`ParetoObjective` requires a [multi-output surrogate model](multi_output_modeling). 
+[`ParetoObjective`](baybe.objectives.pareto.ParetoObjective) requires a 
+[multi-output surrogate model](multi_output_modeling). 
 If you attempt to use a  single-output model, BayBE will automatically turn it into a 
 [`CompositeSurrogate`](baybe.surrogates.composite.CompositeSurrogate) 
 using [independent replicates](auto_replication).

--- a/docs/userguide/surrogates.md
+++ b/docs/userguide/surrogates.md
@@ -18,7 +18,8 @@ available within BayBE:
 * [`NGBoostSurrogate`](baybe.surrogates.ngboost.NGBoostSurrogate)
 * [`RandomForestSurrogate`](baybe.surrogates.random_forest.RandomForestSurrogate)
 
-## Multi-output Modeling
+(multi_output_modeling)= 
+## Multi-Output Modeling
 Depending on the use case at hand, it may be necessary to model multiple output
 variables simultaneously. However, not all surrogate types natively provide (joint)
 predictive distributions for more than one variable, as indicated by their
@@ -51,6 +52,8 @@ However, there are very few cases where such an explicit conversion is required.
 using a single-output surrogate model in a multi-output context would trivially fail, and
 because BayBE cares deeply about its users' lives, it automatically performs this conversion
 for you behind the scenes:
+
+(auto_replication)=
 ```{admonition} Auto-Replication
 :class: important
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from tenacity import (
 from torch._C import _LinAlgError
 
 from baybe._optional.info import CHEM_INSTALLED
-from baybe.acquisition import qLogExpectedImprovement
+from baybe.acquisition import qLogEI, qLogNEHVI
 from baybe.campaign import Campaign
 from baybe.constraints import (
     ContinuousCardinalityConstraint,
@@ -42,6 +42,7 @@ from baybe.constraints import (
     ThresholdCondition,
 )
 from baybe.kernels import MaternKernel
+from baybe.objectives import ParetoObjective
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.single import SingleTargetObjective
 from baybe.parameters import (
@@ -698,9 +699,12 @@ def fixture_default_streaming_sequential_meta_recommender():
 
 
 @pytest.fixture(name="acqf")
-def fixture_default_acquisition_function():
+def fixture_default_acquisition_function(objective):
     """The default acquisition function to be used if not specified differently."""
-    return qLogExpectedImprovement()
+    if isinstance(objective, ParetoObjective):
+        return qLogNEHVI()
+    else:
+        return qLogEI()
 
 
 @pytest.fixture(name="lengthscale_prior")

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -128,6 +128,7 @@ def test_setting_allow_flags(flag, space_type, value):
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_update_measurements(ongoing_campaign):
+    """Updating measurements makes the expected changes."""
     p_name, t_name = "Num_disc_1", ongoing_campaign.targets[0].name
     updated = ongoing_campaign.measurements.iloc[[0], :]
 

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -124,6 +124,29 @@ def test_setting_allow_flags(flag, space_type, value):
 
 
 @pytest.mark.parametrize(
+    "parameter_names", [["Categorical_1", "Categorical_2", "Num_disc_1"]]
+)
+@pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
+def test_update_measurements(ongoing_campaign):
+    p_name, t_name = "Num_disc_1", ongoing_campaign.targets[0].name
+    updated = ongoing_campaign.measurements.iloc[[0], :]
+
+    # Perform the update
+    updated.iloc[0, updated.columns.get_loc(p_name)] = 1337
+    updated.iloc[0, updated.columns.get_loc(t_name)] = 1337
+    ongoing_campaign.update_measurements(
+        updated, numerical_measurements_must_be_within_tolerance=False
+    )
+
+    # Make sure values are updated and resets have been made
+    meas = ongoing_campaign.measurements
+    assert meas.iloc[0, updated.columns.get_loc(p_name)] == 1337
+    assert meas.iloc[0, updated.columns.get_loc(t_name)] == 1337
+    assert meas.iloc[[0], updated.columns.get_loc("FitNr")].isna().all()
+    assert ongoing_campaign._cached_recommendation.empty
+
+
+@pytest.mark.parametrize(
     ("parameter_names", "objective", "surrogate_model", "acqf", "batch_size"),
     [
         param(

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -41,9 +41,7 @@ def test_bad_parameter_input_value(campaign, bad_val, fake_measurements):
 @pytest.mark.parametrize(
     "bad_val, target_names",
     [
-        param(np.nan, ["Target_max"], id="num_target_nan"),
         param("asd", ["Target_max"], id="num_target_str"),
-        param(np.nan, ["Target_binary"], id="binary_target_nan"),
         param(1337, ["Target_binary"], id="binary_target_num"),
         param("asd", ["Target_binary"], id="binary_target_str"),
     ],

--- a/tests/test_partial_measurements.py
+++ b/tests/test_partial_measurements.py
@@ -1,0 +1,56 @@
+"""Tests pending experiments mechanism."""
+
+from contextlib import nullcontext
+
+import numpy as np
+import pytest
+from pytest import param
+
+from baybe.objectives import DesirabilityObjective, ParetoObjective
+from baybe.targets import NumericalTarget
+
+
+@pytest.mark.parametrize(
+    "objective",
+    [
+        param(NumericalTarget("t1", "MAX").to_objective(), id="single_target"),
+        param(
+            DesirabilityObjective(
+                [
+                    NumericalTarget("t1", "MAX", (0, 1)),
+                    NumericalTarget("t2", "MIN", (0, 1)),
+                ]
+            ),
+            id="desirability",
+        ),
+        param(
+            ParetoObjective(
+                [NumericalTarget("t1", "MAX"), NumericalTarget("t2", "MIN")],
+            ),
+            id="pareto",
+        ),
+    ],
+)
+@pytest.mark.parametrize("n_iterations", [2], ids=["i2"])
+@pytest.mark.parametrize("batch_size", [5], ids=["b5"])
+@pytest.mark.parametrize("n_grid_points", [5], ids=["g5"])
+def test_pending_measurements(ongoing_campaign, objective):
+    c = ongoing_campaign
+    m = c.measurements
+    ts = c.targets
+
+    # Mark some measurements as pending and failed
+    m.iloc[0, m.columns.get_loc(ts[0].name)] = np.nan
+    m.iloc[-1, m.columns.get_loc(ts[-1].name)] = np.nan
+    c.update_measurements(m)
+
+    # Failure is expected when single surrogates are used, which is exactly the case
+    # for non-Pareto objectives. For ParetoObjectives, the filtering is expected to
+    # remove affected rows, resulting in no error.
+    context = nullcontext()
+    if not isinstance(objective, ParetoObjective):
+        context = pytest.raises(ValueError, match="Bad input in the rows")
+
+    # Trigger refit
+    with context:
+        c.recommend(2)

--- a/tests/test_partial_measurements.py
+++ b/tests/test_partial_measurements.py
@@ -1,4 +1,4 @@
-"""Tests pending experiments mechanism."""
+"""Tests for partial measurements."""
 
 from contextlib import nullcontext
 
@@ -34,12 +34,12 @@ from baybe.targets import NumericalTarget
 @pytest.mark.parametrize("n_iterations", [2], ids=["i2"])
 @pytest.mark.parametrize("batch_size", [5], ids=["b5"])
 @pytest.mark.parametrize("n_grid_points", [5], ids=["g5"])
-def test_pending_measurements(ongoing_campaign, objective):
+def test_partial_measurements(ongoing_campaign, objective):
     c = ongoing_campaign
     m = c.measurements
     ts = c.targets
 
-    # Mark some measurements as pending and failed
+    # Mark some measurements as unmeasured / failed
     m.iloc[0, m.columns.get_loc(ts[0].name)] = np.nan
     m.iloc[-1, m.columns.get_loc(ts[-1].name)] = np.nan
     c.update_measurements(m)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -14,7 +14,7 @@ from baybe.utils.dataframe import (
     add_noise_to_perturb_degenerate_rows,
     add_parameter_noise,
     fuzzy_row_match,
-    handle_invalid_target_values,
+    handle_invalid_column_values,
 )
 
 
@@ -193,8 +193,8 @@ def test_measurement_singletons():
     with pytest.raises(
         ValueError, match=r"Bad input in the rows with these indices: \[123, 5\]"
     ):
-        handle_invalid_target_values(df, targets)
+        handle_invalid_column_values(df, [t.name for t in targets])
 
     # Test NaN removal
-    df_new = handle_invalid_target_values(df, targets, drop=True)
+    df_new = handle_invalid_column_values(df, [t.name for t in targets], drop=True)
     assert_frame_equal(df.iloc[1:-1, :], df_new)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -14,7 +14,7 @@ from baybe.utils.dataframe import (
     add_noise_to_perturb_degenerate_rows,
     add_parameter_noise,
     fuzzy_row_match,
-    handle_invalid_column_values,
+    handle_missing_values,
 )
 
 
@@ -193,8 +193,8 @@ def test_measurement_singletons():
     with pytest.raises(
         ValueError, match=r"Bad input in the rows with these indices: \[123, 5\]"
     ):
-        handle_invalid_column_values(df, [t.name for t in targets])
+        handle_missing_values(df, [t.name for t in targets])
 
     # Test NaN removal
-    df_new = handle_invalid_column_values(df, [t.name for t in targets], drop=True)
+    df_new = handle_missing_values(df, [t.name for t in targets], drop=True)
     assert_frame_equal(df.iloc[1:-1, :], df_new)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -9,10 +9,12 @@ from pandas.testing import assert_frame_equal
 from pytest import param
 
 from baybe.exceptions import SearchSpaceMatchWarning
+from baybe.targets import BinaryTarget, NumericalTarget
 from baybe.utils.dataframe import (
     add_noise_to_perturb_degenerate_rows,
     add_parameter_noise,
     fuzzy_row_match,
+    handle_invalid_target_values,
 )
 
 
@@ -170,3 +172,29 @@ def test_invalid_fuzzy_row_match(searchspace, invalid):
     match = f"corresponding column in the {invalid} dataframe."
     with pytest.raises(ValueError, match=match):
         fuzzy_row_match(left_df, right_df, searchspace.parameters)
+
+
+def test_measurement_singletons():
+    """Correct treatment of rows with unmeasured targets."""
+    df = pd.DataFrame(
+        {
+            "A": [np.nan, 2, 3, 4, 5],
+            "B": ["a", "b", "b", "a", np.nan],
+            "C": [55, 44, 33, 22, 11],
+        },
+        index=[123, 2, 3, 4, 5],
+    )
+    targets = [
+        NumericalTarget(name="A", mode="MAX"),
+        BinaryTarget(name="B", success_value="a", failure_value="b"),
+    ]
+
+    # Test NaN block
+    with pytest.raises(
+        ValueError, match=r"Bad input in the rows with these indices: \[123, 5\]"
+    ):
+        handle_invalid_target_values(df, targets)
+
+    # Test NaN removal
+    df_new = handle_invalid_target_values(df, targets, drop=True)
+    assert_frame_equal(df.iloc[1:-1, :], df_new)


### PR DESCRIPTION
Enables partial measurements when composite surrogates and `ParetoObjective` are used.

- Added method `Campaign.update_measurements` enabling the update of
already existing measurements (should come in handy in pending
measurement scenarios)
- Target validation now allows NaNs
- Minimal adjustments in pure and composite surrogates now either block
NaNs (failing at recommendation attempt) or drop the corresponding rows when creating
single-target surrogates (this is what enables partial measurements)
- Added documentation mostly focused on the async workflows page