### PR TITLE
Remove ONNX Workarounds

### DIFF
--- a/.lockfiles/py310-dev.lock
+++ b/.lockfiles/py310-dev.lock
@@ -465,7 +465,6 @@ numpy==2.2.6
     #   ngboost
     #   numba
     #   onnx
-    #   onnxconverter-common
     #   onnxruntime
     #   pandas
     #   pandas-stubs
@@ -523,10 +522,7 @@ nvidia-nvtx-cu12==12.6.77 ; platform_machine == 'x86_64' and sys_platform == 'li
 onnx==1.18.0
     # via
     #   baybe (pyproject.toml)
-    #   onnxconverter-common
     #   skl2onnx
-onnxconverter-common==1.13.0
-    # via skl2onnx
 onnxruntime==1.22.0
     # via baybe (pyproject.toml)
 openpyxl==3.1.5
@@ -587,7 +583,6 @@ packaging==24.2
     #   matplotlib
     #   mordredcommunity
     #   nbconvert
-    #   onnxconverter-common
     #   onnxruntime
     #   pip-audit
     #   pip-requirements-parser
@@ -671,7 +666,6 @@ protobuf==5.29.4
     # via
     #   googleapis-common-protos
     #   onnx
-    #   onnxconverter-common
     #   onnxruntime
     #   opentelemetry-proto
     #   streamlit
@@ -862,7 +856,7 @@ six==1.17.0
     #   pybtex
     #   python-dateutil
     #   rfc3339-validator
-skl2onnx==1.18.0
+skl2onnx==1.19.1
     # via baybe (pyproject.toml)
 slicer==0.0.8
     # via shap

--- a/examples/Custom_Surrogates/custom_pretrained.py
+++ b/examples/Custom_Surrogates/custom_pretrained.py
@@ -8,21 +8,6 @@
 
 ### Necessary imports
 
-from packaging.version import Version
-
-# NOTE: Due to some issues with depracated functions in onnx-related packages,
-# it is currently necessary to perform the following import.
-try:
-    import onnx
-
-    onnx_version = onnx.__version__
-    if Version(onnx_version) >= Version("1.18.0"):
-        from onnx.helper import _split_complex_to_pairs
-
-        onnx.helper.split_complex_to_pairs = _split_complex_to_pairs
-except ImportError as error:
-    raise error
-
 import numpy as np
 import torch
 from skl2onnx import convert_sklearn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ chem = [
 onnx = [
     "onnx>=1.16.0", # see AUDIT NOTE, required by skl2onnx
     "onnxruntime>=1.15.1",
-    "skl2onnx>=1.15.0",
+    "skl2onnx>=1.19.1",
 ]
 
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,12 +95,6 @@ if strtobool(os.getenv("CI", "false")):
 # https://docs.pytest.org/en/stable/reference/reference.html#pytest-fixture
 
 
-_onnx_issue = (
-    "Breaking change in onnx 0.18.0, which causes skl2onnx to fail. "
-    "Fix is already on the way: https://github.com/onnx/sklearn-onnx/pull/1181"
-)
-
-
 @pytest.fixture(scope="session", autouse=True)
 def disable_telemetry():
     """Disables telemetry during pytesting via fixture."""

--- a/tests/serialization/test_surrogate_serialization.py
+++ b/tests/serialization/test_surrogate_serialization.py
@@ -11,21 +11,8 @@ from baybe.surrogates.ngboost import NGBoostSurrogate
 from baybe.surrogates.random_forest import RandomForestSurrogate
 from baybe.utils.basic import get_subclasses
 
-from ..conftest import _onnx_issue
 
-
-@pytest.mark.parametrize(
-    "surrogate_cls",
-    [
-        pytest.param(
-            s,
-            marks=[pytest.mark.xfail(reason=_onnx_issue, strict=True)]
-            if issubclass(s, CustomONNXSurrogate)
-            else [],
-        )
-        for s in get_subclasses(Surrogate)
-    ],
-)
+@pytest.mark.parametrize("surrogate_cls", get_subclasses(Surrogate))
 def test_surrogate_serialization(request, surrogate_cls):
     """A serialization roundtrip yields an equivalent object."""
     if issubclass(surrogate_cls, CustomONNXSurrogate):

--- a/tests/test_custom_surrogate.py
+++ b/tests/test_custom_surrogate.py
@@ -9,10 +9,7 @@ from baybe._optional.info import ONNX_INSTALLED
 from baybe.surrogates import CustomONNXSurrogate
 from tests.conftest import run_iterations
 
-from .conftest import _onnx_issue
 
-
-@pytest.mark.xfail(reason=_onnx_issue, strict=True)
 @pytest.mark.skipif(
     not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
 )
@@ -40,7 +37,6 @@ def test_invalid_onnx_str():
         CustomONNXSurrogate(onnx_input_name="input", onnx_str=b"onnx_str")
 
 
-@pytest.mark.xfail(reason=_onnx_issue, strict=True)
 @pytest.mark.skipif(
     not ONNX_INSTALLED, reason="Optional onnx dependency not installed."
 )


### PR DESCRIPTION
recently we had to introduce workarounds due to [an issue with onnx and sklearn-onnx](https://github.com/onnx/sklearn-onnx/pull/1181)
[Since these are fixed now](https://github.com/onnx/sklearn-onnx/releases/tag/v1.19.1) I'm
- removing the workarounds
- bumping the version requirement for the package
