### PR TITLE
Harmonize `float` Related Converters and Validators in Constraints and Conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Random seed context is correctly set within benchmarks
 - Measurement input validation now respects typical tolerances associated with floating
   point representation inaccuracy
+- Exotic serialization issues with constraints and conditions arising from missing
+  converters for floats
 
 ### Removed
 - Telemetry

--- a/baybe/constraints/conditions.py
+++ b/baybe/constraints/conditions.py
@@ -13,7 +13,9 @@ import cattrs
 import numpy as np
 import pandas as pd
 from attrs import define, field
-from attrs.validators import in_, min_len
+from attrs.converters import optional as optional_c
+from attrs.validators import ge, in_, min_len
+from attrs.validators import optional as optional_v
 from numpy.typing import ArrayLike
 from typing_extensions import override
 
@@ -26,6 +28,7 @@ from baybe.serialization import (
 )
 from baybe.utils.basic import to_tuple
 from baybe.utils.numerical import DTypeFloatNumpy
+from baybe.utils.validation import finite_float
 
 if TYPE_CHECKING:
     import polars as pl
@@ -127,13 +130,15 @@ class ThresholdCondition(Condition):
     """Class for modelling threshold-based conditions."""
 
     # object variables
-    threshold: float = field()
+    threshold: float = field(converter=float, validator=finite_float)
     """The threshold value used in the condition."""
 
     operator: str = field(validator=[in_(_threshold_operators)])
     """The operator used in the condition."""
 
-    tolerance: float | None = field()
+    tolerance: float | None = field(
+        converter=optional_c(float), validator=optional_v([finite_float, ge(0)])
+    )
     """A numerical tolerance. Set to a reasonable default tolerance."""
 
     @tolerance.default

--- a/baybe/constraints/continuous.py
+++ b/baybe/constraints/continuous.py
@@ -9,9 +9,10 @@ from itertools import combinations
 from math import comb
 from typing import TYPE_CHECKING, Any
 
+import cattrs
 import numpy as np
 from attrs import define, field
-from attrs.validators import deep_iterable, gt, in_, instance_of, lt
+from attrs.validators import deep_iterable, gt, in_, lt
 
 from baybe.constraints.base import (
     CardinalityConstraint,
@@ -43,10 +44,8 @@ class ContinuousLinearConstraint(ContinuousConstraint):
     coefficients for `<=`."""
 
     coefficients: tuple[float, ...] = field(
-        converter=lambda x: tuple(float(itm) for itm in x),
-        validator=deep_iterable(
-            member_validator=finite_float, iterable_validator=instance_of(tuple)
-        ),
+        converter=lambda x: cattrs.structure(x, tuple[float, ...]),
+        validator=deep_iterable(member_validator=finite_float),
     )
     """In-/equality coefficient for each entry in ``parameters``."""
 
@@ -55,7 +54,7 @@ class ContinuousLinearConstraint(ContinuousConstraint):
 
     @coefficients.validator
     def _validate_coefficients(  # noqa: DOC101, DOC103
-        self, _: Any, coefficients: tuple[float, ...]
+        self, _: Any, coefficients: Sequence[float]
     ) -> None:
         """Validate the coefficients.
 

--- a/baybe/constraints/continuous.py
+++ b/baybe/constraints/continuous.py
@@ -10,8 +10,8 @@ from math import comb
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from attr.validators import gt, in_, lt
 from attrs import define, field
+from attrs.validators import deep_iterable, gt, in_, lt
 
 from baybe.constraints.base import (
     CardinalityConstraint,
@@ -42,7 +42,10 @@ class ContinuousLinearConstraint(ContinuousConstraint):
     """Defines the operator used in the equation. Internally this will negate rhs and
     coefficients for `<=`."""
 
-    coefficients: list[float] = field()
+    coefficients: list[float] = field(
+        converter=lambda x: list(float(itm) for itm in x),
+        validator=deep_iterable(member_validator=finite_float),
+    )
     """In-/equality coefficient for each entry in ``parameters``."""
 
     rhs: float = field(default=0.0, converter=float, validator=finite_float)

--- a/baybe/constraints/continuous.py
+++ b/baybe/constraints/continuous.py
@@ -96,7 +96,7 @@ class ContinuousLinearConstraint(ContinuousConstraint):
         parameters = [p for p in self.parameters if p not in parameter_names]
         coefficients = [
             c
-            for p, c in zip(self.parameters, self.coefficients)
+            for p, c in zip(self.parameters, self.coefficients, strict=True)
             if p not in parameter_names
         ]
         return ContinuousLinearConstraint(

--- a/docs/userguide/constraints.md
+++ b/docs/userguide/constraints.md
@@ -58,7 +58,7 @@ from baybe.constraints import ContinuousLinearConstraint
 ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],  # these parameters must exist in the search space
     operator="=",
-    coefficients=[1.0, 1.0, 1.0],
+    coefficients=(1.0, 1.0, 1.0),
     rhs=1.0,
 )
 ```
@@ -74,7 +74,7 @@ from baybe.constraints import ContinuousLinearConstraint
 ContinuousLinearConstraint(
     parameters=["x_1", "x_2", "x_3"],
     operator="<=",
-    coefficients=[1.0, 1.0, 1.0],
+    coefficients=(1.0, 1.0, 1.0),
     rhs=0.8,
 )
 ```

--- a/examples/Constraints_Continuous/hybrid_space.py
+++ b/examples/Constraints_Continuous/hybrid_space.py
@@ -83,7 +83,7 @@ constraints = [
         ),
     ),
     ContinuousLinearConstraint(
-        parameters=["x_3", "x_4"], operator="=", coefficients=[1.0, -1.0], rhs=2.0
+        parameters=["x_3", "x_4"], operator="=", coefficients=(1.0, -1.0), rhs=2.0
     ),
 ]
 

--- a/examples/Constraints_Continuous/linear_constraints.py
+++ b/examples/Constraints_Continuous/linear_constraints.py
@@ -60,16 +60,16 @@ parameters = [
 
 constraints = [
     ContinuousLinearConstraint(
-        parameters=["x_1", "x_2"], operator="=", coefficients=[1.0, 1.0], rhs=1.0
+        parameters=["x_1", "x_2"], operator="=", coefficients=(1.0, 1.0), rhs=1.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_3", "x_4"], operator="=", coefficients=[1.0, -1.0], rhs=2.0
+        parameters=["x_3", "x_4"], operator="=", coefficients=(1.0, -1.0), rhs=2.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_1", "x_3"], operator=">=", coefficients=[1.0, 1.0], rhs=1.0
+        parameters=["x_1", "x_3"], operator=">=", coefficients=(1.0, 1.0), rhs=1.0
     ),
     ContinuousLinearConstraint(
-        parameters=["x_2", "x_4"], operator="<=", coefficients=[2.0, 3.0], rhs=-1.0
+        parameters=["x_2", "x_4"], operator="<=", coefficients=(2.0, 3.0), rhs=-1.0
     ),
 ]
 

--- a/examples/Mixtures/traditional.py
+++ b/examples/Mixtures/traditional.py
@@ -60,7 +60,7 @@ p_g3_amounts = [
 c_total_sum = ContinuousLinearConstraint(
     parameters=g1 + g2 + g3,
     operator="=",
-    coefficients=[1] * len(g1 + g2 + g3),
+    coefficients=(1,) * len(g1 + g2 + g3),
     rhs=100,
 )
 
@@ -69,7 +69,7 @@ c_total_sum = ContinuousLinearConstraint(
 c_g2_min = ContinuousLinearConstraint(
     parameters=g2,
     operator=">=",
-    coefficients=[1] * len(g2),
+    coefficients=(1,) * len(g2),
     rhs=10,
 )
 
@@ -78,7 +78,7 @@ c_g2_min = ContinuousLinearConstraint(
 c_g3_max = ContinuousLinearConstraint(
     parameters=g3,
     operator="<=",
-    coefficients=[1] * len(g3),
+    coefficients=(1,) * len(g3),
     rhs=5,
 )
 

--- a/tests/hypothesis_strategies/constraints.py
+++ b/tests/hypothesis_strategies/constraints.py
@@ -228,13 +228,7 @@ def continuous_linear_constraints(
         assert len(parameter_names) > 0
         assert len(parameter_names) == len(set(parameter_names))
 
-    coefficients = draw(
-        st.lists(
-            finite_floats(),
-            min_size=len(parameter_names),
-            max_size=len(parameter_names),
-        )
-    )
+    coefficients = draw(st.tuples(*([finite_floats()] * len(parameter_names))))
     rhs = draw(finite_floats())
 
     # Optionally add the operator


### PR DESCRIPTION
Fixes #579 

Due to missing converters, exotic type usage could break the serialization (see issue).