### PR TITLE
Fix guard clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   random or deterministic sampling for equidistant cases
 - `random_tie_break` and `initialization` attributes to `FPSRecommender` to
   control sampling in `farthest_point_sampling`
+
 ### Fixed
 - `simulate_scenarios` not making use of fully parallel computation
+- Using `PosteriorStandardDeviation` with `MIN` targets no longer results in 
+  minimization of the acquisition function
 
 ### Fixed
 - Added missing garbage collection call to pareto.py, potentially solving serialization

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -19,8 +19,10 @@ from botorch.models.model import Model
 from torch import Tensor
 
 from baybe.acquisition.acqfs import (
+    PosteriorStandardDeviation,
     _ExpectedHypervolumeImprovement,
     qNegIntegratedPosteriorVariance,
+    qPosteriorStandardDeviation,
     qThompsonSampling,
 )
 from baybe.acquisition.base import AcquisitionFunction, _get_botorch_acqf_class
@@ -180,9 +182,9 @@ class BotorchAcquisitionFunctionBuilder:
         if issubclass(
             type(self.acqf),
             (
-                bo_acqf.qNegIntegratedPosteriorVariance,
-                bo_acqf.PosteriorStandardDeviation,
-                bo_acqf.qPosteriorStandardDeviation,
+                qNegIntegratedPosteriorVariance,
+                PosteriorStandardDeviation,
+                qPosteriorStandardDeviation,
             ),
         ):
             # No action needed for the active learning acquisition functions:

--- a/streamlit/surrogate_models.py
+++ b/streamlit/surrogate_models.py
@@ -97,12 +97,7 @@ def main():
     st_function_name = st.sidebar.selectbox(
         "Test function", list(test_functions.keys())
     )
-    st_target_mode = st.sidebar.radio(
-        "Objective",
-        ["MAX", "MIN"],
-        format_func=lambda x: {"MAX": "Maximization", "MIN": "Minimization"}[x],
-        horizontal=True,
-    )
+    st_minimize = st.sidebar.checkbox("Minimize")
     st.sidebar.markdown("---")
     st.sidebar.markdown("# Model")
     st_surrogate_name = st.sidebar.selectbox(
@@ -168,11 +163,16 @@ def main():
         ),
     )
     searchspace = SearchSpace.from_product(parameters=[parameter])
-    objective = NumericalTarget(name="y", mode=st_target_mode).to_objective()
+    target_mode = "MIN" if st_minimize else "MAX"
+    objective = NumericalTarget(name="y", mode=target_mode).to_objective()
 
     # Create the surrogate model, acquisition function, and the recommender
     surrogate_model = surrogate_model_classes[st_surrogate_name]()
-    acqf = acquisition_function_classes[st_acqf_name]()
+    acqf_cls = acquisition_function_classes[st_acqf_name]
+    try:
+        acqf = acqf_cls(maximize=not st_minimize)
+    except TypeError:
+        acqf = acqf_cls()
     recommender = BotorchRecommender(
         surrogate_model=surrogate_model, acquisition_function=acqf
     )


### PR DESCRIPTION
Fixes a wrong type check that resulted in `PosteriorStandardDeviation` always being minimized (regardless of its own `maximize` flag) when used in combination with a single `MIN` target, because the flag was overwritten in the code lines below. The other two active learning acquisition functions were not affected since the code execution does not reach the corresponding line in these cases.