### PR TITLE
Support `PositiveIndexKernel` and dispatching via `TaskParameter`

### DIFF
--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -18,11 +18,11 @@ from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.numerical import DTypeFloatNumpy
 
 
-class TransferMode(Enum):
-    """Transfer learning modes for TaskParameter."""
+class TaskCorrelation(Enum):
+    """Task correlation modes for TaskParameter."""
 
-    JOINT = "joint"
-    JOINT_POS = "joint_pos"
+    UNKNOWN = "unknown"
+    POSITIVE = "positive"
 
 
 def _convert_values(value, self, field) -> tuple[str, ...]:
@@ -96,27 +96,27 @@ class TaskParameter(CategoricalParameter):
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
     # See base class.
 
-    transfer_mode: TransferMode = field(default=TransferMode.JOINT_POS)
-    """Transfer learning mode. Defaults to transfer via PositiveIndexKernel."""
+    task_correlation: TaskCorrelation = field(default=TaskCorrelation.POSITIVE)
+    """Task correlation. Defaults to positive correlation via PositiveIndexKernel."""
 
-    @transfer_mode.validator
-    def _validate_transfer_mode_active_values(  # noqa: DOC101, DOC103
-        self, _: Any, value: TransferMode
+    @task_correlation.validator
+    def _validate_task_correlation_active_values(  # noqa: DOC101, DOC103
+        self, _: Any, value: TaskCorrelation
     ) -> None:
-        """Validate active values compatibility with transfer mode.
+        """Validate active values compatibility with task correlation mode.
 
         Raises:
-            ValueError: If transfer_mode is JOINT_POS but active_values contains more
+            ValueError: If task_correlation is POSITIVE but active_values contains more
                 than one value.
         """
-        # Check JOINT_POS constraint: must have exactly one active value
+        # Check POSITIVE constraint: must have exactly one active value
         # Note: _active_values is the internal field, could be None
-        if value == TransferMode.JOINT_POS and self._active_values is not None:
+        if value == TaskCorrelation.POSITIVE and self._active_values is not None:
             if len(self._active_values) > 1:
                 raise ValueError(
-                    f"Transfer mode '{TransferMode.JOINT_POS.value}' requires exactly "
+                    f"Task correlation '{TaskCorrelation.POSITIVE.value}' requires "
                     f"one active value, but {len(self._active_values)} were provided: "
-                    f"{self._active_values}. The JOINT_POS mode uses the "
+                    f"{self._active_values}. The POSITIVE mode uses the "
                     f"PositiveIndexKernel which assumes a single target task."
                 )
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -1,6 +1,7 @@
 """Categorical parameters."""
 
 import gc
+from enum import Enum
 from functools import cached_property
 
 import numpy as np
@@ -14,6 +15,13 @@ from baybe.parameters.enum import CategoricalEncoding
 from baybe.parameters.validation import validate_unique_values
 from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.numerical import DTypeFloatNumpy
+
+
+class TransferMode(Enum):
+    """Transfer learning modes for TaskParameter."""
+
+    JOINT = "joint"
+    JOINT_POS = "joint_pos"
 
 
 def _convert_values(value, self, field) -> tuple[str, ...]:
@@ -86,6 +94,9 @@ class TaskParameter(CategoricalParameter):
 
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
     # See base class.
+
+    transfer_mode: TransferMode = field(default=TransferMode.JOINT_POS)
+    """Transfer learning mode. Defaults to transfer via PositiveIndexKernel."""
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -15,7 +15,7 @@ from baybe.constraints import validate_constraints
 from baybe.constraints.base import Constraint
 from baybe.parameters import TaskParameter
 from baybe.parameters.base import Parameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
     MemorySize,
@@ -306,14 +306,14 @@ class SearchSpace(SerialMixin):
             return None
 
     @property
-    def transfer_mode(self) -> TransferMode | None:
-        """The transfer learning mode for this searchspace."""
+    def task_correlation(self) -> TaskCorrelation | None:
+        """The task correlation mode for this searchspace."""
         # TODO [16932]: This approach only works for a single task parameter.
         try:
             task_param = next(
                 p for p in self.parameters if isinstance(p, TaskParameter)
             )
-            return task_param.transfer_mode
+            return task_param.task_correlation
 
         # When there are no task parameters, we return None
         except StopIteration:

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -15,6 +15,7 @@ from baybe.constraints import validate_constraints
 from baybe.constraints.base import Constraint
 from baybe.parameters import TaskParameter
 from baybe.parameters.base import Parameter
+from baybe.parameters.categorical import TransferMode
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
     MemorySize,
@@ -278,6 +279,45 @@ class SearchSpace(SerialMixin):
         # When there are no task parameters, we effectively have a single task
         except StopIteration:
             return 1
+
+    @property
+    def target_task_idxs(self) -> list[int] | None:
+        """The indices of the target tasks in the computational representation.
+
+        Returns a list of integer indices corresponding to each active value in the
+        TaskParameter. Returns None when there are no task parameters.
+        """
+        # TODO [16932]: This approach only works for a single task parameter.
+        try:
+            task_param = next(
+                p for p in self.parameters if isinstance(p, TaskParameter)
+            )
+            comp_df = task_param.comp_df
+
+            # Extract computational representation indices for all active values
+            target_task_idxs = [
+                int(comp_df.loc[active_value].iloc[0])
+                for active_value in task_param.active_values
+            ]
+            return target_task_idxs
+
+        # When there are no task parameters, return None
+        except StopIteration:
+            return None
+
+    @property
+    def transfer_mode(self) -> TransferMode | None:
+        """The transfer learning mode for this searchspace."""
+        # TODO [16932]: This approach only works for a single task parameter.
+        try:
+            task_param = next(
+                p for p in self.parameters if isinstance(p, TaskParameter)
+            )
+            return task_param.transfer_mode
+
+        # When there are no task parameters, we return None
+        except StopIteration:
+            return None
 
     def get_comp_rep_parameter_indices(self, name: str, /) -> tuple[int, ...]:
         """Find a parameter's column indices in the computational representation.

--- a/benchmarks/definition/regression/core.py
+++ b/benchmarks/definition/regression/core.py
@@ -108,10 +108,6 @@ def spearman_rho_score(x: np.ndarray, y: np.ndarray, /) -> float:
     return rho
 
 
-# Transfer learning modes to evaluate (no longer need TL_MODELS dict)
-# Dispatching now happens automatically via TaskCorrelation in searchspace
-
-
 # Regression metrics to evaluate model performance
 REGRESSION_METRICS = {
     root_mean_squared_error,
@@ -245,7 +241,7 @@ def run_tl_regression_benchmark(
             result.update(metrics)
             results.append(result)
 
-            # IndexKernel on full search space
+            # IndexKernel on full search space, no source data
             metrics = _evaluate_model(
                 GaussianProcessSurrogate(),
                 target_train,
@@ -265,7 +261,7 @@ def run_tl_regression_benchmark(
             result.update(metrics)
             results.append(result)
 
-            # PositiveIndexKernel on full search space
+            # PositiveIndexKernel on full search space, no source data
             metrics = _evaluate_model(
                 GaussianProcessSurrogate(),
                 target_train,
@@ -308,7 +304,7 @@ def run_tl_regression_benchmark(
 
                 combined_data = pd.concat([source_subset, target_train])
 
-                # Evaluate IndexKernel (JOINT mode)
+                # Evaluate IndexKernel
                 scenario_name = f"{int(100 * fraction_source)}_index"
                 metrics = _evaluate_model(
                     GaussianProcessSurrogate(),
@@ -329,7 +325,7 @@ def run_tl_regression_benchmark(
                 result.update(metrics)
                 results.append(result)
 
-                # Evaluate PositiveIndexKernel (JOINT_POS mode)
+                # Evaluate PositiveIndexKernel
                 scenario_name = f"{int(100 * fraction_source)}_pos_index"
                 metrics = _evaluate_model(
                     GaussianProcessSurrogate(),

--- a/benchmarks/definition/regression/core.py
+++ b/benchmarks/definition/regression/core.py
@@ -20,7 +20,7 @@ from tqdm import tqdm
 
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import TaskParameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from benchmarks.definition import TransferLearningRegressionBenchmarkSettings
@@ -44,7 +44,7 @@ class SearchSpaceFactory(Protocol):
         self,
         data: pd.DataFrame,
         use_task_parameter: bool,
-        transfer_mode: TransferMode = TransferMode.JOINT,
+        task_correlation: TaskCorrelation = TaskCorrelation.UNKNOWN,
     ) -> SearchSpace:
         """Create a SearchSpace for regression benchmark evaluation.
 
@@ -54,7 +54,7 @@ class SearchSpaceFactory(Protocol):
                 scenarios. If True, creates search space with TaskParameter for
                 TL models. If False, creates vanilla search space without
                 task parameter.
-            transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+            task_correlation: The task correlation mode (UNKNOWN or POSITIVE).
                 Only used when use_task_parameter is True.
 
         Returns:
@@ -109,7 +109,7 @@ def spearman_rho_score(x: np.ndarray, y: np.ndarray, /) -> float:
 
 
 # Transfer learning modes to evaluate (no longer need TL_MODELS dict)
-# Dispatching now happens automatically via TransferMode in searchspace
+# Dispatching now happens automatically via TaskCorrelation in searchspace
 
 
 # Regression metrics to evaluate model performance
@@ -169,10 +169,10 @@ def run_tl_regression_benchmark(
 
     # Create transfer learning search spaces (with task parameter)
     tl_index_searchspace = searchspace_factory(
-        data=data, use_task_parameter=True, transfer_mode=TransferMode.JOINT
+        data=data, use_task_parameter=True, task_correlation=TaskCorrelation.UNKNOWN
     )
     tl_pos_index_searchspace = searchspace_factory(
-        data=data, use_task_parameter=True, transfer_mode=TransferMode.JOINT_POS
+        data=data, use_task_parameter=True, task_correlation=TaskCorrelation.POSITIVE
     )
 
     # Extract task parameter details (use index searchspace as reference)

--- a/benchmarks/domains/aryl_halides/core.py
+++ b/benchmarks/domains/aryl_halides/core.py
@@ -18,6 +18,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import SubstanceParameter, TaskParameter
 from baybe.parameters.base import DiscreteParameter
+from baybe.parameters.categorical import TransferMode
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -48,8 +49,19 @@ def make_searchspace(
     data: pd.DataFrame,
     target_tasks: Sequence[str] | None = None,
     source_tasks: Sequence[str] | None = None,
+    transfer_mode: TransferMode = TransferMode.JOINT,
 ) -> SearchSpace:
-    """Create the search space for the benchmark."""
+    """Create the search space for the benchmark.
+
+    Args:
+        data: The benchmark data.
+        target_tasks: The target tasks for transfer learning.
+        source_tasks: The source tasks for transfer learning.
+        transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+
+    Returns:
+        The configured search space.
+    """
     params: list[DiscreteParameter] = [
         SubstanceParameter(
             name=substance,
@@ -60,12 +72,12 @@ def make_searchspace(
     ]
     if target_tasks is not None and source_tasks is not None:
         all_tasks = [*source_tasks, *target_tasks]
-        all_tasks = [*source_tasks, *target_tasks]
         params.append(
             TaskParameter(
                 name="aryl_halide",
                 values=all_tasks,
                 active_values=target_tasks,
+                transfer_mode=transfer_mode,
             )
         )
     return SearchSpace.from_product(parameters=params)
@@ -109,10 +121,17 @@ def aryl_halide_tl_substance_benchmark(
     """
     data = load_data()
 
-    searchspace = make_searchspace(
+    searchspace_tl_index = make_searchspace(
         data=data,
         source_tasks=source_tasks,
         target_tasks=target_tasks,
+        transfer_mode=TransferMode.JOINT,
+    )
+    searchspace_tl_pos_index = make_searchspace(
+        data=data,
+        source_tasks=source_tasks,
+        target_tasks=target_tasks,
+        transfer_mode=TransferMode.JOINT_POS,
     )
     searchspace_nontl = make_searchspace(data=data)
 
@@ -120,8 +139,12 @@ def aryl_halide_tl_substance_benchmark(
     initial_data = make_initial_data(data, source_tasks)
     objective = make_objective()
 
-    tl_campaign = Campaign(
-        searchspace=searchspace,
+    tl_index_campaign = Campaign(
+        searchspace=searchspace_tl_index,
+        objective=objective,
+    )
+    tl_pos_index_campaign = Campaign(
+        searchspace=searchspace_tl_pos_index,
         objective=objective,
     )
     nontl_campaign = Campaign(searchspace=searchspace_nontl, objective=objective)
@@ -138,7 +161,8 @@ def aryl_halide_tl_substance_benchmark(
         results.append(
             simulate_scenarios(
                 {
-                    f"{int(100 * p)}": tl_campaign,
+                    f"{int(100 * p)}_index": tl_index_campaign,
+                    f"{int(100 * p)}_pos_index": tl_pos_index_campaign,
                     f"{int(100 * p)}_naive": nontl_campaign,
                 },
                 lookup,
@@ -151,7 +175,11 @@ def aryl_halide_tl_substance_benchmark(
         )
     results.append(
         simulate_scenarios(
-            {"0": tl_campaign, "0_naive": nontl_campaign},
+            {
+                "0_index": tl_index_campaign,
+                "0_pos_index": tl_pos_index_campaign,
+                "0_naive": nontl_campaign,
+            },
             lookup,
             batch_size=settings.batch_size,
             n_doe_iterations=settings.n_doe_iterations,

--- a/benchmarks/domains/aryl_halides/core.py
+++ b/benchmarks/domains/aryl_halides/core.py
@@ -18,7 +18,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import SubstanceParameter, TaskParameter
 from baybe.parameters.base import DiscreteParameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -49,7 +49,7 @@ def make_searchspace(
     data: pd.DataFrame,
     target_tasks: Sequence[str] | None = None,
     source_tasks: Sequence[str] | None = None,
-    transfer_mode: TransferMode = TransferMode.JOINT,
+    task_correlation: TaskCorrelation = TaskCorrelation.UNKNOWN,
 ) -> SearchSpace:
     """Create the search space for the benchmark.
 
@@ -57,7 +57,7 @@ def make_searchspace(
         data: The benchmark data.
         target_tasks: The target tasks for transfer learning.
         source_tasks: The source tasks for transfer learning.
-        transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+        task_correlation: The task correlation mode (UNKNOWN or POSITIVE).
 
     Returns:
         The configured search space.
@@ -77,7 +77,7 @@ def make_searchspace(
                 name="aryl_halide",
                 values=all_tasks,
                 active_values=target_tasks,
-                transfer_mode=transfer_mode,
+                task_correlation=task_correlation,
             )
         )
     return SearchSpace.from_product(parameters=params)
@@ -125,13 +125,13 @@ def aryl_halide_tl_substance_benchmark(
         data=data,
         source_tasks=source_tasks,
         target_tasks=target_tasks,
-        transfer_mode=TransferMode.JOINT,
+        task_correlation=TaskCorrelation.UNKNOWN,
     )
     searchspace_tl_pos_index = make_searchspace(
         data=data,
         source_tasks=source_tasks,
         target_tasks=target_tasks,
-        transfer_mode=TransferMode.JOINT_POS,
+        task_correlation=TaskCorrelation.POSITIVE,
     )
     searchspace_nontl = make_searchspace(data=data)
 

--- a/benchmarks/domains/aryl_halides/regression_tl.py
+++ b/benchmarks/domains/aryl_halides/regression_tl.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import pandas as pd
 
+from baybe.parameters.categorical import TransferMode
 from benchmarks.definition import (
     TransferLearningRegressionBenchmark,
     TransferLearningRegressionBenchmarkSettings,
@@ -58,12 +59,17 @@ def _aryl_halide_tl_regr(
         DataFrame with benchmark results.
     """
 
-    def make_searchspace_wrapper(data: pd.DataFrame, use_task_parameter: bool):
+    def make_searchspace_wrapper(
+        data: pd.DataFrame,
+        use_task_parameter: bool,
+        transfer_mode: TransferMode = TransferMode.JOINT,
+    ):
         if use_task_parameter:
             return make_searchspace(
                 data=data,
                 source_tasks=source_tasks,
                 target_tasks=target_tasks,
+                transfer_mode=transfer_mode,
             )
         else:
             return make_searchspace(data=data)

--- a/benchmarks/domains/aryl_halides/regression_tl.py
+++ b/benchmarks/domains/aryl_halides/regression_tl.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 
 import pandas as pd
 
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from benchmarks.definition import (
     TransferLearningRegressionBenchmark,
     TransferLearningRegressionBenchmarkSettings,
@@ -62,14 +62,14 @@ def _aryl_halide_tl_regr(
     def make_searchspace_wrapper(
         data: pd.DataFrame,
         use_task_parameter: bool,
-        transfer_mode: TransferMode = TransferMode.JOINT,
+        task_correlation: TaskCorrelation = TaskCorrelation.UNKNOWN,
     ):
         if use_task_parameter:
             return make_searchspace(
                 data=data,
                 source_tasks=source_tasks,
                 target_tasks=target_tasks,
-                transfer_mode=transfer_mode,
+                task_correlation=task_correlation,
             )
         else:
             return make_searchspace(data=data)

--- a/benchmarks/domains/direct_arylation/convergence_tl.py
+++ b/benchmarks/domains/direct_arylation/convergence_tl.py
@@ -15,7 +15,7 @@ from baybe.parameters import (
     TaskParameter,
 )
 from baybe.parameters.base import DiscreteParameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -42,14 +42,14 @@ def load_data() -> pd.DataFrame:
 def make_searchspace(
     data: pd.DataFrame,
     use_task_parameter: bool,
-    transfer_mode: TransferMode = TransferMode.JOINT,
+    task_correlation: TaskCorrelation = TaskCorrelation.UNKNOWN,
 ) -> SearchSpace:
     """Create the search space for the benchmark.
 
     Args:
         data: The benchmark data.
         use_task_parameter: Whether to include a task parameter.
-        transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+        task_correlation: The task correlation mode (UNKNOWN or POSITIVE).
 
     Returns:
         The configured search space.
@@ -73,7 +73,7 @@ def make_searchspace(
                 name="Temp_C",
                 values=["90", "105", "120"],
                 active_values=["105"],
-                transfer_mode=transfer_mode,
+                task_correlation=task_correlation,
             )
         )
     return SearchSpace.from_product(parameters=params)
@@ -133,12 +133,12 @@ def direct_arylation_tl_temperature(
     tl_index_searchspace = make_searchspace(
         data=data,
         use_task_parameter=True,
-        transfer_mode=TransferMode.JOINT,
+        task_correlation=TaskCorrelation.UNKNOWN,
     )
     tl_pos_index_searchspace = make_searchspace(
         data=data,
         use_task_parameter=True,
-        transfer_mode=TransferMode.JOINT_POS,
+        task_correlation=TaskCorrelation.POSITIVE,
     )
     searchspace_nontl = make_searchspace(
         data=data,

--- a/benchmarks/domains/easom/convergence_tl.py
+++ b/benchmarks/domains/easom/convergence_tl.py
@@ -11,7 +11,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter, TaskParameter
 from baybe.parameters.base import DiscreteParameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -90,13 +90,13 @@ def easom_tl_47_negate_noise5(settings: ConvergenceBenchmarkSettings) -> pd.Data
         name="Function",
         values=["Target_Function", "Source_Function"],
         active_values=["Target_Function"],
-        transfer_mode=TransferMode.JOINT,
+        task_correlation=TaskCorrelation.UNKNOWN,
     )
     task_param_pos_index = TaskParameter(
         name="Function",
         values=["Target_Function", "Source_Function"],
         active_values=["Target_Function"],
-        transfer_mode=TransferMode.JOINT_POS,
+        task_correlation=TaskCorrelation.POSITIVE,
     )
     params_tl_index = params + [task_param_index]
     params_tl_pos_index = params + [task_param_pos_index]

--- a/benchmarks/domains/easom/convergence_tl.py
+++ b/benchmarks/domains/easom/convergence_tl.py
@@ -11,6 +11,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter, TaskParameter
 from baybe.parameters.base import DiscreteParameter
+from baybe.parameters.categorical import TransferMode
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -85,21 +86,34 @@ def easom_tl_47_negate_noise5(settings: ConvergenceBenchmarkSettings) -> pd.Data
         NumericalDiscreteParameter(name=name, values=values)
         for name, values in grid_locations.items()
     ]
-    task_param = TaskParameter(
+    task_param_index = TaskParameter(
         name="Function",
         values=["Target_Function", "Source_Function"],
         active_values=["Target_Function"],
+        transfer_mode=TransferMode.JOINT,
     )
-    params_tl = params + [task_param]
+    task_param_pos_index = TaskParameter(
+        name="Function",
+        values=["Target_Function", "Source_Function"],
+        active_values=["Target_Function"],
+        transfer_mode=TransferMode.JOINT_POS,
+    )
+    params_tl_index = params + [task_param_index]
+    params_tl_pos_index = params + [task_param_pos_index]
 
     searchspace_nontl = SearchSpace.from_product(parameters=params)
-    searchspace_tl = SearchSpace.from_product(parameters=params_tl)
+    tl_index_searchspace = SearchSpace.from_product(parameters=params_tl_index)
+    tl_pos_index_searchspace = SearchSpace.from_product(parameters=params_tl_pos_index)
 
     objective = SingleTargetObjective(
         target=NumericalTarget(name="Target", minimize=not negate)
     )
-    tl_campaign = Campaign(
-        searchspace=searchspace_tl,
+    tl_index_campaign = Campaign(
+        searchspace=tl_index_searchspace,
+        objective=objective,
+    )
+    tl_pos_index_campaign = Campaign(
+        searchspace=tl_pos_index_searchspace,
         objective=objective,
     )
     nontl_campaign = Campaign(
@@ -137,7 +151,8 @@ def easom_tl_47_negate_noise5(settings: ConvergenceBenchmarkSettings) -> pd.Data
         results.append(
             simulate_scenarios(
                 {
-                    f"{int(100 * p)}": tl_campaign,
+                    f"{int(100 * p)}_index": tl_index_campaign,
+                    f"{int(100 * p)}_pos_index": tl_pos_index_campaign,
                     f"{int(100 * p)}_naive": nontl_campaign,
                 },
                 lookup,
@@ -150,7 +165,11 @@ def easom_tl_47_negate_noise5(settings: ConvergenceBenchmarkSettings) -> pd.Data
         )
     results.append(
         simulate_scenarios(
-            {"0": tl_campaign, "0_naive": nontl_campaign},
+            {
+                "0_index": tl_index_campaign,
+                "0_pos_index": tl_pos_index_campaign,
+                "0_naive": nontl_campaign,
+            },
             lookup,
             batch_size=settings.batch_size,
             n_doe_iterations=settings.n_doe_iterations,

--- a/benchmarks/domains/hartmann/convergence_tl.py
+++ b/benchmarks/domains/hartmann/convergence_tl.py
@@ -11,7 +11,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalDiscreteParameter, TaskParameter
 from baybe.parameters.base import DiscreteParameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -67,13 +67,13 @@ def hartmann_tl_3_20_15(settings: ConvergenceBenchmarkSettings) -> pd.DataFrame:
         name="Function",
         values=["Target_Function", "Source_Function"],
         active_values=["Target_Function"],
-        transfer_mode=TransferMode.JOINT,
+        task_correlation=TaskCorrelation.UNKNOWN,
     )
     task_param_pos_index = TaskParameter(
         name="Function",
         values=["Target_Function", "Source_Function"],
         active_values=["Target_Function"],
-        transfer_mode=TransferMode.JOINT_POS,
+        task_correlation=TaskCorrelation.POSITIVE,
     )
     params_tl_index = params + [task_param_index]
     params_tl_pos_index = params + [task_param_pos_index]

--- a/benchmarks/domains/michalewicz/convergence_tl.py
+++ b/benchmarks/domains/michalewicz/convergence_tl.py
@@ -18,7 +18,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalContinuousParameter, TaskParameter
 from baybe.parameters.base import Parameter
-from baybe.parameters.categorical import TransferMode
+from baybe.parameters.categorical import TaskCorrelation
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -28,13 +28,14 @@ from benchmarks.definition.base import RunMode
 
 
 def make_searchspace(
-    use_task_parameter: bool, transfer_mode: TransferMode = TransferMode.JOINT
+    use_task_parameter: bool,
+    task_correlation: TaskCorrelation = TaskCorrelation.UNKNOWN,
 ) -> SearchSpace:
     """Create search space for the benchmark.
 
     Args:
         use_task_parameter: Whether to include a task parameter.
-        transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+        task_correlation: The task correlation mode (UNKNOWN or POSITIVE).
 
     Returns:
         The configured search space.
@@ -52,7 +53,7 @@ def make_searchspace(
                 name="Function",
                 values=["Target_Function", "Source_Function"],
                 active_values=["Target_Function"],
-                transfer_mode=transfer_mode,
+                task_correlation=task_correlation,
             )
         )
 
@@ -145,10 +146,10 @@ def michalewicz_tl_continuous(settings: ConvergenceBenchmarkSettings) -> pd.Data
     }
     searchspace_nontl = make_searchspace(use_task_parameter=False)
     tl_index_searchspace = make_searchspace(
-        use_task_parameter=True, transfer_mode=TransferMode.JOINT
+        use_task_parameter=True, task_correlation=TaskCorrelation.UNKNOWN
     )
     tl_pos_index_searchspace = make_searchspace(
-        use_task_parameter=True, transfer_mode=TransferMode.JOINT_POS
+        use_task_parameter=True, task_correlation=TaskCorrelation.POSITIVE
     )
 
     objective = make_objective()

--- a/benchmarks/domains/michalewicz/convergence_tl.py
+++ b/benchmarks/domains/michalewicz/convergence_tl.py
@@ -18,6 +18,7 @@ from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
 from baybe.parameters import NumericalContinuousParameter, TaskParameter
 from baybe.parameters.base import Parameter
+from baybe.parameters.categorical import TransferMode
 from baybe.searchspace import SearchSpace
 from baybe.simulation import simulate_scenarios
 from baybe.targets import NumericalTarget
@@ -26,8 +27,18 @@ from benchmarks.definition import ConvergenceBenchmark, ConvergenceBenchmarkSett
 from benchmarks.definition.base import RunMode
 
 
-def make_searchspace(use_task_parameter: bool) -> SearchSpace:
-    """Create search space for the benchmark."""
+def make_searchspace(
+    use_task_parameter: bool, transfer_mode: TransferMode = TransferMode.JOINT
+) -> SearchSpace:
+    """Create search space for the benchmark.
+
+    Args:
+        use_task_parameter: Whether to include a task parameter.
+        transfer_mode: The transfer learning mode (JOINT or JOINT_POS).
+
+    Returns:
+        The configured search space.
+    """
     params: list[Parameter] = [
         NumericalContinuousParameter(
             name=f"x{k}",
@@ -41,6 +52,7 @@ def make_searchspace(use_task_parameter: bool) -> SearchSpace:
                 name="Function",
                 values=["Target_Function", "Source_Function"],
                 active_values=["Target_Function"],
+                transfer_mode=transfer_mode,
             )
         )
 
@@ -132,14 +144,23 @@ def michalewicz_tl_continuous(settings: ConvergenceBenchmarkSettings) -> pd.Data
         "Target_Function": Michalewicz(dim=5, negate=True),
     }
     searchspace_nontl = make_searchspace(use_task_parameter=False)
-    searchspace_tl = make_searchspace(use_task_parameter=True)
+    tl_index_searchspace = make_searchspace(
+        use_task_parameter=True, transfer_mode=TransferMode.JOINT
+    )
+    tl_pos_index_searchspace = make_searchspace(
+        use_task_parameter=True, transfer_mode=TransferMode.JOINT_POS
+    )
 
     objective = make_objective()
-    campaign_tl = Campaign(
-        searchspace=searchspace_tl,
+    tl_index_campaign = Campaign(
+        searchspace=tl_index_searchspace,
         objective=objective,
     )
-    campaign_nontl = Campaign(
+    tl_pos_index_campaign = Campaign(
+        searchspace=tl_pos_index_searchspace,
+        objective=objective,
+    )
+    nontl_campaign = Campaign(
         searchspace=searchspace_nontl,
         objective=objective,
     )
@@ -158,7 +179,11 @@ def michalewicz_tl_continuous(settings: ConvergenceBenchmarkSettings) -> pd.Data
     for p in n_points:
         results.append(
             simulate_scenarios(
-                {f"{p}": campaign_tl, f"{p}_naive": campaign_nontl},
+                {
+                    f"{p}_index": tl_index_campaign,
+                    f"{p}_pos_index": tl_pos_index_campaign,
+                    f"{p}_naive": nontl_campaign,
+                },
                 lambda x: wrap_function(
                     functions["Target_Function"], "Target_Function", x
                 ),
@@ -171,7 +196,11 @@ def michalewicz_tl_continuous(settings: ConvergenceBenchmarkSettings) -> pd.Data
         )
     results.append(
         simulate_scenarios(
-            {"0": campaign_tl, "0_naive": campaign_nontl},
+            {
+                "0_index": tl_index_campaign,
+                "0_pos_index": tl_pos_index_campaign,
+                "0_naive": nontl_campaign,
+            },
             lambda x: wrap_function(functions["Target_Function"], "Target_Function", x),
             batch_size=settings.batch_size,
             n_doe_iterations=settings.n_doe_iterations,


### PR DESCRIPTION
Dispatching between BoTorch's `PositiveIndexKernel` and GPyTorch's `IndexKernel` for transfer learning.

1) New `task_correlation` Parameter on `TaskParameter`

Can specify correlation mode when creating a `TaskParameter`:

```
# Use PositiveIndexKernel (default)
task_param = TaskParameter(
    name="task",
    values=["source_task_1", "source_task_2", "target_task"],
    active_values=["target_task"],
    task_correlation=TaskCorrelation.POSITIVE, 
)

# Use IndexKernel
task_param = TaskParameter(
    name="task",
    values=["source_task_1", "source_task_2", "target_task"],
    active_values=["target_task"],
    task_correlation=TaskCorrelation.UNKNOWN, 
```
2) Kernel Dispatching

The `GaussianProcessSurrogate` selects the kernel based on the `task_correlation`:

- `TaskCorrelation.POSITIVE` → uses `botorch.models.kernels.PositiveIndexKernel`
- `TaskCorrelation.UNKNOWN` → uses `gpytorch.kernels.IndexKernel` 

3) Integrated both modes into benchmarks.
