### PR TITLE
Fix/overlapping target parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `Campaign` no longer allows overlapping names between parameters and targets
+
 ## [0.13.2] - 2025-07-09
 ### Changed
 - Lockfiles are now generated using `uv lock` and consumed using `uv sync`

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -126,6 +126,22 @@ class Campaign(SerialMixin):
     When passing a :class:`baybe.targets.base.Target`, conversion to
     :class:`baybe.objectives.single.SingleTargetObjective` is automatically applied."""
 
+    @objective.validator
+    def _validate_objective(  # noqa: DOC101, DOC103
+        self, _: Any, value: Objective | None
+    ) -> None:
+        """Validate no overlapping names between target and parameter names."""
+        if value is None:
+            return
+
+        p_names = {p.name for p in self.searchspace.parameters}
+        t_names = {t.name for t in value.targets}
+        if overlap := p_names.intersection(t_names):
+            raise ValueError(
+                f"Parameters and targets cannot have overlapping names. "
+                f"The following names appear in both collections: {overlap}."
+            )
+
     recommender: RecommenderProtocol = field(
         factory=TwoPhaseMetaRecommender,
         validator=instance_of(RecommenderProtocol),

--- a/tests/validation/test_campaign_validation.py
+++ b/tests/validation/test_campaign_validation.py
@@ -1,0 +1,28 @@
+"""Validation tests for Campaign."""
+
+import pytest
+
+from baybe import Campaign
+from baybe.objectives import ParetoObjective
+from baybe.parameters import NumericalDiscreteParameter
+from baybe.searchspace import SearchSpace
+from baybe.targets import NumericalTarget
+
+
+def test_overlapping_target_parameter_names():
+    """Overlapping names between parameters and targets are not allowed."""
+    targets = (
+        NumericalTarget("n1", "MAX"),
+        NumericalTarget("n2", "MAX"),
+        NumericalTarget("n3", "MAX"),
+    )
+    parameters = (
+        NumericalDiscreteParameter("n1", [1, 2, 3]),
+        NumericalDiscreteParameter("dies", [4, 5, 6]),
+        NumericalDiscreteParameter("n2", [7, 8, 9]),
+    )
+    searchspace = SearchSpace.from_product(parameters)
+    objective = ParetoObjective(targets)
+
+    with pytest.raises(ValueError, match="appear in both collections: {'n2', 'n1'}."):
+        Campaign(searchspace=searchspace, objective=objective)


### PR DESCRIPTION
A fix for the minor issue described in #571 

This fix is only partial, depending on the view point (see Issue)