### PR TITLE
Option to increment random seeds across scenarios during simulation

### DIFF
--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -79,7 +79,7 @@ class _Rollouts:
     def _validate_mc_scenarios(self, _: Attribute, value: Any):
         if value and self.n_mc_iterations is not None:
             raise ValueError(
-                "If `n_mc_iteratios` is not `None`, `mc_scenarios` does not have an "
+                "If `n_mc_iterations` is not `None`, `mc_scenarios` does not have an "
                 "effect. Perhaps you misspecified the parameters? If not, consider "
                 "setting `mc_scenarios` to False."
             )


### PR DESCRIPTION
Solution to the discussion in https://github.com/emdgroup/baybe/issues/722

Now simulate scenarios has two general options:
- if n_mc_iteratios is a number: as before produce a cartesian product of n_mc_iterations * initial_data * scenarios
- if n_mc_iteratios is None then increment the seed as follows:
  - if mc_scenarios is False (default, original behaviour): increment seed for every initial_data and create a cartesian product with scenarios
  - if mc_scenarios is True (the new behaviour requested in the issue): increment seed for every combination (cartesian product) of initial_data and scenarios

Note:
- This changes `_Rolllouts` interface with breaking changes. I hope that is ok since this is a private class.
- [ ] No test are added or changed as of yet (same for changelog) - lets first discuss if the interface and behaviour even make sense.


This is an example of cases to be run when using 2 scenarios with different parameters:

```
n_mc_iterations=None, n_initial_data=None, mc_scenarios=True
   Scenario  Initial_Data  Random_Seed
0         0           NaN            0
1         1           NaN            1
n_mc_iterations=None, n_initial_data=None, mc_scenarios=False
Setting the number of Monte Carlo iterations to `None` requires that either initial data or multiple scenarios for MC are specified. Perhaps you forgot to do so? If not, consider setting the number of iterations to 1.
n_mc_iterations=None, n_initial_data=2, mc_scenarios=True
   Scenario  Initial_Data  Random_Seed
0         0             0            0
1         0             1            1
2         1             0            2
3         1             1            3
n_mc_iterations=None, n_initial_data=2, mc_scenarios=False
   Scenario  Initial_Data  Random_Seed
0         0             0            0
1         0             1            1
2         1             0            0
3         1             1            1
n_mc_iterations=2, n_initial_data=None, mc_scenarios=True
If `n_mc_iteratios` is not `None`, `mc_scenarios` does not have an effect. Perhaps you misspecified the parameters? If not, consider setting the n_mc_iterations to None.
n_mc_iterations=2, n_initial_data=None, mc_scenarios=False
   Random_Seed  Initial_Data  Scenario
0            0           NaN         0
1            0           NaN         1
2            1           NaN         0
3            1           NaN         1
n_mc_iterations=2, n_initial_data=2, mc_scenarios=True
If `n_mc_iteratios` is not `None`, `mc_scenarios` does not have an effect. Perhaps you misspecified the parameters? If not, consider setting the n_mc_iterations to None.
n_mc_iterations=2, n_initial_data=2, mc_scenarios=False
   Random_Seed  Initial_Data  Scenario
0            0             0         0
1            0             0         1
2            0             1         0
3            0             1         1
4            1             0         0
5            1             0         1
6            1             1         0
7            1             1         1

```