### PR TITLE
Warn users when simulating campaigns without an objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `simulate_scenarios` now works with campaigns that have no objective (e.g., campaigns
   using `RandomRecommender`). A warning is emitted for campaigns without objectives,
-  and those campaigns are simulated without target tracking.
+  and those campaigns are simulated without target tracking
 
 ### Deprecations
 - `set_random_seed` and `temporary_seed` utility functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `parallel_runs` argument from `simulate_scenarios`, since parallelization
   can now be conveniently controlled via the new `Settings` mechanism
 
+### Fixed
+- `simulate_scenarios` now works with campaigns that have no objective (e.g., campaigns
+  using `RandomRecommender`), as long as another campaign in the scenarios dict provides
+  one. The objective is automatically propagated to campaigns that need it for target
+  tracking during simulation.
+
 ### Deprecations
 - `set_random_seed` and `temporary_seed` utility functions
 - The environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `simulate_scenarios` now works with campaigns that have no objective (e.g., campaigns
-  using `RandomRecommender`), as long as another campaign in the scenarios dict provides
-  one. The objective is automatically propagated to campaigns that need it for target
-  tracking during simulation.
+  using `RandomRecommender`). A warning is emitted for campaigns without objectives,
+  and those campaigns are simulated without target tracking.
 
 ### Deprecations
 - `set_random_seed` and `temporary_seed` utility functions

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -90,6 +90,14 @@ def simulate_experiment(
     """
     # TODO: Use a `will_terminate` campaign property to decide if the campaign will
     #   run indefinitely or not, and allow omitting `n_doe_iterations` for the latter.
+    # Warn if campaign has no objective
+    if campaign.objective is None:
+        warnings.warn(
+            "Simulating a campaign without an objective. No target tracking will "
+            "be performed, and target-related columns will not be available in "
+            "the results.",
+            UserWarning,
+        )
     with (
         Settings(random_seed=random_seed) if random_seed is not None else nullcontext()
     ):

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -90,7 +90,6 @@ def simulate_experiment(
     """
     # TODO: Use a `will_terminate` campaign property to decide if the campaign will
     #   run indefinitely or not, and allow omitting `n_doe_iterations` for the latter.
-    # Warn if campaign has no objective
     if campaign.objective is None:
         warnings.warn(
             "Simulating a campaign without an objective. No target tracking will "

--- a/baybe/simulation/core.py
+++ b/baybe/simulation/core.py
@@ -90,12 +90,6 @@ def simulate_experiment(
     """
     # TODO: Use a `will_terminate` campaign property to decide if the campaign will
     #   run indefinitely or not, and allow omitting `n_doe_iterations` for the latter.
-    if campaign.objective is None:
-        raise ValueError(
-            "The given campaign has no objective defined, hence there are no targets "
-            "to be tracked."
-        )
-
     with (
         Settings(random_seed=random_seed) if random_seed is not None else nullcontext()
     ):

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -240,7 +240,6 @@ def simulate_scenarios(
     batch_simulator = make_xyzpy_callable(result_variable)
 
     with warnings.catch_warnings():
-        # Suppress warnings from individual simulations that will be aggregated
         warnings.filterwarnings(
             "ignore",
             category=UnusedObjectWarning,

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -207,10 +207,11 @@ def simulate_scenarios(
         # Concatenate all results into a single dataframe
         return pd.concat(dfs, ignore_index=True)
 
-    # Warn about campaigns without objectives
+    # Identify campaigns without objectives (warnings will be caught and aggregated)
     _no_obj_keys = [
         key for key, campaign in scenarios.items() if campaign.objective is None
     ]
+    # Emit a combined warning for all scenarios without objectives
     if _no_obj_keys:
         warnings.warn(
             f"The following scenario(s) have campaigns without an objective "
@@ -235,10 +236,16 @@ def simulate_scenarios(
     batch_simulator = make_xyzpy_callable(result_variable)
 
     with warnings.catch_warnings():
+        # Suppress warnings from individual simulations that will be aggregated
         warnings.filterwarnings(
             "ignore",
             category=UnusedObjectWarning,
             module="baybe.recommenders.pure.nonpredictive.base",
+        )
+        warnings.filterwarnings(
+            "ignore",
+            category=UserWarning,
+            message="Simulating a campaign without an objective",
         )
         da_results = batch_simulator.run_cases(
             cases, parallel=active_settings.parallelize_simulation_runs
@@ -322,16 +329,26 @@ def _simulate_groupby(
 
         # Run the group simulation
         try:
-            df_group = simulate_experiment(
-                campaign_group,
-                lookup,
-                batch_size=batch_size,
-                n_doe_iterations=n_doe_iterations,
-                initial_data=initial_data,
-                random_seed=random_seed,
-                impute_mode=impute_mode,
-                noise_percent=noise_percent,
-            )
+            # Suppress individual warnings that will be aggregated later.
+            # This is necessary for parallel execution where the warning filter
+            # context from simulate_scenarios doesn't propagate to worker processes.
+            # Without this, individual warnings would leak to stderr in parallel mode.
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    category=UserWarning,
+                    message="Simulating a campaign without an objective",
+                )
+                df_group = simulate_experiment(
+                    campaign_group,
+                    lookup,
+                    batch_size=batch_size,
+                    n_doe_iterations=n_doe_iterations,
+                    initial_data=initial_data,
+                    random_seed=random_seed,
+                    impute_mode=impute_mode,
+                    noise_percent=noise_percent,
+                )
         except NothingToSimulateError:
             continue
 

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -328,11 +328,11 @@ def _simulate_groupby(
 
         # Run the group simulation
         try:
-            # Suppress individual warnings that will be aggregated later.
-            # This is necessary for parallel execution where the warning filter
-            # context from simulate_scenarios doesn't propagate to worker processes.
-            # Without this, individual warnings would leak to stderr in parallel mode.
             with warnings.catch_warnings():
+                # Suppress individual warnings that will be re-calculated later. This is
+                # necessary for parallel execution where the warning filter context
+                # from simulate_scenarios doesn't propagate to worker processes. Without
+                # this, individual warnings would leak to stderr in parallel mode.
                 warnings.filterwarnings(
                     "ignore",
                     category=UserWarning,

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -242,11 +242,6 @@ def simulate_scenarios(
             category=UnusedObjectWarning,
             module="baybe.recommenders.pure.nonpredictive.base",
         )
-        warnings.filterwarnings(
-            "ignore",
-            category=UserWarning,
-            message="Simulating a campaign without an objective",
-        )
         da_results = batch_simulator.run_cases(
             cases, parallel=active_settings.parallelize_simulation_runs
         )[result_variable]

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
-from attrs import Attribute, define, evolve, field
+from attrs import Attribute, define, field
 from attrs.validators import ge, instance_of, optional
 
 from baybe.campaign import Campaign
@@ -112,11 +112,9 @@ def simulate_scenarios(
     A wrapper function around :func:`baybe.simulation.core.simulate_experiment` that
     allows to specify multiple simulation settings at once.
 
-    Campaigns without an objective (e.g. using
-    :class:`~baybe.recommenders.pure.nonpredictive.sampling.RandomRecommender`) are
-    supported as long as at least one other campaign in the ``scenarios`` dict provides
-    an objective. The objective is then automatically propagated to the campaigns that
-    lack one, enabling target tracking during simulation.
+    If any campaigns lack an objective, a warning is emitted. Those campaigns
+    will still be simulated but will not track any targets (no target-related
+    columns in their results).
 
     Args:
         scenarios: A dictionary mapping scenario identifiers to DOE specifications.
@@ -209,19 +207,18 @@ def simulate_scenarios(
         # Concatenate all results into a single dataframe
         return pd.concat(dfs, ignore_index=True)
 
-    # For campaigns without objectives, infer the objective from other campaigns
-    # so that target tracking works during simulation (e.g. RandomRecommender
-    # campaigns that don't need an objective for recommendations).
-    _ref_objective = next(
-        (c.objective for c in scenarios.values() if c.objective is not None), None
-    )
-    if _ref_objective is not None:
-        scenarios = {
-            key: evolve(campaign, objective=_ref_objective)
-            if campaign.objective is None
-            else campaign
-            for key, campaign in scenarios.items()
-        }
+    # Warn about campaigns without objectives
+    _no_obj_keys = [
+        key for key, campaign in scenarios.items() if campaign.objective is None
+    ]
+    if _no_obj_keys:
+        warnings.warn(
+            f"The following scenario(s) have campaigns without an objective "
+            f"and will not track any targets during simulation: {_no_obj_keys}. "
+            f"If this was not intended, make sure to define an objective for "
+            f"each campaign.",
+            UserWarning,
+        )
 
     # Collect the settings to be simulated
     rollouts = _Rollouts(

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -212,6 +212,10 @@ def simulate_scenarios(
         key for key, campaign in scenarios.items() if campaign.objective is None
     ]
     # Emit a combined warning for all scenarios without objectives
+    # NOTE: This "re-computes" the warning message from scratch and does not use the
+    # individual warnings from the calls of `simulate_experiment`. Using those is not
+    # possible due to the issues with parallel execution which does not allow to catch
+    # warnings from worker processes.
     if _no_obj_keys:
         warnings.warn(
             f"The following scenario(s) have campaigns without an objective "

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
-from attrs import Attribute, define, field
+from attrs import Attribute, define, evolve, field
 from attrs.validators import ge, instance_of, optional
 
 from baybe.campaign import Campaign
@@ -112,6 +112,12 @@ def simulate_scenarios(
     A wrapper function around :func:`baybe.simulation.core.simulate_experiment` that
     allows to specify multiple simulation settings at once.
 
+    Campaigns without an objective (e.g. using
+    :class:`~baybe.recommenders.pure.nonpredictive.sampling.RandomRecommender`) are
+    supported as long as at least one other campaign in the ``scenarios`` dict provides
+    an objective. The objective is then automatically propagated to the campaigns that
+    lack one, enabling target tracking during simulation.
+
     Args:
         scenarios: A dictionary mapping scenario identifiers to DOE specifications.
         lookup: See :func:`baybe.simulation.core.simulate_experiment`.
@@ -202,6 +208,20 @@ def simulate_scenarios(
 
         # Concatenate all results into a single dataframe
         return pd.concat(dfs, ignore_index=True)
+
+    # For campaigns without objectives, infer the objective from other campaigns
+    # so that target tracking works during simulation (e.g. RandomRecommender
+    # campaigns that don't need an objective for recommendations).
+    _ref_objective = next(
+        (c.objective for c in scenarios.values() if c.objective is not None), None
+    )
+    if _ref_objective is not None:
+        scenarios = {
+            key: evolve(campaign, objective=_ref_objective)
+            if campaign.objective is None
+            else campaign
+            for key, campaign in scenarios.items()
+        }
 
     # Collect the settings to be simulated
     rollouts = _Rollouts(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -10,10 +10,15 @@ import pandas as pd
 import pytest
 from pytest import param
 
+from baybe.campaign import Campaign
+from baybe.objectives import SingleTargetObjective
+from baybe.parameters import NumericalContinuousParameter
+from baybe.recommenders import RandomRecommender
+from baybe.searchspace import SearchSpace
 from baybe.settings import Settings
 from baybe.simulation import simulate_scenarios
 from baybe.simulation.scenarios import _Rollouts
-from baybe.targets.numerical import NumericalTarget
+from baybe.targets import NumericalTarget
 from baybe.utils.dataframe import create_fake_input
 
 pytestmark = pytest.mark.skipif(
@@ -146,3 +151,50 @@ def test_simulate_scenarios_structure(
 
     groupby_cols = ["Scenario", "Random_Seed", "Initial_Data"]
     result.groupby(groupby_cols).apply(_validate_target_data, targets=campaign.targets)
+
+
+@Settings(parallelize_simulation_runs=False)
+def test_simulate_scenarios_campaign_without_objective():
+    """Test simulations where only one campaign has an objective."""
+    searchspace = SearchSpace.from_product(
+        parameters=[NumericalContinuousParameter(name="x", bounds=(0.0, 1.0))]
+    )
+    objective = SingleTargetObjective(target=NumericalTarget(name="t"))
+
+    scenarios = {
+        "NoObj": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
+        "WithObj": Campaign(searchspace=searchspace, objective=objective),
+    }
+
+    result = simulate_scenarios(
+        scenarios,
+        lambda df: df.assign(t=0.5),
+        batch_size=1,
+        n_doe_iterations=2,
+        n_mc_iterations=1,
+    )
+
+    assert set(result["Scenario"].unique()) == {"NoObj", "WithObj"}
+    assert "t_CumBest" in result.columns
+
+
+@Settings(parallelize_simulation_runs=False)
+def test_simulate_scenarios_all_campaigns_without_objective():
+    """Test that simulate_scenarios fails when no campaign has an objective."""
+    searchspace = SearchSpace.from_product(
+        parameters=[NumericalContinuousParameter(name="x", bounds=(0.0, 1.0))]
+    )
+
+    scenarios = {
+        "A": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
+        "B": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
+    }
+
+    with pytest.raises(ValueError, match="no objective defined"):
+        simulate_scenarios(
+            scenarios,
+            lambda df: df.assign(t=0.5),
+            batch_size=1,
+            n_doe_iterations=2,
+            n_mc_iterations=1,
+        )

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -158,7 +158,7 @@ def test_simulate_scenarios_structure(
     "lookup_fn",
     [
         param(None, id="None"),
-        param(lambda df: df.assign(t=0.5), id="callabe"),
+        param(lambda df: df.assign(t=0.5), id="callable"),
         param(
             pd.DataFrame({"x": [0.0, 0.5, 1.0], "t": [0.0, 0.5, 1.0]}),
             id="dataframe",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -253,16 +253,13 @@ def test_simulate_experiment_campaign_without_objective():
     with pytest.warns(
         UserWarning,
         match="Simulating a campaign without an objective",
-    ) as record:
+    ):
         result = simulate_experiment(
             campaign,
             lambda df: df.assign(t=0.5),
             batch_size=1,
             n_doe_iterations=1,
         )
-
-    # Should have exactly one warning
-    assert len(record) == 1, f"Expected 1 warning, got {len(record)}"
 
     # Result should not contain target columns
     assert "t_CumBest" not in result.columns

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -17,6 +17,7 @@ from baybe.recommenders import RandomRecommender
 from baybe.searchspace import SearchSpace
 from baybe.settings import Settings
 from baybe.simulation import simulate_scenarios
+from baybe.simulation.core import simulate_experiment
 from baybe.simulation.scenarios import _Rollouts
 from baybe.targets import NumericalTarget
 from baybe.utils.dataframe import create_fake_input
@@ -193,3 +194,77 @@ def test_simulate_scenarios_campaign_without_objective(lookup_fn):
     # NoObj rows have NaN for target columns
     no_obj_rows = result[result["Scenario"] == "NoObj"]
     assert no_obj_rows["t_CumBest"].isna().all()
+
+
+@pytest.mark.parametrize(
+    "parallelize",
+    [
+        param(False, id="serial"),
+        param(True, id="parallel"),
+    ],
+)
+def test_simulate_scenarios_aggregated_warning(parallelize):
+    """Test that campaigns without objectives produce an aggregated warning."""
+    searchspace = SearchSpace.from_product(
+        parameters=[NumericalDiscreteParameter(name="x", values=[0.0, 0.5, 1.0])],
+    )
+
+    # Create multiple scenarios without objectives
+    scenarios = {
+        "NoObj1": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
+        "NoObj2": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
+    }
+
+    # The aggregated warning should list all scenarios
+    with (
+        Settings(parallelize_simulation_runs=parallelize),
+        pytest.warns(
+            UserWarning,
+            match=r"following scenario\(s\) have campaigns without an objective",
+        ) as record,
+    ):
+        simulate_scenarios(
+            scenarios,
+            lambda df: df.assign(t=0.5),
+            batch_size=1,
+            n_doe_iterations=1,
+            n_mc_iterations=1,
+        )
+
+    # Verify that individual warnings were suppressed (not emitted)
+    individual_warnings = [
+        w
+        for w in record
+        if "Simulating a campaign without an objective" in str(w.message)
+    ]
+    assert len(individual_warnings) == 0, (
+        f"Expected no individual warnings, but got {len(individual_warnings)}"
+    )
+
+
+def test_simulate_experiment_campaign_without_objective():
+    """Test that simulate_experiment emits a warning for campaigns without objective."""
+    searchspace = SearchSpace.from_product(
+        parameters=[NumericalDiscreteParameter(name="x", values=[0.0, 0.5, 1.0])],
+    )
+    campaign = Campaign(searchspace=searchspace, recommender=RandomRecommender())
+
+    # Should emit exactly one warning
+    with pytest.warns(
+        UserWarning,
+        match="Simulating a campaign without an objective",
+    ) as record:
+        result = simulate_experiment(
+            campaign,
+            lambda df: df.assign(t=0.5),
+            batch_size=1,
+            n_doe_iterations=1,
+        )
+
+    # Should have exactly one warning
+    assert len(record) == 1, f"Expected 1 warning, got {len(record)}"
+
+    # Result should not contain target columns
+    assert "t_CumBest" not in result.columns
+    assert "t_IterBest" not in result.columns
+    assert "t_Measurements" not in result.columns

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -12,7 +12,7 @@ from pytest import param
 
 from baybe.campaign import Campaign
 from baybe.objectives import SingleTargetObjective
-from baybe.parameters import NumericalContinuousParameter
+from baybe.parameters import NumericalDiscreteParameter
 from baybe.recommenders import RandomRecommender
 from baybe.searchspace import SearchSpace
 from baybe.settings import Settings
@@ -154,10 +154,21 @@ def test_simulate_scenarios_structure(
 
 
 @Settings(parallelize_simulation_runs=False)
-def test_simulate_scenarios_campaign_without_objective():
-    """Test simulations where only one campaign has an objective."""
+@pytest.mark.parametrize(
+    "lookup_fn",
+    [
+        param(None, id="None"),
+        param(lambda df: df.assign(t=0.5), id="callabe"),
+        param(
+            pd.DataFrame({"x": [0.0, 0.5, 1.0], "t": [0.0, 0.5, 1.0]}),
+            id="dataframe",
+        ),
+    ],
+)
+def test_simulate_scenarios_campaign_without_objective(lookup_fn):
+    """Test that campaigns without an objective are simulated with a warning."""
     searchspace = SearchSpace.from_product(
-        parameters=[NumericalContinuousParameter(name="x", bounds=(0.0, 1.0))]
+        parameters=[NumericalDiscreteParameter(name="x", values=[0.0, 0.5, 1.0])],
     )
     objective = SingleTargetObjective(target=NumericalTarget(name="t"))
 
@@ -166,35 +177,19 @@ def test_simulate_scenarios_campaign_without_objective():
         "WithObj": Campaign(searchspace=searchspace, objective=objective),
     }
 
-    result = simulate_scenarios(
-        scenarios,
-        lambda df: df.assign(t=0.5),
-        batch_size=1,
-        n_doe_iterations=2,
-        n_mc_iterations=1,
-    )
-
-    assert set(result["Scenario"].unique()) == {"NoObj", "WithObj"}
-    assert "t_CumBest" in result.columns
-
-
-@Settings(parallelize_simulation_runs=False)
-def test_simulate_scenarios_all_campaigns_without_objective():
-    """Test that simulate_scenarios fails when no campaign has an objective."""
-    searchspace = SearchSpace.from_product(
-        parameters=[NumericalContinuousParameter(name="x", bounds=(0.0, 1.0))]
-    )
-
-    scenarios = {
-        "A": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
-        "B": Campaign(searchspace=searchspace, recommender=RandomRecommender()),
-    }
-
-    with pytest.raises(ValueError, match="no objective defined"):
-        simulate_scenarios(
+    with pytest.warns(UserWarning, match="without an objective"):
+        result = simulate_scenarios(
             scenarios,
-            lambda df: df.assign(t=0.5),
+            lookup_fn,
             batch_size=1,
             n_doe_iterations=2,
             n_mc_iterations=1,
         )
+
+    # Both scenarios should be present in the results
+    assert set(result["Scenario"].unique()) == {"NoObj", "WithObj"}
+    # Target columns exist (from WithObj campaign)
+    assert "t_CumBest" in result.columns
+    # NoObj rows have NaN for target columns
+    no_obj_rows = result[result["Scenario"] == "NoObj"]
+    assert no_obj_rows["t_CumBest"].isna().all()


### PR DESCRIPTION
Fixes #749 by warning users that there are campaign without an objective instead of crashing.

`simulate_scenarios` will now run for the case described above, but warn the users about the missing objective(s). The code from the original bug now produces the following warning
```bash
(baybe) mXXXXX@LTDE0243486 baybe % python bug_test.py
/Users/mXXXXX/Programming/BayesianBE/baybe/baybe/simulation/scenarios.py:215: UserWarning: The following scenario(s) have campaigns without an objective and will not track any targets during simulation: ['Random Search']. If this was not intended, make sure to define an objective for each campaign.
```
and the following result dataframe:
```bash
        Scenario  Random_Seed  Initial_Data  Iteration  Num_Experiments
0  Random Search         1337           NaN          0                1
1  Random Search         1337           NaN          1                2
2  Random Search         1337           NaN          2                3
```

When also using a campaign that actually has an objective, the resulting dataframe looks as follows:
```bash
         Scenario  Random_Seed  Initial_Data  Iteration  Num_Experiments t_Measurements  t_IterBest  t_CumBest
0   Random Search         1337           NaN          0                1            NaN         NaN        NaN
1   Random Search         1337           NaN          1                2            NaN         NaN        NaN
2   Random Search         1337           NaN          2                3            NaN         NaN        NaN
3  With Objective         1337           NaN          0                1          [0.5]         0.5        0.5
4  With Objective         1337           NaN          1                2          [0.5]         0.5        0.5
5  With Objective         1337           NaN          2                3          [0.5]         0.5        0.5
```
