### PR TITLE
Drop unused type ignores

### DIFF
--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -39,7 +39,7 @@ class CategoricalParameter(_DiscreteLabelLikeParameter):
     _values: tuple[str | bool, ...] = field(
         alias="values",
         converter=Converter(_convert_values, takes_self=True, takes_field=True),  # type: ignore
-        validator=(  # type: ignore
+        validator=(
             validate_unique_values,
             deep_iterable(
                 member_validator=(instance_of((str, bool)), _validate_label_min_len),

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -31,7 +31,7 @@ class NumericalDiscreteParameter(DiscreteParameter):
     _values: tuple[float, ...] = field(
         alias="values",
         # FIXME[typing]: https://github.com/python-attrs/cattrs/issues/111
-        converter=lambda x: sorted(cattrs.structure(x, tuple[float, ...])),  # type: ignore
+        converter=lambda x: sorted(cattrs.structure(x, tuple[float, ...])),
         # FIXME[typing]: https://github.com/python-attrs/attrs/issues/1197
         validator=[
             min_len(2),

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -461,7 +461,7 @@ class BotorchRecommender(BayesianRecommender):
         # Prepare all considered discrete configurations in the
         # List[Dict[int, float]] format expected by BoTorch.
         num_comp_columns = len(candidates_comp.columns)
-        candidates_comp.columns = list(range(num_comp_columns))  # type: ignore
+        candidates_comp.columns = list(range(num_comp_columns))
         fixed_features_list = candidates_comp.to_dict("records")
 
         # Actual call of the BoTorch optimization routine

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -202,18 +202,18 @@ class SubspaceContinuous(SerialMixin):
         """See :class:`baybe.searchspace.core.SearchSpace`."""
         constraints = constraints or []
         return SubspaceContinuous(
-            parameters=[p for p in parameters if p.is_continuous],  # type:ignore[misc]
-            constraints_lin_eq=[  # type:ignore[attr-misc]
+            parameters=[p for p in parameters if p.is_continuous],
+            constraints_lin_eq=[
                 c
                 for c in constraints
                 if (isinstance(c, ContinuousLinearConstraint) and c.is_eq)
             ],
-            constraints_lin_ineq=[  # type:ignore[attr-misc]
+            constraints_lin_ineq=[
                 c
                 for c in constraints
                 if (isinstance(c, ContinuousLinearConstraint) and not c.is_eq)
             ],
-            constraints_nonlin=[  # type:ignore[attr-misc]
+            constraints_nonlin=[
                 c for c in constraints if isinstance(c, ContinuousNonlinearConstraint)
             ],
         )

--- a/baybe/targets/binary.py
+++ b/baybe/targets/binary.py
@@ -33,14 +33,14 @@ class BinaryTarget(Target, SerialMixin):
 
     success_value: ChoiceValue = field(
         default=True,
-        validator=[instance_of(ChoiceValue), validate_not_nan],  # type: ignore[call-overload]
+        validator=[instance_of(ChoiceValue), validate_not_nan],
         kw_only=True,
     )
     """Experimental representation of the success value."""
 
     failure_value: ChoiceValue = field(
         default=False,
-        validator=[instance_of(ChoiceValue), validate_not_nan],  # type: ignore[call-overload]
+        validator=[instance_of(ChoiceValue), validate_not_nan],
         kw_only=True,
     )
     """Experimental representation of the failure value."""

--- a/baybe/transformations/basic.py
+++ b/baybe/transformations/basic.py
@@ -483,7 +483,7 @@ class SigmoidTransformation(MonotonicTransformation):
         try:
             anchors = cattrs.structure(
                 anchors, tuple[tuple[float, float], tuple[float, float]]
-            )  # type: ignore[call-arg]
+            )
         except cattrs.IterableValidationError as ex:
             raise ValueError(
                 f"The specified anchor point argument must be convertible to two "

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,7 @@ packages = baybe,benchmarks
 ; * https://github.com/python/mypy/issues/4717
 disable_error_code = type-abstract
 
-enable_error_code = explicit-override
+enable_error_code = explicit-override, unused-ignore
 
 ; at some point, these excludes should all be gone ...
 exclude = (?x)(


### PR DESCRIPTION
Activates the `unused-ignore` mypy rule to identify and remove unnecessary type ignore statements