### PR TITLE
Implement Transfer Learning dispatching via TaskParameter.transfer_mode

### DIFF
--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -1,6 +1,7 @@
 """Categorical parameters."""
 
 import gc
+from enum import Enum
 from functools import cached_property
 
 import numpy as np
@@ -14,6 +15,13 @@ from baybe.parameters.enum import CategoricalEncoding
 from baybe.parameters.validation import validate_unique_values
 from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.numerical import DTypeFloatNumpy
+
+
+class TransferMode(Enum):
+    """Transfer learning modes for TaskParameter."""
+
+    JOINT = "joint"  # Use IndexKernel approach (multi-task GP)
+    MEAN = "mean"  # Use mean transfer from source prior
 
 
 def _convert_values(value, self, field) -> tuple[str, ...]:
@@ -86,6 +94,9 @@ class TaskParameter(CategoricalParameter):
 
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
     # See base class.
+
+    transfer_mode: TransferMode = field(default=TransferMode.JOINT)
+    """The transfer learning mode for this task parameter."""
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -22,12 +22,13 @@ from baybe.exceptions import (
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace import SearchSpace
-from baybe.surrogates import CustomONNXSurrogate, GaussianProcessSurrogate
+from baybe.surrogates import CustomONNXSurrogate
 from baybe.surrogates.base import (
     IndependentGaussianSurrogate,
     Surrogate,
     SurrogateProtocol,
 )
+from baybe.surrogates.gaussian_process.core import AdaptiveGaussianProcessSurrogate
 from baybe.utils.dataframe import _ValidatedDataFrame, normalize_input_dtypes
 from baybe.utils.validation import (
     validate_object_names,
@@ -52,7 +53,7 @@ class BayesianRecommender(PureRecommender, ABC):
     """An abstract class for Bayesian Recommenders."""
 
     _surrogate_model: SurrogateProtocol = field(
-        alias="surrogate_model", factory=GaussianProcessSurrogate
+        alias="surrogate_model", factory=AdaptiveGaussianProcessSurrogate
     )
     """The surrogate model."""
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -192,6 +192,32 @@ class SearchSpace(SerialMixin):
             ),
         )
 
+    def remove_task_parameters(self) -> SearchSpace:
+        """Return a new SearchSpace with TaskParameter instances removed.
+
+        Returns:
+            A new SearchSpace without TaskParameter instances. If no TaskParameter
+            exists, returns a copy of the original SearchSpace.
+
+        Raises:
+            ValueError: If removing TaskParameters would result in an empty SearchSpace.
+        """
+        all_parameters = list(self.parameters)
+        filtered_parameters = [
+            param for param in all_parameters if not isinstance(param, TaskParameter)
+        ]
+
+        if not filtered_parameters:
+            raise ValueError(
+                "Cannot remove TaskParameters: this would result"
+                "in an empty SearchSpace. "
+                "At least one non-TaskParameter must be present."
+            )
+
+        return SearchSpace.from_product(
+            parameters=filtered_parameters, constraints=list(self.constraints)
+        )
+
     @property
     def parameters(self) -> tuple[Parameter, ...]:
         """Return the list of parameters of the search space."""

--- a/baybe/surrogates/transfer_learning/source_prior.py
+++ b/baybe/surrogates/transfer_learning/source_prior.py
@@ -1,0 +1,168 @@
+"""Source prior transfer learning surrogate using DataFrame-based operations."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pandas as pd
+from attrs import define, field
+from botorch.models.model import Model
+from botorch.posteriors import Posterior
+from typing_extensions import override
+
+from baybe.exceptions import ModelNotTrainedError
+from baybe.objectives.base import Objective
+from baybe.parameters import TaskParameter
+from baybe.searchspace.core import SearchSpace
+from baybe.surrogates.gaussian_process.core import (
+    GaussianProcessSurrogate,
+)
+
+
+@define
+class SourcePriorGaussianProcessSurrogate(GaussianProcessSurrogate):
+    """Source prior transfer learning Gaussian process surrogate.
+
+    This surrogate implements transfer learning by:
+    1. Splitting measurement data into source and target tasks
+    2. Training a source GP on source task data (without task dimension)
+    3. Training a target GP on target task data, using source GP as prior
+    4. Using only the target GP for predictions
+
+    Transfer learning is configured via TransferConfig objects that specify how to
+    transfer mean functions and/or covariance functions from the source GP.
+    """
+
+    # Class variables
+    supports_transfer_learning: ClassVar[bool] = True
+    """Class variable encoding transfer learning support."""
+
+    supports_multi_output: ClassVar[bool] = False
+    """Class variable encoding multi-output compatibility."""
+
+    # Private attributes for storing model state
+    _source_surrogate: GaussianProcessSurrogate | None = field(
+        init=False, default=None, eq=False
+    )
+    """The source surrogate (needed for posterior calls)."""
+
+    _target_surrogate: GaussianProcessSurrogate | None = field(
+        init=False, default=None, eq=False
+    )
+    """The target surrogate (needed for posterior calls)."""
+
+    _reduced_searchspace: SearchSpace | None = field(init=False, default=None, eq=False)
+    """SearchSpace without task parameter (for routing posterior calls)."""
+
+    _objective: Objective | None = field(init=False, default=None, eq=False)
+    """Stored objective for creating target surrogate."""
+
+    _task_name: str | None = field(init=False, default=None, eq=False)
+    """Name of the task parameter."""
+
+    @override
+    def fit(
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: pd.DataFrame,
+    ) -> None:
+        """Fit source and target GPs using data splitting.
+
+        Args:
+            searchspace: The search space including TaskParameter
+            objective: The objective to optimize
+            measurements: Training data including task column
+
+        Raises:
+            ValueError: If no TaskParameter found in searchspace
+            ValueError: If no source data available for transfer learning
+        """
+        # Validate and extract task information
+        task_param = next(
+            (p for p in searchspace.parameters if isinstance(p, TaskParameter)), None
+        )
+        if task_param is None:
+            raise ValueError(
+                "SourcePriorGaussianProcessSurrogate requires a TaskParameter"
+            )
+
+        target_tasks = task_param.active_values
+        source_tasks = [t for t in task_param.values if t not in target_tasks]
+        self._task_name = task_param.name
+
+        source_data = measurements[
+            measurements[self._task_name].isin(source_tasks)
+        ].drop(columns=[self._task_name])
+        target_data = measurements[
+            measurements[self._task_name].isin(target_tasks)
+        ].drop(columns=[self._task_name])
+
+        if len(source_data) == 0:
+            raise ValueError(
+                "No source data found. SourcePriorGaussianProcessSurrogate requires "
+                "at least source data for transfer learning."
+            )
+
+        # Store context
+        reduced_searchspace = searchspace.remove_task_parameters()
+        # TODO: Do we need to store?
+        self._reduced_searchspace = reduced_searchspace
+        self._searchspace = searchspace
+        self._objective = objective
+
+        # Train source GP
+        self._source_surrogate = GaussianProcessSurrogate(
+            kernel_or_factory=self.kernel_factory
+        )
+        self._source_surrogate.fit(reduced_searchspace, objective, source_data)
+        # Train target GP with source prior
+        if len(target_data) == 0:
+            # No target data - use source surrogate directly
+            self._target_surrogate = self._source_surrogate  # type: ignore[return-value]
+        else:
+            # Create target surrogate with transfer learning
+            self._target_surrogate = GaussianProcessSurrogate.from_prior(
+                prior_gp=self._source_surrogate.to_botorch(),  # type: ignore[union-attr]
+                kernel_factory=self.kernel_factory,
+            )
+
+            # Fit the target surrogate with target data
+            self._target_surrogate.fit(reduced_searchspace, objective, target_data)
+
+    @override
+    def posterior(self, candidates: pd.DataFrame) -> Posterior:
+        """Get posterior predictions from target GP only.
+
+        Args:
+            candidates: DataFrame with parameter configurations
+
+        Returns:
+            Posterior distribution for target task only
+
+        Raises:
+            ModelNotTrainedError: If model not fitted
+            ValueError: If candidates contain source task data
+        """
+        if self._target_surrogate is None:
+            raise ModelNotTrainedError("Model must be fitted first")
+
+        candidates_clean = candidates.drop(columns=self._task_name, errors="ignore")
+
+        return self._target_surrogate.posterior(candidates_clean)
+
+    @override
+    def to_botorch(self) -> Model:
+        """Return the BoTorch model representation.
+
+        Returns:
+            A wrapper model that delegates to the target surrogate
+
+        Raises:
+            ModelNotTrainedError: If model not fitted
+        """
+        if self._target_surrogate is None:
+            raise ModelNotTrainedError(
+                "Model must be fitted before accessing BoTorch model."
+            )
+        return self._target_surrogate.to_botorch()


### PR DESCRIPTION
Users previously had to configure transfer learning in two places: adding a `TaskParameter` to the searchspace AND explicitly choosing `SourcePriorGaussianProcessSurrogate` in the recommender. The new implementation makes transfer learning configurable via `TaskParameter.transfer_mode` and makes `SourcePriorGaussianProcessSurrogate` an internal implementation detail which is not user facing.

Key Changes

  1. `TaskParameter` with Transfer Modes
  - Added `TransferMode` enum with `JOINT` (default) and `MEAN` values
  - Added `transfer_mode` field to `TaskParameter` with `JOINT` as backward-compatible default


  2. Adaptive Surrogate Dispatch System
  - Implemented `AdaptiveGaussianProcessSurrogate` as a dispatching wrapper
  - Automatically dispatches based on `TaskParameter.transfer_mode`:
    - `JOINT` mode → `GaussianProcessSurrogate` (`IndexKernel` multi-task)
    - `MEAN `mode → `SourcePriorGaussianProcessSurrogate` (mean transfer)

  3. Updated Recommender Factory
  - Changed default factory from `GaussianProcessSurrogate` to `AdaptiveGaussianProcessSurrogate`

  4. SearchSpace helpers
  - Added helper methods for transfer learning with `SourcePriorGaussianProcessSurrogate`

**New API**

**Before**

```
# Required TWO configuration points
task_param = TaskParameter(name="task", values=["source", "target"])  # Point 1
searchspace = SearchSpace.from_product([numerical_param, task_param])

# Point 2: Explicit surrogate selection
recommender = BotorchRecommender(
    surrogate_model=SourcePriorGaussianProcessSurrogate()  # Manual choice
)
```

**After (Single Configuration)**

```
# Single configuration point
task_param = TaskParameter(
    name="task",
    values=["source", "target"],
    transfer_mode=TransferMode.MEAN  # Only configuration needed!
)
searchspace = SearchSpace.from_product([numerical_param, task_param])

# Automatic dispatch - no explicit surrogate needed
recommender = BotorchRecommender()  # Auto-creates appropriate surrogate
```

