### PR TITLE
Make import of deprecated ONNX function robust

### DIFF
--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -17,7 +17,7 @@ try:
     # It is important to note that the main branch of "skl2onnx" already uses the new
     # function, so this issue will be resolved in the next release.
     onnx_version = onnx.__version__
-    if onnx_version >= Version("1.18.0"):
+    if Version(onnx_version) >= Version("1.18.0"):
         from onnx.helper import _split_complex_to_pairs
 
         onnx.helper.split_complex_to_pairs = _split_complex_to_pairs

--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -11,11 +11,8 @@ try:
     # NOTE: In version 1.18.0, the function `onnx.helper.split_complex_to_pairs` was
     # replaced by the "private" function `_split_complex_to_pairs`.
     # Not all dependencies, in particulat "skl2onnx" have been updated to use the
-    # new function. To ensure backwards compatibility, we check the version of onnx
-    # and if it is lower than 1.18.0, we import the old function.
+    # new function.
     # This is a temporary fix until all dependencies are updated.
-    # It is important to note that the main branch of "skl2onnx" already uses the new
-    # function, so this issue will be resolved in the next release.
     onnx_version = onnx.__version__
     if Version(onnx_version) >= Version("1.18.0"):
         from onnx.helper import _split_complex_to_pairs

--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -3,7 +3,15 @@
 from baybe.exceptions import OptionalImportError
 
 try:
+    import onnx
     import onnxruntime
+
+    try:
+        from onnx.helper import split_complex_to_pairs  # noqa: F401
+    except ImportError:
+        from onnx.helper import _split_complex_to_pairs
+
+        onnx.helper.split_complex_to_pairs = _split_complex_to_pairs
 except ModuleNotFoundError as ex:
     raise OptionalImportError(name="onnxruntime", group="onnx") from ex
 

--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -1,14 +1,23 @@
 """Optional ONNX import."""
 
+from packaging.version import Version
+
 from baybe.exceptions import OptionalImportError
 
 try:
     import onnx
     import onnxruntime
 
-    try:
-        from onnx.helper import split_complex_to_pairs  # noqa: F401
-    except ImportError:
+    # NOTE: In version 1.18.0, the function `onnx.helper.split_complex_to_pairs` was
+    # replaced by the "private" function `_split_complex_to_pairs`.
+    # Not all dependencies, in particulat "skl2onnx" have been updated to use the
+    # new function. To ensure backwards compatibility, we check the version of onnx
+    # and if it is lower than 1.18.0, we import the old function.
+    # This is a temporary fix until all dependencies are updated.
+    # It is important to note that the main branch of "skl2onnx" already uses the new
+    # function, so this issue will be resolved in the next release.
+    onnx_version = onnx.__version__
+    if onnx_version >= Version("1.18.0"):
         from onnx.helper import _split_complex_to_pairs
 
         onnx.helper.split_complex_to_pairs = _split_complex_to_pairs

--- a/mypy.ini
+++ b/mypy.ini
@@ -73,3 +73,6 @@ ignore_missing_imports = True
 
 [mypy-shap.*]
 ignore_missing_imports = True
+
+[mypy-onnx.*]
+ignore_missing_imports = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,6 +888,10 @@ def fixture_default_simplex_config():
 @pytest.fixture(name="onnx_str")
 def fixture_default_onnx_str() -> bytes:
     """The default ONNX model string to be used if not specified differently."""
+    # Since the onnx import is done later in the tests bur this fixture uses
+    # the deprecated function, we need to do this manual import here.
+    import baybe._optional.onnx  # noqa: F401, I001
+
     from skl2onnx import convert_sklearn
     from skl2onnx.common.data_types import FloatTensorType
     from sklearn.linear_model import BayesianRidge

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,8 +888,14 @@ def fixture_default_simplex_config():
 @pytest.fixture(name="onnx_str")
 def fixture_default_onnx_str() -> bytes:
     """The default ONNX model string to be used if not specified differently."""
-    # Since the onnx import is done later in the tests bur this fixture uses
-    # the deprecated function, we need to do this manual import here.
+    # NOTE: In version 1.18.0 of `onnx`, the function
+    # `onnx.helper.split_complex_to_pairs` was removed.
+    # This requires us to do some monkeypatching in the baybe._optional.onnx, and we
+    # refer to this place if you are interested in the details.
+    # Since using this fixture imports "skl2onnx", we need to ensure that this
+    # monkeypatching is done before this import, hence we do the additional import here.
+    # Note that this is only a temporary fix until all dependencies are updated to use
+    # the new function.
     import baybe._optional.onnx  # noqa: F401, I001
 
     from skl2onnx import convert_sklearn


### PR DESCRIPTION
This PR introduces a robust import of the function `split_complex_to_pairs` of ONNX.

The reason is that this function seems to have been deprecated in `onnx>=1.18.0`, but some other packages still rely on it. To avoid an explicit version pin, this robust import is introduced.

Note that this also requires a slightly whacky import in `conftest`, since the actual import of the optional dependency only happens later, causing an error when pytest wants to access the fixture.