### PR TITLE
Extend onnx monkeypatch

### DIFF
--- a/baybe/__init__.py
+++ b/baybe/__init__.py
@@ -1,11 +1,28 @@
 """BayBE — A Bayesian Back End for Design of Experiments."""
 
+import sys
 import warnings
 
 from baybe.campaign import Campaign
 
 # Show deprecation warnings
 warnings.filterwarnings("default", category=DeprecationWarning, module="baybe")
+
+
+# >>>>> Temporary monkeypatch for onnx >>>>>
+# 1) Ensures that the patch is applied when baybe is imported first
+class CustomImporter:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "skl2onnx":
+            from baybe._optional.onnx import patch_onnx  # noqa
+
+
+sys.meta_path.insert(0, CustomImporter())
+
+# 2) Ensures that the patch is applied when skl2onnx is imported first
+if "onnx" in sys.modules:
+    from baybe._optional.onnx import patch_onnx  # noqa
+# <<<<<<<<<<
 
 
 def infer_version() -> str:  # pragma: no cover

--- a/baybe/_optional/onnx.py
+++ b/baybe/_optional/onnx.py
@@ -4,20 +4,26 @@ from packaging.version import Version
 
 from baybe.exceptions import OptionalImportError
 
-try:
-    import onnx
-    import onnxruntime
 
-    # NOTE: In version 1.18.0, the function `onnx.helper.split_complex_to_pairs` was
-    # replaced by the "private" function `_split_complex_to_pairs`.
-    # Not all dependencies, in particulat "skl2onnx" have been updated to use the
-    # new function.
-    # This is a temporary fix until all dependencies are updated.
-    onnx_version = onnx.__version__
-    if Version(onnx_version) >= Version("1.18.0"):
+def patch_onnx():
+    """Monkeypatch onnx module to fix backward compatibility issues."""
+    # NOTE: In version 1.18.0, the function `onnx.helper.split_complex_to_pairs`
+    #   became private, resulting in a backward-incompatible change.
+    #   Because not all consuming packages (e.g. "skl2onnx") have been updated,
+    #   we temporarily monkeypatch the module.
+
+    import onnx
+
+    if Version(onnx.__version__) >= Version("1.18.0"):
         from onnx.helper import _split_complex_to_pairs
 
         onnx.helper.split_complex_to_pairs = _split_complex_to_pairs
+
+
+try:
+    import onnxruntime
+
+    patch_onnx()
 except ModuleNotFoundError as ex:
     raise OptionalImportError(name="onnxruntime", group="onnx") from ex
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,16 +888,6 @@ def fixture_default_simplex_config():
 @pytest.fixture(name="onnx_str")
 def fixture_default_onnx_str() -> bytes:
     """The default ONNX model string to be used if not specified differently."""
-    # NOTE: In version 1.18.0 of `onnx`, the function
-    # `onnx.helper.split_complex_to_pairs` was removed.
-    # This requires us to do some monkeypatching in the baybe._optional.onnx, and we
-    # refer to this place if you are interested in the details.
-    # Since using this fixture imports "skl2onnx", we need to ensure that this
-    # monkeypatching is done before this import, hence we do the additional import here.
-    # Note that this is only a temporary fix until all dependencies are updated to use
-    # the new function.
-    import baybe._optional.onnx  # noqa: F401, I001
-
     from skl2onnx import convert_sklearn
     from skl2onnx.common.data_types import FloatTensorType
     from sklearn.linear_model import BayesianRidge


### PR DESCRIPTION
This PR extends #555 in that the monkeypatch now fixes both cases:
1) baybe imported first, then skl2onnx imported  
2) skl2onnx imported first, then baybe imported 

The second fix was missing, which had the consequence that the onnx example script did not run.

Note: I've also tried to fix the general case where skl2onnx is imported without any actual baybe import. This happens, for example, in the fixture considered in #555 but there we're lucky because conftest.py imports baybe in the outer scope. But there could be cases where a user write s similar code like in the fixture, without having the baybe import. Played around with `sitecustomize.py` with the intention to apply the monkeypatch at baybe install time, but couldn't make it work. 
Anyway, there is hopfully a proper fix from the skl2onnx side soon.