### PR TITLE
Enable parallel execution of scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   random or deterministic sampling for equidistant cases
 - `random_tie_break` and `initialization` attributes to `FPSRecommender` to
   control sampling in `farthest_point_sampling`
+### Fixed
+- `simulate_scenarios` not making use of fully parallel computation
 
 ## [0.13.0] - 2025-04-16
 ### Added

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -152,7 +152,7 @@ def simulate_scenarios(
             category=UnusedObjectWarning,
             module="baybe.recommenders.pure.nonpredictive.base",
         )
-        da_results = batch_simulator.run_combos(combos)[result_variable]
+        da_results = batch_simulator.run_combos(combos, parallel=True)[result_variable]
 
     df_results = unpack_simulation_results(da_results)
 


### PR DESCRIPTION
I noticed that `simulate_scenarios` doesn't actually saturate all cores on my machine. The `run_combos` function takes a `parallel` parameter that we can set to true to spread the simulation across all cores.

https://xyzpy.readthedocs.io/en/latest/gen_parallel.html
