### PR TITLE
Remove polars xfails

### DIFF
--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -2,7 +2,6 @@
 
 import pytest
 from pandas.testing import assert_frame_equal
-from pytest import param
 
 from baybe._optional.info import POLARS_INSTALLED
 from baybe.searchspace.discrete import (
@@ -123,10 +122,6 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
 
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_7"]])
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/pola-rs/polars/issues/23187#issuecomment-2983037337",
-)
 def test_polars_label_duplicates(parameters, constraints):
     """Tests Polars implementation of no-label duplicates constraint."""
     ldf = _lazyframe_from_product(parameters)
@@ -146,10 +141,6 @@ def test_polars_label_duplicates(parameters, constraints):
 
 @pytest.mark.parametrize("parameter_names", [["Solvent_1", "Solvent_2", "Solvent_3"]])
 @pytest.mark.parametrize("constraint_names", [["Constraint_15"]])
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://github.com/pola-rs/polars/issues/23187#issuecomment-2983037337",
-)
 def test_polars_linked_parameters(parameters, constraints):
     """Tests Polars implementation of linked parameters constraint."""
     ldf = _lazyframe_from_product(parameters)
@@ -186,13 +177,7 @@ def test_polars_linked_parameters(parameters, constraints):
     [
         ["Constraint_4"],
         ["Constraint_12"],
-        param(
-            ["Constraint_15", "Constraint_8", "Constraint_9"],
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="https://github.com/pola-rs/polars/issues/23187#issuecomment-2983037337",
-            ),
-        ),
+        ["Constraint_15", "Constraint_8", "Constraint_9"],
     ],
 )
 def test_polars_product(constraints, parameters):


### PR DESCRIPTION
The reason that [prompted us to introduce xfails for some polars tests](https://github.com/emdgroup/baybe/pull/586) was [fixed](https://github.com/pola-rs/polars/issues/23187#issuecomment-3049601926) and [released](https://github.com/pola-rs/polars/releases/tag/py-1.32.0)