### PR TITLE
Remove xfail for fixed SHAP case

### DIFF
--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -162,10 +162,6 @@ def test_plots(ongoing_campaign: Campaign, use_comp_rep, plot_type):
         with mock.patch("matplotlib.pyplot.show"):
             shap_insight.plot(plot_type, df)
             plt.close()
-    except AttributeError as e:
-        if "no attribute 'colors'" in str(e) and plot_type == "beeswarm":
-            pytest.xfail("SHAP bug")
-        raise e
     except ValueError as e:
         if "zero-size array to reduction" in str(e) and plot_type == "scatter":
             pytest.xfail("SHAP bug")


### PR DESCRIPTION
Since `shap==0.47.1` was published, @fabianliebig's fix is published and the `xfail` for that error is not necessary anymore and should be removed again from the test

Afaik the other error is also fixed but no release available