### PR TITLE
Add qLogNParEGO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `qPSTD` acquisition function
 - `SHAPInsight` now supports the `waterfall` plot type
 - `ParetoObjective` class for Pareto optimization of multiple targets and corresponding
-  `qLogNoisyExpectedHypervolumeImprovement` acquisition function
+  `qLogNoisyExpectedHypervolumeImprovement` / `qLogNParEGO` acquisition functions
 - `Surrogate.replicate` method for making single-target surrogate models multi-target
   compatible
 - `CompositeSurrogate` class for composing multi-target surrogates from single-target

--- a/baybe/acquisition/__init__.py
+++ b/baybe/acquisition/__init__.py
@@ -12,6 +12,7 @@ from baybe.acquisition.acqfs import (
     qLogExpectedImprovement,
     qLogNoisyExpectedHypervolumeImprovement,
     qLogNoisyExpectedImprovement,
+    qLogNParEGO,
     qNegIntegratedPosteriorVariance,
     qNoisyExpectedImprovement,
     qPosteriorStandardDeviation,
@@ -68,6 +69,8 @@ __all__ = [
     "qThompsonSampling",
     # Hypervolume Improvement
     "qLogNoisyExpectedHypervolumeImprovement",
+    # ParEGO
+    "qLogNParEGO",
     ######################### Abbreviations
     # Knowledge Gradient
     "qKG",

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -319,12 +319,26 @@ class qThompsonSampling(qSimpleRegret):
 
 
 ########################################################################################
+### Pareto Efficient Global Optimization (Chebyshev scalarization of objectives)
+@define(frozen=True)
+class qLogNParEGO(AcquisitionFunction):
+    """Pareto ranking via Chebyshev scalarization of the objectives."""
+
+    abbreviation: ClassVar[str] = "qLogNParEGO"
+    supports_multi_output: ClassVar[bool] = True
+
+    prune_baseline: bool = field(default=True, validator=instance_of(bool))
+    """Auto-prune candidates that are unlikely to be the best."""
+
+
+########################################################################################
 ### Hypervolume Improvement
 @define(frozen=True)
 class qLogNoisyExpectedHypervolumeImprovement(AcquisitionFunction):
     """Logarithmic Monte Carlo based noisy expected hypervolume improvement."""
 
     abbreviation: ClassVar[str] = "qLogNEHVI"
+    supports_multi_output: ClassVar[bool] = True
 
     reference_point: float | tuple[float, ...] | None = field(
         default=None, converter=optional_c(convert_to_float)

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -319,10 +319,10 @@ class qThompsonSampling(qSimpleRegret):
 
 
 ########################################################################################
-### Pareto Efficient Global Optimization (Chebyshev scalarization of objectives)
+### Pareto Efficient Global Optimization (Chebyshev scalarization of targets)
 @define(frozen=True)
 class qLogNParEGO(AcquisitionFunction):
-    """Pareto ranking via Chebyshev scalarization of the objectives."""
+    """Pareto optimization via Chebyshev scalarization of the targets."""
 
     abbreviation: ClassVar[str] = "qLogNParEGO"
     supports_multi_output: ClassVar[bool] = True

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -38,7 +38,7 @@ class AcquisitionFunction(ABC, SerialMixin):
     """An alternative name for type resolution."""
 
     supports_multi_output: ClassVar[bool] = False
-    """Whether this acqf can handle models with multiple outputs."""
+    """Whether this acquisition function can handle models with multiple outputs."""
 
     @classproperty
     def supports_batching(cls) -> bool:

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -37,6 +37,9 @@ class AcquisitionFunction(ABC, SerialMixin):
     abbreviation: ClassVar[str]
     """An alternative name for type resolution."""
 
+    supports_multi_output: ClassVar[bool] = False
+    """Whether this acqf can handle models with multiple outputs."""
+
     @classproperty
     def supports_batching(cls) -> bool:
         """Flag indicating whether batch recommendation is supported."""
@@ -49,11 +52,6 @@ class AcquisitionFunction(ABC, SerialMixin):
         This is based on the same mechanism underlying batched recommendations.
         """
         return cls.supports_batching
-
-    @classproperty
-    def supports_multi_output(cls) -> bool:
-        """Flag indicating whether multiple outputs are supported."""
-        return "Hypervolume" in cls.__name__  # type: ignore[attr-defined]
 
     @classproperty
     def _non_botorch_attrs(cls) -> tuple[str, ...]:
@@ -93,8 +91,10 @@ def _get_botorch_acqf_class(
     import botorch
 
     for cls in baybe_acqf_cls.mro():
-        if acqf_cls := getattr(botorch.acquisition, cls.__name__, False) or getattr(
-            botorch.acquisition.multi_objective, cls.__name__, False
+        if (
+            acqf_cls := getattr(botorch.acquisition, cls.__name__, False)
+            or getattr(botorch.acquisition.multi_objective, cls.__name__, False)
+            or getattr(botorch.acquisition.multi_objective.parego, cls.__name__, False)
         ):
             if is_abstract(acqf_cls):
                 continue


### PR DESCRIPTION
Since multi-ouput is now supported we might as well add support for this alternative to qLogNEHVI

Notes:
- changed `AcquisitionFunction.supports_multi_output` to an explicitly set class var
- for this acqf, botorch uses an already heavily abbreviated term, so I made `abbreviation` identical to the original name
- the name stands for batch logarithmic noisy pareto efficient global optimization
- Botorch-latest already has an option `incremental` enabling to chagne qLogNParEGO's behavior in a way that sounds very similar to what `sequential` does. But since its not released I left that out

Here the result with the existing Pareto example indicating this basically works (the actual code change for this was not pushed):
![image](https://github.com/user-attachments/assets/85033600-febf-41d4-92b7-4535a4fdb5bd)
Its also clear that this seems to be inferior to qLogNEHVI, I think this partially could come from the still missing posterior transforms
