### PR TITLE
Make `setuptools-scm` optional

### DIFF
--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -845,7 +845,7 @@ setuptools==71.1.0
     # via
     #   jupyterlab
     #   setuptools-scm
-setuptools-scm==8.1.0
+setuptools-scm==8.2.0
     # via baybe (pyproject.toml)
 shap==0.46.0
     # via baybe (pyproject.toml)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `fuzzy_row_match` will no longer warn about entries not matching to the search space 
 - `funcy` dependency
+- `setuptools-scm` as a runtime dependency
 
 ## [0.12.2] - 2025-01-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `benchmarks` module now accepts a list of domains to be executed
 - Construction of BoTorch acquisition functions has been redesigned from ground up
 - `ngboost` and `scikit-learn-extra` are now optional dependencies
+- `setuptools-scm` is now an optional dependency, used for improved version inference
 - `create_example_plots`, `to_string` and `indent` have been relocated within utils
 
 ### Fixed
@@ -66,7 +67,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `fuzzy_row_match` will no longer warn about entries not matching to the search space 
 - `funcy` dependency
-- `setuptools-scm` as a runtime dependency
 
 ## [0.12.2] - 2025-01-31
 ### Changed

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The available groups are:
 - `insights`: Required for built-in model and campaign analysis (e.g. using [SHAP](https://shap.readthedocs.io/)).
 - `simulation`: Enabling the [simulation](https://emdgroup.github.io/baybe/stable/_autosummary/baybe.simulation.html) module.
 - `test`: Required for running the tests.
-- `dev`: All of the above plus `uv`, `tox-uv` and `pip-audit`. For code contributors.
+- `dev`: All of the above plus dev tools. For code contributors.
 
 ## 📡 Telemetry
 BayBE collects anonymous usage statistics **only** for employees of Merck KGaA, 

--- a/baybe/__init__.py
+++ b/baybe/__init__.py
@@ -12,22 +12,12 @@ def infer_version() -> str:  # pragma: no cover
     """Determine the package version for the different ways the code can be invoked."""
     # ----------------------------------------------------------------------------------
     # Attempt 1:
-    # If the package has been installed, read the version from the metadata created
-    # during the installation process. In this case, the version string has been
-    # determined via setuptools_scm from the git history. (If the install had been
-    # attempted without the git folder in place, setuptools_scm would have complained,
-    # causing the installation process to fail.)
-    from importlib.metadata import version
-
-    try:
-        return version(__name__)
-    except ModuleNotFoundError:
-        pass
-
-    # ----------------------------------------------------------------------------------
-    # Attempt 2:
-    # If the package is not installed, try to replicate the version on the fly, using
-    # the same logic by invoking setuptools_scm (provided the latter is installed).
+    # Try to dynamically infer the version on the fly from the git history using
+    # setuptools_scm, provided the latter is installed. This relies on the same logic as
+    # for writing the version metadata during the installation process (see Attempt 2
+    # below) but has the advantage that the version info is always up-to-date, even when
+    # using an "editable installation" using the "-e" flag, where the metadata file may
+    # become outdated when the git HEAD changes.
     try:
         from pathlib import Path
 
@@ -42,9 +32,22 @@ def infer_version() -> str:  # pragma: no cover
         pass
 
     # ----------------------------------------------------------------------------------
+    # Attempt 2:
+    # If the package is installed, retrieve the version from the metadata generated
+    # via setuptools_scm during the installation process. (If the install had been
+    # attempted without the git folder in place, setuptools_scm would have complained,
+    # causing the installation process to fail.)
+    from importlib.metadata import version
+
+    try:
+        return version(__name__)
+    except ModuleNotFoundError:
+        pass
+
+    # ----------------------------------------------------------------------------------
     # Fallback:
-    # If the package has not been installed and also no git history is available,
-    # there is no way to figure out the correct version.
+    # If neither the package is installed nor the git history is available, return
+    # "unknown" since the version cannot be determined.
     return "unknown"
 
 

--- a/baybe/__init__.py
+++ b/baybe/__init__.py
@@ -27,18 +27,18 @@ def infer_version() -> str:  # pragma: no cover
     # ----------------------------------------------------------------------------------
     # Attempt 2:
     # If the package is not installed, try to replicate the version on the fly, using
-    # the same logic by invoking setuptools_scm.
-    from pathlib import Path
-
-    from setuptools_scm import get_version
-
+    # the same logic by invoking setuptools_scm (provided the latter is installed).
     try:
+        from pathlib import Path
+
+        from setuptools_scm import get_version
+
         return get_version(
             root=str(Path(__path__[0]).parent),
             version_scheme="post-release",
             local_scheme="dirty-tag",
         )
-    except LookupError:
+    except (LookupError, ImportError):
         pass
 
     # ----------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "pandas>=1.4.2,<3",
     "scikit-learn>=1.1.1,<2",
     "scipy>=1.10.1",
-    "setuptools-scm>=7.1.0",
     "torch>=1.13.1,<3",
     "typing_extensions>=4.7.0",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
     "baybe[test]",
     "baybe[benchmarking]",
     "pip-audit>=2.5.5",
+    "setuptools-scm>=7.1.0",
     "tox-uv>=1.7.0",
     "uv>=0.3.0", #  `uv lock` (for lockfiles) is stable since 0.3.0: https://github.com/astral-sh/uv/issues/2679#event-13950215962
 ]


### PR DESCRIPTION
Partially addresses #525 by dropping `setuptools-scm` as a runtime dependency.