### PR TITLE
Add missing decorator return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   minimization of the acquisition function
 - Added missing garbage collection call to `pareto.py`, potentially solving serialization
   issues in certain cases
+- `catch_constant_targets` decorator is now properly typed
 
 ## [0.13.0] - 2025-04-16
 ### Added

--- a/baybe/surrogates/utils.py
+++ b/baybe/surrogates/utils.py
@@ -24,7 +24,9 @@ surrogate models that temporarily have a fallback attached because they were
 trained on constant training targets. Values are the corresponding fallback models."""
 
 
-def catch_constant_targets(cls: type[Surrogate], std_threshold: float = 1e-6):
+def catch_constant_targets(
+    cls: type[_TSurrogate], std_threshold: float = 1e-6
+) -> type[_TSurrogate]:
     """Make a ``Surrogate`` class robustly handle constant training targets.
 
     More specifically, "constant training targets" can mean either of:


### PR DESCRIPTION
A small typing improvement to enable static type checking and autocompletion of surrogates decorated with `catch_constant_targets`