### PR TITLE
Fix random seed handling in simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set to `True`, targets seek to avoid the given `match_value` instead of matching it.
 - Transfer learning regression benchmarks infrastructure for evaluating TL model
   performance on regression tasks
+
+### Fixed
+- Random seed not entering simulation when explicitly passed to `simulate_scenarios`
  
 ## [0.14.1] - 2025-10-01
 ### Added

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -107,7 +107,9 @@ def simulate_scenarios(
         ):
             """Callable for xyzpy simulation."""
             data = None if initial_data is None else initial_data[Initial_Data]
-            seed = None if random_seed is None else Monte_Carlo_Run + _DEFAULT_SEED
+            seed = Monte_Carlo_Run + (
+                _DEFAULT_SEED if random_seed is None else random_seed
+            )
             result = _simulate_groupby(
                 scenarios[Scenario],
                 lookup,

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -47,7 +47,7 @@ def test_simulate_scenarios_structure(campaign, batch_size):
     """Test simulate_scenarios output structure and correctness."""
     doe_iterations = 2
     n_mc_iterations = 2
-    simulation_random_seed = 1337
+    simulation_random_seed = 59234  # <-- uncommon number to avoid clash with default
     scenarios = {"test": campaign}
 
     result = simulate_scenarios(


### PR DESCRIPTION
Fixes a wrong assignment for controlling the random seeds in `simulate_scenarios`. Potentially, this was the cause for many weird effects noticed in the benchmarking module in the past.