### PR TITLE
Allow Booleans for `CategoricalParameter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control sampling in `farthest_point_sampling`
 - Flag for toggling parallel computation in `simulate_scenarios`
 - Additional transfer learning and synthetic benchmarks
+- Utility `normalize_input_dtypes` for ensuring all input dataframe columns have the
+  expected dtypes
+
+### Changed
+- `CategoricalParameter` and `TaskParameter` now also allow Boolean entries as 
+  `values` and `active_values`
+- `SubspaceDiscrete.from_dataframe` now handles purely Boolean columns differently, 
+  inferring a `CategoricalParameter` with `INT` encoding for them
+- `add_measurements`, `update_measurements`, `fuzzy_row_match` and some `.recommend` 
+  calls now operate on dtype-normalized copies of the input if it contained unexpected
+  dtypes for a parameter or target
 
 ### Changed
 - `scikit-learn` and `scipy` are now lazy-loaded

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -47,7 +47,12 @@ from baybe.telemetry import (
 from baybe.utils.basic import UNSPECIFIED, UnspecifiedType, is_all_instance
 from baybe.utils.boolean import eq_dataframe
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import _ValidatedDataFrame, filter_df, fuzzy_row_match
+from baybe.utils.dataframe import (
+    _ValidatedDataFrame,
+    filter_df,
+    fuzzy_row_match,
+    normalize_input_dtypes,
+)
 from baybe.utils.validation import validate_parameter_input, validate_target_input
 
 if TYPE_CHECKING:
@@ -288,6 +293,7 @@ class Campaign(SerialMixin):
         validate_parameter_input(
             data, self.parameters, numerical_measurements_must_be_within_tolerance
         )
+        data = normalize_input_dtypes(data, self.parameters, self.targets)
         data.__class__ = _ValidatedDataFrame
 
         # Read in measurements and add them to the database
@@ -339,6 +345,7 @@ class Campaign(SerialMixin):
         validate_parameter_input(
             data, self.parameters, numerical_measurements_must_be_within_tolerance
         )
+        data = normalize_input_dtypes(data, self.parameters, self.targets)
         data.__class__ = _ValidatedDataFrame
 
         # Block duplicate input indices
@@ -455,6 +462,9 @@ class Campaign(SerialMixin):
         if (pending_experiments is not None) and not pending_experiments.empty:
             self._cached_recommendation = pd.DataFrame()
             validate_parameter_input(pending_experiments, self.parameters)
+            pending_experiments = normalize_input_dtypes(
+                pending_experiments, self.parameters
+            )
             pending_experiments.__class__ = _ValidatedDataFrame
 
         # If there are cached recommendations and the batch size of those is equal to

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -293,7 +293,7 @@ class Campaign(SerialMixin):
         validate_parameter_input(
             data, self.parameters, numerical_measurements_must_be_within_tolerance
         )
-        data = normalize_input_dtypes(data, self.parameters, self.targets)
+        data = normalize_input_dtypes(data, self.parameters + self.targets)
         data.__class__ = _ValidatedDataFrame
 
         # Read in measurements and add them to the database
@@ -345,7 +345,7 @@ class Campaign(SerialMixin):
         validate_parameter_input(
             data, self.parameters, numerical_measurements_must_be_within_tolerance
         )
-        data = normalize_input_dtypes(data, self.parameters, self.targets)
+        data = normalize_input_dtypes(data, self.parameters + self.targets)
         data.__class__ = _ValidatedDataFrame
 
         # Block duplicate input indices

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -10,6 +10,10 @@ from typing_extensions import override
 ##### Warnings #####
 
 
+class InputDataTypeWarning(UserWarning):
+    """An input has unexpected data type."""
+
+
 class UnusedObjectWarning(UserWarning):
     """
     A method or function was called with undesired arguments which indicates an

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -176,7 +176,7 @@ class _DiscreteLabelLikeParameter(DiscreteParameter, ABC):
     # See base class.
 
     # object variables
-    _active_values: tuple[str, ...] | None = field(
+    _active_values: tuple[str | bool, ...] | None = field(
         default=None,
         converter=optional_c(to_tuple),
         kw_only=True,
@@ -186,7 +186,7 @@ class _DiscreteLabelLikeParameter(DiscreteParameter, ABC):
 
     @override
     @property
-    def active_values(self) -> tuple[str, ...]:
+    def active_values(self) -> tuple[str | bool, ...]:
         if self._active_values is None:
             return self.values
 
@@ -194,7 +194,7 @@ class _DiscreteLabelLikeParameter(DiscreteParameter, ABC):
 
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103
-        self, _: Any, content: tuple[str, ...]
+        self, _: Any, content: tuple[str | bool, ...]
     ) -> None:
         """Validate the active parameter values.
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -22,10 +22,11 @@ def _convert_values(value, self, field) -> tuple[str, ...]:
     return tuple(sorted(value, key=lambda x: (str(type(x)), x)))
 
 
-def _label_min_len(_, __, value):
+def _validate_label_min_len(self, attr, value) -> None:
+    """An attrs-compatible validator to ensure minimum label length."""  # noqa: D401
     if isinstance(value, str) and len(value) < 1:
         raise ValueError(
-            f"Strings used as 'values' for '{CategoricalParameter.__name__}' must "
+            f"Strings used as '{attr.alias}' for '{self.__class__.__name__}' must "
             f"have at least 1 character."
         )
 
@@ -41,7 +42,7 @@ class CategoricalParameter(_DiscreteLabelLikeParameter):
         validator=(  # type: ignore
             validate_unique_values,
             deep_iterable(
-                member_validator=(instance_of((str, bool)), _label_min_len),
+                member_validator=(instance_of((str, bool)), _validate_label_min_len),
                 iterable_validator=min_len(2),
             ),
         ),

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -19,7 +19,15 @@ from baybe.utils.numerical import DTypeFloatNumpy
 def _convert_values(value, self, field) -> tuple[str, ...]:
     """Sort and convert values for categorical parameters."""
     value = nonstring_to_tuple(value, self, field)
-    return tuple(sorted(value))
+    return tuple(sorted(value, key=lambda x: (str(type(x)), x)))
+
+
+def _label_min_len(_, __, value):
+    if isinstance(value, str) and len(value) < 1:
+        raise ValueError(
+            f"Strings used as 'values' for '{CategoricalParameter.__name__}' must "
+            f"have at least 1 character."
+        )
 
 
 @define(frozen=True, slots=False)
@@ -27,13 +35,15 @@ class CategoricalParameter(_DiscreteLabelLikeParameter):
     """Parameter class for categorical parameters."""
 
     # object variables
-    _values: tuple[str, ...] = field(
+    _values: tuple[str | bool, ...] = field(
         alias="values",
         converter=Converter(_convert_values, takes_self=True, takes_field=True),  # type: ignore
         validator=(  # type: ignore
-            min_len(2),
             validate_unique_values,
-            deep_iterable(member_validator=(instance_of(str), min_len(1))),
+            deep_iterable(
+                member_validator=(instance_of((str, bool)), _label_min_len),
+                iterable_validator=min_len(2),
+            ),
         ),
     )
     # See base class.
@@ -53,7 +63,10 @@ class CategoricalParameter(_DiscreteLabelLikeParameter):
     @cached_property
     def comp_df(self) -> pd.DataFrame:
         if self.encoding is CategoricalEncoding.OHE:
-            cols = [f"{self.name}_{val}" for val in self.values]
+            cols = [
+                f"{self.name}_{'b' if isinstance(val, bool) else ''}{val}"
+                for val in self.values
+            ]
             comp_df = pd.DataFrame(
                 np.eye(len(self.values), dtype=DTypeFloatNumpy), columns=cols
             )

--- a/baybe/parameters/utils.py
+++ b/baybe/parameters/utils.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Collection
 from functools import partial
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -20,7 +20,7 @@ _TParameter = TypeVar("_TParameter", bound=Parameter)
 
 def get_parameters_from_dataframe(
     df: pd.DataFrame,
-    factory: Callable[[str, Collection[Any]], _TParameter],
+    factory: Callable[[str, npt.NDArray], _TParameter],
     parameters: Collection[_TParameter] | None = None,
 ) -> list[_TParameter]:
     """Create a list of parameters from a dataframe.
@@ -37,8 +37,8 @@ def get_parameters_from_dataframe(
 
     Args:
         df: The dataframe from which to create the parameters.
-        factory: A parameter factor, creating parameter objects for the columns
-            from the column name and the unique column values.
+        factory: A callable creating parameter objects for the columns from the column
+            name and the unique column values.
         parameters: An optional list of parameter objects to bypass the factory
             creation for columns whose names match with the parameter names.
 

--- a/baybe/parameters/utils.py
+++ b/baybe/parameters/utils.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Collection
 from functools import partial
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -20,7 +20,7 @@ _TParameter = TypeVar("_TParameter", bound=Parameter)
 
 def get_parameters_from_dataframe(
     df: pd.DataFrame,
-    factory: Callable[[str, npt.NDArray], _TParameter],
+    factory: Callable[[str, Collection[Any]], _TParameter],
     parameters: Collection[_TParameter] | None = None,
 ) -> list[_TParameter]:
     """Create a list of parameters from a dataframe.

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -15,7 +15,7 @@ from baybe.searchspace import SearchSpace
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpaceType
 from baybe.searchspace.discrete import SubspaceDiscrete
-from baybe.utils.dataframe import _ValidatedDataFrame
+from baybe.utils.dataframe import _ValidatedDataFrame, normalize_input_dtypes
 from baybe.utils.validation import validate_parameter_input, validate_target_input
 
 _DEPRECATION_ERROR_MESSAGE = (
@@ -108,6 +108,9 @@ class PureRecommender(ABC, RecommenderProtocol):
         ):
             validate_target_input(measurements, objective.targets)
             validate_parameter_input(measurements, searchspace.parameters)
+            measurements = normalize_input_dtypes(
+                measurements, searchspace.parameters, objective.targets
+            )
             measurements.__class__ = _ValidatedDataFrame
         if (
             pending_experiments is not None
@@ -115,6 +118,9 @@ class PureRecommender(ABC, RecommenderProtocol):
             and searchspace is not None
         ):
             validate_parameter_input(pending_experiments, searchspace.parameters)
+            pending_experiments = normalize_input_dtypes(
+                pending_experiments, searchspace.parameters
+            )
             pending_experiments.__class__ = _ValidatedDataFrame
 
         if searchspace.type is SearchSpaceType.CONTINUOUS:

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -109,7 +109,7 @@ class PureRecommender(ABC, RecommenderProtocol):
             validate_target_input(measurements, objective.targets)
             validate_parameter_input(measurements, searchspace.parameters)
             measurements = normalize_input_dtypes(
-                measurements, searchspace.parameters, objective.targets
+                measurements, searchspace.parameters + objective.targets
             )
             measurements.__class__ = _ValidatedDataFrame
         if (

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -28,7 +28,7 @@ from baybe.surrogates.base import (
     Surrogate,
     SurrogateProtocol,
 )
-from baybe.utils.dataframe import _ValidatedDataFrame
+from baybe.utils.dataframe import _ValidatedDataFrame, normalize_input_dtypes
 from baybe.utils.validation import validate_parameter_input, validate_target_input
 
 if TYPE_CHECKING:
@@ -169,11 +169,17 @@ class BayesianRecommender(PureRecommender, ABC):
         if not isinstance(measurements, _ValidatedDataFrame):
             validate_target_input(measurements, objective.targets)
             validate_parameter_input(measurements, searchspace.parameters)
+            measurements = normalize_input_dtypes(
+                measurements, searchspace.parameters, objective.targets
+            )
             measurements.__class__ = _ValidatedDataFrame
         if pending_experiments is not None and not isinstance(
             pending_experiments, _ValidatedDataFrame
         ):
             validate_parameter_input(pending_experiments, searchspace.parameters)
+            pending_experiments = normalize_input_dtypes(
+                pending_experiments, searchspace.parameters
+            )
             pending_experiments.__class__ = _ValidatedDataFrame
 
         if (

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -170,7 +170,7 @@ class BayesianRecommender(PureRecommender, ABC):
             validate_target_input(measurements, objective.targets)
             validate_parameter_input(measurements, searchspace.parameters)
             measurements = normalize_input_dtypes(
-                measurements, searchspace.parameters, objective.targets
+                measurements, searchspace.parameters + objective.targets
             )
             measurements.__class__ = _ValidatedDataFrame
         if pending_experiments is not None and not isinstance(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -11,7 +11,6 @@ from math import prod
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 from attrs import define, field
 from cattrs import IterableValidationError
@@ -245,11 +244,11 @@ class SubspaceDiscrete(SerialMixin):
         """
 
         def discrete_parameter_factory(
-            name: str, values: npt.NDArray
+            name: str, values: Collection[Any]
         ) -> DiscreteParameter:
             """Try to create a numerical parameter or use a categorical fallback."""
             try:
-                if pd.api.types.is_bool_dtype(values):
+                if pd.api.types.is_bool_dtype(np.asarray(values)):
                     # Due to the difference between bool and np.bool and pandas'
                     # auto-casting into the latter, the usage of is_bool_dtype and map
                     # is required here.

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -254,7 +254,7 @@ class SubspaceDiscrete(SerialMixin):
                     # is required here.
                     return CategoricalParameter(
                         name=name,
-                        values=tuple(map(bool, values)),
+                        values=map(bool, values),
                         encoding=CategoricalEncoding.INT,
                     )
                 return NumericalDiscreteParameter(name=name, values=values)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -31,7 +31,11 @@ from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.basic import to_tuple
 from baybe.utils.boolean import eq_dataframe, strtobool
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import get_transform_objects, pretty_print_df
+from baybe.utils.dataframe import (
+    get_transform_objects,
+    normalize_input_dtypes,
+    pretty_print_df,
+)
 from baybe.utils.memory import bytes_to_human_readable
 from baybe.utils.numerical import DTypeFloatNumpy
 
@@ -269,6 +273,9 @@ class SubspaceDiscrete(SerialMixin):
         parameters = get_parameters_from_dataframe(
             df, discrete_parameter_factory, parameters
         )
+
+        # Ensure dtype consistency
+        df = normalize_input_dtypes(df, parameters)
 
         return cls(parameters=parameters, exp_rep=df, empty_encoding=empty_encoding)
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -23,8 +23,7 @@ if TYPE_CHECKING:
 
     from baybe.targets.base import Target
 
-    _Component = Parameter | Target
-    _T = TypeVar("_T", bound=_Component)
+    _T = TypeVar("_T", bound=Parameter | Target)
     _ArrayLike = TypeVar("_ArrayLike", np.ndarray, Tensor)
 
 
@@ -841,9 +840,7 @@ def handle_missing_values(
     return data.loc[~mask]
 
 
-def normalize_input_dtypes(
-    df: pd.DataFrame, objects: Iterable[_Component], /
-) -> pd.DataFrame:
+def normalize_input_dtypes(df: pd.DataFrame, objects: Iterable[_T], /) -> pd.DataFrame:
     """Ensure that the input dataframe has the expected dtypes for all columns.
 
     Args:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -527,6 +527,12 @@ def fuzzy_row_match(
 
     # Match numerical parameters
     for col in num_cols:
+        # Enforce float data type for entire column to make distance calculation safe.
+        if not pd.api.types.is_float_dtype(left_df[col]):
+            left_df[col] = left_df[col].astype(float, copy=False)
+        if not pd.api.types.is_float_dtype(right_df[col]):
+            right_df[col] = right_df[col].astype(float, copy=False)
+
         # Per numerical parameter, this identifies the rows with the smallest absolute
         # difference and records them in a matrix.
         abs_diff = np.abs(right_df[col].values[:, None] - left_df[col].values[None, :])

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -527,15 +527,11 @@ def fuzzy_row_match(
 
     # Match numerical parameters
     for col in num_cols:
-        # Enforce float data type for entire column to make distance calculation safe.
-        if not pd.api.types.is_float_dtype(left_df[col]):
-            left_df[col] = left_df[col].astype(float, copy=False)
-        if not pd.api.types.is_float_dtype(right_df[col]):
-            right_df[col] = right_df[col].astype(float, copy=False)
+        left_col = left_df[col].to_numpy(dtype=DTypeFloatNumpy, copy=False)
+        right_col = right_df[col].to_numpy(dtype=DTypeFloatNumpy, copy=False)
 
-        # Per numerical parameter, this identifies the rows with the smallest absolute
-        # difference and records them in a matrix.
-        abs_diff = np.abs(right_df[col].values[:, None] - left_df[col].values[None, :])
+        # Compute absolute differences and find the minimum difference
+        abs_diff = np.abs(right_col[:, None] - left_col[None, :])
         min_diff = abs_diff.min(axis=1, keepdims=True)
         match_matrix &= abs_diff == min_diff
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -849,7 +849,7 @@ def normalize_input_dtypes(
 
     Args:
         data: The input dataframe to be checked.
-        parameters: The parameters for which corresponding columns ill be checked.
+        parameters: The parameters for which corresponding columns will be checked.
         targets: The targets for which corresponding columns will be checked.
 
     Returns:

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -31,7 +31,9 @@ decorrelations = st.one_of(
 parameter_names = st.text(min_size=1)
 """A strategy that generates parameter names."""
 
-categories = st.lists(st.text(min_size=1), min_size=2, unique=True)
+categories = st.lists(
+    st.one_of(st.text(min_size=1), st.booleans()), min_size=2, unique=True
+)
 """A strategy that generates parameter categories."""
 
 

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -103,7 +103,8 @@ def test_discrete_from_dataframe_dtype_consistency():
     subspace = SubspaceDiscrete.from_dataframe(df)
 
     assert isinstance(
-        [p for p in subspace.parameters if p.name == "C"][0], NumericalDiscreteParameter
+        next(p for p in subspace.parameters if p.name == "C"),
+        NumericalDiscreteParameter,
     )
     assert pd.api.types.is_float_dtype(subspace.exp_rep["C"])
 

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -91,6 +91,23 @@ def test_discrete_searchspace_creation_from_dataframe():
     assert df.equals(searchspace.discrete.exp_rep)
 
 
+def test_discrete_from_dataframe_dtype_consistency():
+    """Inconsistent but valid dtypes are correctly converted."""
+    df = pd.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": ["x", "y", "z"],
+            "C": [int(1), 2.2, True],  # Valid but inconsistent dtypes
+        }
+    )
+    subspace = SubspaceDiscrete.from_dataframe(df)
+
+    assert isinstance(
+        [p for p in subspace.parameters if p.name == "C"][0], NumericalDiscreteParameter
+    )
+    assert pd.api.types.is_float_dtype(subspace.exp_rep["C"])
+
+
 def test_invalid_simplex_creating_with_overlapping_parameters():
     """Creating a simplex searchspace with overlapping simplex and product parameters
     raises an error."""  # noqa

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -242,8 +242,8 @@ def test_measurement_singletons():
 def test_input_dtype(data, warning, match, parameters, targets):
     """If necessary, utility converts input dtype and raises warning."""
     with nullcontext() if warning is None else pytest.warns(warning, match=match):
-        converted = normalize_input_dtypes(data, parameters, targets)
-        converted = normalize_input_dtypes(data, parameters, targets)
+        converted = normalize_input_dtypes(data, parameters + targets)
+        converted = normalize_input_dtypes(data, parameters + targets)
         print(data)
         print(converted)
 

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -241,11 +241,8 @@ def test_measurement_singletons():
 )
 def test_input_dtype(data, warning, match, parameters, targets):
     """If necessary, utility converts input dtype and raises warning."""
-    context = nullcontext()
-    if warning is not None:
-        context = pytest.warns(warning, match=match)
-
-    with context:
+    with nullcontext() if warning is None else pytest.warns(warning, match=match):
+        converted = normalize_input_dtypes(data, parameters, targets)
         converted = normalize_input_dtypes(data, parameters, targets)
         print(data)
         print(converted)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -248,7 +248,5 @@ def test_input_dtype(data, warning, match, parameters, targets):
         print(converted)
 
     # Asserts converted columns have expected dtypes
-    if not pd.api.types.is_float_dtype(data["Num_disc_1"]):
-        assert pd.api.types.is_float_dtype(converted["Num_disc_1"]), (data, converted)
-    if not pd.api.types.is_float_dtype(data["Target_max"]):
-        assert pd.api.types.is_float_dtype(converted["Target_max"]), (data, converted)
+    assert pd.api.types.is_float_dtype(converted["Num_disc_1"]), (data, converted)
+    assert pd.api.types.is_float_dtype(converted["Target_max"]), (data, converted)

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -8,13 +8,14 @@ import pytest
 from pandas.testing import assert_frame_equal
 from pytest import param
 
-from baybe.exceptions import SearchSpaceMatchWarning
+from baybe.exceptions import InputDataTypeWarning, SearchSpaceMatchWarning
 from baybe.targets import BinaryTarget, NumericalTarget
 from baybe.utils.dataframe import (
     add_noise_to_perturb_degenerate_rows,
     add_parameter_noise,
     fuzzy_row_match,
     handle_missing_values,
+    normalize_input_dtypes,
 )
 
 
@@ -198,3 +199,59 @@ def test_measurement_singletons():
     # Test NaN removal
     df_new = handle_missing_values(df, [t.name for t in targets], drop=True)
     assert_frame_equal(df.iloc[1:-1, :], df_new)
+
+
+@pytest.mark.parametrize(
+    "data, warning, match",
+    [
+        param(
+            pd.DataFrame(
+                {
+                    "Num_disc_1": [1.1, 2.2],
+                    "Target_max": [3.3, 4.4],
+                }
+            ),
+            None,
+            "",
+            id="valid",
+        ),
+        param(
+            pd.DataFrame(
+                {
+                    "Num_disc_1": [1.1, True],
+                    "Target_max": [3.3, 4.4],
+                }
+            ),
+            InputDataTypeWarning,
+            "Num_disc_1",
+            id="bool_in_num_parameter",
+        ),
+        param(
+            pd.DataFrame(
+                {
+                    "Num_disc_1": [1.1, 2.2],
+                    "Target_max": [3.3, False],
+                }
+            ),
+            InputDataTypeWarning,
+            "Target_max",
+            id="bool_in_num_target",
+        ),
+    ],
+)
+def test_input_dtype(data, warning, match, parameters, targets):
+    """If necessary, utility converts input dtype and raises warning."""
+    context = nullcontext()
+    if warning is not None:
+        context = pytest.warns(warning, match=match)
+
+    with context:
+        converted = normalize_input_dtypes(data, parameters, targets)
+        print(data)
+        print(converted)
+
+    # Asserts converted columns have expected dtypes
+    if not pd.api.types.is_float_dtype(data["Num_disc_1"]):
+        assert pd.api.types.is_float_dtype(converted["Num_disc_1"]), (data, converted)
+    if not pd.api.types.is_float_dtype(data["Target_max"]):
+        assert pd.api.types.is_float_dtype(converted["Target_max"]), (data, converted)


### PR DESCRIPTION
This is response to Issue #542 

- `CategoricalParameter` (and the derived `TaskParameter`) now also support Boolean entries in `values`. This also has consequneces for the type hint of `active_values`
- `SubspaceDiscrete.from_dataframe` now handles the special case of a column containing only Booleans by assigning a `CategoricalParameter(encoding="INT")` to it, effectively fixing the problem reported in the issue
- `fuzzy_row_match` now also contains a conditional cast to float before attempting distance calculation, otherwise one could still break it by reading in data eg from a columns containing mixed bool/float values

Notes:
- The treatment of Booleans in pandas can be tricky, e.g. a `series.dtype` will say bool, but each individual element is `np.bool`. Those two dtypes are not recognized as identical by e.g. `isinstance`. So I am using `pd.api.types.is_bool_dtype` which required a type narrowing to the second argument of `get_parameters_from_dataframe`
- I also notice that no validation or casting of values is done to `df` in `SubspaceDiscrete.from_dataframe` which probably enables further type shananigans if strange dfs are provided. We can see below for instance also that the parameter order is not changed to reflect the order in the inferred `parameters`.

Here is the searchspace created by the code snippet from #542 where the parameter of interest is `media_A`
Before:
```terminal
SearchSpace
   Search Space Type: DISCRETE
   SubspaceDiscrete
      Discrete Parameters
                   Name                        Type  ...                 Encoding nActiveValues
         0      inducer        CategoricalParameter  ...  CategoricalEncoding.OHE           2.0
         1      media_A  NumericalDiscreteParameter  ...                     None           NaN
         2  temperature  NumericalDiscreteParameter  ...                     None           NaN
         
         [3 rows x 5 columns]
      Experimental Representation
            media_A inducer  temperature
         0     True       A           30
         1    False       B           40
      Constraints
         Empty DataFrame
         Columns: []
         Index: []
      Computational Representation
            inducer_A  inducer_B  media_A  temperature
         0        1.0        0.0     True           30
         1        0.0        1.0    False           40
```

After the changes:
```terminal
SearchSpace
   Search Space Type: DISCRETE
   SubspaceDiscrete
      Discrete Parameters
                   Name                        Type  ...                 Encoding nActiveValues
         0      inducer        CategoricalParameter  ...  CategoricalEncoding.OHE           2.0
         1      media_A        CategoricalParameter  ...  CategoricalEncoding.INT           2.0
         2  temperature  NumericalDiscreteParameter  ...                     None           NaN
         
         [3 rows x 5 columns]
      Experimental Representation
            media_A inducer  temperature
         0     True       A           30
         1    False       B           40
      Constraints
         Empty DataFrame
         Columns: []
         Index: []
      Computational Representation
            inducer_A  inducer_B  media_A  temperature
         0        1.0        0.0      1.0           30
         1        0.0        1.0      0.0           40
```