### PR TITLE
Fix width issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,12 @@ If you find BayBE useful, please consider citing [our paper](https://doi.org/10.
 
 ```bibtex
 @article{baybe_2025,
-  author = "Fitzner, Martin and {\v S}o{\v s}i{\'c}, Adrian and Hopp, Alexander V. and M{\"u}ller, Marcel and Rihana, Rim and Hrovatin, Karin and Liebig, Fabian and Winkel, Mathias and Halter, Wolfgang and Brandenburg, Jan Gerit",
-  title  = "{BayBE}: a {B}ayesian {B}ack {E}nd for experimental planning in the low-to-no-data regime",
+  author = "Fitzner, Martin and {\v S}o{\v s}i{\'c}, Adrian and 
+            Hopp, Alexander V. and M{\"u}ller, Marcel and Rihana, Rim and 
+            Hrovatin, Karin and Liebig, Fabian and Winkel, Mathias and 
+            Halter, Wolfgang and Brandenburg, Jan Gerit",
+  title  = "{BayBE}: a {B}ayesian {B}ack {E}nd for experimental planning 
+            in the low-to-no-data regime",
   journal = "Digital Discovery",
   year = "2025",
   volume = "4",


### PR DESCRIPTION
This PR fixes the width issue that we were seeing in the README of the documentation.

The issue was due to the list of authors in the citation being too long. It has thus been reformatted.

*IMPORTANT*: Please investigate the documentation that was built on the fork on different devices to ensure that the issue is indeed solved by this simple reformatting: https://avhopp.github.io/baybe_dev/latest/