### PR TITLE
Forbid Overlap in Target and Parameter Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `initialization`, using them for pre-selecting points 
 
 ### Fixed
-- `Campaign` no longer allows overlapping names between parameters and targets
+- It is no longer possible to use identical names between parameters and targets
 - Random seed context is correctly set within benchmarks
 - Measurement input validation now respects typical tolerances associated with floating
   point representation inaccuracy

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -48,7 +48,11 @@ from baybe.utils.dataframe import (
     fuzzy_row_match,
     normalize_input_dtypes,
 )
-from baybe.utils.validation import validate_parameter_input, validate_target_input
+from baybe.utils.validation import (
+    validate_object_names,
+    validate_parameter_input,
+    validate_target_input,
+)
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction
@@ -129,13 +133,7 @@ class Campaign(SerialMixin):
         if value is None:
             return
 
-        p_names = {p.name for p in self.searchspace.parameters}
-        t_names = {t.name for t in value.targets}
-        if overlap := p_names.intersection(t_names):
-            raise ValueError(
-                f"Parameters and targets cannot have overlapping names. "
-                f"The following names appear in both collections: {overlap}."
-            )
+        validate_object_names(self.searchspace.parameters + value.targets)
 
     recommender: RecommenderProtocol = field(
         factory=TwoPhaseMetaRecommender,

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -16,6 +16,7 @@ from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin, converter, unstructure_base
 from baybe.serialization.core import get_base_structure_hook
+from baybe.utils.validation import validate_object_names
 
 
 @define
@@ -99,6 +100,9 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         """See :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
+        if objective is not None:
+            validate_object_names(searchspace.parameters + objective.targets)
+
         recommender = self.select_recommender(
             batch_size=batch_size,
             searchspace=searchspace,

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -16,7 +16,11 @@ from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpaceType
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.utils.dataframe import _ValidatedDataFrame, normalize_input_dtypes
-from baybe.utils.validation import validate_parameter_input, validate_target_input
+from baybe.utils.validation import (
+    validate_object_names,
+    validate_parameter_input,
+    validate_target_input,
+)
 
 _DEPRECATION_ERROR_MESSAGE = (
     "The attribute '{}' is no longer available for recommenders. "
@@ -99,6 +103,9 @@ class PureRecommender(ABC, RecommenderProtocol):
         pending_experiments: pd.DataFrame | None = None,
     ) -> pd.DataFrame:
         # Validation
+        if objective is not None:
+            validate_object_names(searchspace.parameters + objective.targets)
+
         if (
             measurements is not None
             and not isinstance(measurements, _ValidatedDataFrame)

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -29,7 +29,11 @@ from baybe.surrogates.base import (
     SurrogateProtocol,
 )
 from baybe.utils.dataframe import _ValidatedDataFrame, normalize_input_dtypes
-from baybe.utils.validation import validate_parameter_input, validate_target_input
+from baybe.utils.validation import (
+    validate_object_names,
+    validate_parameter_input,
+    validate_target_input,
+)
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
@@ -159,6 +163,8 @@ class BayesianRecommender(PureRecommender, ABC):
                 f"Recommenders of type '{BayesianRecommender.__name__}' require "
                 f"that an objective is specified."
             )
+
+        validate_object_names(searchspace.parameters + objective.targets)
 
         # Experimental input validation
         if (measurements is None) or measurements.empty:

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -177,3 +177,21 @@ def validate_parameter_input(
                     f"the flag 'numerical_measurements_must_be_within_tolerance' "
                     f"to 'False' to disable this behavior."
                 )
+
+
+def validate_object_names(objects: Iterable[Parameter | Target]) -> None:
+    """Validate that the provided objects have unique names.
+
+    Args:
+        objects: An iterable of parameters or targets.
+
+    Raises:
+        ValueError: If two or more objects have the same name.
+    """
+    names = [obj.name for obj in objects]
+    if len(names) != len(set(names)):
+        duplicates = {name for name in names if names.count(name) > 1}
+        raise ValueError(
+            f"All parameters and targets must have unique names. The following names "
+            f"appear multiple times: {duplicates}."
+        )

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -179,7 +179,7 @@ def validate_parameter_input(
                 )
 
 
-def validate_object_names(objects: Iterable[Parameter | Target]) -> None:
+def validate_object_names(objects: Iterable[Parameter | Target], /) -> None:
     """Validate that the provided objects have unique names.
 
     Args:

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -183,7 +183,7 @@ def validate_object_names(objects: Iterable[Parameter | Target]) -> None:
     """Validate that the provided objects have unique names.
 
     Args:
-        objects: An iterable of parameters or targets.
+        objects: An iterable containing a combination of parameters and targets.
 
     Raises:
         ValueError: If two or more objects have the same name.

--- a/tests/validation/test_campaign_validation.py
+++ b/tests/validation/test_campaign_validation.py
@@ -5,26 +5,50 @@ import pytest
 from baybe import Campaign
 from baybe.objectives import ParetoObjective
 from baybe.parameters import NumericalDiscreteParameter
+from baybe.recommenders import TwoPhaseMetaRecommender
+from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
 
+_targets = (
+    NumericalTarget("n1", "MAX"),
+    NumericalTarget("n2", "MAX"),
+    NumericalTarget("n3", "MAX"),
+)
+_parameters = (
+    NumericalDiscreteParameter("n1", (1, 2, 3)),
+    NumericalDiscreteParameter("bla", (4, 5, 6)),
+    NumericalDiscreteParameter("n2", (7, 8, 9)),
+)
+_searchspace = SearchSpace.from_product(_parameters)
+_objective = ParetoObjective(_targets)
+_context = pytest.raises(
+    ValueError, match="appear multiple times: {(?:'n1', 'n2'|'n2', 'n1')}"
+)
 
-def test_overlapping_target_parameter_names():
+
+def test_overlapping_target_parameter_names_campaign():
     """Overlapping names between parameters and targets are not allowed."""
-    targets = (
-        NumericalTarget("n1", "MAX"),
-        NumericalTarget("n2", "MAX"),
-        NumericalTarget("n3", "MAX"),
-    )
-    parameters = (
-        NumericalDiscreteParameter("n1", [1, 2, 3]),
-        NumericalDiscreteParameter("bla", [4, 5, 6]),
-        NumericalDiscreteParameter("n2", [7, 8, 9]),
-    )
-    searchspace = SearchSpace.from_product(parameters)
-    objective = ParetoObjective(targets)
+    with _context:
+        Campaign(searchspace=_searchspace, objective=_objective)
 
-    with pytest.raises(
-        ValueError, match="appear in both collections: {(?:'n1', 'n2'|'n2', 'n1')}"
-    ):
-        Campaign(searchspace=searchspace, objective=objective)
+
+@pytest.mark.parametrize(
+    "recommender",
+    [
+        # Note that a non-predictive recommender is not tested here because they do not
+        # support objectives and are not passed an objective if they are part of
+        # meta-recommenders.
+        pytest.param(BayesianRecommender(), id="pure"),
+        pytest.param(
+            TwoPhaseMetaRecommender(initial_recommender=BayesianRecommender()),
+            id="meta",
+        ),
+    ],
+)
+def test_overlapping_target_parameter_names_stateless(recommender):
+    """Overlapping names between parameters and targets are not allowed."""
+    with _context:
+        recommender.recommend(
+            2, searchspace=_searchspace, objective=_objective, measurements=None
+        )

--- a/tests/validation/test_campaign_validation.py
+++ b/tests/validation/test_campaign_validation.py
@@ -5,7 +5,7 @@ import pytest
 from baybe import Campaign
 from baybe.objectives import ParetoObjective
 from baybe.parameters import NumericalDiscreteParameter
-from baybe.recommenders import TwoPhaseMetaRecommender
+from baybe.recommenders import FPSRecommender, TwoPhaseMetaRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
@@ -36,13 +36,15 @@ def test_overlapping_target_parameter_names_campaign():
 @pytest.mark.parametrize(
     "recommender",
     [
-        # Note that a non-predictive recommender is not tested here because they do not
-        # support objectives and are not passed an objective if they are part of
-        # meta-recommenders.
-        pytest.param(BayesianRecommender(), id="pure"),
+        pytest.param(BayesianRecommender(), id="pure_predictive"),
         pytest.param(
             TwoPhaseMetaRecommender(initial_recommender=BayesianRecommender()),
-            id="meta",
+            id="meta_predictive",
+        ),
+        pytest.param(FPSRecommender(), id="pure_non-predictive"),
+        pytest.param(
+            TwoPhaseMetaRecommender(initial_recommender=FPSRecommender()),
+            id="meta_non-predictive",
         ),
     ],
 )


### PR DESCRIPTION
Fixes #571 

This PR contains further work to avoid the problem described in the issue. This now works for both stateful and stateless mode. The corresponding validations use the new utility `validate_object_names`

**Notes**:
I've also added the validation to meta-recommenders. This has the consequence that an error will also be thrown if the meta recommender uses a non-predictive recommender which does not use an objective. Overlapping names would not strictly represent a problem for this specific situation, however I would argue this still represents a misconfiguration that should be avoided.