### PR TITLE
Fix Numerical Test Failures

### DIFF
--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -170,8 +170,8 @@ valid_meta_recommenders = get_subclasses(MetaRecommender)
 
 valid_priors = [
     GammaPrior(3, 1),
-    HalfCauchyPrior(2),
-    HalfNormalPrior(2),
+    HalfCauchyPrior(0.5),
+    HalfNormalPrior(0.5),
     LogNormalPrior(1, 2),
     NormalPrior(1, 2),
     SmoothedBoxPrior(0, 3, 0.1),


### PR DESCRIPTION
Fixes #612 

- Removed `PeriodicKernel` when parametried via `period_length_prior`. This was the main culprit behind sporadic numerical failures. Arguably, that kernel type is already present via another parametrization (parametrized via `lengthscale_prior` in the line below deleted one). Other kernels also have additional parameters which are not tested and the tests takes long already, so removal is warranted.
- Changed the prior slightly for half-width priors as this seemingly caused issues with the `RQKernel` sometimes (albeit an order of magnitude more rarely compared to the periodic kernel)