### PR TITLE
Fix lockfile creation for uv>=0.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,4 +93,4 @@ setenv =
     DEFAULT_DOCS_LOCKFILE_PATH = .lockfiles/py310-dev.lock
 commands =
     python --version
-    uv pip compile --universal --python 310 pyproject.toml --extra dev -o {env:DOCS_LOCKFILE_PATH:{env:DEFAULT_DOCS_LOCKFILE_PATH}} {posargs}
+    uv pip compile --universal --python-version 3.10 pyproject.toml --extra dev -o {env:DOCS_LOCKFILE_PATH:{env:DEFAULT_DOCS_LOCKFILE_PATH}} {posargs}


### PR DESCRIPTION
Makes our tox lockfile command compatible with `uv>=0.6.0` which introduced a breaking change regarding the semantics of the python version specifier.