### PR TITLE
Remove MAPLE test skips

### DIFF
--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -154,20 +154,7 @@ def test_shap_explainers(ongoing_campaign, explainer_cls, use_comp_rep):
 
 @mark.parametrize(
     "explainer_cls",
-    [
-        param(
-            cls,
-            marks=mark.xfail(
-                condition=(
-                    cls == "Maple" and np.lib.NumpyVersion(np.__version__) >= "2.4.0"
-                ),
-                reason="Maple in the shap package is broken with numpy>=2.4, see "
-                "https://github.com/shap/shap/issues/4280 ",
-                strict=True,
-            ),
-        )
-        for cls in sorted(NON_SHAP_EXPLAINERS)
-    ],
+    [cls for cls in sorted(NON_SHAP_EXPLAINERS)],
 )
 def test_non_shap_explainers(ongoing_campaign, explainer_cls):
     """Test the non-SHAP explainers in computational representation."""


### PR DESCRIPTION
The [fix](https://github.com/shap/shap/pull/4285) for the shap maple code was merged and pretty much [released](https://github.com/shap/shap/releases/tag/v0.51.0) immediately... faster than I had merged the PR adding the skips... which are thus obsolete... and thus removed in here again