### PR TITLE
Drop pydoclint link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,6 @@ If you have questions or problems, simply ask for advice.
 |:------------------------------------------------------------------------------------------------|:------------------------------------------|
 | [ruff](https://docs.astral.sh/ruff/)                                                            | code linting and formatting               |
 | [mypy](https://mypy.readthedocs.io/)                                                            | static type checking                      |
-| [typos](https://github.com/crate-ci/typos)                                                      | basic spell checking                      |
 | [pytest](https://docs.pytest.org/)                                                              | testing                                   |
 | [pytest-cov](https://pytest-cov.readthedocs.io/)                                                | measuring test coverage                   |
 | [sphinx](https://www.sphinx-doc.org/)                                                           | generating our documentation              |


### PR DESCRIPTION
Pydoclint has been deprecated and the docs are no longer available. Hence, our docbuild linkcheck fails. However, ruff officially takes over the ownership for the pydoclint rules and provides a corresponding plugin, which is already activated in our settings.