### PR TITLE
Provide version fallback in case scm fails to infer version during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Incorrect optimization direction with `PSTD` with a single minimization target
+- Provide version fallback in case scm fails to infer version during installation
 
 ### Removed
 - `fuzzy_row_match` will no longer warn about entries not matching to the search space 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 version_scheme = 'post-release'
 local_scheme = "dirty-tag"
+fallback_version = "0.0+unknown"
 
 [tool.setuptools]
 packages = ["baybe"]


### PR DESCRIPTION
Fix installation if setuptools-scm version inference fails.

In the specific case, baybe was installed format the git repository inside a docker container that did not provide the ` git` command, leading setuptools-scm to fail. Same happens if for any reason the .git directory is missing (e.g. when downloading a tarbal from github).

The fallback version is set to `0.0+unknown` to ensure we adhere to PyPa (https://packaging.python.org/en/latest/specifications/version-specifiers/#examples-of-compliant-version-schemes) while still ensuring any user will be able to recognize this as a non-standard version identifier.

Fixes #521 