### PR TITLE
Drop attrs typing workaround

### DIFF
--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pandas as pd
 from attrs import define, field
-from attrs.validators import and_, deep_mapping, instance_of, min_len
+from attrs.validators import deep_mapping, instance_of, min_len
 from typing_extensions import override
 
 from baybe.parameters.base import _DiscreteLabelLikeParameter
@@ -44,7 +44,7 @@ class SubstanceParameter(_DiscreteLabelLikeParameter):
         converter=lambda x: dict(sorted(x.items())),
         validator=deep_mapping(
             mapping_validator=min_len(2),
-            key_validator=and_(instance_of(str), min_len(1)),
+            key_validator=[instance_of(str), min_len(1)],
         ),
     )
     """A mapping that provides the SMILES strings for all available parameter values."""

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -44,7 +44,7 @@ class SubstanceParameter(_DiscreteLabelLikeParameter):
         converter=lambda x: dict(sorted(x.items())),
         validator=deep_mapping(
             mapping_validator=min_len(2),
-            key_validator=[instance_of(str), min_len(1)],
+            key_validator=(instance_of(str), min_len(1)),
         ),
     )
     """A mapping that provides the SMILES strings for all available parameter values."""

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -44,9 +44,7 @@ class SubstanceParameter(_DiscreteLabelLikeParameter):
         converter=lambda x: dict(sorted(x.items())),
         validator=deep_mapping(
             mapping_validator=min_len(2),
-            # FIXME[typing]: https://github.com/python-attrs/attrs/issues/1206
             key_validator=and_(instance_of(str), min_len(1)),
-            value_validator=lambda *x: None,
         ),
     )
     """A mapping that provides the SMILES strings for all available parameter values."""

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -7,7 +7,7 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any
 
 from attrs import define, field
-from attrs.validators import and_, deep_iterable, instance_of, max_len, min_len
+from attrs.validators import deep_iterable, instance_of, max_len, min_len
 from typing_extensions import override
 
 from baybe.transformations.base import Transformation
@@ -69,7 +69,7 @@ class AdditiveTransformation(Transformation):
     transformations: tuple[Transformation, Transformation] = field(
         converter=to_tuple,
         validator=deep_iterable(
-            iterable_validator=and_(min_len(2), max_len(2)),
+            iterable_validator=(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),
         ),
     )
@@ -94,7 +94,7 @@ class MultiplicativeTransformation(Transformation):
     transformations: tuple[Transformation, Transformation] = field(
         converter=to_tuple,
         validator=deep_iterable(
-            iterable_validator=and_(min_len(2), max_len(2)),
+            iterable_validator=(min_len(2), max_len(2)),
             member_validator=instance_of(Transformation),
         ),
     )

--- a/baybe/utils/metadata.py
+++ b/baybe/utils/metadata.py
@@ -31,8 +31,6 @@ class Metadata(SerialMixin):
         validator=deep_mapping(
             mapping_validator=instance_of(dict),
             key_validator=instance_of(str),
-            # FIXME: https://github.com/python-attrs/attrs/issues/1246
-            value_validator=lambda *x: None,
         ),
         kw_only=True,
     )

--- a/benchmarks/definition/regression.py
+++ b/benchmarks/definition/regression.py
@@ -1,7 +1,7 @@
 """Regression benchmark configuration."""
 
 from attrs import define, field
-from attrs.validators import and_, deep_iterable, ge, instance_of, le
+from attrs.validators import deep_iterable, ge, instance_of, le
 
 from baybe.utils.validation import finite_float
 from benchmarks.definition.base import Benchmark, BenchmarkSettings
@@ -17,7 +17,7 @@ class RegressionBenchmarkSettings(BenchmarkSettings):
     max_n_train_points: int = field(validator=instance_of(int))
     """Maximum number of training points to consider."""
 
-    noise_std: float = field(converter=float, validator=and_(finite_float, ge(0.0)))
+    noise_std: float = field(converter=float, validator=[finite_float, ge(0.0)])
     """Standard deviation of noise to add to the data."""
 
 
@@ -27,7 +27,7 @@ class TransferLearningRegressionBenchmarkSettings(RegressionBenchmarkSettings):
 
     source_fractions: tuple[float, ...] = field(
         validator=deep_iterable(
-            member_validator=and_(ge(0.0), le(1.0)),
+            member_validator=(ge(0.0), le(1.0)),
             iterable_validator=instance_of(tuple),
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = [
 ]
 dynamic = ['version']
 dependencies = [
-    "attrs>=24.1.0",
+    "attrs>=25.4.0",
     "botorch>=0.13.0,<1",
     "cattrs>=25.2.0",
     "exceptiongroup",

--- a/uv.lock
+++ b/uv.lock
@@ -126,11 +126,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.3.0"
+version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "attrs", specifier = ">=24.1.0" },
+    { name = "attrs", specifier = ">=25.4.0" },
     { name = "baybe", extras = ["benchmarking"], marker = "extra == 'dev'" },
     { name = "baybe", extras = ["chem"], marker = "extra == 'benchmarking'" },
     { name = "baybe", extras = ["chem"], marker = "extra == 'extras'" },


### PR DESCRIPTION
Now fixed upstream in the new `attrs` version.
* https://github.com/python-attrs/attrs/pull/1448
* https://github.com/python-attrs/attrs/pull/1449