### PR TITLE
Exclude packages that are newer than 7 days for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,3 +185,6 @@ fallback_version = "0.0+unknown"
 
 [tool.setuptools]
 packages = ["baybe"]
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-03T08:31:57.919196Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"


### PR DESCRIPTION
This PR improves the configuration of BayBE such that only package version older than 7 days can be installed.

I have tested this locally and can confirm that it works: I've attempted to raise the version of `uv` itself in this PR, which was not possible as the latest version of `uv` is only 4 days old. I've also done a check using a value of 100 days, which results in an error that the necessary version `0.14.11.` of `ruff` cannot be installed. Since 100 days ago was December 20, 2025, this also checks out:
<img width="493" height="182" alt="image" src="https://github.com/user-attachments/assets/65f47630-711b-4bce-838b-0415f3a95be8" />
