### PR TITLE
Posterior Stats: Catch No Measurements Case

### DIFF
--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -17,7 +17,11 @@ from attrs.validators import instance_of
 from typing_extensions import override
 
 from baybe.constraints.base import DiscreteConstraint
-from baybe.exceptions import IncompatibilityError, NotEnoughPointsLeftError
+from baybe.exceptions import (
+    EmptyMeasurementsError,
+    IncompatibilityError,
+    NotEnoughPointsLeftError,
+)
 from baybe.objectives.base import Objective, to_objective
 from baybe.parameters.base import Parameter
 from baybe.recommenders.base import RecommenderProtocol
@@ -559,6 +563,13 @@ class Campaign(SerialMixin):
             A dataframe with posterior statistics for each target and candidate.
         """
         if candidates is None:
+            if self.measurements.empty:
+                raise EmptyMeasurementsError(
+                    f"No candidates were provided and the campaign measurements are "
+                    f"empty. '{self.posterior_stats.__name__}' cannot be computed in "
+                    f"this case."
+                )
+
             candidates = self.measurements[[p.name for p in self.parameters]]
 
         surrogate = self.get_surrogate()

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -18,8 +18,8 @@ from typing_extensions import override
 
 from baybe.constraints.base import DiscreteConstraint
 from baybe.exceptions import (
-    EmptyMeasurementsError,
     IncompatibilityError,
+    NoMeasurementsError,
     NotEnoughPointsLeftError,
 )
 from baybe.objectives.base import Objective, to_objective
@@ -564,10 +564,10 @@ class Campaign(SerialMixin):
         """
         if candidates is None:
             if self.measurements.empty:
-                raise EmptyMeasurementsError(
-                    f"No candidates were provided and the campaign measurements are "
-                    f"empty. '{self.posterior_stats.__name__}' cannot be computed in "
-                    f"this case."
+                raise NoMeasurementsError(
+                    f"No candidates were provided and the campaign has no measurements "
+                    f"yet. '{self.posterior_stats.__name__}' has no candidates to "
+                    f"compute statistics for in this case."
                 )
 
             candidates = self.measurements[[p.name for p in self.parameters]]

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -89,8 +89,8 @@ class EmptySearchSpaceError(Exception):
     """The created search space contains no parameters."""
 
 
-class EmptyMeasurementsError(Exception):
-    """The measurements are emtpy."""
+class NoMeasurementsError(Exception):
+    """A context expected measurements but none were available."""
 
 
 class NothingToSimulateError(Exception):

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -89,6 +89,10 @@ class EmptySearchSpaceError(Exception):
     """The created search space contains no parameters."""
 
 
+class EmptyMeasurementsError(Exception):
+    """The measurements are emtpy."""
+
+
 class NothingToSimulateError(Exception):
     """There is nothing to simulate because there are no testable configurations."""
 

--- a/baybe/insights/shap.py
+++ b/baybe/insights/shap.py
@@ -14,7 +14,7 @@ from shap import KernelExplainer
 
 from baybe import Campaign
 from baybe._optional.insights import shap
-from baybe.exceptions import IncompatibleExplainerError
+from baybe.exceptions import EmptyMeasurementsError, IncompatibleExplainerError
 from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
 from baybe.searchspace import SearchSpace
@@ -193,7 +193,9 @@ class SHAPInsight:
             ValueError: If the campaign does not contain any measurements.
         """
         if campaign.measurements.empty:
-            raise ValueError("The campaign does not contain any measurements.")
+            raise EmptyMeasurementsError(
+                "The campaign does not contain any measurements."
+            )
         data = campaign.measurements[[p.name for p in campaign.parameters]]
         background_data = campaign.searchspace.transform(data) if use_comp_rep else data
 

--- a/baybe/insights/shap.py
+++ b/baybe/insights/shap.py
@@ -14,7 +14,7 @@ from shap import KernelExplainer
 
 from baybe import Campaign
 from baybe._optional.insights import shap
-from baybe.exceptions import EmptyMeasurementsError, IncompatibleExplainerError
+from baybe.exceptions import IncompatibleExplainerError, NoMeasurementsError
 from baybe.objectives.base import Objective
 from baybe.recommenders.base import RecommenderProtocol
 from baybe.searchspace import SearchSpace
@@ -193,9 +193,7 @@ class SHAPInsight:
             ValueError: If the campaign does not contain any measurements.
         """
         if campaign.measurements.empty:
-            raise EmptyMeasurementsError(
-                "The campaign does not contain any measurements."
-            )
+            raise NoMeasurementsError("The campaign does not contain any measurements.")
         data = campaign.measurements[[p.name for p in campaign.parameters]]
         background_data = campaign.searchspace.transform(data) if use_comp_rep else data
 

--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -10,7 +10,7 @@ import pytest
 from pytest import mark
 
 from baybe._optional.info import INSIGHTS_INSTALLED
-from baybe.exceptions import IncompatibleExplainerError
+from baybe.exceptions import IncompatibleExplainerError, EmptyMeasurementsError
 
 if not INSIGHTS_INSTALLED:
     pytest.skip("Optional insights package not installed.", allow_module_level=True)
@@ -175,7 +175,7 @@ def test_plots(ongoing_campaign: Campaign, use_comp_rep, plot_type):
 def test_updated_campaign_explanations(campaign, n_iterations, batch_size):
     """Test explanations for campaigns with updated measurements."""
     with pytest.raises(
-        ValueError,
+        EmptyMeasurementsError,
         match="The campaign does not contain any measurements.",
     ):
         SHAPInsight.from_campaign(campaign)

--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -10,7 +10,7 @@ import pytest
 from pytest import mark
 
 from baybe._optional.info import INSIGHTS_INSTALLED
-from baybe.exceptions import IncompatibleExplainerError, EmptyMeasurementsError
+from baybe.exceptions import IncompatibleExplainerError, NoMeasurementsError
 
 if not INSIGHTS_INSTALLED:
     pytest.skip("Optional insights package not installed.", allow_module_level=True)
@@ -175,7 +175,7 @@ def test_plots(ongoing_campaign: Campaign, use_comp_rep, plot_type):
 def test_updated_campaign_explanations(campaign, n_iterations, batch_size):
     """Test explanations for campaigns with updated measurements."""
     with pytest.raises(
-        EmptyMeasurementsError,
+        NoMeasurementsError,
         match="The campaign does not contain any measurements.",
     ):
         SHAPInsight.from_campaign(campaign)


### PR DESCRIPTION
A minor improvement that throws an understandable error in case `posterior_stats` is called with empty candidates on a campaign with no measurements (useful for the API)