### PR TITLE
Lazy-load sklearn and scipy + adjust required model validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flag for toggling parallel computation in `simulate_scenarios`
 - Additional transfer learning and synthetic benchmarks
 
+### Changed
+- `scikit-learn` and `scipy` are now lazy-loaded
+- Validity of optional `model_params` attribute of `RandomForestSurrogate`, 
+  `NGBoostSurrogate` and `BayesianLinearSurrogate` is now checked via a hardcoded 
+  `TypedDict` instead of dynamically retrieved specifications, required for 
+  lazy-loading related packages
+- `CustomONNXSurrogate.onnx_str` is no longer validated before being used
+
 ### Fixed
 - Using `PosteriorStandardDeviation` with `MIN` targets no longer results in 
   minimization of the acquisition function

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -7,7 +7,6 @@ from typing import ClassVar
 import numpy as np
 import pandas as pd
 from attrs import define, field
-from scipy.stats import multivariate_normal
 from sklearn.base import ClusterMixin
 from sklearn.metrics import pairwise_distances
 from sklearn.preprocessing import StandardScaler
@@ -280,6 +279,8 @@ class GaussianMixtureClusteringRecommender(SKLearnClusteringRecommender):
         Returns:
             A list with positional indices of the selected candidates.
         """
+        from scipy.stats import multivariate_normal
+
         predicted_clusters = model.predict(candidates_scaled)
         selection = []
         for k_cluster in range(model.n_components):

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -2,19 +2,19 @@
 
 import gc
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import pandas as pd
 from attrs import define, field
-from sklearn.base import ClusterMixin
-from sklearn.metrics import pairwise_distances
-from sklearn.preprocessing import StandardScaler
 from typing_extensions import override
 
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType, SubspaceDiscrete
 from baybe.utils.conversion import to_string
+
+if TYPE_CHECKING:
+    from sklearn.base import ClusterMixin
 
 
 @define
@@ -103,6 +103,8 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         batch_size: int,
     ) -> pd.Index:
         # Fit scaler on entire search space
+        from sklearn.preprocessing import StandardScaler
+
         # TODO [Scaling]: scaling should be handled by search space object
         scaler = StandardScaler()
         scaler.fit(subspace_discrete.comp_rep)
@@ -234,6 +236,8 @@ class KMeansClusteringRecommender(SKLearnClusteringRecommender):
         Returns:
             A list with positional indices of the selected candidates.
         """
+        from sklearn.metrics import pairwise_distances
+
         distances = pairwise_distances(candidates_scaled, model.cluster_centers_)
         # Set the distances of points that were not assigned by the model to that
         # cluster to infinity. This assures that one unique point per cluster is

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -1,5 +1,7 @@
 """Recommenders based on clustering."""
 
+from __future__ import annotations
+
 import gc
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 from attrs.validators import instance_of
-from sklearn.preprocessing import StandardScaler
 from typing_extensions import override
 
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
@@ -92,6 +91,8 @@ class FPSRecommender(NonPredictiveRecommender):
         batch_size: int,
     ) -> pd.Index:
         # Fit scaler on entire search space
+        from sklearn.preprocessing import StandardScaler
+
         # TODO [Scaling]: scaling should be handled by search space object
         scaler = StandardScaler()
         scaler.fit(subspace_discrete.comp_rep)

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -21,7 +21,7 @@ _T = TypeVar("_T")
 #   switch to the cattrs built-in subclass recommender.
 # Using GenConverter for built-in overrides for sets, see
 # https://catt.rs/en/latest/indepth.html#customizing-collection-unstructuring
-converter = cattrs.GenConverter(unstruct_collection_overrides={set: list})
+converter = cattrs.Converter(unstruct_collection_overrides={set: list})
 """The default converter for (de-)serializing BayBE-related objects."""
 
 configure_union_passthrough(bool | int | float | str, converter)

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import gc
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar, TypedDict
 
 from attrs import define, field
 from typing_extensions import override
@@ -14,8 +14,26 @@ from baybe.surrogates.validation import get_model_params_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
-    from sklearn.linear_model import ARDRegression
     from torch import Tensor
+
+
+class _ARDRegressionParams(TypedDict, total=False):
+    """Optional ARDRegression parameters.
+
+    See :class:`~sklearn.linear_model.ARDRegression`.
+    """
+
+    max_iter: int
+    tol: float
+    alpha_1: float
+    alpha_2: float
+    lambda_1: float
+    lambda_2: float
+    compute_score: bool
+    threshold_lambda: float
+    fit_intercept: bool
+    copy_X: bool
+    verbose: bool
 
 
 @catch_constant_targets
@@ -26,14 +44,16 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     supports_transfer_learning: ClassVar[bool] = False
     # See base class.
 
-    model_params: dict[str, Any] = field(
+    model_params: _ARDRegressionParams = field(
         factory=dict,
         converter=dict,
-        validator=get_model_params_validator(ARDRegression.__init__),
+        validator=get_model_params_validator(_ARDRegressionParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 
-    _model: ARDRegression | None = field(init=False, default=None, eq=False)
+    # TODO: type should be `ARDRegression | None` but is currently omitted due to:
+    #  https://github.com/python-attrs/cattrs/issues/531
+    _model = field(init=False, default=None, eq=False)
     """The actual model."""
 
     @override

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
-from baybe.surrogates.validation import get_dict_validator
+from baybe.surrogates.validation import make_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     model_params: _ARDRegressionParams = field(
         factory=dict,
         converter=dict,
-        validator=get_dict_validator(_ARDRegressionParams),
+        validator=make_dict_validator(_ARDRegressionParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -6,7 +6,6 @@ import gc
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from attrs import define, field
-from sklearn.linear_model import ARDRegression
 from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate
@@ -15,6 +14,7 @@ from baybe.surrogates.validation import get_model_params_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
+    from sklearn.linear_model import ARDRegression
     from torch import Tensor
 
 
@@ -58,6 +58,8 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
 
     @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
+        from sklearn.linear_model import ARDRegression
+
         self._model = ARDRegression(**(self.model_params))
         self._model.fit(train_x, train_y.ravel())
 

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -49,7 +49,10 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
         converter=dict,
         validator=make_dict_validator(_ARDRegressionParams),
     )
-    """Optional model parameter that will be passed to the surrogate constructor."""
+    """Optional model parameter that will be passed to the surrogate constructor.
+
+    For allowed keys and values, see :class:`~sklearn.linear_model.ARDRegression`.
+    """
 
     # TODO: type should be `ARDRegression | None` but is currently omitted due to:
     #  https://github.com/python-attrs/cattrs/issues/531

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
-from baybe.surrogates.validation import get_model_params_validator
+from baybe.surrogates.validation import get_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
     model_params: _ARDRegressionParams = field(
         factory=dict,
         converter=dict,
-        validator=get_model_params_validator(_ARDRegressionParams),
+        validator=get_dict_validator(_ARDRegressionParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from attrs import define, field
+from numpy.random import RandomState
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
@@ -19,6 +20,25 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 
+class _NGBRegressorParams(TypedDict, total=False):
+    """Optional NGBRegressor parameters."""
+
+    Dist: Any
+    Score: Any
+    Base: Any
+    natural_gradient: bool
+    n_estimators: int
+    learning_rate: float
+    minibatch_frac: float
+    col_sample: float
+    verbose: bool
+    verbose_eval: int
+    tol: float
+    random_state: int | RandomState | None
+    validation_fraction: float
+    early_stopping_rounds: int | None
+
+
 @catch_constant_targets
 @define
 class NGBoostSurrogate(IndependentGaussianSurrogate):
@@ -30,20 +50,17 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
     _default_model_params: ClassVar[dict] = {"n_estimators": 25, "verbose": False}
     """Class variable encoding the default model parameters."""
 
-    model_params: dict[str, Any] = field(factory=dict, converter=dict)
+    model_params: _NGBRegressorParams = field(
+        factory=dict,
+        converter=dict,
+        validator=get_model_params_validator(_NGBRegressorParams),
+    )
     """Optional model parameter that will be passed to the surrogate constructor."""
 
     # TODO: Type should be `NGBRegressor | None` but is currently
     #   omitted due to: https://github.com/python-attrs/cattrs/issues/531
     _model = field(init=False, default=None, eq=False)
     """The actual model."""
-
-    @model_params.validator
-    def _validate_model_params(self, attr, value) -> None:
-        from baybe._optional.ngboost import NGBRegressor
-
-        validator = get_model_params_validator(NGBRegressor.__init__)
-        validator(self, attr, value)
 
     def __attrs_post_init__(self):
         self.model_params = {**self._default_model_params, **self.model_params}

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
-from baybe.surrogates.validation import get_model_params_validator
+from baybe.surrogates.validation import get_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
     model_params: _NGBRegressorParams = field(
         factory=dict,
         converter=dict,
-        validator=get_model_params_validator(_NGBRegressorParams),
+        validator=get_dict_validator(_NGBRegressorParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from attrs import define, field
-from numpy.random import RandomState
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
@@ -34,7 +33,7 @@ class _NGBRegressorParams(TypedDict, total=False):
     verbose: bool
     verbose_eval: int
     tol: float
-    random_state: int | RandomState | None
+    random_state: int | None  # Unlike ngboost, we do not allow ``RandomState``
     validation_fraction: float
     early_stopping_rounds: int | None
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from attrs import define, field
+from numpy.random import RandomState
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
@@ -33,7 +34,7 @@ class _NGBRegressorParams(TypedDict, total=False):
     verbose: bool
     verbose_eval: int
     tol: float
-    random_state: int | None  # Unlike ngboost, we do not allow ``RandomState``
+    random_state: int | RandomState | None
     validation_fraction: float
     early_stopping_rounds: int | None
 

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import IndependentGaussianSurrogate
 from baybe.surrogates.utils import batchify_mean_var_prediction, catch_constant_targets
-from baybe.surrogates.validation import get_dict_validator
+from baybe.surrogates.validation import make_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -53,7 +53,7 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
     model_params: _NGBRegressorParams = field(
         factory=dict,
         converter=dict,
-        validator=get_dict_validator(_NGBRegressorParams),
+        validator=make_dict_validator(_NGBRegressorParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -68,7 +68,10 @@ class RandomForestSurrogate(Surrogate):
         converter=dict,
         validator=make_dict_validator(_RandomForestRegressorParams),
     )
-    """Optional model parameter that will be passed to the surrogate constructor."""
+    """Optional model parameter that will be passed to the surrogate constructor.
+
+    For allowed keys and values, see :class:`~sklearn.ensemble.RandomForestRegressor`.
+    """
 
     # TODO: type should be `RandomForestRegressor | None` but is currently omitted due
     #  to: https://github.com/python-attrs/cattrs/issues/531

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify_ensemble_predictor, catch_constant_targets
-from baybe.surrogates.validation import get_dict_validator
+from baybe.surrogates.validation import make_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ class RandomForestSurrogate(Surrogate):
     model_params: _RandomForestRegressorParams = field(
         factory=dict,
         converter=dict,
-        validator=get_dict_validator(_RandomForestRegressorParams),
+        validator=make_dict_validator(_RandomForestRegressorParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -8,13 +8,12 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypedDict
 import numpy as np
 import numpy.typing as npt
 from attrs import define, field
-from numpy.random import RandomState
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
 from baybe.surrogates.base import Surrogate
 from baybe.surrogates.utils import batchify_ensemble_predictor, catch_constant_targets
-from baybe.surrogates.validation import get_model_params_validator
+from baybe.surrogates.validation import get_dict_validator
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
@@ -42,7 +41,7 @@ class _RandomForestRegressorParams(TypedDict, total=False):
     bootstrap: bool
     oob_score: bool  # Unlike sklearn, we do not allow callables
     n_jobs: int | None
-    random_state: int | RandomState | None
+    random_state: int | None  # Unlike sklearn, we do not allow ``RandomState``
     verbose: int
     warm_start: bool
     ccp_alpha: float
@@ -67,7 +66,7 @@ class RandomForestSurrogate(Surrogate):
     model_params: _RandomForestRegressorParams = field(
         factory=dict,
         converter=dict,
-        validator=get_model_params_validator(_RandomForestRegressorParams),
+        validator=get_dict_validator(_RandomForestRegressorParams),
     )
     """Optional model parameter that will be passed to the surrogate constructor."""
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 import numpy as np
 from attrs import define, field
-from sklearn.ensemble import RandomForestRegressor
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
@@ -20,8 +19,8 @@ if TYPE_CHECKING:
     from botorch.models.ensemble import EnsemblePosterior
     from botorch.models.transforms.input import InputTransform
     from botorch.models.transforms.outcome import OutcomeTransform
+    from sklearn.ensemble import RandomForestRegressor
     from torch import Tensor
-
 
 class _Predictor(Protocol):
     """A basic predictor."""
@@ -101,6 +100,8 @@ class RandomForestSurrogate(Surrogate):
 
     @override
     def _fit(self, train_x: Tensor, train_y: Tensor) -> None:
+        from sklearn.ensemble import RandomForestRegressor
+
         self._model = RandomForestRegressor(**(self.model_params))
         self._model.fit(train_x.numpy(), train_y.numpy().ravel())
 

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypedDict
 import numpy as np
 import numpy.typing as npt
 from attrs import define, field
+from numpy.random import RandomState
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
@@ -39,9 +40,9 @@ class _RandomForestRegressorParams(TypedDict, total=False):
     max_leaf_nodes: int | None
     min_impurity_decrease: float
     bootstrap: bool
-    oob_score: bool  # Unlike sklearn, we do not allow callables
+    oob_score: bool
     n_jobs: int | None
-    random_state: int | None  # Unlike sklearn, we do not allow ``RandomState``
+    random_state: int | RandomState | None
     verbose: int
     warm_start: bool
     ccp_alpha: float

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -97,7 +97,7 @@ type_validation_converter.register_structure_hook(float, _strict_float_structure
 type_validation_converter.register_structure_hook(bool, _strict_bool_structure_hook)
 
 
-def get_dict_validator(specification: type) -> Callable:
+def make_dict_validator(specification: type) -> Callable:
     """Construct an attrs dictionary validator based on a ``TypedDict``.
 
     Args:

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -58,13 +58,13 @@ def validate_custom_architecture_cls(model_cls: type) -> None:
 
 
 # Create a strict type validation converter
-type_validation_converter = cattrs.GenConverter(forbid_extra_keys=True)
+type_validation_converter = cattrs.Converter(forbid_extra_keys=True)
 """Converter used for strict type validation."""
-
 
 configure_union_passthrough(int | float | str | None, type_validation_converter)
 
 
+@type_validation_converter.register_structure_hook
 def _strict_int_structure_hook(obj: Any, _: type[int]) -> int:
     if isinstance(obj, int) and not isinstance(obj, bool):  # Exclude bools
         return obj
@@ -74,6 +74,7 @@ def _strict_int_structure_hook(obj: Any, _: type[int]) -> int:
     )
 
 
+@type_validation_converter.register_structure_hook
 def _strict_float_structure_hook(obj: Any, _: type[float]) -> float:
     if isinstance(obj, float):
         return obj
@@ -83,6 +84,7 @@ def _strict_float_structure_hook(obj: Any, _: type[float]) -> float:
     )
 
 
+@type_validation_converter.register_structure_hook
 def _strict_bool_structure_hook(obj: Any, _: type[bool]) -> bool:
     if isinstance(obj, bool):
         return obj
@@ -90,11 +92,6 @@ def _strict_bool_structure_hook(obj: Any, _: type[bool]) -> bool:
         f"Value '{obj}' (type: {type(obj).__name__}) is not a valid boolean. "
         "Only actual 'bool' instances (True, False) are accepted."
     )
-
-
-type_validation_converter.register_structure_hook(int, _strict_int_structure_hook)
-type_validation_converter.register_structure_hook(float, _strict_float_structure_hook)
-type_validation_converter.register_structure_hook(bool, _strict_bool_structure_hook)
 
 
 def make_dict_validator(specification: type) -> Callable:

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -58,7 +58,7 @@ def validate_custom_architecture_cls(model_cls: type) -> None:
 
 
 # Create a strict type validation converter
-type_validation_converter = converter = cattrs.GenConverter(forbid_extra_keys=True)
+type_validation_converter = cattrs.GenConverter(forbid_extra_keys=True)
 """Converter used for strict type validation."""
 
 

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Type, TypedDict
+from typing import Any
 
 import cattrs
 from cattrs import ClassValidationError
@@ -65,7 +65,7 @@ type_validation_converter = converter = cattrs.GenConverter(forbid_extra_keys=Tr
 configure_union_passthrough(int | float | str | None, type_validation_converter)
 
 
-def _strict_int_structure_hook(obj: Any, _: Type[int]) -> int:
+def _strict_int_structure_hook(obj: Any, _: type[int]) -> int:
     if isinstance(obj, int) and not isinstance(obj, bool):  # Exclude bools
         return obj
     raise ValueError(
@@ -74,7 +74,7 @@ def _strict_int_structure_hook(obj: Any, _: Type[int]) -> int:
     )
 
 
-def _strict_float_structure_hook(obj: Any, _: Type[float]) -> float:
+def _strict_float_structure_hook(obj: Any, _: type[float]) -> float:
     if isinstance(obj, float):
         return obj
     raise ValueError(
@@ -83,7 +83,7 @@ def _strict_float_structure_hook(obj: Any, _: Type[float]) -> float:
     )
 
 
-def _strict_bool_structure_hook(obj: Any, _: Type[bool]) -> bool:
+def _strict_bool_structure_hook(obj: Any, _: type[bool]) -> bool:
     if isinstance(obj, bool):
         return obj
     raise ValueError(
@@ -97,7 +97,7 @@ type_validation_converter.register_structure_hook(float, _strict_float_structure
 type_validation_converter.register_structure_hook(bool, _strict_bool_structure_hook)
 
 
-def get_dict_validator(specification: Type[TypedDict]) -> Callable:
+def get_dict_validator(specification: type) -> Callable:
     """Construct an attrs dictionary validator based on a ``TypedDict``.
 
     Args:
@@ -105,9 +105,6 @@ def get_dict_validator(specification: Type[TypedDict]) -> Callable:
 
     Returns:
         An attrs compatible validator.
-
-    Raises:
-        TypeError: If the dictionary does not match the specification.
     """
 
     def validate_model_params(_instance: Any, attr: Any, value: dict) -> None:

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -53,11 +53,11 @@ def validate_custom_architecture_cls(model_cls: type) -> None:
         )
 
 
-def get_model_params_validator(model_init: Callable | None = None) -> Callable:
-    """Construct a validator based on the model class.
+def get_model_params_validator(model_params: dict) -> Callable:
+    """Construct a validator based on the model type dict.
 
     Args:
-        model_init: The init method for the model.
+        model_params: The init method for the model.
 
     Returns:
         A validator function to validate parameters.
@@ -66,39 +66,7 @@ def get_model_params_validator(model_init: Callable | None = None) -> Callable:
     def validate_model_params(  # noqa: DOC101, DOC103
         obj: Any, _: Any, model_params: dict
     ) -> None:
-        """Validate the model params attribute of an object.
-
-        Raises:
-            ValueError: When model params are given for non-supported objects.
-            ValueError: When surrogate is not recognized (no valid model_init).
-            ValueError: When invalid params are given for a model.
-        """
-        # Get model class name
-        model = obj.__class__.__name__
-
-        if not model_params:
-            return
-
-        # GP does not support additional model params
-        # Neither does custom models
-        if "GaussianProcess" in model or "Custom" in model:
-            raise ValueError(f"{model} does not support model params.")
-
-        if not model_init:
-            raise ValueError(
-                f"Cannot validate model params for unrecognized Surrogate: {model}"
-            )
-
-        # Invalid params
-        invalid_params = ", ".join(
-            [
-                key
-                for key in model_params.keys()
-                if key not in model_init.__code__.co_varnames
-            ]
-        )
-
-        if invalid_params:
-            raise ValueError(f"Invalid model params for {model}: {invalid_params}.")
+        """Validate the model params attribute of an object."""
+        pass
 
     return validate_model_params

--- a/baybe/surrogates/validation.py
+++ b/baybe/surrogates/validation.py
@@ -62,7 +62,7 @@ type_validation_converter = converter = cattrs.GenConverter(forbid_extra_keys=Tr
 """Converter used for strict type validation."""
 
 
-configure_union_passthrough(bool | int | float | str | None, type_validation_converter)
+configure_union_passthrough(int | float | str | None, type_validation_converter)
 
 
 def _strict_int_structure_hook(obj: Any, _: Type[int]) -> int:

--- a/baybe/utils/sampling_algorithms.py
+++ b/baybe/utils/sampling_algorithms.py
@@ -6,7 +6,6 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
-from sklearn.metrics import pairwise_distances
 
 
 def farthest_point_sampling(
@@ -71,6 +70,8 @@ def farthest_point_sampling(
     points = points[sort_idx]
 
     # Pre-compute the pairwise distances between all points
+    from sklearn.metrics import pairwise_distances
+
     dist_matrix = pairwise_distances(points)
 
     # Avoid wrong behavior situations where all (remaining) points are duplicates

--- a/examples/Custom_Surrogates/surrogate_params.py
+++ b/examples/Custom_Surrogates/surrogate_params.py
@@ -68,7 +68,7 @@ surrogate_model = NGBoostSurrogate(model_params={"n_estimators": 50, "verbose": 
 
 try:
     invalid_surrogate_model = NGBoostSurrogate(model_params={"NOT_A_PARAM": None})
-except ValueError as e:
+except TypeError as e:
     print("The validator will give an error here:")
     print(e)
 

--- a/tests/test_custom_surrogate.py
+++ b/tests/test_custom_surrogate.py
@@ -31,15 +31,6 @@ def test_invalid_onnx_creation(onnx_str):
 @pytest.mark.skipif(
     not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
 )
-def test_invalid_onnx_str():
-    """Invalid onnx string causes error."""
-    with pytest.raises(Exception):
-        CustomONNXSurrogate(onnx_input_name="input", onnx_str=b"onnx_str")
-
-
-@pytest.mark.skipif(
-    not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
-)
 @pytest.mark.parametrize("surrogate_model", ["onnx"], indirect=True)
 @pytest.mark.parametrize(
     ["parameter_names", "should_raise"],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -63,6 +63,31 @@ WHITELISTS = {
         "baybe.surrogates._adapter",
         "baybe.utils.torch",
     ],
+    "scipy": [
+        "baybe._optional.chem",
+        "baybe._optional.insights",
+        "baybe._optional.ngboost",
+        "baybe.acquisition._builder",
+        "baybe.acquisition.partial",
+        "baybe.insights",
+        "baybe.insights.shap",
+        "baybe.surrogates._adapter",
+        "baybe.utils.chemistry",
+        "baybe.utils.clustering_algorithms",
+        "baybe.utils.clustering_algorithms.third_party",
+        "baybe.utils.clustering_algorithms.third_party.kmedoids",
+    ],
+    "sklearn": [
+        "baybe._optional.chem",
+        "baybe._optional.insights",
+        "baybe._optional.ngboost",
+        "baybe.insights",
+        "baybe.insights.shap",
+        "baybe.utils.chemistry",
+        "baybe.utils.clustering_algorithms",
+        "baybe.utils.clustering_algorithms.third_party",
+        "baybe.utils.clustering_algorithms.third_party.kmedoids",
+    ],
 }
 """Modules (dict values) for which certain imports (dict keys) are permitted."""
 

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from pytest import param
 
 from baybe.objectives.pareto import ParetoObjective
 from baybe.parameters.numerical import NumericalDiscreteParameter
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
+from baybe.surrogates import BayesianLinearSurrogate, NGBoostSurrogate
 from baybe.surrogates.composite import CompositeSurrogate
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.surrogates.random_forest import RandomForestSurrogate
@@ -51,3 +53,59 @@ def test_composite_surrogates(surrogate):
     BotorchRecommender(surrogate_model=surrogate).recommend(
         2, searchspace, objective, measurements
     )
+
+
+@pytest.mark.parametrize(
+    "model_cls, params",
+    [
+        param(RandomForestSurrogate, {"n_estimators": 5}, id="rf_1"),
+        param(RandomForestSurrogate, {"criterion": "squared_error"}, id="rf_2"),
+        param(RandomForestSurrogate, {"max_features": 0.4}, id="rf_3"),
+        param(RandomForestSurrogate, {"monotonic_cst": None}, id="rf_4"),
+        param(NGBoostSurrogate, {"n_estimators": 5}, id="ng_1"),
+        param(NGBoostSurrogate, {"learning_rate": 0.05}, id="ng_2"),
+        param(NGBoostSurrogate, {"verbose": True}, id="ng_3"),
+        param(NGBoostSurrogate, {"early_stopping_rounds": None}, id="ng_4"),
+        param(BayesianLinearSurrogate, {"max_iter": 10}, id="lin_1"),
+        param(BayesianLinearSurrogate, {"alpha_1": 0.3}, id="lin_2"),
+        param(BayesianLinearSurrogate, {"fit_intercept": True}, id="lin_3"),
+    ],
+)
+def test_valid_model_params(model_cls, params):
+    """Ensure valid model_params can be set."""
+    model_cls(model_params=params)
+
+
+@pytest.mark.parametrize(
+    "model_cls, params",
+    [
+        param(RandomForestSurrogate, {"n_estimators": 5.3}, id="rf_float_not_int"),
+        param(
+            RandomForestSurrogate,
+            {"criterion": "squared_error123"},
+            id="rf_wrong_literal",
+        ),
+        param(RandomForestSurrogate, {"max_features": True}, id="rf_unsupported_bool"),
+        param(
+            RandomForestSurrogate, {"min_samples_split": None}, id="rf_unsupported_none"
+        ),
+        param(RandomForestSurrogate, {"bla": None}, id="rf_extra_key"),
+        param(NGBoostSurrogate, {"n_estimators": 5.3}, id="ng_float_not_int"),
+        param(NGBoostSurrogate, {"learning_rate": 4}, id="ng_int_not_float"),
+        param(NGBoostSurrogate, {"verbose": 1.0}, id="ng_float_not_bool"),
+        param(
+            NGBoostSurrogate, {"early_stopping_rounds": 3.4}, id="ng_unsupported_float"
+        ),
+        param(NGBoostSurrogate, {"col_sample": None}, id="ng_unsupported_none"),
+        param(NGBoostSurrogate, {"bla": 3.4}, id="ng_extra_key"),
+        param(BayesianLinearSurrogate, {"max_iter": 10.3}, id="lin_float_not_int"),
+        param(BayesianLinearSurrogate, {"alpha_1": 4}, id="lin_int_not_float"),
+        param(BayesianLinearSurrogate, {"fit_intercept": 0.0}, id="lin_float_not_bool"),
+        param(BayesianLinearSurrogate, {"copy_X": None}, id="lin_unsupported_none"),
+        param(BayesianLinearSurrogate, {"bla": 0.0}, id="lin_extra_key"),
+    ],
+)
+def test_invalid_model_params(model_cls, params):
+    """Ensure valid model_params cannot be set."""
+    with pytest.raises(TypeError, match="model_params"):
+        model_cls(model_params=params)


### PR DESCRIPTION
- Lazy-load `scikit-learn` and `scipy`
- This required changes to how the optional `model_params` are validated for `RandomForestSurrogate`, `NGBoostSurrogate` and `BayesianLinearSurrogate`. These are now checked against a hardcoded `TypedDict`
- A few things were required to make it work. E.g. cattrs does not complain if `123.3` is provided for a field that has `iunt`-only type hint as it cuts the float and considers this valid. Hence I used a converter thats more strict via custom structure hooks. This is not entirely perfect, as eg the basic baybe constructor is not that strict, hence its possible to bypass this strictness of an object is created from a json_string
- I've moved the onnx model instantiation to the point where its needed. This means the onnx string is not validated anymore and would fail at runtime -> the price to pay for making the dependency uninstallable. This is in one commit so can be removed again easily

I've verified that I can validate configs after doing
```terminal
pip install '.[extras]' && pip uninstall -y torch botorch grpcio polars pyarrow scikit-image scipy onnxruntime onnx sympy scikit-learn scipy matplotlib
```
causing this package footprint whilst maintaining the ability to validate configs:
```terminal
 93M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/rdkit
 87M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/llvmlite
 60M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/pandas
 30M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/numpy
 24M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/numba
 16M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/fontTools
 14M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/networkx
 12M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/xarray
 12M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/dask
 11M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/pip
 11M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/PIL
 10M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/h5py
9.5M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/descriptastorus
8.4M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/setuptools
5.7M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/pyro
3.8M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/mpmath
3.8M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/huggingface_hub
3.5M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/google
3.3M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/opentelemetry
3.0M    /Users/XYZ/mambaforge/envs/baybe-BLA/lib/python3.10/site-packages/rdkit-stubs
```
 