### PR TITLE
Move target negation to objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DesirabilityObjective.as_pre_transformation` flag). As a result, posterior
   evaluations now return information for each target individually, instead of just for
   the desirability value.
+- Objective transformations (both tensor and dataframe based) now always use the Torch
+  computation route, avoiding the need for duplicated transformation logic
 - Specifying bounds for `Interval` is now optional
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `as_pre_transformation` flag to `DesirabilityObjective` for controlling whether the 
   desirability transformation is applied before or after model fitting
 - `supports_partial_measurements` property to `Objective`
-- `total_transformation` and `is_normalized` properties to `NumericalTarget`
+- `is_normalized` property to `NumericalTarget`
 - `negate`, `normalize`, `abs`, `clamp`, `log`, `exp` and `power` methods to
   `NumericalTarget` for easy creation of transformed targets from existing ones
 - Addition and multiplication dunder methods (for scalar values) to `NumericalTarget`

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -37,6 +37,7 @@ from baybe.surrogates.base import SurrogateProtocol
 from baybe.targets.binary import BinaryTarget
 from baybe.targets.numerical import NumericalTarget
 from baybe.transformations import AffineTransformation
+from baybe.transformations.basic import IdentityTransformation
 from baybe.utils.basic import match_attributes
 from baybe.utils.dataframe import handle_missing_values, to_tensor
 
@@ -217,7 +218,7 @@ class BotorchAcquisitionFunctionBuilder:
                     raise NotImplementedError("No transformation handling implemented.")
 
             match t := target.transformation:
-                case AffineTransformation():
+                case IdentityTransformation() | AffineTransformation():
                     oriented = t.negate() if target.minimize else t
                     self._args.posterior_transform = (
                         oriented.to_botorch_posterior_transform()

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from functools import cached_property
 from inspect import signature
 from types import MappingProxyType
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 import torch
@@ -219,7 +219,12 @@ class BotorchAcquisitionFunctionBuilder:
 
             match t := target.transformation:
                 case IdentityTransformation() | AffineTransformation():
-                    oriented = t.negate() if target.minimize else t
+                    # The identity/affine type narrowing is lost due to the `negate`
+                    # call, but we know that the result will be an AffineTransformation
+                    # in this specific context
+                    oriented = cast(
+                        AffineTransformation, t.negate() if target.minimize else t
+                    )
                     self._args.posterior_transform = (
                         oriented.to_botorch_posterior_transform()
                     )

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -36,8 +36,7 @@ from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.base import SurrogateProtocol
 from baybe.targets.binary import BinaryTarget
 from baybe.targets.numerical import NumericalTarget
-from baybe.transformations import AffineTransformation
-from baybe.transformations.basic import IdentityTransformation
+from baybe.transformations import AffineTransformation, IdentityTransformation
 from baybe.utils.basic import match_attributes
 from baybe.utils.dataframe import handle_missing_values, to_tensor
 

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -99,11 +99,13 @@ class Objective(ABC, SerialMixin):
             GenericMCMultiOutputObjective,
         )
 
+        oriented_targets = (t.negate() if t.minimize else t for t in self.targets)
+
         return GenericMCMultiOutputObjective(
             lambda samples, X: torch.stack(
                 [
-                    t.total_transformation.to_botorch_objective()(samples[..., i])
-                    for i, t in enumerate(self.targets)
+                    t.transformation.to_botorch_objective()(samples[..., i])
+                    for i, t in enumerate(oriented_targets)
                 ],
                 dim=-1,
             )

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -103,7 +103,7 @@ class Objective(ABC, SerialMixin):
 
     def to_botorch(self) -> MCAcquisitionObjective:
         """Convert to BoTorch representation."""
-        if not is_all_instance(self.targets, NumericalTarget):
+        if not is_all_instance(self._oriented_targets, NumericalTarget):
             raise NotImplementedError(
                 "Conversion to BoTorch is only supported for numerical targets."
             )

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -99,7 +99,7 @@ class Objective(ABC, SerialMixin):
             GenericMCMultiOutputObjective,
         )
 
-        oriented_targets = (t.negate() if t.minimize else t for t in self.targets)
+        oriented_targets = [t.negate() if t.minimize else t for t in self.targets]
 
         return GenericMCMultiOutputObjective(
             lambda samples, X: torch.stack(

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -204,7 +204,7 @@ class DesirabilityObjective(Objective):
 
     @override
     @property
-    def _full_transformation(self) -> pd.DataFrame:
+    def _full_transformation(self) -> MCAcquisitionObjective:
         return self._to_botorch_full()
 
     @override

--- a/baybe/objectives/desirability.py
+++ b/baybe/objectives/desirability.py
@@ -191,6 +191,7 @@ class DesirabilityObjective(Objective):
 
         return to_string("Objective", *fields)
 
+    @override
     @property
     def _oriented_targets(self) -> tuple[Target, ...]:
         # For desirability, we do not only negate but also shift by 1 so that
@@ -201,6 +202,7 @@ class DesirabilityObjective(Objective):
             for t in self.targets
         )
 
+    @override
     @property
     def _full_transformation(self) -> pd.DataFrame:
         return self._to_botorch_full()

--- a/baybe/objectives/pareto.py
+++ b/baybe/objectives/pareto.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import gc
-import warnings
 from typing import ClassVar
 
-import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_iterable, instance_of, min_len
 from typing_extensions import override
@@ -15,7 +13,6 @@ from baybe.objectives.base import Objective
 from baybe.objectives.validation import validate_target_names
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import to_tuple
-from baybe.utils.dataframe import transform_target_columns
 
 
 @define(frozen=True, slots=False)
@@ -50,50 +47,6 @@ class ParetoObjective(Objective):
     @property
     def supports_partial_measurements(self) -> bool:
         return True
-
-    @override
-    def transform(
-        self,
-        df: pd.DataFrame | None = None,
-        /,
-        *,
-        allow_missing: bool = False,
-        allow_extra: bool | None = None,
-        data: pd.DataFrame | None = None,
-    ) -> pd.DataFrame:
-        # >>>>>>>>>> Deprecation
-        if not ((df is None) ^ (data is None)):
-            raise ValueError(
-                "Provide the dataframe to be transformed as first positional argument."
-            )
-
-        if data is not None:
-            df = data
-            warnings.warn(
-                "Providing the dataframe via the `data` argument is deprecated and "
-                "will be removed in a future version. Please pass your dataframe "
-                "as positional argument instead.",
-                DeprecationWarning,
-            )
-
-        # Mypy does not infer from the above that `df` must be a dataframe here
-        assert isinstance(df, pd.DataFrame)
-
-        if allow_extra is None:
-            allow_extra = True
-            if set(df.columns) - {p.name for p in self.targets}:
-                warnings.warn(
-                    "For backward compatibility, the new `allow_extra` flag is set "
-                    "to `True` when left unspecified. However, this behavior will be "
-                    "changed in a future version. If you want to invoke the old "
-                    "behavior, please explicitly set `allow_extra=True`.",
-                    DeprecationWarning,
-                )
-        # <<<<<<<<<< Deprecation
-
-        return transform_target_columns(
-            df, self.targets, allow_missing=allow_missing, allow_extra=allow_extra
-        )
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/objectives/single.py
+++ b/baybe/objectives/single.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import gc
-import warnings
 from typing import TYPE_CHECKING, ClassVar
 
 import pandas as pd
@@ -17,7 +16,6 @@ from baybe.targets.numerical import NumericalTarget
 from baybe.utils.conversion import to_string
 from baybe.utils.dataframe import (
     pretty_print_df,
-    transform_target_columns,
 )
 
 if TYPE_CHECKING:
@@ -71,50 +69,6 @@ class SingleTargetObjective(Objective):
             return ChainedMCObjective(super().to_botorch(), IdentityMCObjective())
 
         return IdentityMCObjective()
-
-    @override
-    def transform(
-        self,
-        df: pd.DataFrame | None = None,
-        /,
-        *,
-        allow_missing: bool = False,
-        allow_extra: bool | None = None,
-        data: pd.DataFrame | None = None,
-    ) -> pd.DataFrame:
-        # >>>>>>>>>> Deprecation
-        if not ((df is None) ^ (data is None)):
-            raise ValueError(
-                "Provide the dataframe to be transformed as first positional argument."
-            )
-
-        if data is not None:
-            df = data
-            warnings.warn(
-                "Providing the dataframe via the `data` argument is deprecated and "
-                "will be removed in a future version. Please pass your dataframe "
-                "as positional argument instead.",
-                DeprecationWarning,
-            )
-
-        # Mypy does not infer from the above that `df` must be a dataframe here
-        assert isinstance(df, pd.DataFrame)
-
-        if allow_extra is None:
-            allow_extra = True
-            if set(df.columns) - {p.name for p in self.targets}:
-                warnings.warn(
-                    "For backward compatibility, the new `allow_extra` flag is set "
-                    "to `True` when left unspecified. However, this behavior will be "
-                    "changed in a future version. If you want to invoke the old "
-                    "behavior, please explicitly set `allow_extra=True`.",
-                    DeprecationWarning,
-                )
-        # <<<<<<<<<< Deprecation
-
-        return transform_target_columns(
-            df, self.targets, allow_missing=allow_missing, allow_extra=allow_extra
-        )
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/simulation/_imputation.py
+++ b/baybe/simulation/_imputation.py
@@ -52,7 +52,10 @@ def impute_target_values(
             # TODO: Add option to control how ties are handled (e.g. random, first, all)
             transformed = transformed.sample(frac=1, replace=False)
 
-            opt_idx = transformed.idxmax() if mode == "best" else transformed.idxmin()
+            operator = (
+                "idxmax" if (mode == "best") == (not target.minimize) else "idxmin"
+            )
+            opt_idx = getattr(transformed, operator)()
             values[target.name] = lookup.loc[opt_idx, target.name]
         return pd.Series(values)
 

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -9,7 +9,6 @@ from typing import Any, cast
 
 import pandas as pd
 from attrs import define, evolve, field
-from attrs.converters import optional
 from attrs.validators import instance_of
 from typing_extensions import override
 
@@ -100,7 +99,7 @@ class NumericalTarget(Target, SerialMixin):
     """Class for numerical targets."""
 
     transformation: Transformation = field(
-        factory=IdentityTransformation, converter=optional(convert_transformation)
+        factory=IdentityTransformation, converter=convert_transformation
     )
     """An optional target transformation."""
 

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -26,7 +26,7 @@ def _image_equals_codomain(cls: type[_TTransformation], /) -> type[_TTransformat
     return cls
 
 
-@define
+@define(frozen=True)
 class Transformation(SerialMixin, ABC):
     """Abstract base class for all transformations."""
 
@@ -181,6 +181,7 @@ class Transformation(SerialMixin, ABC):
 
 
 @_image_equals_codomain
+@define(frozen=True)
 class MonotonicTransformation(Transformation, ABC):
     """Abstract base class for monotonic transformations."""
 

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -56,6 +56,16 @@ class CustomTransformation(Transformation):
 class IdentityTransformation(MonotonicTransformation):
     """The identity transformation."""
 
+    def to_botorch_posterior_transform(self) -> AffinePosteriorTransform:
+        """Convert to BoTorch posterior transform.
+
+        Returns:
+            The representation of the transform as BoTorch posterior transform.
+        """
+        from baybe.targets.botorch import AffinePosteriorTransform
+
+        return AffinePosteriorTransform(factor=1.0, shift=0.0)
+
     @override
     def __call__(self, x: Tensor, /) -> Tensor:
         return x

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     """Type alias for a torch-based function mapping from reals to reals."""
 
 
-@define
+@define(frozen=True)
 class CustomTransformation(Transformation):
     """A custom transformation applying an arbitrary torch callable."""
 
@@ -52,7 +52,7 @@ class CustomTransformation(Transformation):
         return self.function(x)
 
 
-@define
+@define(frozen=True)
 class IdentityTransformation(MonotonicTransformation):
     """The identity transformation."""
 
@@ -67,7 +67,7 @@ class IdentityTransformation(MonotonicTransformation):
         return NotImplemented
 
 
-@define(init=False)
+@define(frozen=True, init=False)
 class ClampingTransformation(MonotonicTransformation):
     """A transformation clamping values between specified bounds."""
 
@@ -84,9 +84,11 @@ class ClampingTransformation(MonotonicTransformation):
         return x.clamp(*self.bounds.to_tuple())
 
 
-@define(slots=False, init=False)
+@define(frozen=True, init=False)
 class AffineTransformation(MonotonicTransformation):
     """An affine transformation."""
+
+    __hash__ = object.__hash__
 
     factor: float = field(default=1.0, converter=float, validator=finite_float)
     """The multiplicative factor of the transformation."""
@@ -167,7 +169,7 @@ class AffineTransformation(MonotonicTransformation):
 
 
 @_image_equals_codomain
-@define(slots=False)
+@define(frozen=True)
 class TwoSidedAffineTransformation(Transformation):
     """A transformation with two affine segments on either side of a midpoint."""
 
@@ -207,7 +209,7 @@ class TwoSidedAffineTransformation(Transformation):
 
 
 @_image_equals_codomain
-@define(slots=False)
+@define(frozen=True)
 class BellTransformation(Transformation):
     """A Gaussian bell curve transformation."""
 
@@ -241,7 +243,7 @@ class BellTransformation(Transformation):
 
 
 @_image_equals_codomain
-@define(slots=False)
+@define(frozen=True)
 class AbsoluteTransformation(Transformation):
     """A transformation computing absolute values."""
 
@@ -262,7 +264,7 @@ class AbsoluteTransformation(Transformation):
 
 
 @_image_equals_codomain
-@define(slots=False)
+@define(frozen=True)
 class TriangularTransformation(Transformation):
     r"""A transformation with a triangular shape.
 
@@ -310,7 +312,7 @@ class TriangularTransformation(Transformation):
                 "the cutoffs are too close to the peak, leading to numerical overflow "
                 "when computing the slopes."
             )
-        self._transformation = (
+        t = (
             TwoSidedAffineTransformation(
                 slope_left=1 / self.margins[0],
                 slope_right=-1 / self.margins[1],
@@ -318,6 +320,7 @@ class TriangularTransformation(Transformation):
             )
             + 1
         ).clamp(min=0)
+        object.__setattr__(self, "_transformation", t)
 
     @cutoffs.validator
     def _validate_cutoffs(self, _, cutoffs: Interval) -> None:
@@ -385,7 +388,7 @@ class ExponentialTransformation(MonotonicTransformation):
 
 
 @_image_equals_codomain
-@define(slots=False)
+@define(frozen=True)
 class PowerTransformation(Transformation):
     """A transformation computing the power."""
 
@@ -412,7 +415,7 @@ class PowerTransformation(Transformation):
         return x.pow(self.exponent)
 
 
-@define(slots=False)
+@define(frozen=True)
 class SigmoidTransformation(MonotonicTransformation):
     """A sigmoid transformation."""
 

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -98,6 +98,7 @@ class ClampingTransformation(MonotonicTransformation):
 class AffineTransformation(MonotonicTransformation):
     """An affine transformation."""
 
+    # https://github.com/python-attrs/attrs/issues/1462
     __hash__ = object.__hash__
 
     factor: float = field(default=1.0, converter=float, validator=finite_float)

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 class ChainedTransformation(Transformation):
     """A chained transformation composing several individual transformations."""
 
+    # https://github.com/python-attrs/attrs/issues/1462
     __hash__ = object.__hash__
 
     transformations: tuple[Transformation, ...] = field(

--- a/baybe/transformations/composite.py
+++ b/baybe/transformations/composite.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 
-@define
+@define(frozen=True)
 class ChainedTransformation(Transformation):
     """A chained transformation composing several individual transformations."""
+
+    __hash__ = object.__hash__
 
     transformations: tuple[Transformation, ...] = field(
         converter=compress_transformations,
@@ -58,7 +60,7 @@ class ChainedTransformation(Transformation):
         return compose(*(t.__call__ for t in self.transformations))(x)
 
 
-@define
+@define(frozen=True)
 class AdditiveTransformation(Transformation):
     """A transformation implementing the sum of two transformations."""
 
@@ -83,7 +85,7 @@ class AdditiveTransformation(Transformation):
         return self.transformations[0](x) + self.transformations[1](x)
 
 
-@define
+@define(frozen=True)
 class MultiplicativeTransformation(Transformation):
     """A transformation implementing the product of two transformations."""
 

--- a/tests/serialization/test_objective_serialization.py
+++ b/tests/serialization/test_objective_serialization.py
@@ -23,7 +23,7 @@ from tests.hypothesis_strategies.objectives import (
 
 def _get_involved_transformations(target: Target) -> list[Transformation]:
     """Get all transformations involved in a target."""
-    match t := target._transformation:
+    match t := target.transformation:
         case ChainedTransformation():
             return t.transformations
         case _:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -419,7 +419,7 @@ def test_constructor_equivalence_match(transformation):
             None,
             None,
             ModernTarget("t", minimize=True),
-            -sample_input(),
+            sample_input(),
             id="min_no_bounds_with_flag",
         ),
         param(
@@ -431,7 +431,7 @@ def test_constructor_equivalence_match(transformation):
             None,  # should be `LegacyTarget("t", "MIN")` but see explanation above
             ModernTarget("t", "MIN"),
             ModernTarget("t", minimize=True),
-            -sample_input(),
+            sample_input(),
             id="min",
         ),
         param(

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -36,7 +36,7 @@ def targets():
     return [
         NumericalTarget("t_max"),
         NumericalTarget("t_min", minimize=True),
-        NumericalTarget.match_triangular("t_match", 40, cutoffs=(20, 60)),
+        NumericalTarget.match_triangular("t_match", 40, cutoffs=(10, 60)),
     ]
 
 

--- a/tests/test_objective.py
+++ b/tests/test_objective.py
@@ -43,15 +43,15 @@ class TestInvalidObjectiveCreation:
             SingleTargetObjective(target={"A": 1, "B": 2})
 
     def test_negative_targets_for_desirability(self):
+        """Negative targets are not allowed unless explicitly declared."""
         t1 = NumericalTarget("t1").clamp(0, 1)
-
-        # Is normalized but the minimize flag appends another transformation
         t2 = NumericalTarget(
-            "t2", transformation=ClampingTransformation(0, 1), minimize=True
+            "t2", transformation=ClampingTransformation(-1, 0), minimize=True
         )
-
         with pytest.raises(ValueError, match="transformed to a non-negative range"):
             DesirabilityObjective([t1, t2])
+        DesirabilityObjective([t1.normalize(), t2.normalize()])
+        DesirabilityObjective([t1, t2], require_normalization=False, scalarizer="MEAN")
 
     def test_unnormalized_targets_for_desirability(self):
         """Unnormalized targets are not allowed unless explicitly declared."""

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -16,7 +16,7 @@ def test_target_addition():
     t1 = NumericalTarget("t") + 1
     t2 = NumericalTarget("t") - (-1)
     assert t1 == t2
-    assert t1._transformation == AffineTransformation(shift=1)
+    assert t1.transformation == AffineTransformation(shift=1)
 
 
 def test_target_multiplication():
@@ -24,7 +24,7 @@ def test_target_multiplication():
     t1 = NumericalTarget("t") * 2
     t2 = NumericalTarget("t") / 0.5
     assert t1 == t2
-    assert t1._transformation == AffineTransformation(factor=2)
+    assert t1.transformation == AffineTransformation(factor=2)
 
 
 def test_target_inversion():


### PR DESCRIPTION
### Motivation
In the previous code, the role of `NumericalTarget` was twofold:
* Specification of the quantity to be optimized (i.e. defining a named signal and which derivative of that signal is to be optimized, declared via a `transformation`) + defining the corresponding optimization direction (i.e. via the `minimize` flag)
* Implementing the translation into the actual quantity entering the optimization engine, i.e. applying the actual effect of the `minimize` flag via optional negation of the target.

This was nice from a user story because it allowed for the simple `targets are always transformed and then maximized` narrative. However, applying also the second step from above actually mixed the two concerns of `what is to be optimized` (i.e. the target specification) and `how it is optimized`. This results in subtle issues that are problematic from a user perspective. 

In particular:
A user would expect calling `is_normalized` on `NumericalTarget("t", transformation=ClampingTransformation(0, 1), minimize=True)` to evaluate to `True` because they provided a normalizing transform. However, because of the appended negation step, the image of the target is actually [-1, 0] instead of [0, 1], which is a consequence of mixing the two concerns.

### Solution
This PR makes the necessary changes to strictly separate the "what" from the "how" by moving the negation step into the objective, making the `Target` class a pure "specification" class.  With the new change, it now becomes the responsibility of the `Objective` to decide how to handle (minimization) targets and potentially customize this step to the respective context. This allows us to implement special logic for certain cases, like for the `DesirabilityObjective`, which now handles minimization targets by `negation + 1` instead of the default `negation` step. That is, `DesirabilityObjective` handles the negation in a way that makes it compatible with its custom logic applied in subsequent steps.

### Implications
The story in the user guide needs to be slightly adjusted in that targets are no longer simply `transformed` and then `maximized`, but they now carry the specification of the quantity to be optimized (i.e. via transformation) + the notion of an optimization direction. That is, the "what" and the "what to do with it", but no longer the "how to do it". Accordingly, the target transformation pictures for the match constructors should be adjusted in that an optimization direction gets included.

### Other Improvements
The `transform` computation logic of objectives now reuses the already existing torch route, which has two benefits:
* significantly less code (which was copy-pasted logic in a sense)
* automatically ensures that torch and dataframe based routes yield the same result

Corresponding tests for the transformation method are also added.