### PR TITLE
Make `allow_*` flags work with caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `batch_size>1`
 - Crash with minimized targets constructed via the legacy interface
 - `Campaign.allow_*` flags now properly take into account recommendation caching
+- The campaign recommendation cache is now properly invalidated during context changes
 
 ## [0.14.0] - 2025-09-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crash in `simulate_experiment` when calculating cumulative best values for
   `batch_size>1`
 - Crash with minimized targets constructed via the legacy interface
+- `Campaign.allow_*` flags now properly take into account recommendation caching
 
 ## [0.14.0] - 2025-09-10
 ### Added

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -525,7 +525,7 @@ class Campaign(SerialMixin):
         if self.searchspace.type is SearchSpaceType.DISCRETE:
             # TODO: This implementation should at some point be hidden behind an
             #   appropriate public interface, like `SubspaceDiscrete.filter()`
-            mask_todrop = self._searchspace_metadata[_EXCLUDED].copy()
+            mask_todrop = self._searchspace_metadata[_EXCLUDED].astype(bool)
             if not self.allow_recommending_already_recommended:
                 mask_todrop |= self._searchspace_metadata[_RECOMMENDED]
             if not self.allow_recommending_already_measured:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -367,7 +367,7 @@ class Campaign(SerialMixin):
             ValueError: If the given data contains indices not present in existing
                 measurements.
         """
-        # With new measurements, the recommendations must always be recomputed
+        # With changed measurements, the recommendations must always be recomputed
         self.clear_cache()
 
         # Validate target and parameter input values

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -316,9 +316,6 @@ class Campaign(SerialMixin):
             numerical_measurements_must_be_within_tolerance: Flag indicating if
                 numerical parameters need to be within their tolerances.
         """
-        # With new measurements, the recommendations must always be recomputed
-        self.clear_cache()
-
         # Validate target and parameter input values
         validate_target_input(data, self.targets)
         if self.objective is not None:
@@ -328,6 +325,9 @@ class Campaign(SerialMixin):
         )
         data = normalize_input_dtypes(data, self.parameters + self.targets)
         data.__class__ = _ValidatedDataFrame
+
+        # With new measurements, the recommendations must always be recomputed
+        self.clear_cache()
 
         # Read in measurements and add them to the database
         self.n_batches_done += 1
@@ -367,9 +367,6 @@ class Campaign(SerialMixin):
             ValueError: If the given data contains indices not present in existing
                 measurements.
         """
-        # With changed measurements, the recommendations must always be recomputed
-        self.clear_cache()
-
         # Validate target and parameter input values
         validate_target_input(data, self.targets)
         if self.objective is not None:
@@ -379,6 +376,9 @@ class Campaign(SerialMixin):
         )
         data = normalize_input_dtypes(data, self.parameters + self.targets)
         data.__class__ = _ValidatedDataFrame
+
+        # With changed measurements, the recommendations must always be recomputed
+        self.clear_cache()
 
         # Block duplicate input indices
         if data.index.has_duplicates:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -83,8 +83,9 @@ def _make_allow_flag_default_factory(
 
 
 def _set_with_cache_cleared(instance: Campaign, attribute: Attribute, value: _T) -> _T:
-    """Attrs-compatible hook to clear the cache when setting an attribute."""
-    instance.clear_cache()
+    """Attrs-compatible hook to clear the cache when changing an attribute."""
+    if value != getattr(instance, attribute.name):
+        instance.clear_cache()
     return value
 
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -489,6 +489,12 @@ class Campaign(SerialMixin):
         Raises:
             ValueError: If ``batch_size`` is smaller than 1.
         """
+        if batch_size < 1:
+            raise ValueError(
+                f"You must at least request one recommendation per batch, but provided "
+                f"{batch_size=}."
+            )
+
         # IMPROVE: The cache handling needs improvement:
         #   * Currently, we simply invalidate the cache whenever pending experiments are
         #     provided, because in order to use it, we need to check if the previous
@@ -500,14 +506,8 @@ class Campaign(SerialMixin):
         #     pending experiments have no intersection with the cached recommendations.
         #     Additional shortcuts might be possible.
 
-        if batch_size < 1:
-            raise ValueError(
-                f"You must at least request one recommendation per batch, but provided "
-                f"{batch_size=}."
-            )
-
         if pending_experiments is not None:
-            self.clear_cache()  # see IMPROVE comment above
+            self.clear_cache()
 
             validate_parameter_input(pending_experiments, self.parameters)
             pending_experiments = normalize_input_dtypes(
@@ -515,7 +515,6 @@ class Campaign(SerialMixin):
             )
             pending_experiments.__class__ = _ValidatedDataFrame
 
-        # This condition may be improved in the future (see IMPROVE comment above)
         if (
             pending_experiments is None
             and (cache := self._cached_recommendation) is not None

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -400,7 +400,7 @@ class Campaign(SerialMixin):
         cols = [p.name for p in self.parameters] + [t.name for t in self.targets]
         self._measurements_exp.loc[data.index, cols] = data[cols]
 
-        # Reset fit number and cached recommendations
+        # Reset fit number
         self._measurements_exp.loc[data.index, "FitNr"] = np.nan
 
     def toggle_discrete_candidates(  # noqa: DOC501

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -495,16 +495,9 @@ class Campaign(SerialMixin):
                 f"{batch_size=}."
             )
 
-        # IMPROVE: The cache handling needs improvement:
-        #   * Currently, we simply invalidate the cache whenever pending experiments are
-        #     provided, because in order to use it, we need to check if the previous
-        #     call was done with the same pending experiments.
-        #   * Ideally, once the previous pending experiments are stored,
-        #     we could do a smart check if the cache can be reused even when the
-        #     new pending experiments differ. For example, the cache is still valid
-        #     if a previous call was done without pending experiments and the new
-        #     pending experiments have no intersection with the cached recommendations.
-        #     Additional shortcuts might be possible.
+        # IMPROVE: Currently, we simply invalidate the cache whenever pending
+        #     experiments are provided, because in order to use it, we need to check if
+        #     the previous call was done with the same pending experiments.
 
         if pending_experiments is not None:
             self.clear_cache()

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -426,7 +426,7 @@ def test_cache_invalidation(
 ):
     """Altering mutable public attributes invalidates the cache."""
     if isinstance(value, bool):
-        new_value = not value if change else value
+        new_value = value ^ change
     else:
         # Important: Even if we do not change, we use a new instance of the same class
         #   to test that equality is a sufficient condition for not clearing the cache

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -166,14 +166,14 @@ def test_allow_measured_flag(campaign_for_flag_test: Campaign):
                 # Because the data context is different in each loop iteration,
                 # the recommender must be called instead of using the cache
                 rec = campaign.recommend(1)
-                assert mock_recommend.call_count == i + 1
+            assert mock_recommend.call_count == i + 1
 
-                # A follow-up call should use the cache
-                campaign.recommend(1)
-                assert mock_recommend.call_count == i + 1
+            # A follow-up call should use the cache
+            campaign.recommend(1)
+            assert mock_recommend.call_count == i + 1
 
-            add_fake_measurements(rec, campaign.targets)
-            campaign.add_measurements(rec)
+        add_fake_measurements(rec, campaign.targets)
+        campaign.add_measurements(rec)
 
 
 @pytest.mark.parametrize(
@@ -249,7 +249,7 @@ def test_update_measurements(ongoing_campaign):
     assert meas.iloc[0, updated.columns.get_loc(p_name)] == 1337
     assert meas.iloc[0, updated.columns.get_loc(t_name)] == 1337
     assert meas.iloc[[0], updated.columns.get_loc("FitNr")].isna().all()
-    assert ongoing_campaign._cached_recommendation.empty
+    assert ongoing_campaign._cached_recommendation is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -20,6 +20,7 @@ from baybe.parameters.numerical import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
 )
+from baybe.recommenders.base import RecommenderProtocol
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.recommenders.pure.nonpredictive.sampling import (
     FPSRecommender,
@@ -49,7 +50,10 @@ def campaign_for_flag_test(request) -> Campaign:
         **request.param,
     }
     campaign = Campaign(searchspace, objective, **flags)
-    return evolve(campaign, recommender=Mock(wraps=TwoPhaseMetaRecommender()))
+    return evolve(
+        campaign,
+        recommender=Mock(wraps=TwoPhaseMetaRecommender(), spec=RecommenderProtocol),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_pending_experiments.py
+++ b/tests/test_pending_experiments.py
@@ -116,7 +116,7 @@ def test_pending_points(campaign, batch_size, fake_measurements):
     # some recommenders which could also trivially avoid overlap
     with temporary_seed(1337):
         rec1 = campaign.recommend(batch_size)
-    campaign._cached_recommendation is None
+    campaign.clear_cache()
     with temporary_seed(1337):
         rec2 = campaign.recommend(batch_size=batch_size, pending_experiments=rec1)
 

--- a/tests/test_pending_experiments.py
+++ b/tests/test_pending_experiments.py
@@ -116,7 +116,7 @@ def test_pending_points(campaign, batch_size, fake_measurements):
     # some recommenders which could also trivially avoid overlap
     with temporary_seed(1337):
         rec1 = campaign.recommend(batch_size)
-    campaign._cached_recommendation = pd.DataFrame()  # ensure no recommendation cache
+    campaign._cached_recommendation is None
     with temporary_seed(1337):
         rec2 = campaign.recommend(batch_size=batch_size, pending_experiments=rec1)
 


### PR DESCRIPTION
Fixes #654. 

Improvements that are out of scope for this bugfix PR:
* Less strict cache invalidation: For several cases, the PR clears the cache too conservatively (see also comments added).  In particular, caching is not used at all / immediately cleared as soon as pending experiments enter the stage. By storing the previous recommendation context and using more fine-grained conditions, cache usage could be further extended.
* Instead of manually maintaining the caching logic and conditions, we might also consider switching to a built-in approach (e.g. using `@cached` directly on the recommender level), which would potentially simply the logic significantly and avoid future bugs due to not having to think about edge cases. However, the caching approach would then be even stricter as it is now, since it would only work based on the incoming objects.