### PR TITLE
Composite transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `transformations` subpackage 
 - New `NumericalTarget` interface, including advanced machinery for defining and
-  manipulating target transformations based on the new `transformations` subpackage
+  manipulating target transformations based on the new `Transformation` class hierarchy
 - `match_bell` and `match_triangular` convenience constructors to `NumericalTarget`
   for reproducing the legacy `MATCH` modes
 - `normalize_ramp` convenience constructor to `NumericalTarget` for reproducing the
@@ -42,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The Python version specifier now also allows patch versions of Python 3.13
-
 
 ### Removed
 - Option to specify reference values for `add_fake_measurements`

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -124,7 +124,8 @@ class DesirabilityObjective(Objective):
                 f"Either normalize your targets (e.g. using their "
                 f"'{NumericalTarget.normalize.__name__}' method / by specifying "
                 f"a suitable target transformation) or explicitly set "
-                f"'{fields(DesirabilityObjective).require_normalization.name}' to "
+                f"'{DesirabilityObjective.__name__}."
+                f"{fields(DesirabilityObjective).require_normalization.name}' to "
                 f"'True' to allow unnormalized targets."
             )
 

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -18,6 +18,7 @@ from baybe.objectives.base import Objective
 from baybe.objectives.enum import Scalarizer
 from baybe.objectives.validation import validate_target_names
 from baybe.targets import NumericalTarget
+from baybe.targets.numerical import UncertainBool
 from baybe.utils.basic import to_tuple
 from baybe.utils.conversion import to_string
 from baybe.utils.dataframe import get_transform_objects, pretty_print_df, to_tensor
@@ -100,7 +101,7 @@ class DesirabilityObjective(Objective):
     def _validate_targets(self, _, targets) -> None:  # noqa: DOC101, DOC103
         # Validate non-negativity when using geometric mean
         if self.scalarizer is Scalarizer.GEOM_MEAN and (
-            negative := {t.name for t in targets if t.get_image().lower < 0}
+            negative := {t.name for t in targets if t.get_codomain().lower < 0}
         ):
             raise ValueError(
                 f"Using '{Scalarizer.GEOM_MEAN}' for '{self.__class__.__name__}' "
@@ -111,12 +112,16 @@ class DesirabilityObjective(Objective):
 
         # Validate normalization
         if self.require_normalization and (
-            unnormalized := {t.name for t in targets if not t.is_normalized}
+            unnormalized := {
+                t.name for t in targets if t.is_normalized is not UncertainBool.TRUE
+            }
         ):
             raise ValueError(
                 f"By default, '{self.__class__.__name__}' only accepts normalized "
-                f"targets but the following targets are not normalized: "
-                f"{unnormalized}. Either normalize your targets (e.g. using their "
+                f"targets but the following targets are either not normalized or their "
+                f"normalization status is unclear because the image "
+                f"of the underlying transformation is unknown: {unnormalized}. "
+                f"Either normalize your targets (e.g. using their "
                 f"'{NumericalTarget.normalize.__name__}' method / by specifying "
                 f"a suitable target transformation) or explicitly set "
                 f"'{fields(DesirabilityObjective).require_normalization.name}' to "

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -320,7 +320,7 @@ class NumericalTarget(Target, SerialMixin):
             name: The name of the target.
             match_value: The value to be matched.
             sigma: The scale parameter controlling the width of the bell curve. For more
-                details, see :class:`baybe.transformations.core.BellTransformation`.
+                details, see :class:`baybe.transformations.basic.BellTransformation`.
 
         Returns:
             The target with applied bell matching transformation.
@@ -360,7 +360,7 @@ class NumericalTarget(Target, SerialMixin):
 
         Args:
             name: The name of the target.
-            anchors: See :class:`baybe.transformations.core.SigmoidTransformation`.
+            anchors: See :class:`baybe.transformations.basic.SigmoidTransformation`.
 
         Returns:
             The target with applied sigmoid transformation.

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -413,21 +413,16 @@ class NumericalTarget(Target, SerialMixin):
         """
         return self._append_transformation(AffineTransformation(factor=-1))
 
-    def normalize(self, codomain: bool = False) -> NumericalTarget:
+    def normalize(self) -> NumericalTarget:
         """Normalize the target to the unit interval using an affine transformation.
 
-        Args:
-            codomain: Boolean flag controlling if the image or the codomain of the
-                target should be normalized.
-
         Raises:
-            IncompatibilityError: If the target image or codomain (depending on the
-                flag) is not bounded.
+            IncompatibilityError: If the target image is not bounded.
 
         Returns:
             The normalized target.
         """
-        bounds = self.get_codomain() if codomain else self.get_image()
+        bounds = self.get_image()
         if not bounds.is_bounded:
             raise IncompatibilityError("Only bounded targets can be normalized.")
 

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -36,6 +36,7 @@ from baybe.transformations import (
     TriangularTransformation,
     convert_transformation,
 )
+from baybe.utils.basic import UncertainBool
 from baybe.utils.interval import ConvertibleToInterval, Interval
 
 
@@ -368,9 +369,11 @@ class NumericalTarget(Target, SerialMixin):
         return NumericalTarget(name, SigmoidTransformation.from_anchors(anchors))
 
     @property
-    def is_normalized(self) -> bool:
+    def is_normalized(self) -> UncertainBool:
         """Boolean flag indicating if the target is normalized to the unit interval."""
-        return self.get_image() == Interval(0, 1)
+        return UncertainBool.from_erroneous_callable(
+            lambda: self.get_image() == Interval(0, 1)
+        )
 
     @property
     def total_transformation(self) -> Transformation:
@@ -378,8 +381,12 @@ class NumericalTarget(Target, SerialMixin):
         tr = self._transformation
         return self._transformation if not self.minimize else tr.negate()
 
+    def get_codomain(self, interval: Interval | None = None, /) -> Interval:
+        """Get the codomain of an interval (assuming transformation continuity)."""
+        return self.total_transformation.get_codomain(interval)
+
     def get_image(self, interval: Interval | None = None, /) -> Interval:
-        """Get the image of a certain interval (assuming transformation continuity)."""
+        """Get the image of an interval (assuming transformation continuity)."""
         return self.total_transformation.get_image(interval)
 
     def _append_transformation(self, transformation: Transformation) -> NumericalTarget:

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -413,21 +413,27 @@ class NumericalTarget(Target, SerialMixin):
         """
         return self._append_transformation(AffineTransformation(factor=-1))
 
-    def normalize(self) -> NumericalTarget:
+    def normalize(self, codomain: bool = False) -> NumericalTarget:
         """Normalize the target to the unit interval using an affine transformation.
 
+        Args:
+            codomain: Boolean flag controlling if the image or the codomain of the
+                target should be normalized.
+
         Raises:
-            IncompatibilityError: If the target is not bounded.
+            IncompatibilityError: If the target image or codomain (depending on the
+                flag) is not bounded.
 
         Returns:
             The normalized target.
         """
-        if not self.get_image().is_bounded:
+        bounds = self.get_codomain() if codomain else self.get_image()
+        if not bounds.is_bounded:
             raise IncompatibilityError("Only bounded targets can be normalized.")
 
         return self._append_transformation(
             AffineTransformation.from_points_mapped_to_unit_interval_bounds(
-                *self.get_image().to_tuple()
+                *bounds.to_tuple()
             )
         )
 

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -223,7 +223,7 @@ class NumericalTarget(Target, SerialMixin):
         """
         return NumericalTarget(
             name,
-            AffineTransformation(shift=-match_value) + AbsoluteTransformation(),
+            AffineTransformation(shift=-match_value) | AbsoluteTransformation(),
             minimize=True,
         )
 
@@ -257,8 +257,8 @@ class NumericalTarget(Target, SerialMixin):
         return NumericalTarget(
             name,
             AffineTransformation(shift=-match_value)
-            + AbsoluteTransformation()
-            + PowerTransformation(exponent),
+            | AbsoluteTransformation()
+            | PowerTransformation(exponent),
             minimize=True,
         )
 

--- a/baybe/transformations/__init__.py
+++ b/baybe/transformations/__init__.py
@@ -15,7 +15,11 @@ from baybe.transformations.basic import (
     TriangularTransformation,
     TwoSidedAffineTransformation,
 )
-from baybe.transformations.composite import ChainedTransformation
+from baybe.transformations.composite import (
+    AdditiveTransformation,
+    ChainedTransformation,
+    MultiplicativeTransformation,
+)
 from baybe.transformations.utils import (
     combine_affine_transformations,
     compress_transformations,
@@ -27,12 +31,11 @@ __all__ = [
     # ------------
     "MonotonicTransformation",
     "Transformation",
-    # Core transformations
+    # Basic transformations
     # --------------------
     "AbsoluteTransformation",
     "AffineTransformation",
     "BellTransformation",
-    "ChainedTransformation",
     "ClampingTransformation",
     "CustomTransformation",
     "ExponentialTransformation",
@@ -42,6 +45,11 @@ __all__ = [
     "SigmoidTransformation",
     "TriangularTransformation",
     "TwoSidedAffineTransformation",
+    # Composite transformations
+    # -----------------------
+    "AdditiveTransformation",
+    "ChainedTransformation",
+    "MultiplicativeTransformation",
     # Utilities
     # ---------
     "combine_affine_transformations",

--- a/baybe/transformations/__init__.py
+++ b/baybe/transformations/__init__.py
@@ -1,11 +1,10 @@
 """BayBE transformations."""
 
 from baybe.transformations.base import MonotonicTransformation, Transformation
-from baybe.transformations.core import (
+from baybe.transformations.basic import (
     AbsoluteTransformation,
     AffineTransformation,
     BellTransformation,
-    ChainedTransformation,
     ClampingTransformation,
     CustomTransformation,
     ExponentialTransformation,
@@ -16,6 +15,7 @@ from baybe.transformations.core import (
     TriangularTransformation,
     TwoSidedAffineTransformation,
 )
+from baybe.transformations.composite import ChainedTransformation
 from baybe.transformations.utils import (
     combine_affine_transformations,
     compress_transformations,

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -51,7 +51,7 @@ class Transformation(SerialMixin, ABC):
 
     def negate(self) -> Transformation:
         """Negate the output of the transformation."""
-        from baybe.transformations.core import AffineTransformation
+        from baybe.transformations.basic import AffineTransformation
 
         return self + AffineTransformation(factor=-1)
 
@@ -63,24 +63,24 @@ class Transformation(SerialMixin, ABC):
             raise ValueError(
                 "A clamping transformation requires at least one finite boundary value."
             )
-        from baybe.transformations.core import ClampingTransformation
+        from baybe.transformations.basic import ClampingTransformation
 
         return self + ClampingTransformation(min, max)
 
     def abs(self) -> Transformation:
         """Take the absolute value of the output of the transformation."""
-        from baybe.transformations.core import AbsoluteTransformation
+        from baybe.transformations.basic import AbsoluteTransformation
 
         return self + AbsoluteTransformation()
 
     def __add__(self, other: Transformation | int | float) -> Transformation:
         """Chain another transformation or shift the output of the current one."""
-        from baybe.transformations.core import (
+        from baybe.transformations import (
             AffineTransformation,
             ChainedTransformation,
             IdentityTransformation,
+            combine_affine_transformations,
         )
-        from baybe.transformations.utils import combine_affine_transformations
 
         if isinstance(other, IdentityTransformation):
             return self
@@ -95,7 +95,7 @@ class Transformation(SerialMixin, ABC):
     def __mul__(self, other: int | float) -> Transformation:
         """Scale the output of the transformation."""
         if isinstance(other, (int, float)):
-            from baybe.transformations.core import AffineTransformation
+            from baybe.transformations.basic import AffineTransformation
 
             return self + AffineTransformation(factor=other)
         return NotImplemented
@@ -111,7 +111,7 @@ class Transformation(SerialMixin, ABC):
                 "if the transformation enters as the only (positional) argument."
             )
 
-        from baybe.transformations.core import CustomTransformation
+        from baybe.transformations.basic import CustomTransformation
 
         return args[0] + CustomTransformation(func)
 

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -122,7 +122,7 @@ class Transformation(SerialMixin, ABC):
         if isinstance(other, (int, float)):
             from baybe.transformations import AffineTransformation
 
-            return self | AffineTransformation(shift=other)
+            return self | AffineTransformation(factor=other)
         return NotImplemented
 
     def __or__(self, other: Transformation) -> Transformation:

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -73,8 +73,24 @@ class Transformation(SerialMixin, ABC):
 
         return self | AbsoluteTransformation()
 
-    def __add__(self, other: int | float) -> Transformation:
-        """Shift the output of the transformation."""
+    def __add__(self, other: Transformation | int | float) -> Transformation:
+        """Add a constant or the output from another transformation."""
+        if isinstance(other, Transformation):
+            from baybe.transformations import AdditiveTransformation
+
+            return AdditiveTransformation([self, other])
+        if isinstance(other, (int, float)):
+            from baybe.transformations import AffineTransformation
+
+            return self | AffineTransformation(shift=other)
+        return NotImplemented
+
+    def __mul__(self, other: Transformation | int | float) -> Transformation:
+        """Multiply with a constant or the output from another transformation."""
+        if isinstance(other, Transformation):
+            from baybe.transformations import MultiplicativeTransformation
+
+            return MultiplicativeTransformation([self, other])
         if isinstance(other, (int, float)):
             from baybe.transformations import AffineTransformation
 
@@ -96,14 +112,6 @@ class Transformation(SerialMixin, ABC):
             return combine_affine_transformations(*t)
         if isinstance(other, Transformation):
             return ChainedTransformation([self, other])
-        return NotImplemented
-
-    def __mul__(self, other: int | float) -> Transformation:
-        """Scale the output of the transformation."""
-        if isinstance(other, (int, float)):
-            from baybe.transformations.basic import AffineTransformation
-
-            return self | AffineTransformation(factor=other)
         return NotImplemented
 
     @classmethod

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -98,7 +98,7 @@ class Transformation(SerialMixin, ABC):
         return NotImplemented
 
     def __or__(self, other: Transformation) -> Transformation:
-        """Chain the transformation with another one."""
+        """Chain the transformation with another one. Inspired by the Unix "pipe"."""
         from baybe.transformations import (
             AffineTransformation,
             ChainedTransformation,

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -74,7 +74,7 @@ class Transformation(SerialMixin, ABC):
         return self | AbsoluteTransformation()
 
     def __add__(self, other: Transformation | int | float) -> Transformation:
-        """Add a constant or the output from another transformation."""
+        """Add a constant or the output of another transformation."""
         if isinstance(other, Transformation):
             from baybe.transformations import AdditiveTransformation
 
@@ -86,7 +86,7 @@ class Transformation(SerialMixin, ABC):
         return NotImplemented
 
     def __mul__(self, other: Transformation | int | float) -> Transformation:
-        """Multiply with a constant or the output from another transformation."""
+        """Multiply with a constant or the output of another transformation."""
         if isinstance(other, Transformation):
             from baybe.transformations import MultiplicativeTransformation
 

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -22,7 +22,7 @@ _TTransformation = TypeVar("_TTransformation", bound="Transformation")
 
 def _image_equals_codomain(cls: type[_TTransformation], /) -> type[_TTransformation]:
     """Make the image of a transformation identical to its codomain."""
-    cls.get_image = cls.get_codomain
+    cls.get_image = cls.get_codomain  # type: ignore[method-assign]
     return cls
 
 

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -38,11 +38,14 @@ class Transformation(SerialMixin, ABC):
     def get_codomain(self, interval: Interval | None = None, /) -> Interval:
         """Get the codomain of a certain interval (assuming transformation continuity).
 
-        We use a slightly generalized definition of a function's
-        `codomain <https://en.wikipedia.org/wiki/Codomain>`_ here, which extends
-        to arbitrary intervals. Like the image of an interval obtained under a given
-        function, we define the codomain of that interval to be any suitable
-        superset of its image, i.e. an interval that contains the image.
+        In accordance with the mathematical definition of a function's `codomain
+        <https://en.wikipedia.org/wiki/Codomain>`_, we define the codomain of a given
+        :class:`~baybe.utils.interval.Interval` under a certain (assumed continuous)
+        :class:`~Transformation` to be an :class:`~baybe.utils.interval.Interval`
+        guaranteed to contain all possible outcomes when the :class:`~Transformation` is
+        applied to all points in the input :class:`~baybe.utils.interval.Interval`. In
+        cases where the image cannot exactly be computed, it is often still possible to
+        compute a codomain. The codomain always contains the image, but might be larger.
         """
 
     def get_image(self, interval: Interval | None = None, /) -> Interval:

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -61,10 +61,10 @@ class IdentityTransformation(MonotonicTransformation):
         return x
 
     @override
-    def __add__(self, other: Transformation | int | float) -> Transformation:
-        if isinstance(other, (int, float)):
-            return AffineTransformation(shift=other)
-        return other
+    def __or__(self, other: Transformation) -> Transformation:
+        if isinstance(other, Transformation):
+            return other
+        return NotImplemented
 
 
 @define(init=False)

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -109,15 +109,13 @@ class AffineTransformation(MonotonicTransformation):
 
     @override
     def __eq__(self, other: Any, /) -> bool:
-        # An affine transformation without shift and scaling is effectively an
-        # identity transformation
-        if (
-            isinstance(other, IdentityTransformation)
-            and self.factor == 1.0
-            and self.shift == 0.0
-        ):
-            return True
-        return super().__eq__(other)
+        if isinstance(other, IdentityTransformation):
+            # An affine transformation without shift and scaling is effectively an
+            # identity transformation
+            return self.factor == 1.0 and self.shift == 0.0
+        if isinstance(other, AffineTransformation):
+            return self.factor == other.factor and self.shift == other.shift
+        return NotImplemented
 
     def to_botorch_posterior_transform(self) -> AffinePosteriorTransform:
         """Convert to BoTorch posterior transform.

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -29,10 +29,13 @@ class ChainedTransformation(Transformation):
 
     @override
     def __eq__(self, other: Any, /) -> bool:
-        # A chained transformation with only one element is equivalent to that element
         if len(self.transformations) == 1:
+            # A chained transformation with only one element is equivalent to that
+            # element
             return self.transformations[0] == other
-        return super().__eq__(other)
+        if isinstance(other, ChainedTransformation):
+            return self.transformations == other.transformations
+        return NotImplemented
 
     @override
     def get_codomain(self, interval: Interval | None = None, /) -> Interval:

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -1,0 +1,44 @@
+"""Composite transformations."""
+
+from functools import reduce
+from typing import Any
+
+from attrs import define, field
+from attrs.validators import deep_iterable, instance_of, min_len
+from torch import Tensor
+from typing_extensions import override
+
+from baybe.transformations.base import Transformation
+from baybe.transformations.utils import compress_transformations
+from baybe.utils.basic import compose
+from baybe.utils.interval import Interval
+
+
+@define
+class ChainedTransformation(Transformation):
+    """A chained transformation composing several individual transformations."""
+
+    transformations: tuple[Transformation, ...] = field(
+        converter=compress_transformations,
+        validator=[
+            min_len(1),
+            deep_iterable(member_validator=instance_of(Transformation)),
+        ],
+    )
+    """The transformations to be composed."""
+
+    @override
+    def __eq__(self, other: Any, /) -> bool:
+        # A chained transformation with only one element is equivalent to that element
+        if len(self.transformations) == 1:
+            return self.transformations[0] == other
+        return super().__eq__(other)
+
+    @override
+    def get_image(self, interval: Interval | None = None, /) -> Interval:
+        interval = Interval.create(interval)
+        return reduce(lambda acc, t: t.get_image(acc), self.transformations, interval)
+
+    @override
+    def __call__(self, x: Tensor, /) -> Tensor:
+        return compose(*(t.__call__ for t in self.transformations))(x)

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from baybe.transformations.base import Transformation
 from baybe.transformations.utils import compress_transformations
-from baybe.utils.basic import compose
+from baybe.utils.basic import compose, to_tuple
 from baybe.utils.interval import Interval
 
 
@@ -59,7 +59,7 @@ class AdditiveTransformation(Transformation):
     """A transformation implementing the sum of two transformations."""
 
     transformations: tuple[Transformation, Transformation] = field(
-        converter=tuple,
+        converter=to_tuple,
         validator=deep_iterable(
             iterable_validator=and_(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),
@@ -84,7 +84,7 @@ class MultiplicativeTransformation(Transformation):
     """A transformation implementing the product of two transformations."""
 
     transformations: tuple[Transformation, Transformation] = field(
-        converter=tuple,
+        converter=to_tuple,
         validator=deep_iterable(
             iterable_validator=and_(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -59,6 +59,12 @@ class AdditiveTransformation(Transformation):
 
     @override
     def get_image(self, interval: Interval | None = None, /) -> Interval:
+        # NOTE: This only provides a conservative estimate of the image in that it
+        #   computes an "upper bound" (i.e. an interval that contains the actual image),
+        #   which is produced under the assumption that the extremal values of the two
+        #   individual transformations occur at the same input value. Computing the
+        #   exact image without additional information would require evaluating the
+        #   transformation on the entire (uncountable) input space, which is infeasible.
         interval = Interval.create(interval)
         im1 = self.transformations[0].get_image(interval)
         im2 = self.transformations[1].get_image(interval)
@@ -84,6 +90,12 @@ class MultiplicativeTransformation(Transformation):
 
     @override
     def get_image(self, interval: Interval | None = None, /) -> Interval:
+        # NOTE: This only provides a conservative estimate of the image in that it
+        #   computes an "upper bound" (i.e. an interval that contains the actual image),
+        #   which is produced under the assumption that the extremal values of the two
+        #   individual transformations occur at the same input value. Computing the
+        #   exact image without additional information would require evaluating the
+        #   transformation on the entire (uncountable) input space, which is infeasible.
         interval = Interval.create(interval)
         im1 = self.transformations[0].get_image(interval)
         im2 = self.transformations[1].get_image(interval)

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -4,7 +4,7 @@ from functools import reduce
 from typing import Any
 
 from attrs import define, field
-from attrs.validators import deep_iterable, instance_of, min_len
+from attrs.validators import and_, deep_iterable, instance_of, max_len, min_len
 from torch import Tensor
 from typing_extensions import override
 
@@ -51,7 +51,7 @@ class AdditiveTransformation(Transformation):
     transformations: tuple[Transformation, Transformation] = field(
         converter=tuple,
         validator=deep_iterable(
-            iterable_validator=min_len(2),
+            iterable_validator=and_(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),
         ),
     )
@@ -76,7 +76,7 @@ class MultiplicativeTransformation(Transformation):
     transformations: tuple[Transformation, Transformation] = field(
         converter=tuple,
         validator=deep_iterable(
-            iterable_validator=min_len(2),
+            iterable_validator=and_(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),
         ),
     )

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -1,17 +1,21 @@
 """Composite transformations."""
 
+from __future__ import annotations
+
 from functools import reduce
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from attrs import define, field
 from attrs.validators import and_, deep_iterable, instance_of, max_len, min_len
-from torch import Tensor
 from typing_extensions import override
 
 from baybe.transformations.base import Transformation
 from baybe.transformations.utils import compress_transformations
 from baybe.utils.basic import compose, to_tuple
 from baybe.utils.interval import Interval
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @define

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -65,7 +65,7 @@ class AdditiveTransformation(Transformation):
         interval = Interval.create(interval)
         im1 = self.transformations[0].get_codomain(interval)
         im2 = self.transformations[1].get_codomain(interval)
-        return Interval([im1.lower + im2.lower, im1.upper + im2.upper])
+        return Interval(im1.lower + im2.lower, im1.upper + im2.upper)
 
     @override
     def __call__(self, x: Tensor, /) -> Tensor:

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -8,13 +8,12 @@ from attrs.validators import and_, deep_iterable, instance_of, max_len, min_len
 from torch import Tensor
 from typing_extensions import override
 
-from baybe.transformations.base import Transformation, _image_equals_codomain
+from baybe.transformations.base import Transformation
 from baybe.transformations.utils import compress_transformations
 from baybe.utils.basic import compose
 from baybe.utils.interval import Interval
 
 
-@_image_equals_codomain
 @define
 class ChainedTransformation(Transformation):
     """A chained transformation composing several individual transformations."""
@@ -41,6 +40,11 @@ class ChainedTransformation(Transformation):
         return reduce(
             lambda acc, t: t.get_codomain(acc), self.transformations, interval
         )
+
+    @override
+    def get_image(self, interval: Interval | None = None, /) -> Interval:
+        interval = Interval.create(interval)
+        return reduce(lambda acc, t: t.get_image(acc), self.transformations, interval)
 
     @override
     def __call__(self, x: Tensor, /) -> Tensor:

--- a/baybe/transformations/utils.py
+++ b/baybe/transformations/utils.py
@@ -16,14 +16,14 @@ if TYPE_CHECKING:
 
 def convert_transformation(x: Transformation | TensorCallable, /) -> Transformation:
     """Autowrap a torch callable as transformation (with transformation passthrough)."""
-    from baybe.transformations.core import CustomTransformation
+    from baybe.transformations.basic import CustomTransformation
 
     return x if isinstance(x, Transformation) else CustomTransformation(x)
 
 
 def combine_affine_transformations(t1, t2, /):
     """Combine two affine transformations into one."""
-    from baybe.transformations.core import AffineTransformation
+    from baybe.transformations.basic import AffineTransformation
 
     return AffineTransformation(
         factor=t2.factor * t1.factor,
@@ -35,7 +35,7 @@ def _flatten_transformations(
     transformations: Iterable[Transformation], /
 ) -> Iterable[Transformation]:
     """Recursively flatten nested chained transformations."""
-    from baybe.transformations.core import ChainedTransformation
+    from baybe.transformations.composite import ChainedTransformation
 
     for t in transformations:
         if isinstance(t, ChainedTransformation):
@@ -57,7 +57,7 @@ def compress_transformations(
     Returns:
         The minimum sequence of transformations that is equivalent to the input.
     """
-    from baybe.transformations.core import AffineTransformation, IdentityTransformation
+    from baybe.transformations.basic import AffineTransformation, IdentityTransformation
 
     aggregated: list[Transformation] = []
     last = None

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -56,7 +56,7 @@ class UncertainBool(enum.Enum):
             raise TypeError(f"'{UncertainBool.UNKNOWN}' has no Boolean representation.")
 
     @classmethod
-    def from_erroneous_callable(cls, callable_: callable, /) -> UncertainBool:
+    def from_erroneous_callable(cls, callable_: Callable, /) -> UncertainBool:
         """Create an uncertain Boolean from a potentially erroneous Boolean call."""
         try:
             return cls.TRUE if callable_() else cls.FALSE

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -40,6 +40,30 @@ UNSPECIFIED = UnspecifiedType.UNSPECIFIED
 """Sentinel indicating an unspecified value when `None` is ambiguous."""
 
 
+class UncertainBool(enum.Enum):
+    """Enum for representing uncertain Boolean values."""
+
+    TRUE = "TRUE"
+    FALSE = "FALSE"
+    UNKNOWN = "UNKNOWN"
+
+    def __bool__(self):
+        if self is UncertainBool.TRUE:
+            return True
+        elif self is UncertainBool.FALSE:
+            return False
+        else:
+            raise TypeError(f"'{UncertainBool.UNKNOWN}' has no Boolean representation.")
+
+    @classmethod
+    def from_erroneous_callable(cls, callable_: callable, /) -> UncertainBool:
+        """Create an uncertain Boolean from a potentially erroneous Boolean call."""
+        try:
+            return cls.TRUE if callable_() else cls.FALSE
+        except Exception:
+            return cls.UNKNOWN
+
+
 @dataclass(frozen=True, repr=False)
 class Dummy:
     """Placeholder element for array-like data types.

--- a/tests/hypothesis_strategies/transformations.py
+++ b/tests/hypothesis_strategies/transformations.py
@@ -29,7 +29,7 @@ exponential_transformations = lambda: st.just(ExponentialTransformation())  # no
 
 @st.composite
 def clamping_transformations(draw: st.DrawFn) -> ClampingTransformation:
-    """Generate :class:`baybe.transformations.core.ClampingTransformation`."""
+    """Generate :class:`baybe.transformations.basic.ClampingTransformation`."""
     min = draw(st.floats(allow_nan=False, max_value=float("inf"), exclude_max=True))
     max = draw(st.floats(allow_nan=False, min_value=min, exclude_min=True))
     return ClampingTransformation(min, max)
@@ -37,7 +37,7 @@ def clamping_transformations(draw: st.DrawFn) -> ClampingTransformation:
 
 @st.composite
 def affine_transformations(draw: st.DrawFn) -> AffineTransformation:  # type: ignore[return]
-    """Generate :class:`baybe.transformations.core.AffineTransformation`."""
+    """Generate :class:`baybe.transformations.basic.AffineTransformation`."""
     factor = draw(finite_floats())
     shift = draw(finite_floats())
     shift_first = draw(st.booleans())
@@ -50,7 +50,7 @@ def affine_transformations(draw: st.DrawFn) -> AffineTransformation:  # type: ig
 
 @st.composite
 def two_sided_affine_transformations(draw: st.DrawFn) -> TwoSidedAffineTransformation:
-    """Generate :class:`baybe.transformations.core.TwoSidedAffineTransformation`."""
+    """Generate :class:`baybe.transformations.basic.TwoSidedAffineTransformation`."""
     slope_left = draw(finite_floats())
     slope_right = draw(finite_floats())
     center = draw(finite_floats())
@@ -59,7 +59,7 @@ def two_sided_affine_transformations(draw: st.DrawFn) -> TwoSidedAffineTransform
 
 @st.composite
 def bell_transformations(draw: st.DrawFn) -> BellTransformation:
-    """Generate :class:`baybe.transformations.core.BellTransformation`."""
+    """Generate :class:`baybe.transformations.basic.BellTransformation`."""
     center = draw(finite_floats())
     sigma = draw(positive_finite_floats())
     return BellTransformation(center=center, sigma=sigma)
@@ -67,7 +67,7 @@ def bell_transformations(draw: st.DrawFn) -> BellTransformation:
 
 @st.composite
 def triangular_transformations(draw: st.DrawFn) -> TriangularTransformation:  # type: ignore[return]
-    """Generate :class:`baybe.transformations.core.TriangularTransformation`."""
+    """Generate :class:`baybe.transformations.basic.TriangularTransformation`."""
     cutoffs = draw(intervals(exclude_fully_unbounded=True, exclude_half_bounded=True))
     try:
         peak = draw(
@@ -93,7 +93,7 @@ def triangular_transformations(draw: st.DrawFn) -> TriangularTransformation:  # 
 
 @st.composite
 def power_transformations(draw: st.DrawFn) -> PowerTransformation:
-    """Generate :class:`baybe.transformations.core.PowerTransformation`."""
+    """Generate :class:`baybe.transformations.basic.PowerTransformation`."""
     exponent = draw(st.integers(min_value=2))
     return PowerTransformation(exponent=exponent)
 
@@ -102,7 +102,7 @@ def power_transformations(draw: st.DrawFn) -> PowerTransformation:
 def chained_transformations(
     draw: st.DrawFn, min_size: int = 2, max_size: int = 3
 ) -> ChainedTransformation:
-    """Generate :class:`baybe.transformations.core.ChainedTransformation`."""
+    """Generate :class:`baybe.transformations.basic.ChainedTransformation`."""
     transformations = draw(
         st.lists(single_transformations, min_size=min_size, max_size=max_size)
     )

--- a/tests/serialization/test_objective_serialization.py
+++ b/tests/serialization/test_objective_serialization.py
@@ -9,8 +9,11 @@ from pytest import param
 
 from baybe.objectives.base import Objective
 from baybe.targets.base import Target
-from baybe.transformations.base import Transformation
-from baybe.transformations.core import ChainedTransformation, ClampingTransformation
+from baybe.transformations import (
+    ChainedTransformation,
+    ClampingTransformation,
+    Transformation,
+)
 from tests.hypothesis_strategies.objectives import (
     desirability_objectives,
     pareto_objectives,

--- a/tests/serialization/test_target_serialization.py
+++ b/tests/serialization/test_target_serialization.py
@@ -5,7 +5,7 @@ from hypothesis import given
 
 from baybe.targets.base import Target
 from baybe.targets.numerical import NumericalTarget
-from baybe.transformations.core import ClampingTransformation
+from baybe.transformations.basic import ClampingTransformation
 from tests.serialization.test_objective_serialization import (
     _get_involved_transformations,
 )

--- a/tests/serialization/test_transformation_serialization.py
+++ b/tests/serialization/test_transformation_serialization.py
@@ -5,8 +5,11 @@ import pytest
 from hypothesis import given
 from pytest import param
 
-from baybe.transformations import Transformation
-from baybe.transformations.core import ChainedTransformation, ClampingTransformation
+from baybe.transformations import (
+    ChainedTransformation,
+    ClampingTransformation,
+    Transformation,
+)
 
 from ..hypothesis_strategies.transformations import (
     absolute_transformations,

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -43,7 +43,7 @@ from baybe.targets._deprecated import (
     triangular_transform,
 )
 from baybe.targets.binary import BinaryTarget
-from baybe.transformations.core import AffineTransformation
+from baybe.transformations.basic import AffineTransformation
 
 
 def test_sequentialgreedyrecommender_class():

--- a/tests/test_objective.py
+++ b/tests/test_objective.py
@@ -12,6 +12,8 @@ from baybe.parameters.numerical import NumericalContinuousParameter
 from baybe.recommenders import BotorchRecommender
 from baybe.targets import NumericalTarget
 from baybe.transformations import ClampingTransformation
+from baybe.transformations.basic import IdentityTransformation
+from baybe.utils.interval import Interval
 
 
 class TestInvalidObjectiveCreation:
@@ -55,8 +57,22 @@ class TestInvalidObjectiveCreation:
         t2 = NumericalTarget("t2").clamp(min=0, max=3)
         with pytest.raises(ValueError, match="are not normalized"):
             DesirabilityObjective([t1, t2])
-        DesirabilityObjective([t1, t2], require_normalization=False)
         DesirabilityObjective([t1.normalize(), t2.normalize()])
+        DesirabilityObjective([t1, t2], require_normalization=False)
+
+    def test_unknown_target_images_for_desirability(self):
+        """Unknown target images are not allowed unless explicitly declared."""
+        # Create some targets with bounded codomain but unknown image
+        t = IdentityTransformation()
+        t1 = NumericalTarget.match_bell("t1", 0, 1)._append_transformation(t + t)
+        t2 = NumericalTarget.match_bell("t2", 0, 1)._append_transformation(t + t)
+        assert t1.get_codomain() == Interval(0, 2)
+
+        with pytest.raises(ValueError, match="normalization status is unclear"):
+            DesirabilityObjective([t1, t2], require_normalization=True)
+        with pytest.raises(NotImplementedError, match="cannot be computed"):
+            DesirabilityObjective([t1.normalize(), t2.normalize()])
+        DesirabilityObjective([t1, t2], require_normalization=False)
 
     def test_invalid_combination_function(self):
         with pytest.raises(ValueError):

--- a/tests/test_objective.py
+++ b/tests/test_objective.py
@@ -55,7 +55,7 @@ class TestInvalidObjectiveCreation:
         """Unnormalized targets are not allowed unless explicitly declared."""
         t1 = NumericalTarget("t1").clamp(min=1, max=2)
         t2 = NumericalTarget("t2").clamp(min=0, max=3)
-        with pytest.raises(ValueError, match="are not normalized"):
+        with pytest.raises(ValueError, match="are either not normalized"):
             DesirabilityObjective([t1, t2])
         DesirabilityObjective([t1.normalize(), t2.normalize()])
         DesirabilityObjective([t1, t2], require_normalization=False)

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -7,7 +7,7 @@ from pytest import param
 
 from baybe.exceptions import IncompatibilityError
 from baybe.targets.numerical import NumericalTarget
-from baybe.transformations.core import AffineTransformation
+from baybe.transformations.basic import AffineTransformation
 from baybe.utils.interval import Interval
 
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -36,8 +36,7 @@ def test_target_inversion():
     assert_series_equal(transformed, tii.transform(series))
 
 
-@pytest.mark.parametrize("codomain", [True, False])
-def test_target_normalization(codomain: bool, monkeypatch):
+def test_target_normalization(monkeypatch):
     """Target normalization works as expected."""
     # We artificially create some transform whose codomain does not coincide with the
     # image but is twice as broad.
@@ -51,16 +50,12 @@ def test_target_normalization(codomain: bool, monkeypatch):
 
     t = NumericalTarget("t")
     with pytest.raises(IncompatibilityError, match="Only bounded targets"):
-        t.normalize(codomain)
+        t.normalize()
 
     assert t.clamp(-2, 4).get_image() == Interval(-2, 4)
     assert t.clamp(-2, 4).get_codomain() == Interval(-4, 8)
-    if codomain:
-        assert t.clamp(-2, 4).normalize(codomain).get_image() != Interval(0, 1)
-        assert t.clamp(-2, 4).normalize(codomain).get_codomain() == Interval(0, 1)
-    else:
-        assert t.clamp(-2, 4).normalize(codomain).get_image() == Interval(0, 1)
-        assert t.clamp(-2, 4).normalize(codomain).get_codomain() != Interval(0, 1)
+    assert t.clamp(-2, 4).normalize().get_image() == Interval(0, 1)
+    assert t.clamp(-2, 4).normalize().get_codomain() != Interval(0, 1)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -59,19 +59,20 @@ def test_target_normalization(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "target",
+    ("target", "transformed_value"),
     [
-        param(NumericalTarget.match_bell("t", 2, 1), id="match"),
-        param(NumericalTarget.match_power("t", 2, 2), id="power"),
-        param(NumericalTarget.match_quadratic("t", 2), id="quadratic"),
-        param(NumericalTarget.match_absolute("t", 2), id="absolute"),
-        param(NumericalTarget.match_triangular("t", 2, width=40), id="triangular"),
+        param(NumericalTarget.match_bell("t", 2, 1), 1, id="bell"),
+        param(NumericalTarget.match_power("t", 2, 2), 0, id="power"),
+        param(NumericalTarget.match_quadratic("t", 2), 0, id="quadratic"),
+        param(NumericalTarget.match_absolute("t", 2), 0, id="absolute"),
+        param(NumericalTarget.match_triangular("t", 2, width=40), 1, id="triangular"),
     ],
 )
-def test_match_constructors(target):
+def test_match_constructors(target, transformed_value):
     """Larger distance to match values yields smaller transformed values."""
-    delta = [0.01, -0.02, 0.1, -0.2, 1, -2, 10, -20]
+    delta = [0, 0.01, -0.02, 0.1, -0.2, 1, -2, 10, -20]
     match_value = 2
 
     transformed = target.transform(pd.Series(delta) + match_value)
+    assert transformed[0] == transformed_value
     assert (transformed.diff().dropna() < 0).all()

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -50,9 +50,9 @@ def test_transformation_chaining(chained_first):
 
     expected = ChainedTransformation([t1, t2, t3, t1, t2])
     if chained_first:
-        actual = (c + t3) + c
+        actual = (c | t3) | c
     else:
-        actual = c + (t3 + c)
+        actual = c | (t3 | c)
     assert actual == expected
 
 
@@ -82,10 +82,10 @@ def test_affine_transformation_compression():
     """Compression of affine transformations works as expected."""
     t = IdentityTransformation()
 
-    t1 = t * 2 + 3 + t
+    t1 = t * 2 + 3 | t
     assert t1 == AffineTransformation(factor=2, shift=3)
 
-    t2 = (t + 3) * 2 + t
+    t2 = (t + 3) * 2 | t
     assert t2 == AffineTransformation(factor=2, shift=3, shift_first=True)
 
 
@@ -119,7 +119,7 @@ def test_transformation_addition(tensor):
         [AbsoluteTransformation(), AffineTransformation(shift=1)]
     )
     t2 = AbsoluteTransformation() + 1
-    t3 = AbsoluteTransformation() + AffineTransformation(shift=1)
+    t3 = AbsoluteTransformation() | AffineTransformation(shift=1)
 
     transformed = t1(tensor)
     assert torch.equal(transformed, t2(tensor))
@@ -132,7 +132,7 @@ def test_transformation_multiplication(tensor):
         [AbsoluteTransformation(), AffineTransformation(factor=2)]
     )
     t2 = AbsoluteTransformation() * 2
-    t3 = AbsoluteTransformation() + AffineTransformation(factor=2)
+    t3 = AbsoluteTransformation() | AffineTransformation(factor=2)
 
     transformed = t1(tensor)
     assert torch.equal(transformed, t2(tensor))
@@ -141,7 +141,7 @@ def test_transformation_multiplication(tensor):
 
 def test_torch_overloading(tensor):
     """Transformations can be passed to torch callables for chaining."""
-    t1 = AffineTransformation(factor=2) + CustomTransformation(torch.abs)
+    t1 = AffineTransformation(factor=2) | CustomTransformation(torch.abs)
     t2 = torch.abs(AffineTransformation(factor=2))
     torch.equal(t1(tensor), t2(tensor))
 
@@ -248,7 +248,7 @@ def test_affine_transformation_operator_order(series):
 def test_identity_affine_transformation_chaining():
     """Chaining an identity affine transformation has no effect."""
     assert (
-        AffineTransformation() + ExponentialTransformation()
+        AffineTransformation() | ExponentialTransformation()
         == ExponentialTransformation()
     )
 
@@ -258,7 +258,7 @@ def test_affine_transformation_chaining(series):
     t1 = AffineTransformation(factor=3, shift=2)
     t2 = AffineTransformation(factor=4, shift=3)
 
-    chained = t1 + t2
+    chained = t1 | t2
     chained_factor = t2.factor * t1.factor
     chained_shift = t2.factor * t1.shift + t2.shift
     expected = AffineTransformation(factor=chained_factor, shift=chained_shift)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -22,6 +22,10 @@ from baybe.transformations import (
     TriangularTransformation,
     TwoSidedAffineTransformation,
 )
+from baybe.transformations.composite import (
+    AdditiveTransformation,
+    MultiplicativeTransformation,
+)
 from baybe.utils.dataframe import to_tensor
 from baybe.utils.interval import Interval
 
@@ -293,3 +297,31 @@ def test_degenerate_transformations(transformation):
     """Degenerate transformations produce proper (non-nan) outputs."""
     assert transformation.get_image() == Interval(0, 0)
     assert transformation.get_image((20, None)) == Interval(0, 0)
+
+
+def test_additive_transformation(tensor):
+    """Additive transformations compute the sum of two transformations."""
+    t1 = ExponentialTransformation()
+    t2 = PowerTransformation(exponent=2)
+
+    expected = t1(tensor) + t2(tensor)
+    comp1 = AdditiveTransformation([t1, t2])
+    comp2 = t1 + t2
+
+    assert comp1 == comp2
+    assert torch.equal(comp1(tensor), expected)
+    assert torch.equal(comp2(tensor), expected)
+
+
+def test_multiplicative_transformation(tensor):
+    """Multiplicative transformations compute the product of two transformations."""
+    t1 = ExponentialTransformation()
+    t2 = PowerTransformation(exponent=2)
+
+    expected = t1(tensor) * t2(tensor)
+    comp1 = MultiplicativeTransformation([t1, t2])
+    comp2 = t1 * t2
+
+    assert comp1 == comp2
+    assert torch.equal(comp1(tensor), expected)
+    assert torch.equal(comp2(tensor), expected)

--- a/tests/validation/test_objective_validation.py
+++ b/tests/validation/test_objective_validation.py
@@ -43,7 +43,7 @@ def test_invalid_target(target):
         ),
         param([t1], ValueError, "must be >= 2: 1", id="too_short"),
         param([t1, t1], ValueError, "unique names", id="duplicate_names"),
-        param([t1, t3], ValueError, "are not normalized", id="unnormalized"),
+        param([t1, t3], ValueError, "are either not normalized", id="unnormalized"),
         param([t1, t4], ValueError, "non-negative range", id="negative"),
         param(
             [t1, t_mock],


### PR DESCRIPTION
* Splits the existing transformation `core.py` module into `basic.py` and `composite.py` (similar to other subpackages like `kernels`)
* Changes transformation chaining operator from `+` to `|`
* Adds `AdditiveTransformation` and `MultiplicativeTransformation` classes
* Introduces `get_codomain` in addition to `get_image`