### PR TITLE
Extend scipy Import Whitelist

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -97,7 +97,7 @@ WHITELISTS = {
         "baybe.utils.clustering_algorithms.third_party",
         "baybe.utils.clustering_algorithms.third_party.kmedoids",
     ]
-    + (["baybe._optional.simulation"] if sys.version_info >= (3, 13) else []),
+    + (["baybe._optional.simulation"] if sys.version_info >= (3, 11) else []),
     "sklearn": [
         "baybe._optional.chem",
         "baybe._optional.insights",


### PR DESCRIPTION
The `simulation` module depends on `xyzpy` which itself needs `xarray`. Due to [some changes with its backend](https://docs.xarray.dev/en/stable/whats-new.html#breaking-changes) for some reason this now imports scipy in our package. Thus, the module has to be added to the whitelist for import tests.

This [has previously been done](https://github.com/emdgroup/baybe/commit/1e470af59cd6ab264c3cf4533c9b2b0157401bbd) for Python 3.13, but the regular CI [shows](https://github.com/emdgroup/baybe/actions/runs/18990550790) this is also required for 3.12 and 3.11, which is easily missed because those versions are not tested in normal CI. Python 3.10 is apparently not affected.