### PR TITLE
Refactor Subspace Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of a single tuple (needed for interpoint constraints)
 
 ### Fixed
+- `ContinuousCardinalityConstraint` now works in hybrid search spaces
+- Typo in `_FixedNumericalContinuousParameter` where `is_numeric` was used
+  instead of `is_numerical`
 - `SHAPInsight` breaking with `numpy>=2.4` due to no longer accepted implicit array to 
   scalar conversion
 

--- a/baybe/constraints/utils.py
+++ b/baybe/constraints/utils.py
@@ -25,7 +25,7 @@ def is_cardinality_fulfilled(
     Returns:
         ``True`` if all cardinality constraints are fulfilled, ``False`` otherwise.
     """
-    for c in subspace_continuous.constraints_cardinality:
+    for c in subspace_continuous.constraints_subspaces:
         # Get the activity thresholds for all parameters
         cols = df[c.parameters]
         thresholds = {

--- a/baybe/constraints/utils.py
+++ b/baybe/constraints/utils.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 
+from baybe.constraints.continuous import ContinuousCardinalityConstraint
 from baybe.parameters.utils import is_inactive
 from baybe.searchspace import SubspaceContinuous
 
@@ -25,7 +26,12 @@ def is_cardinality_fulfilled(
     Returns:
         ``True`` if all cardinality constraints are fulfilled, ``False`` otherwise.
     """
-    for c in subspace_continuous.constraints_subspace_generating:
+    cardinality_constraints = [
+        c
+        for c in subspace_continuous.constraints_subspace_generating
+        if isinstance(c, ContinuousCardinalityConstraint)
+    ]
+    for c in cardinality_constraints:
         # Get the activity thresholds for all parameters
         cols = df[c.parameters]
         thresholds = {

--- a/baybe/constraints/utils.py
+++ b/baybe/constraints/utils.py
@@ -25,7 +25,7 @@ def is_cardinality_fulfilled(
     Returns:
         ``True`` if all cardinality constraints are fulfilled, ``False`` otherwise.
     """
-    for c in subspace_continuous.constraints_subspaces:
+    for c in subspace_continuous.constraints_subspace_generating:
         # Get the activity thresholds for all parameters
         cols = df[c.parameters]
         thresholds = {

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -155,7 +155,7 @@ class NumericalContinuousParameter(ContinuousParameter):
 class _FixedNumericalContinuousParameter(ContinuousParameter):
     """Parameter class for fixed numerical parameters."""
 
-    is_numeric: ClassVar[bool] = True
+    is_numerical: ClassVar[bool] = True
     # See base class.
 
     value: float = field(converter=float)

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -301,6 +301,7 @@ class BotorchRecommender(BayesianRecommender):
             )
 
         # Determine search scope based on number of subspace configurations
+        configs: Iterable[frozenset[str]]
         if subspace_continuous.n_subspaces <= self.max_n_subspaces:
             configs = subspace_continuous.subspace_configurations()
         else:
@@ -610,6 +611,7 @@ class BotorchRecommender(BayesianRecommender):
         subspace_c = searchspace.continuous
 
         # Determine exhaustive vs. sampling
+        configs: Iterable[frozenset[str]]
         if subspace_c.n_subspaces <= self.max_n_subspaces:
             configs = subspace_c.subspace_configurations()
         else:

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -16,7 +16,6 @@ from attrs.validators import ge, gt, instance_of
 from typing_extensions import override
 
 from baybe.acquisition.acqfs import qThompsonSampling
-from baybe.constraints import ContinuousCardinalityConstraint
 from baybe.constraints.utils import is_cardinality_fulfilled
 from baybe.exceptions import (
     IncompatibilityError,
@@ -298,8 +297,7 @@ class BotorchRecommender(BayesianRecommender):
         if not subspace_continuous.constraints_subspaces:
             raise ValueError(
                 f"'{self._recommend_continuous_with_subspaces.__name__}' "
-                f"expects a subspace with constraints of type "
-                f"'{ContinuousCardinalityConstraint.__name__}'. "
+                f"expects a subspace with subspace-generating constraints."
             )
 
         # Determine search scope based on number of subspace configurations
@@ -376,8 +374,7 @@ class BotorchRecommender(BayesianRecommender):
         if subspace_continuous.constraints_subspaces:
             raise ValueError(
                 f"'{self._recommend_continuous_without_subspaces.__name__}' "
-                f"expects a subspace without constraints of type "
-                f"'{ContinuousCardinalityConstraint.__name__}'. "
+                f"expects a subspace without subspace-generating constraints."
             )
 
         fixed_parameters = {

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -227,7 +227,7 @@ class BotorchRecommender(BayesianRecommender):
         self, subspace_continuous: SubspaceContinuous, batch_size: int
     ) -> tuple[Tensor, Tensor]:
         """Dispatcher selecting the continuous optimization routine."""
-        if subspace_continuous.constraints_cardinality:
+        if subspace_continuous.constraints_subspaces:
             return self._recommend_continuous_with_cardinality_constraints(
                 subspace_continuous, batch_size
             )
@@ -268,7 +268,7 @@ class BotorchRecommender(BayesianRecommender):
         Raises:
             ValueError: If the continuous search space has no cardinality constraints.
         """
-        if not subspace_continuous.constraints_cardinality:
+        if not subspace_continuous.constraints_subspaces:
             raise ValueError(
                 f"'{self._recommend_continuous_with_cardinality_constraints.__name__}' "
                 f"expects a subspace with constraints of type "
@@ -276,17 +276,14 @@ class BotorchRecommender(BayesianRecommender):
             )
 
         # Determine search scope based on number of inactive parameter combinations
-        exhaustive_search = (
-            subspace_continuous.n_inactive_parameter_combinations
-            <= self.max_n_subspaces
-        )
+        exhaustive_search = subspace_continuous.n_subspaces <= self.max_n_subspaces
         iterator: Iterable[Collection[str]]
         if exhaustive_search:
             # If manageable, evaluate all combinations of inactive parameters
-            iterator = subspace_continuous.inactive_parameter_combinations()
+            iterator = subspace_continuous.subspace_configurations()
         else:
             # Otherwise, draw a random subset of inactive parameter combinations
-            iterator = subspace_continuous._sample_inactive_parameters(
+            iterator = subspace_continuous._sample_subspace_configurations(
                 self.max_n_subspaces
             )
 
@@ -336,7 +333,7 @@ class BotorchRecommender(BayesianRecommender):
         import torch
         from botorch.optim import optimize_acqf
 
-        if subspace_continuous.constraints_cardinality:
+        if subspace_continuous.constraints_subspaces:
             raise ValueError(
                 f"'{self._recommend_continuous_without_cardinality_constraints.__name__}' "  # noqa: E501
                 f"expects a subspace without constraints of type "

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 import math
 import warnings
-from collections.abc import Collection, Iterable
+from collections.abc import Callable, Collection, Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -131,6 +131,34 @@ class BotorchRecommender(BayesianRecommender):
 
     @override
     def _recommend_discrete(
+        self,
+        subspace_discrete: SubspaceDiscrete,
+        candidates_exp: pd.DataFrame,
+        batch_size: int,
+    ) -> pd.Index:
+        """Generate recommendations from a discrete search space.
+
+        Dispatches to the appropriate optimization routine depending on whether
+        subspace-generating constraints are present. Currently, no discrete
+        constraints generate subspaces, so this always routes to
+        ``_recommend_discrete_without_subspaces``.
+
+        Args:
+            subspace_discrete: The discrete subspace from which to generate
+                recommendations.
+            candidates_exp: The experimental representation of all discrete candidate
+                points to be considered.
+            batch_size: The size of the recommendation batch.
+
+        Returns:
+            The dataframe indices of the recommended points in the provided
+            experimental representation.
+        """
+        return self._recommend_discrete_without_subspaces(
+            subspace_discrete, candidates_exp, batch_size
+        )
+
+    def _recommend_discrete_without_subspaces(
         self,
         subspace_discrete: SubspaceDiscrete,
         candidates_exp: pd.DataFrame,
@@ -275,25 +303,37 @@ class BotorchRecommender(BayesianRecommender):
                 f"'{ContinuousCardinalityConstraint.__name__}'. "
             )
 
-        # Determine search scope based on number of inactive parameter combinations
-        exhaustive_search = subspace_continuous.n_subspaces <= self.max_n_subspaces
-        iterator: Iterable[Collection[str]]
-        if exhaustive_search:
-            # If manageable, evaluate all combinations of inactive parameters
-            iterator = subspace_continuous.subspace_configurations()
+        # Determine search scope based on number of subspace configurations
+        if subspace_continuous.n_subspaces <= self.max_n_subspaces:
+            configs = subspace_continuous.subspace_configurations()
         else:
-            # Otherwise, draw a random subset of inactive parameter combinations
-            iterator = subspace_continuous._sample_subspace_configurations(
+            configs = subspace_continuous._sample_subspace_configurations(
                 self.max_n_subspaces
             )
 
-        # Create iterable of subspaces to be optimized
-        subspaces = (
-            (subspace_continuous._enforce_cardinality_constraints(inactive_parameters))
-            for inactive_parameters in iterator
-        )
+        # Create closures for each subspace configuration
+        def make_callable(
+            inactive_params: Collection[str],
+        ) -> Callable[[], tuple[Tensor, Tensor]]:
+            def optimize() -> tuple[Tensor, Tensor]:
+                import torch
 
-        points, acqf_value = self._optimize_continuous_subspaces(subspaces, batch_size)
+                sub = subspace_continuous._enforce_cardinality_constraints(
+                    inactive_params
+                )
+                # Note: We explicitly evaluate the acqf function for the batch
+                # because the object returned by the optimization routine may
+                # contain joint or individual acquisition values, depending on
+                # whether sequential or joint optimization is applied
+                p, _ = self._recommend_continuous_torch(sub, batch_size)
+                with torch.no_grad():
+                    acqf_value = self._botorch_acqf(p)
+                return p, acqf_value
+
+            return optimize
+
+        callables = (make_callable(ip) for ip in configs)
+        points, acqf_value = self._optimize_over_subspaces(callables)
 
         # Check if any minimum cardinality constraints are violated
         if not is_cardinality_fulfilled(
@@ -393,6 +433,34 @@ class BotorchRecommender(BayesianRecommender):
 
     @override
     def _recommend_hybrid(
+        self,
+        searchspace: SearchSpace,
+        candidates_exp: pd.DataFrame,
+        batch_size: int,
+    ) -> pd.DataFrame:
+        """Generate recommendations from a hybrid search space.
+
+        Dispatches to the appropriate optimization routine depending on whether
+        the continuous part contains subspace-generating constraints.
+
+        Args:
+            searchspace: The search space in which the recommendations should be made.
+            candidates_exp: The experimental representation of the candidates
+                of the discrete subspace.
+            batch_size: The size of the calculated batch.
+
+        Returns:
+            The recommended points.
+        """
+        if searchspace.continuous.constraints_subspaces:
+            return self._recommend_hybrid_with_subspaces(
+                searchspace, candidates_exp, batch_size
+            )
+        return self._recommend_hybrid_without_subspaces(
+            searchspace, candidates_exp, batch_size
+        )
+
+    def _recommend_hybrid_without_subspaces(
         self,
         searchspace: SearchSpace,
         candidates_exp: pd.DataFrame,
@@ -520,65 +588,124 @@ class BotorchRecommender(BayesianRecommender):
 
         return rec_exp
 
-    def _optimize_continuous_subspaces(
-        self, subspaces: Iterable[SubspaceContinuous], batch_size: int
-    ) -> tuple[Tensor, Tensor]:
-        """Find the optimum candidates from multiple continuous subspaces.
+    def _recommend_hybrid_with_subspaces(
+        self,
+        searchspace: SearchSpace,
+        candidates_exp: pd.DataFrame,
+        batch_size: int,
+    ) -> pd.DataFrame:
+        """Recommend from a hybrid space with subspace-generating constraints.
 
-        Important:
-            Subspaces without feasible solutions will be silently ignored. If none of
-            the subspaces has a feasible solution, an exception will be raised.
+        Creates subspaces by enumerating/sampling inactive parameter configurations
+        for the continuous part, then runs hybrid optimization per subspace via
+        ``_recommend_hybrid_without_subspaces``.
 
         Args:
-            subspaces: The subspaces to consider for the optimization.
-            batch_size: The number of points to be recommended.
+            searchspace: The search space in which the recommendations should be made.
+            candidates_exp: The experimental representation of the candidates
+                of the discrete subspace.
+            batch_size: The size of the calculated batch.
+
+        Returns:
+            The recommended points.
+        """
+        from attrs import evolve
+
+        subspace_c = searchspace.continuous
+
+        # Determine exhaustive vs. sampling
+        if subspace_c.n_subspaces <= self.max_n_subspaces:
+            configs = subspace_c.subspace_configurations()
+        else:
+            configs = subspace_c._sample_subspace_configurations(self.max_n_subspaces)
+
+        def make_callable(
+            inactive_params: Collection[str],
+        ) -> Callable[[], tuple[pd.DataFrame, Tensor]]:
+            def optimize() -> tuple[pd.DataFrame, Tensor]:
+                import torch
+
+                modified_cont = subspace_c._enforce_cardinality_constraints(
+                    inactive_params
+                )
+                modified_searchspace = evolve(searchspace, continuous=modified_cont)
+                rec = self._recommend_hybrid_without_subspaces(
+                    modified_searchspace, candidates_exp, batch_size
+                )
+                # Evaluate joint acquisition value on the recommended points
+                comp = modified_searchspace.transform(rec)
+                with torch.no_grad():
+                    acqf_value = self._botorch_acqf(to_tensor(comp.values).unsqueeze(0))
+                return rec, acqf_value
+
+            return optimize
+
+        callables = (make_callable(ip) for ip in configs)
+        best_rec, _ = self._optimize_over_subspaces(callables)
+
+        # Post-check minimum cardinality on continuous columns
+        if not is_cardinality_fulfilled(
+            best_rec[list(subspace_c.parameter_names)],
+            subspace_c,
+            check_maximum=False,
+        ):
+            warnings.warn(
+                "At least one minimum cardinality constraint has been violated. "
+                "This may occur when parameter ranges extend beyond zero in both "
+                "directions, making the feasible region non-convex. For such "
+                "parameters, minimum cardinality constraints are currently not "
+                "enforced due to the complexity of the resulting optimization problem.",
+                MinimumCardinalityViolatedWarning,
+            )
+
+        return best_rec
+
+    def _optimize_over_subspaces(
+        self,
+        subspace_callables: Iterable[Callable[[], tuple[Any, Tensor]]],
+    ) -> tuple[Any, Tensor]:
+        """Optimize across subspaces and return the result with the best acqf value.
+
+        Each callable performs optimization for one subspace configuration and returns
+        a ``(result, acquisition_value)`` tuple. Subspaces that raise
+        ``InfeasibilityError`` are silently skipped.
+
+        Args:
+            subspace_callables: An iterable of zero-argument callables. Each callable
+                runs the optimization for one subspace and returns
+                ``(result, acqf_value)``. It may raise ``InfeasibilityError`` if the
+                subspace is infeasible.
 
         Raises:
             InfeasibilityError: If none of the subspaces has a feasible solution.
 
         Returns:
-            The batch of candidates and the corresponding acquisition value.
+            The result and acquisition value of the best subspace.
         """
-        import torch
         from botorch.exceptions.errors import InfeasibilityError as BoInfeasibilityError
 
+        results_all: list = []
         acqf_values_all: list[Tensor] = []
-        points_all: list[Tensor] = []
 
-        for subspace in subspaces:
+        for optimize_fn in subspace_callables:
             try:
-                # Optimize the acquisition function
-                # Note: We explicitly evaluate the acqf function for the batch because
-                #   the object returned by the optimization routine may contain joint or
-                #   individual acquisition values, depending on the whether sequential
-                #   or joint optimization is applied
-                p, _ = self._recommend_continuous_torch(subspace, batch_size)
-                with torch.no_grad():
-                    acqf = self._botorch_acqf(p)
-
-                # Append optimization results
-                points_all.append(p)
-                acqf_values_all.append(acqf)
-
-            # The optimization problem may be infeasible in certain subspaces
-            except BoInfeasibilityError:
+                result, acqf_value = optimize_fn()
+                results_all.append(result)
+                acqf_values_all.append(acqf_value)
+            except (BoInfeasibilityError, InfeasibilityError):
                 pass
 
-        if not points_all:
+        if not results_all:
             raise InfeasibilityError(
                 "No feasible solution could be found. Potentially the specified "
                 "constraints are too restrictive, i.e. there may be too many "
                 "constraints or thresholds may have been set too tightly. "
-                "Considered relaxing the constraints to improve the chances "
+                "Consider relaxing the constraints to improve the chances "
                 "of finding a feasible solution."
             )
 
-        # Find the best option f
         best_idx = np.argmax(acqf_values_all)
-        points = points_all[best_idx]
-        acqf_value = acqf_values_all[best_idx]
-
-        return points, acqf_value
+        return results_all[best_idx], acqf_values_all[best_idx]
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -253,7 +253,7 @@ class BotorchRecommender(BayesianRecommender):
         self, subspace_continuous: SubspaceContinuous, batch_size: int
     ) -> tuple[Tensor, Tensor]:
         """Dispatcher selecting the continuous optimization routine."""
-        if subspace_continuous.constraints_subspaces:
+        if subspace_continuous.constraints_subspace_generating:
             return self._recommend_continuous_with_subspaces(
                 subspace_continuous, batch_size
             )
@@ -294,7 +294,7 @@ class BotorchRecommender(BayesianRecommender):
             ValueError: If the continuous search space has no subspace-generating
                 constraints.
         """
-        if not subspace_continuous.constraints_subspaces:
+        if not subspace_continuous.constraints_subspace_generating:
             raise ValueError(
                 f"'{self._recommend_continuous_with_subspaces.__name__}' "
                 f"expects a subspace with subspace-generating constraints."
@@ -371,7 +371,7 @@ class BotorchRecommender(BayesianRecommender):
         import torch
         from botorch.optim import optimize_acqf
 
-        if subspace_continuous.constraints_subspaces:
+        if subspace_continuous.constraints_subspace_generating:
             raise ValueError(
                 f"'{self._recommend_continuous_without_subspaces.__name__}' "
                 f"expects a subspace without subspace-generating constraints."
@@ -448,7 +448,7 @@ class BotorchRecommender(BayesianRecommender):
         Returns:
             The recommended points.
         """
-        if searchspace.continuous.constraints_subspaces:
+        if searchspace.continuous.constraints_subspace_generating:
             return self._recommend_hybrid_with_subspaces(
                 searchspace, candidates_exp, batch_size
             )

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -91,11 +91,10 @@ class BotorchRecommender(BayesianRecommender):
     """
 
     max_n_subspaces: int = field(default=10, validator=[instance_of(int), ge(1)])
-    """Threshold defining the maximum number of subspaces to consider for exhaustive
-    search in the presence of cardinality constraints. If the combinatorial number of
-    groupings into active and inactive parameters dictated by the constraints is greater
-    than this number, that many randomly selected combinations are selected for
-    optimization."""
+    """Maximum number of subspaces to evaluate when subspace-generating constraints are
+    present (e.g., continuous cardinality constraints). If the total number of subspaces
+    exceeds this limit, a random subset of that size is sampled for optimization instead
+    of performing an exhaustive search."""
 
     @sampling_percentage.validator
     def _validate_percentage(  # noqa: DOC101, DOC103

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -228,34 +228,33 @@ class BotorchRecommender(BayesianRecommender):
     ) -> tuple[Tensor, Tensor]:
         """Dispatcher selecting the continuous optimization routine."""
         if subspace_continuous.constraints_subspaces:
-            return self._recommend_continuous_with_cardinality_constraints(
+            return self._recommend_continuous_with_subspaces(
                 subspace_continuous, batch_size
             )
         else:
-            return self._recommend_continuous_without_cardinality_constraints(
+            return self._recommend_continuous_without_subspaces(
                 subspace_continuous, batch_size
             )
 
-    def _recommend_continuous_with_cardinality_constraints(
+    def _recommend_continuous_with_subspaces(
         self,
         subspace_continuous: SubspaceContinuous,
         batch_size: int,
     ) -> tuple[Tensor, Tensor]:
-        """Recommend from a continuous search space with cardinality constraints.
+        """Recommend from a continuous space with subspace-generating constraints.
 
-        This is achieved by considering the individual restricted subspaces that can be
-        obtained by splitting the parameters into sets of active and inactive
-        parameters, according to what is allowed by the cardinality constraints.
+        Optimizes the acquisition function across subspaces defined by constraints
+        (currently only cardinality constraints) and returns the best result.
 
         The specific collection of subspaces considered by the recommender is obtained
         as either the full combinatorial set of possible parameter splits or a random
         selection thereof, depending on the upper bound specified by the corresponding
         recommender attribute.
 
-        In each of these spaces, the (in)activity assignment is fixed, so that the
-        cardinality constraints can be removed and a regular optimization can be
-        performed. The recommendation is then constructed from the combined optimization
-        results of the unconstrained spaces.
+        In each subspace, the constraint-imposed configuration is fixed, so that the
+        constraints can be removed and a regular optimization can be performed. The
+        recommendation is then constructed from the combined optimization results of the
+        unconstrained spaces.
 
         Args:
             subspace_continuous: The continuous subspace from which to generate
@@ -266,11 +265,12 @@ class BotorchRecommender(BayesianRecommender):
             The recommendations and corresponding acquisition values.
 
         Raises:
-            ValueError: If the continuous search space has no cardinality constraints.
+            ValueError: If the continuous search space has no subspace-generating
+                constraints.
         """
         if not subspace_continuous.constraints_subspaces:
             raise ValueError(
-                f"'{self._recommend_continuous_with_cardinality_constraints.__name__}' "
+                f"'{self._recommend_continuous_with_subspaces.__name__}' "
                 f"expects a subspace with constraints of type "
                 f"'{ContinuousCardinalityConstraint.__name__}'. "
             )
@@ -312,12 +312,12 @@ class BotorchRecommender(BayesianRecommender):
 
         return points, acqf_value
 
-    def _recommend_continuous_without_cardinality_constraints(
+    def _recommend_continuous_without_subspaces(
         self,
         subspace_continuous: SubspaceContinuous,
         batch_size: int,
     ) -> tuple[Tensor, Tensor]:
-        """Recommend from a continuous search space without cardinality constraints.
+        """Recommend from a continuous search space without subspace decomposition.
 
         Args:
             subspace_continuous: The continuous subspace from which to generate
@@ -328,14 +328,15 @@ class BotorchRecommender(BayesianRecommender):
             The recommendations and corresponding acquisition values.
 
         Raises:
-            ValueError: If the continuous search space has cardinality constraints.
+            ValueError: If the continuous search space has subspace-generating
+                constraints.
         """
         import torch
         from botorch.optim import optimize_acqf
 
         if subspace_continuous.constraints_subspaces:
             raise ValueError(
-                f"'{self._recommend_continuous_without_cardinality_constraints.__name__}' "  # noqa: E501
+                f"'{self._recommend_continuous_without_subspaces.__name__}' "
                 f"expects a subspace without constraints of type "
                 f"'{ContinuousCardinalityConstraint.__name__}'. "
             )

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -108,8 +108,8 @@ class SubspaceContinuous(SerialMixin):
         return to_string(self.__class__.__name__, *fields)
 
     @property
-    def constraints_cardinality(self) -> tuple[ContinuousCardinalityConstraint, ...]:
-        """Cardinality constraints."""
+    def constraints_subspaces(self) -> tuple[ContinuousCardinalityConstraint, ...]:
+        """Constraints generating subspaces for separate optimization."""
         return tuple(
             c
             for c in self.constraints_nonlin
@@ -143,18 +143,18 @@ class SubspaceContinuous(SerialMixin):
             )
 
     @property
-    def n_inactive_parameter_combinations(self) -> int:
-        """The number of possible inactive parameter combinations."""
+    def n_subspaces(self) -> int:
+        """The number of possible subspace configurations."""
         return math.prod(
-            c.n_inactive_parameter_combinations for c in self.constraints_cardinality
+            c.n_inactive_parameter_combinations for c in self.constraints_subspaces
         )
 
-    def inactive_parameter_combinations(self) -> Iterator[frozenset[str]]:
-        """Get an iterator over all possible combinations of inactive parameters."""
+    def subspace_configurations(self) -> Iterator[frozenset[str]]:
+        """Get an iterator over all possible subspace configurations."""
         for combination in product(
             *[
                 con.inactive_parameter_combinations()
-                for con in self.constraints_cardinality
+                for con in self.constraints_subspaces
             ]
         ):
             yield frozenset(chain(*combination))
@@ -163,11 +163,9 @@ class SubspaceContinuous(SerialMixin):
     def _validate_constraints_nonlin(self, _, __) -> None:
         """Validate nonlinear constraints."""
         # Note: The passed constraints are accessed indirectly through the property
-        validate_cardinality_constraints_are_nonoverlapping(
-            self.constraints_cardinality
-        )
+        validate_cardinality_constraints_are_nonoverlapping(self.constraints_subspaces)
 
-        for con in self.constraints_cardinality:
+        for con in self.constraints_subspaces:
             validate_cardinality_constraint_parameter_bounds(con, self.parameters)
 
     def to_searchspace(self) -> SearchSpace:
@@ -306,9 +304,9 @@ class SubspaceContinuous(SerialMixin):
         return tuple(chain.from_iterable(p.comp_rep_columns for p in self.parameters))
 
     @property
-    def parameter_names_in_cardinality_constraints(self) -> frozenset[str]:
-        """The names of all parameters affected by cardinality constraints."""
-        names_per_constraint = (c.parameters for c in self.constraints_cardinality)
+    def parameter_names_in_subspace_constraints(self) -> frozenset[str]:
+        """The names of all parameters affected by subspace-generating constraints."""
+        names_per_constraint = (c.parameters for c in self.constraints_subspaces)
         return frozenset(chain(*names_per_constraint))
 
     @property
@@ -386,7 +384,7 @@ class SubspaceContinuous(SerialMixin):
         """
         # Extract active parameters involved in cardinality constraints
         active_parameter_names = (
-            self.parameter_names_in_cardinality_constraints.difference(
+            self.parameter_names_in_subspace_constraints.difference(
                 inactive_parameter_names
             )
         )
@@ -400,7 +398,7 @@ class SubspaceContinuous(SerialMixin):
 
             elif p.name in active_parameter_names:
                 constraints = [
-                    c for c in self.constraints_cardinality if p.name in c.parameters
+                    c for c in self.constraints_subspaces if p.name in c.parameters
                 ]
 
                 # Constraint validation should have ensured that each parameter can
@@ -476,7 +474,7 @@ class SubspaceContinuous(SerialMixin):
         if not self.is_constrained:
             return self._sample_from_bounds(batch_size, self.comp_rep_bounds.values)
 
-        if len(self.constraints_cardinality) == 0:
+        if len(self.constraints_subspaces) == 0:
             return self._sample_from_polytope(batch_size, self.comp_rep_bounds.values)
 
         return self._sample_from_polytope_with_cardinality_constraints(batch_size)
@@ -562,7 +560,7 @@ class SubspaceContinuous(SerialMixin):
         self, batch_size: int
     ) -> pd.DataFrame:
         """Draw random samples from a polytope with cardinality constraints."""
-        if not self.constraints_cardinality:
+        if not self.constraints_subspaces:
             raise RuntimeError(
                 f"This method should not be called without any constraints of type "
                 f"'{ContinuousCardinalityConstraint.__name__}' in place. "
@@ -579,7 +577,7 @@ class SubspaceContinuous(SerialMixin):
 
         while len(samples) < batch_size:
             # Randomly set some parameters inactive
-            inactive_params_sample = self._sample_inactive_parameters(1)[0]
+            inactive_params_sample = self._sample_subspace_configurations(1)[0]
 
             # Remove the inactive parameters from the search space. In the first
             # step, the active parameters get activated and inactive parameters are
@@ -617,11 +615,11 @@ class SubspaceContinuous(SerialMixin):
             .fillna(0.0)
         )
 
-    def _sample_inactive_parameters(self, batch_size: int = 1) -> list[set[str]]:
-        """Sample inactive parameters according to the given cardinality constraints."""
+    def _sample_subspace_configurations(self, batch_size: int = 1) -> list[set[str]]:
+        """Sample subspace configurations according to the given constraints."""
         inactives_per_constraint = [
             con.sample_inactive_parameters(batch_size)
-            for con in self.constraints_cardinality
+            for con in self.constraints_subspaces
         ]
         return [set(chain(*x)) for x in zip(*inactives_per_constraint)]
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -108,7 +108,9 @@ class SubspaceContinuous(SerialMixin):
         return to_string(self.__class__.__name__, *fields)
 
     @property
-    def constraints_subspaces(self) -> tuple[ContinuousCardinalityConstraint, ...]:
+    def constraints_subspace_generating(
+        self,
+    ) -> tuple[ContinuousCardinalityConstraint, ...]:
         """Constraints generating subspaces for separate optimization."""
         return tuple(
             c
@@ -146,7 +148,8 @@ class SubspaceContinuous(SerialMixin):
     def n_subspaces(self) -> int:
         """The number of possible subspace configurations."""
         return math.prod(
-            c.n_inactive_parameter_combinations for c in self.constraints_subspaces
+            c.n_inactive_parameter_combinations
+            for c in self.constraints_subspace_generating
         )
 
     def subspace_configurations(self) -> Iterator[frozenset[str]]:
@@ -154,7 +157,7 @@ class SubspaceContinuous(SerialMixin):
         for combination in product(
             *[
                 con.inactive_parameter_combinations()
-                for con in self.constraints_subspaces
+                for con in self.constraints_subspace_generating
             ]
         ):
             yield frozenset(chain(*combination))
@@ -163,9 +166,11 @@ class SubspaceContinuous(SerialMixin):
     def _validate_constraints_nonlin(self, _, __) -> None:
         """Validate nonlinear constraints."""
         # Note: The passed constraints are accessed indirectly through the property
-        validate_cardinality_constraints_are_nonoverlapping(self.constraints_subspaces)
+        validate_cardinality_constraints_are_nonoverlapping(
+            self.constraints_subspace_generating
+        )
 
-        for con in self.constraints_subspaces:
+        for con in self.constraints_subspace_generating:
             validate_cardinality_constraint_parameter_bounds(con, self.parameters)
 
     def to_searchspace(self) -> SearchSpace:
@@ -306,7 +311,9 @@ class SubspaceContinuous(SerialMixin):
     @property
     def parameter_names_in_subspace_constraints(self) -> frozenset[str]:
         """The names of all parameters affected by subspace-generating constraints."""
-        names_per_constraint = (c.parameters for c in self.constraints_subspaces)
+        names_per_constraint = (
+            c.parameters for c in self.constraints_subspace_generating
+        )
         return frozenset(chain(*names_per_constraint))
 
     @property
@@ -398,7 +405,9 @@ class SubspaceContinuous(SerialMixin):
 
             elif p.name in active_parameter_names:
                 constraints = [
-                    c for c in self.constraints_subspaces if p.name in c.parameters
+                    c
+                    for c in self.constraints_subspace_generating
+                    if p.name in c.parameters
                 ]
 
                 # Constraint validation should have ensured that each parameter can
@@ -474,7 +483,7 @@ class SubspaceContinuous(SerialMixin):
         if not self.is_constrained:
             return self._sample_from_bounds(batch_size, self.comp_rep_bounds.values)
 
-        if len(self.constraints_subspaces) == 0:
+        if len(self.constraints_subspace_generating) == 0:
             return self._sample_from_polytope(batch_size, self.comp_rep_bounds.values)
 
         return self._sample_from_polytope_with_cardinality_constraints(batch_size)
@@ -560,7 +569,7 @@ class SubspaceContinuous(SerialMixin):
         self, batch_size: int
     ) -> pd.DataFrame:
         """Draw random samples from a polytope with cardinality constraints."""
-        if not self.constraints_subspaces:
+        if not self.constraints_subspace_generating:
             raise RuntimeError(
                 f"This method should not be called without any constraints of type "
                 f"'{ContinuousCardinalityConstraint.__name__}' in place. "
@@ -619,7 +628,7 @@ class SubspaceContinuous(SerialMixin):
         """Sample subspace configurations according to the given constraints."""
         inactives_per_constraint = [
             con.sample_inactive_parameters(batch_size)
-            for con in self.constraints_subspaces
+            for con in self.constraints_subspace_generating
         ]
         return [set(chain(*x)) for x in zip(*inactives_per_constraint)]
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -624,13 +624,15 @@ class SubspaceContinuous(SerialMixin):
             .fillna(0.0)
         )
 
-    def _sample_subspace_configurations(self, batch_size: int = 1) -> list[set[str]]:
+    def _sample_subspace_configurations(
+        self, batch_size: int = 1
+    ) -> list[frozenset[str]]:
         """Sample subspace configurations according to the given constraints."""
         inactives_per_constraint = [
             con.sample_inactive_parameters(batch_size)
             for con in self.constraints_subspace_generating
         ]
-        return [set(chain(*x)) for x in zip(*inactives_per_constraint)]
+        return [frozenset(chain(*x)) for x in zip(*inactives_per_constraint)]
 
     def sample_from_full_factorial(self, batch_size: int = 1) -> pd.DataFrame:
         """Draw parameter configurations from the full factorial of the space.

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -65,9 +65,12 @@ def _validate_cardinality_constrained_batch(
     # We thus include this check as a safety net for catching regressions. If it
     # turns out the check fails because we observe degenerate batches as actual
     # recommendations, we need to invent something smarter.
-    max_cardinalities = [
-        c.max_cardinality for c in subspace_continuous.constraints_subspace_generating
+    cardinality_constraints = [
+        c
+        for c in subspace_continuous.constraints_subspace_generating
+        if isinstance(c, ContinuousCardinalityConstraint)
     ]
+    max_cardinalities = [c.max_cardinality for c in cardinality_constraints]
     if len(unique_row := batch.drop_duplicates()) == 1:
         assert (unique_row.iloc[0] == 0.0).all() and all(
             max_cardinality == 0 for max_cardinality in max_cardinalities

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -66,7 +66,7 @@ def _validate_cardinality_constrained_batch(
     # turns out the check fails because we observe degenerate batches as actual
     # recommendations, we need to invent something smarter.
     max_cardinalities = [
-        c.max_cardinality for c in subspace_continuous.constraints_subspaces
+        c.max_cardinality for c in subspace_continuous.constraints_subspace_generating
     ]
     if len(unique_row := batch.drop_duplicates()) == 1:
         assert (unique_row.iloc[0] == 0.0).all() and all(

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -66,7 +66,7 @@ def _validate_cardinality_constrained_batch(
     # turns out the check fails because we observe degenerate batches as actual
     # recommendations, we need to invent something smarter.
     max_cardinalities = [
-        c.max_cardinality for c in subspace_continuous.constraints_cardinality
+        c.max_cardinality for c in subspace_continuous.constraints_subspaces
     ]
     if len(unique_row := batch.drop_duplicates()) == 1:
         assert (unique_row.iloc[0] == 0.0).all() and all(

--- a/tests/constraints/test_cardinality_constraint_hybrid.py
+++ b/tests/constraints/test_cardinality_constraint_hybrid.py
@@ -1,0 +1,142 @@
+"""Tests for cardinality constraints in hybrid search spaces.
+
+Regression tests for https://github.com/emdgroup/baybe/issues/567.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from baybe.constraints.continuous import ContinuousCardinalityConstraint
+from baybe.constraints.discrete import DiscreteCardinalityConstraint
+from baybe.parameters.categorical import CategoricalParameter
+from baybe.parameters.numerical import (
+    NumericalContinuousParameter,
+    NumericalDiscreteParameter,
+)
+from baybe.recommenders import BotorchRecommender
+from baybe.searchspace import SearchSpace
+from baybe.targets import NumericalTarget
+
+BATCH_SIZE = 5
+MAX_CARDINALITY = 1
+
+# --- Shared helpers -----------------------------------------------------------
+
+_discrete_params = [
+    NumericalDiscreteParameter(f"d{i}", values=(0.0, 0.5, 1.0)) for i in range(3)
+]
+_continuous_params = [
+    NumericalContinuousParameter(f"c{i}", bounds=(0, 1)) for i in range(2)
+]
+
+# --- Test configurations ------------------------------------------------------
+
+
+def _config_continuous_only():
+    """Hybrid space with a continuous cardinality constraint."""
+    parameters = [
+        CategoricalParameter("cat", values=("A", "B", "C")),
+        *_continuous_params,
+    ]
+    constraints = [
+        ContinuousCardinalityConstraint(
+            parameters=[p.name for p in _continuous_params],
+            max_cardinality=MAX_CARDINALITY,
+        )
+    ]
+    return parameters, constraints
+
+
+def _config_discrete_only():
+    """Hybrid space with a discrete cardinality constraint."""
+    parameters = [
+        *_discrete_params,
+        NumericalContinuousParameter("c_extra", bounds=(0, 1)),
+    ]
+    constraints = [
+        DiscreteCardinalityConstraint(
+            parameters=[p.name for p in _discrete_params],
+            max_cardinality=MAX_CARDINALITY,
+        )
+    ]
+    return parameters, constraints
+
+
+def _config_both():
+    """Hybrid space with both a discrete and a continuous cardinality constraint."""
+    parameters = [*_discrete_params, *_continuous_params]
+    constraints = [
+        DiscreteCardinalityConstraint(
+            parameters=[p.name for p in _discrete_params],
+            max_cardinality=MAX_CARDINALITY,
+        ),
+        ContinuousCardinalityConstraint(
+            parameters=[p.name for p in _continuous_params],
+            max_cardinality=MAX_CARDINALITY,
+        ),
+    ]
+    return parameters, constraints
+
+
+# --- Parametrized test --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("config_fn", "discrete_names", "continuous_names"),
+    [
+        pytest.param(
+            _config_continuous_only,
+            None,
+            [p.name for p in _continuous_params],
+            id="continuous_only",
+        ),
+        pytest.param(
+            _config_discrete_only,
+            [p.name for p in _discrete_params],
+            None,
+            id="discrete_only",
+        ),
+        pytest.param(
+            _config_both,
+            [p.name for p in _discrete_params],
+            [p.name for p in _continuous_params],
+            id="both",
+        ),
+    ],
+)
+def test_cardinality_constraint_hybrid(config_fn, discrete_names, continuous_names):
+    """Cardinality constraints are respected in hybrid search spaces."""
+    parameters, constraints = config_fn()
+    searchspace = SearchSpace.from_product(parameters, constraints)
+    objective = NumericalTarget("t").to_objective()
+
+    # Build measurements covering all parameter columns
+    all_param_names = [p.name for p in parameters]
+    rng = np.random.default_rng(42)
+    measurements = pd.DataFrame({name: rng.random(3) for name in all_param_names})
+    # Snap categorical values to valid entries
+    for p in parameters:
+        if isinstance(p, CategoricalParameter):
+            measurements[p.name] = rng.choice(p.values, size=len(measurements))
+        elif isinstance(p, NumericalDiscreteParameter):
+            measurements[p.name] = rng.choice(list(p.values), size=len(measurements))
+    measurements["t"] = rng.random(len(measurements))
+
+    rec = BotorchRecommender().recommend(
+        BATCH_SIZE, searchspace, objective, measurements
+    )
+
+    # Validate continuous cardinality
+    if continuous_names is not None:
+        n_nonzero = (rec[continuous_names].abs() > 1e-3).sum(axis=1)
+        assert (n_nonzero <= MAX_CARDINALITY).all(), (
+            f"Continuous cardinality constraint violated: {n_nonzero.tolist()}"
+        )
+
+    # Validate discrete cardinality
+    if discrete_names is not None:
+        n_nonzero = (rec[discrete_names] != 0.0).sum(axis=1)
+        assert (n_nonzero <= MAX_CARDINALITY).all(), (
+            f"Discrete cardinality constraint violated: {n_nonzero.tolist()}"
+        )

--- a/tests/constraints/test_cardinality_constraint_hybrid.py
+++ b/tests/constraints/test_cardinality_constraint_hybrid.py
@@ -1,15 +1,10 @@
-"""Tests for cardinality constraints in hybrid search spaces.
+"""Tests for cardinality constraints in hybrid search spaces."""
 
-Regression tests for https://github.com/emdgroup/baybe/issues/567.
-"""
-
-import numpy as np
-import pandas as pd
 import pytest
 
 from baybe.constraints.continuous import ContinuousCardinalityConstraint
 from baybe.constraints.discrete import DiscreteCardinalityConstraint
-from baybe.parameters.categorical import CategoricalParameter
+from baybe.constraints.utils import is_cardinality_fulfilled
 from baybe.parameters.numerical import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
@@ -17,126 +12,77 @@ from baybe.parameters.numerical import (
 from baybe.recommenders import BotorchRecommender
 from baybe.searchspace import SearchSpace
 from baybe.targets import NumericalTarget
+from baybe.utils.dataframe import create_fake_input
 
-BATCH_SIZE = 5
+BATCH_SIZE = 2
 MAX_CARDINALITY = 1
 
-# --- Shared helpers -----------------------------------------------------------
-
 _discrete_params = [
-    NumericalDiscreteParameter(f"d{i}", values=(0.0, 0.5, 1.0)) for i in range(3)
+    NumericalDiscreteParameter(f"d{i}", values=(0.0, 0.5, 1.0)) for i in range(2)
 ]
 _continuous_params = [
     NumericalContinuousParameter(f"c{i}", bounds=(0, 1)) for i in range(2)
 ]
 
-# --- Test configurations ------------------------------------------------------
-
-
-def _config_continuous_only():
-    """Hybrid space with a continuous cardinality constraint."""
-    parameters = [
-        CategoricalParameter("cat", values=("A", "B", "C")),
-        *_continuous_params,
-    ]
-    constraints = [
-        ContinuousCardinalityConstraint(
-            parameters=[p.name for p in _continuous_params],
-            max_cardinality=MAX_CARDINALITY,
-        )
-    ]
-    return parameters, constraints
-
-
-def _config_discrete_only():
-    """Hybrid space with a discrete cardinality constraint."""
-    parameters = [
-        *_discrete_params,
-        NumericalContinuousParameter("c_extra", bounds=(0, 1)),
-    ]
-    constraints = [
-        DiscreteCardinalityConstraint(
-            parameters=[p.name for p in _discrete_params],
-            max_cardinality=MAX_CARDINALITY,
-        )
-    ]
-    return parameters, constraints
-
-
-def _config_both():
-    """Hybrid space with both a discrete and a continuous cardinality constraint."""
-    parameters = [*_discrete_params, *_continuous_params]
-    constraints = [
-        DiscreteCardinalityConstraint(
-            parameters=[p.name for p in _discrete_params],
-            max_cardinality=MAX_CARDINALITY,
-        ),
-        ContinuousCardinalityConstraint(
-            parameters=[p.name for p in _continuous_params],
-            max_cardinality=MAX_CARDINALITY,
-        ),
-    ]
-    return parameters, constraints
-
-
-# --- Parametrized test --------------------------------------------------------
-
 
 @pytest.mark.parametrize(
-    ("config_fn", "discrete_names", "continuous_names"),
+    ("disc_params", "conti_params", "constraints"),
     [
         pytest.param(
-            _config_continuous_only,
-            None,
-            [p.name for p in _continuous_params],
-            id="continuous_only",
+            [NumericalDiscreteParameter("d", values=(0.0, 1.0))],
+            _continuous_params,
+            [
+                ContinuousCardinalityConstraint(
+                    parameters=[p.name for p in _continuous_params],
+                    max_cardinality=MAX_CARDINALITY,
+                )
+            ],
+            id="conti",
         ),
         pytest.param(
-            _config_discrete_only,
-            [p.name for p in _discrete_params],
-            None,
-            id="discrete_only",
+            _discrete_params,
+            [NumericalContinuousParameter("c", bounds=(0, 1))],
+            [
+                DiscreteCardinalityConstraint(
+                    parameters=[p.name for p in _discrete_params],
+                    max_cardinality=MAX_CARDINALITY,
+                )
+            ],
+            id="disc",
         ),
         pytest.param(
-            _config_both,
-            [p.name for p in _discrete_params],
-            [p.name for p in _continuous_params],
-            id="both",
+            _discrete_params,
+            _continuous_params,
+            [
+                DiscreteCardinalityConstraint(
+                    parameters=[p.name for p in _discrete_params],
+                    max_cardinality=MAX_CARDINALITY,
+                ),
+                ContinuousCardinalityConstraint(
+                    parameters=[p.name for p in _continuous_params],
+                    max_cardinality=MAX_CARDINALITY,
+                ),
+            ],
+            id="hybrid",
         ),
     ],
 )
-def test_cardinality_constraint_hybrid(config_fn, discrete_names, continuous_names):
+def test_cardinality_constraint_hybrid(disc_params, conti_params, constraints):
     """Cardinality constraints are respected in hybrid search spaces."""
-    parameters, constraints = config_fn()
+    parameters = [*disc_params, *conti_params]
     searchspace = SearchSpace.from_product(parameters, constraints)
-    objective = NumericalTarget("t").to_objective()
-
-    # Build measurements covering all parameter columns
-    all_param_names = [p.name for p in parameters]
-    rng = np.random.default_rng(42)
-    measurements = pd.DataFrame({name: rng.random(3) for name in all_param_names})
-    # Snap categorical values to valid entries
-    for p in parameters:
-        if isinstance(p, CategoricalParameter):
-            measurements[p.name] = rng.choice(p.values, size=len(measurements))
-        elif isinstance(p, NumericalDiscreteParameter):
-            measurements[p.name] = rng.choice(list(p.values), size=len(measurements))
-    measurements["t"] = rng.random(len(measurements))
+    target = NumericalTarget("t")
+    measurements = create_fake_input(parameters, [target])
 
     rec = BotorchRecommender().recommend(
-        BATCH_SIZE, searchspace, objective, measurements
+        BATCH_SIZE, searchspace, target.to_objective(), measurements
     )
 
-    # Validate continuous cardinality
-    if continuous_names is not None:
-        n_nonzero = (rec[continuous_names].abs() > 1e-3).sum(axis=1)
-        assert (n_nonzero <= MAX_CARDINALITY).all(), (
-            f"Continuous cardinality constraint violated: {n_nonzero.tolist()}"
-        )
-
-    # Validate discrete cardinality
-    if discrete_names is not None:
-        n_nonzero = (rec[discrete_names] != 0.0).sum(axis=1)
-        assert (n_nonzero <= MAX_CARDINALITY).all(), (
-            f"Discrete cardinality constraint violated: {n_nonzero.tolist()}"
-        )
+    for c in constraints:
+        if isinstance(c, ContinuousCardinalityConstraint):
+            assert is_cardinality_fulfilled(
+                rec, searchspace.continuous, check_minimum=False
+            )
+        elif isinstance(c, DiscreteCardinalityConstraint):
+            n_nonzero = (rec[list(c.parameters)] != 0.0).sum(axis=1)
+            assert (n_nonzero <= c.max_cardinality).all()


### PR DESCRIPTION
Fixes #567

This PR essentially refactors the internal objects and pathways that are invoked for constraints that are implemented via optimizing subspaces. Currently this is only the `ContinuousCardinalityConstraint` but the planned `DiscreteBatchConstraint` works in an almost indentical manner which warrants a more unified structure. `DiscreteBatchConstraint` will come in a subsequent PR (yet to be linked)

This touches mostly internal concepts and no major userfacing things.

As a side effect to the refactoring, the `ContinuousCardinalityConstraint` can now also be applied in hybrid spaces, which fixes #567

Changes:
- The properties that were hardcoded in naming to cardinality are renamed to more general names like `constraints_cardinality` to `constraints_subspace_generating`
- The bayesian recommender implements now pathways like
  - discrete / hybrid / continuous will get a `with_subspaces` and `without_subspaces` pathway, the former performing the subspace creation and then invoking the latter
  - there is an overall `_optimize_subspaces` method which is called by all three searchspace type pathways
  - the discrete and hybrid pathways do not yet have all functionality as they will be added in the followup PR, so the full need for this PR might not be easy to see, but when the upcoming discrete batch constraint and a combined hybrid subspace approach are considered it will be clearer
- `_FixedNumericalContinuousParameter` had a bugged property which was named `is_numeric` but it should be `is_numerical`

Further Suggestions:
- The file for the botorch recommender has grown rather large and it would benefit form splitting. But since its all in one class that would require outsourcing some code to functions with very large singnatures. If this is acceptable we can split `botorch.py` into a submodule with `core.py`, `discrete.py`, `continuous.py`, `hybrid.py`. Personally I think that would improve readability despite long signatures (on private functions)