### PR TITLE
Smartly Apply Constraints During Cartesian Product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UnsupportedEarlyFilteringError` exception
 
 ### Breaking Changes
+- `parameter_cartesian_prod_pandas` and `parameter_cartesian_prod_polars` moved
+  from `baybe.searchspace.discrete` to `baybe.searchspace.utils`
 - `ContinuousLinearConstraint.to_botorch` now returns a collection of constraint tuples
   instead of a single tuple (needed for interpoint constraints)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transfer learning benchmarks for shifted and inverted Hartmann functions
 - Coding convention instructions for agentic developers (`AGENTS.md`, `CLAUDE.md`)
 - `has_polars_implementation` property on `DiscreteConstraint`
-- `UnsupportedEarlyFilteringError` exception
+- `allow_missing` flag on `DiscreteConstraint.get_invalid` and `get_valid`
 
 ### Breaking Changes
 - `parameter_cartesian_prod_pandas` and `parameter_cartesian_prod_polars` moved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Interpoint constraints for continuous search spaces
 - Transfer learning benchmarks for shifted and inverted Hartmann functions
 - Coding convention instructions for agentic developers (`AGENTS.md`, `CLAUDE.md`)
+- `has_polars_implementation` property on `DiscreteConstraint`
+- `UnsupportedEarlyFilteringError` exception
 
 ### Breaking Changes
 - `ContinuousLinearConstraint.to_botorch` now returns a collection of constraint tuples
   instead of a single tuple (needed for interpoint constraints)
 
 ### Fixed
+- Broken cache validation for certain `Campaign.recommend` cases
 - `SHAPInsight` breaking with `numpy>=2.4` due to no longer accepted implicit array to 
   scalar conversion
 - Using `np.isclose` for assessing equality of `Interval` bounds instead of hard
@@ -29,9 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `Campaign.allow_*` flag mechanism is now based on `AutoBool` logic, providing
   well-defined Boolean values at query time while exposing the `AUTO` option to the user
-
-### Fixed
-- Broken cache validation for certain `Campaign.recommend` cases
+- Discrete search space construction now applies constraints incrementally during
+  Cartesian product building, significantly reducing memory usage and construction
+  time for constrained spaces
+- Polars path in discrete search space construction now builds the Cartesian product
+  only for parameters involved in Polars-capable constraints, merging the rest
+  incrementally via pandas
 
 ### Removed
 - `parallel_runs` argument from `simulate_scenarios`, since parallelization

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -180,7 +180,7 @@ class DiscreteConstraint(Constraint, ABC):
         return self._get_invalid(df)
 
     @abstractmethod
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         """Get the indices of invalid entries (core logic for subclasses).
 
         This method is only called after it has been confirmed that the dataframe

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -146,13 +146,12 @@ class DiscreteConstraint(Constraint, ABC):
         return df.index.drop(invalid)
 
     def get_invalid(
-        self, data: pd.DataFrame, /, *, allow_missing: bool = False
+        self, df: pd.DataFrame, /, *, allow_missing: bool = False
     ) -> pd.Index:
         """Get the indices of dataframe entries that are invalid under the constraint.
 
         Args:
-            data: A dataframe where each row represents a parameter
-                configuration.
+            df: A dataframe where each row represents a parameter configuration.
             allow_missing: If ``False``, a :class:`ValueError` is raised when
                 the dataframe is missing required parameter columns. If ``True``, the
                 subclass is asked whether it can perform (partial) constraint
@@ -167,7 +166,7 @@ class DiscreteConstraint(Constraint, ABC):
             The dataframe indices of rows that violate the constraint.
         """
         # TODO: Should switch backends (pandas/polars/...) behind the scenes
-        available = set(data.columns)
+        available = set(df.columns)
 
         if not allow_missing:
             if missing := self._required_parameters - available:
@@ -178,10 +177,10 @@ class DiscreteConstraint(Constraint, ABC):
         elif not self._can_evaluate(available):
             return pd.Index([])
 
-        return self._get_invalid(data)
+        return self._get_invalid(df)
 
     @abstractmethod
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
         """Get the indices of invalid entries (core logic for subclasses).
 
         This method is only called after it has been confirmed that the dataframe
@@ -190,7 +189,7 @@ class DiscreteConstraint(Constraint, ABC):
         column-availability checks.
 
         Args:
-            data: A dataframe where each row represents a parameter configuration.
+            df: A dataframe where each row represents a parameter configuration.
 
         Returns:
             The dataframe indices of rows that violate the constraint.

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -98,27 +98,62 @@ class DiscreteConstraint(Constraint, ABC):
     eval_during_modeling: ClassVar[bool] = False
     # See base class.
 
-    def get_valid(self, df: pd.DataFrame, /) -> pd.Index:
+    def get_valid(
+        self, df: pd.DataFrame, /, *, allow_missing: bool = False
+    ) -> pd.Index:
         """Get the indices of dataframe entries that are valid under the constraint.
 
         Args:
             df: A dataframe where each row represents a parameter configuration.
+            allow_missing: If ``False``, a :class:`ValueError` is raised when
+                the dataframe is missing required parameter columns. If
+                ``True``, the constraint performs partial filtering on the
+                available columns.
 
         Returns:
             The dataframe indices of rows that fulfill the constraint.
         """
-        invalid = self.get_invalid(df)
+        invalid = self.get_invalid(df, allow_missing=allow_missing)
         return df.index.drop(invalid)
 
-    @abstractmethod
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def get_invalid(
+        self, data: pd.DataFrame, /, *, allow_missing: bool = False
+    ) -> pd.Index:
         """Get the indices of dataframe entries that are invalid under the constraint.
 
+        Args:
+            data: A dataframe where each row represents a parameter
+                configuration.
+            allow_missing: If ``False``, a :class:`ValueError` is raised when
+                the dataframe is missing required parameter columns. If
+                ``True``, the constraint performs partial filtering on the
+                available columns, returning an empty index when insufficient
+                columns are present.
+
+        Raises:
+            ValueError: If ``allow_missing`` is ``False`` and the dataframe
+                is missing required parameter columns.
+
+        Returns:
+            The dataframe indices of rows that violate the constraint.
+        """
+        # TODO: Should switch backends (pandas/polars/...) behind the scenes
+        if not allow_missing:
+            if missing := self._required_parameters - set(data.columns):
+                raise ValueError(
+                    f"'{self.__class__.__name__}' requires columns {missing} "
+                    f"which are missing from the dataframe."
+                )
+        return self._get_invalid(data)
+
+    @abstractmethod
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        """Get the indices of invalid entries (implementation for subclasses).
+
+        Subclasses implement this method with their specific filtering logic.
         When the dataframe contains only a subset of the constraint's
-        parameters, constraints that support incremental filtering will
-        eliminate invalid rows based on the available subset. Constraints
-        that require the complete set of parameters raise
-        :class:`baybe.exceptions.UnsupportedEarlyFilteringError`.
+        parameters, implementations should return an empty index if they
+        cannot perform useful filtering.
 
         Args:
             data: A dataframe where each row represents a parameter
@@ -127,12 +162,7 @@ class DiscreteConstraint(Constraint, ABC):
 
         Returns:
             The dataframe indices of rows that violate the constraint.
-
-        Raises:
-            UnsupportedEarlyFilteringError: If the constraint cannot perform
-                filtering with the available subset of parameters.
         """
-        # TODO: Should switch backends (pandas/polars/...) behind the scenes
 
     @property
     def _required_parameters(self) -> set[str]:

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -82,6 +82,17 @@ class Constraint(ABC, SerialMixin):
         """Boolean indicating if this is a constraint over discrete parameters."""
         return isinstance(self, DiscreteConstraint)
 
+    @property
+    def _required_parameters(self) -> set[str]:
+        """All parameter names needed for full constraint evaluation.
+
+        For most constraints, this is simply the set of names from
+        :attr:`~baybe.constraints.base.Constraint.parameters`.
+        Constraints with additional parameter references (e.g., affected
+        parameters in dependency constraints) override this to include those.
+        """
+        return set(self.parameters)
+
 
 @define
 class DiscreteConstraint(Constraint, ABC):
@@ -163,17 +174,6 @@ class DiscreteConstraint(Constraint, ABC):
         Returns:
             The dataframe indices of rows that violate the constraint.
         """
-
-    @property
-    def _required_parameters(self) -> set[str]:
-        """All parameter names needed for full constraint evaluation.
-
-        For most constraints, this is simply the set of names from
-        :attr:`~baybe.constraints.base.Constraint.parameters`.
-        Constraints with additional parameter references (e.g., affected
-        parameters in dependency constraints) override this to include those.
-        """
-        return set(self.parameters)
 
     @classproperty
     def has_polars_implementation(cls) -> bool:

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -20,6 +20,7 @@ from baybe.serialization import (
 from baybe.serialization.core import (
     converter,
 )
+from baybe.utils.basic import classproperty
 
 if TYPE_CHECKING:
     import polars as pl
@@ -143,12 +144,10 @@ class DiscreteConstraint(Constraint, ABC):
         """
         return set(self.parameters)
 
-    @property
-    def has_polars_implementation(self) -> bool:
-        """Whether this constraint has a Polars implementation."""
-        return (
-            type(self).get_invalid_polars is not DiscreteConstraint.get_invalid_polars
-        )
+    @classproperty
+    def has_polars_implementation(cls) -> bool:
+        """Whether this constraint class has a Polars implementation."""
+        return cls.get_invalid_polars is not DiscreteConstraint.get_invalid_polars
 
     def get_invalid_polars(self) -> pl.Expr:
         """Translate the constraint to Polars expression identifying undesired rows.

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -109,6 +109,24 @@ class DiscreteConstraint(Constraint, ABC):
     eval_during_modeling: ClassVar[bool] = False
     # See base class.
 
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        """Indicate whether the constraint can be (partially) evaluated.
+
+        Called to decide if the constraint logic should be invoked at all. The default
+        implementation requires *all* parameters considered by the constraint to be
+        present. Subclasses that support useful partial filtering override this to
+        return ``True`` whenever a meaningful subset is available.
+
+        Args:
+            available: The set of column names present in the dataframe that
+                is about to be evaluated.
+
+        Returns:
+            ``True`` if the constraint can apply a meaningful partial filtering
+            given the *available* columns, ``False`` otherwise.
+        """
+        return self._required_parameters <= available
+
     def get_valid(
         self, df: pd.DataFrame, /, *, allow_missing: bool = False
     ) -> pd.Index:
@@ -136,10 +154,10 @@ class DiscreteConstraint(Constraint, ABC):
             data: A dataframe where each row represents a parameter
                 configuration.
             allow_missing: If ``False``, a :class:`ValueError` is raised when
-                the dataframe is missing required parameter columns. If
-                ``True``, the constraint performs partial filtering on the
-                available columns, returning an empty index when insufficient
-                columns are present.
+                the dataframe is missing required parameter columns. If ``True``, the
+                subclass is asked whether it can perform (partial) constraint
+                evaluation; if not, an empty index is returned, signaling to the
+                caller `there are no entries to be excluded *yet*`.
 
         Raises:
             ValueError: If ``allow_missing`` is ``False`` and the dataframe
@@ -149,27 +167,30 @@ class DiscreteConstraint(Constraint, ABC):
             The dataframe indices of rows that violate the constraint.
         """
         # TODO: Should switch backends (pandas/polars/...) behind the scenes
+        available = set(data.columns)
+
         if not allow_missing:
-            if missing := self._required_parameters - set(data.columns):
+            if missing := self._required_parameters - available:
                 raise ValueError(
                     f"'{self.__class__.__name__}' requires columns {missing} "
                     f"which are missing from the dataframe."
                 )
+        elif not self._can_evaluate(available):
+            return pd.Index([])
+
         return self._get_invalid(data)
 
     @abstractmethod
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        """Get the indices of invalid entries (implementation for subclasses).
+        """Get the indices of invalid entries (core logic for subclasses).
 
-        Subclasses implement this method with their specific filtering logic.
-        When the dataframe contains only a subset of the constraint's
-        parameters, implementations should return an empty index if they
-        cannot perform useful filtering.
+        This method is only called after it has been confirmed that the dataframe
+        contains sufficient columns for (at least partial) evaluation. Implementations
+        should therefore contain only the constraint's core filtering logic without
+        column-availability checks.
 
         Args:
-            data: A dataframe where each row represents a parameter
-                configuration. May contain all or a subset of the constraint's
-                parameters.
+            data: A dataframe where each row represents a parameter configuration.
 
         Returns:
             The dataframe indices of rows that violate the constraint.

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -113,13 +113,42 @@ class DiscreteConstraint(Constraint, ABC):
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
         """Get the indices of dataframe entries that are invalid under the constraint.
 
+        When the dataframe contains only a subset of the constraint's
+        parameters, constraints that support incremental filtering will
+        eliminate invalid rows based on the available subset. Constraints
+        that require the complete set of parameters raise
+        :class:`baybe.exceptions.UnsupportedEarlyFilteringError`.
+
         Args:
-            data: A dataframe where each row represents a parameter configuration.
+            data: A dataframe where each row represents a parameter
+                configuration. May contain all or a subset of the constraint's
+                parameters.
 
         Returns:
             The dataframe indices of rows that violate the constraint.
+
+        Raises:
+            UnsupportedEarlyFilteringError: If the constraint cannot perform
+                filtering with the available subset of parameters.
         """
         # TODO: Should switch backends (pandas/polars/...) behind the scenes
+
+    @property
+    def _required_filtering_parameters(self) -> set[str]:
+        """All parameter names needed for full constraint evaluation.
+
+        For most constraints, this is simply the ``parameters`` attribute.
+        Constraints with additional parameter references (e.g., affected
+        parameters in dependency constraints) override this to include those.
+        """
+        return set(self.parameters)
+
+    @property
+    def has_polars_implementation(self) -> bool:
+        """Whether this constraint has a Polars implementation."""
+        return (
+            type(self).get_invalid_polars is not DiscreteConstraint.get_invalid_polars
+        )
 
     def get_invalid_polars(self) -> pl.Expr:
         """Translate the constraint to Polars expression identifying undesired rows.

--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -135,10 +135,11 @@ class DiscreteConstraint(Constraint, ABC):
         # TODO: Should switch backends (pandas/polars/...) behind the scenes
 
     @property
-    def _required_filtering_parameters(self) -> set[str]:
+    def _required_parameters(self) -> set[str]:
         """All parameter names needed for full constraint evaluation.
 
-        For most constraints, this is simply the ``parameters`` attribute.
+        For most constraints, this is simply the set of names from
+        :attr:`~baybe.constraints.base.Constraint.parameters`.
         Constraints with additional parameter references (e.g., affected
         parameters in dependency constraints) override this to include those.
         """

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -54,7 +54,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         return True
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in df]
         satisfied = [cond.evaluate(df[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
@@ -94,7 +94,7 @@ class DiscreteSumConstraint(DiscreteConstraint):
     """The condition modeled by this constraint."""
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         evaluate_df = df[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_df)
 
@@ -127,7 +127,7 @@ class DiscreteProductConstraint(DiscreteConstraint):
     # present. This could be expressed via a _can_evaluate override.
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         evaluate_df = df[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_df)
 
@@ -168,7 +168,7 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         params = [p for p in self.parameters if p in df]
         mask_bad = df[params].nunique(axis=1) != len(params)
 
@@ -205,7 +205,7 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         params = [p for p in self.parameters if p in set(df.columns)]
         mask_bad = df[params].nunique(axis=1) != 1
 
@@ -276,7 +276,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         return params
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         # Create df copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_df = df.copy()
@@ -357,7 +357,7 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         cols = set(df.columns)
         params = [p for p in self.parameters if p in cols]
         # When dependencies exist, permutation dedup on a partial set of
@@ -418,7 +418,7 @@ class DiscreteCustomConstraint(DiscreteConstraint):
     you want to keep/remove."""
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         mask_bad = ~self.validator(df[self.parameters])
 
         return df.index[mask_bad]
@@ -439,7 +439,7 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
         return bool(available & set(self.parameters))
 
     @override
-    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
         params = [p for p in self.parameters if p in set(df.columns)]
         all_present = len(params) == len(self.parameters)
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -47,16 +47,19 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in data]
         if not pairs:
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' has no available parameters "
-                f"for filtering."
+                f"'{self.__class__.__name__}' requires at least one of "
+                f"{self.parameters} but the dataframe only contains "
+                f"{list(data.columns)}."
             )
 
         # Only the OR combiner supports incremental filtering: a single
         # true condition is sufficient to mark a row as invalid.
         if self.combiner != "OR" and len(pairs) < len(self.parameters):
+            missing = set(self.parameters) - set(data.columns)
             raise UnsupportedEarlyFilteringError(
                 f"'{self.__class__.__name__}' with combiner "
-                f"'{self.combiner}' requires all parameters for filtering."
+                f"'{self.combiner}' requires columns {missing} which are "
+                f"missing from the dataframe."
             )
         satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
@@ -92,13 +95,14 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not set(self.parameters) <= set(data.columns):
+        if missing := set(self.parameters) - set(data.columns):
             # IMPROVE: Look-ahead filtering would be possible if parameter
             # value ranges (min/max) were available to the constraint, allowing
             # bound-based pruning of partial sums before all parameters are
             # present.
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires all parameters for filtering."
+                f"'{self.__class__.__name__}' requires columns {missing} "
+                f"which are missing from the dataframe."
             )
         evaluate_data = data[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
@@ -128,13 +132,14 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not set(self.parameters) <= set(data.columns):
+        if missing := set(self.parameters) - set(data.columns):
             # IMPROVE: Look-ahead filtering would be possible if parameter
             # value ranges (min/max) were available to the constraint, allowing
             # bound-based pruning of partial products before all parameters are
             # present.
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires all parameters for filtering."
+                f"'{self.__class__.__name__}' requires columns {missing} "
+                f"which are missing from the dataframe."
             )
         evaluate_data = data[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
@@ -173,8 +178,8 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
         params = [p for p in self.parameters if p in data]
         if len(params) < 2:
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 available "
-                f"parameters for filtering but got {len(params)}."
+                f"'{self.__class__.__name__}' requires at least 2 of "
+                f"{self.parameters} in the dataframe but found only {params}."
             )
         mask_bad = data[params].nunique(axis=1) != len(params)
 
@@ -208,8 +213,8 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
         params = [p for p in self.parameters if p in set(data.columns)]
         if len(params) < 2:
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 available "
-                f"parameters for filtering but got {len(params)}."
+                f"'{self.__class__.__name__}' requires at least 2 of "
+                f"{self.parameters} in the dataframe but found only {params}."
             )
         mask_bad = data[params].nunique(axis=1) != 1
 
@@ -281,10 +286,10 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not self._required_parameters <= set(data.columns):
+        if missing := self._required_parameters - set(data.columns):
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires all parameters and "
-                f"affected parameters for filtering."
+                f"'{self.__class__.__name__}' requires columns {missing} "
+                f"which are missing from the dataframe."
             )
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
@@ -364,8 +369,8 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         params = [p for p in self.parameters if p in cols]
         if len(params) < 2:
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 available "
-                f"parameters for filtering but got {len(params)}."
+                f"'{self.__class__.__name__}' requires at least 2 of "
+                f"{self.parameters} in the dataframe but found only {params}."
             )
         # When dependencies exist, permutation dedup on a partial set of
         # parameters is not safe because the dependency logic can change
@@ -430,9 +435,10 @@ class DiscreteCustomConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not set(self.parameters) <= set(data.columns):
+        if missing := set(self.parameters) - set(data.columns):
             raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires all parameters for filtering."
+                f"'{self.__class__.__name__}' requires columns {missing} "
+                f"which are missing from the dataframe."
             )
         mask_bad = ~self.validator(data[self.parameters])
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -366,13 +366,9 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         # the other parameters and indicate duplicates. This ensures that variation in
         # other parameters is also accounted for.
         other_params = data.columns.drop(params).tolist()
-        df_eval = pd.concat(
-            [
-                data[other_params].copy(),
-                data[params].apply(cast(Callable, frozenset), axis=1),
-            ],
-            axis=1,
-        ).loc[
+        frozen = data[params].apply(cast(Callable, frozenset), axis=1)
+        parts = [data[other_params].copy(), frozen] if other_params else [frozen]
+        df_eval = pd.concat(parts, axis=1).loc[
             ~mask_duplicate_labels  # only consider label-duplicate-free part
         ]
         mask_duplicate_permutations = df_eval.duplicated(keep="first")

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -19,7 +19,6 @@ from baybe.constraints.conditions import (
     _threshold_operators,
     _valid_logic_combiners,
 )
-from baybe.exceptions import UnsupportedEarlyFilteringError
 from baybe.serialization import (
     block_deserialization_hook,
     block_serialization_hook,
@@ -43,24 +42,16 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
     """Operator encoding how to combine the individual conditions."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in data]
         if not pairs:
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least one of "
-                f"{self.parameters} but the dataframe only contains "
-                f"{list(data.columns)}."
-            )
+            return pd.Index([])
 
         # Only the OR combiner supports incremental filtering: a single
         # true condition is sufficient to mark a row as invalid.
         if self.combiner != "OR" and len(pairs) < len(self.parameters):
-            missing = set(self.parameters) - set(data.columns)
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' with combiner "
-                f"'{self.combiner}' requires columns {missing} which are "
-                f"missing from the dataframe."
-            )
+            return pd.Index([])
+
         satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
 
@@ -94,16 +85,13 @@ class DiscreteSumConstraint(DiscreteConstraint):
     """The condition modeled by this constraint."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if missing := set(self.parameters) - set(data.columns):
-            # IMPROVE: Look-ahead filtering would be possible if parameter
-            # value ranges (min/max) were available to the constraint, allowing
-            # bound-based pruning of partial sums before all parameters are
-            # present.
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires columns {missing} "
-                f"which are missing from the dataframe."
-            )
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        # IMPROVE: Look-ahead filtering would be possible if parameter
+        # value ranges (min/max) were available to the constraint, allowing
+        # bound-based pruning of partial sums before all parameters are
+        # present.
+        if not set(self.parameters) <= set(data.columns):
+            return pd.Index([])
         evaluate_data = data[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -131,16 +119,13 @@ class DiscreteProductConstraint(DiscreteConstraint):
     """The condition that is used for this constraint."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if missing := set(self.parameters) - set(data.columns):
-            # IMPROVE: Look-ahead filtering would be possible if parameter
-            # value ranges (min/max) were available to the constraint, allowing
-            # bound-based pruning of partial products before all parameters are
-            # present.
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires columns {missing} "
-                f"which are missing from the dataframe."
-            )
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        # IMPROVE: Look-ahead filtering would be possible if parameter
+        # value ranges (min/max) were available to the constraint, allowing
+        # bound-based pruning of partial products before all parameters are
+        # present.
+        if not set(self.parameters) <= set(data.columns):
+            return pd.Index([])
         evaluate_data = data[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -174,13 +159,10 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
     """
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         params = [p for p in self.parameters if p in data]
         if len(params) < 2:
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 of "
-                f"{self.parameters} in the dataframe but found only {params}."
-            )
+            return pd.Index([])
         mask_bad = data[params].nunique(axis=1) != len(params)
 
         return data.index[mask_bad]
@@ -209,13 +191,10 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
     """
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         params = [p for p in self.parameters if p in set(data.columns)]
         if len(params) < 2:
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 of "
-                f"{self.parameters} in the dataframe but found only {params}."
-            )
+            return pd.Index([])
         mask_bad = data[params].nunique(axis=1) != 1
 
         return data.index[mask_bad]
@@ -285,12 +264,9 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         return params
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if missing := self._required_parameters - set(data.columns):
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires columns {missing} "
-                f"which are missing from the dataframe."
-            )
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not self._required_parameters <= set(data.columns):
+            return pd.Index([])
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
@@ -364,14 +340,11 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         return params
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         cols = set(data.columns)
         params = [p for p in self.parameters if p in cols]
         if len(params) < 2:
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires at least 2 of "
-                f"{self.parameters} in the dataframe but found only {params}."
-            )
+            return pd.Index([])
         # When dependencies exist, permutation dedup on a partial set of
         # parameters is not safe because the dependency logic can change
         # which permutations are equivalent. In this case, only the
@@ -434,12 +407,9 @@ class DiscreteCustomConstraint(DiscreteConstraint):
     you want to keep/remove."""
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if missing := set(self.parameters) - set(data.columns):
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' requires columns {missing} "
-                f"which are missing from the dataframe."
-            )
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not set(self.parameters) <= set(data.columns):
+            return pd.Index([])
         mask_bad = ~self.validator(data[self.parameters])
 
         return data.index[mask_bad]
@@ -454,14 +424,11 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
     # See base class.
 
     @override
-    def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         cols = set(data.columns)
         params = [p for p in self.parameters if p in cols]
         if not params:
-            raise UnsupportedEarlyFilteringError(
-                f"'{self.__class__.__name__}' has no available parameters "
-                f"for filtering."
-            )
+            return pd.Index([])
         all_present = len(params) == len(self.parameters)
 
         non_zeros = (data[params] != 0.0).sum(axis=1)

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -50,6 +50,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
                 f"'{self.__class__.__name__}' has no available parameters "
                 f"for filtering."
             )
+
         # Only the OR combiner supports incremental filtering: a single
         # true condition is sufficient to mark a row as invalid.
         if self.combiner != "OR" and len(pairs) < len(self.parameters):
@@ -57,8 +58,9 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
                 f"'{self.__class__.__name__}' with combiner "
                 f"'{self.combiner}' requires all parameters for filtering."
             )
-       satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
+        satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
+
         return data.index[res]
 
     @override
@@ -270,7 +272,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @property
     @override
-    def _required_filtering_parameters(self) -> set[str]:
+    def _required_parameters(self) -> set[str]:
         """See base class."""
         params = set(self.parameters)
         for group in self.affected_parameters:
@@ -279,7 +281,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not self._required_filtering_parameters <= set(data.columns):
+        if not self._required_parameters <= set(data.columns):
             raise UnsupportedEarlyFilteringError(
                 f"'{self.__class__.__name__}' requires all parameters and "
                 f"affected parameters for filtering."
@@ -349,11 +351,11 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
 
     @property
     @override
-    def _required_filtering_parameters(self) -> set[str]:
+    def _required_parameters(self) -> set[str]:
         """See base class."""
         params = set(self.parameters)
         if self.dependencies:
-            params.update(self.dependencies._required_filtering_parameters)
+            params.update(self.dependencies._required_parameters)
         return params
 
     @override
@@ -370,7 +372,7 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         # which permutations are equivalent. In this case, only the
         # label-dedup part (which is always safe incrementally) is applied.
         if self.dependencies:
-            if not self._required_filtering_parameters <= cols:
+            if not self._required_parameters <= cols:
                 return DiscreteNoLabelDuplicatesConstraint(
                     parameters=params
                 ).get_invalid(data)

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -54,12 +54,12 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
         return True
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in data]
-        satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in df]
+        satisfied = [cond.evaluate(df[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
 
-        return data.index[res]
+        return df.index[res]
 
     @override
     def get_invalid_polars(self) -> pl.Expr:
@@ -94,11 +94,11 @@ class DiscreteSumConstraint(DiscreteConstraint):
     """The condition modeled by this constraint."""
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        evaluate_data = data[self.parameters].sum(axis=1)
-        mask_bad = ~self.condition.evaluate(evaluate_data)
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        evaluate_df = df[self.parameters].sum(axis=1)
+        mask_bad = ~self.condition.evaluate(evaluate_df)
 
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
     @override
     def get_invalid_polars(self) -> pl.Expr:
@@ -127,11 +127,11 @@ class DiscreteProductConstraint(DiscreteConstraint):
     # present. This could be expressed via a _can_evaluate override.
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        evaluate_data = data[self.parameters].prod(axis=1)
-        mask_bad = ~self.condition.evaluate(evaluate_data)
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        evaluate_df = df[self.parameters].prod(axis=1)
+        mask_bad = ~self.condition.evaluate(evaluate_df)
 
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
     @override
     def get_invalid_polars(self) -> pl.Expr:
@@ -168,11 +168,11 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        params = [p for p in self.parameters if p in data]
-        mask_bad = data[params].nunique(axis=1) != len(params)
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        params = [p for p in self.parameters if p in df]
+        mask_bad = df[params].nunique(axis=1) != len(params)
 
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
     @override
     def get_invalid_polars(self) -> pl.Expr:
@@ -205,11 +205,11 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        params = [p for p in self.parameters if p in set(data.columns)]
-        mask_bad = data[params].nunique(axis=1) != 1
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        params = [p for p in self.parameters if p in set(df.columns)]
+        mask_bad = df[params].nunique(axis=1) != 1
 
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
     @override
     def get_invalid_polars(self) -> pl.Expr:
@@ -276,15 +276,15 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         return params
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        # Create data copy and mark entries where the dependency conditions are negative
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        # Create df copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
-        censored_data = data.copy()
+        censored_df = df.copy()
         for k, _ in enumerate(self.parameters):
             # .loc assignments are not supported by mypy + pandas-stubs yet
             # See https://github.com/pandas-dev/pandas-stubs/issues/572
-            censored_data.loc[  # type: ignore[call-overload]
-                ~self.conditions[k].evaluate(data[self.parameters[k]]),
+            censored_df.loc[  # type: ignore[call-overload]
+                ~self.conditions[k].evaluate(df[self.parameters[k]]),
                 self.affected_parameters[k],
             ] = Dummy()
 
@@ -293,17 +293,17 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         # will become invariant when frozenset is applied to them.
         for k, param in enumerate(self.parameters):
             for affected_param in self.affected_parameters[k]:
-                censored_data[affected_param] = list(
-                    zip(censored_data[affected_param], censored_data[param])
+                censored_df[affected_param] = list(
+                    zip(censored_df[affected_param], censored_df[param])
                 )
 
         # Merge the invariant indicator with all other parameters (i.e. neither the
         # affected nor the dependency-causing ones) and detect duplicates in that space.
         all_affected_params = [col for cols in self.affected_parameters for col in cols]
         other_params = (
-            data.columns.drop(all_affected_params).drop(self.parameters).tolist()
+            df.columns.drop(all_affected_params).drop(self.parameters).tolist()
         )
-        invariant_indicator = censored_data[all_affected_params].apply(
+        invariant_indicator = censored_df[all_affected_params].apply(
             cast(Callable, frozenset)
             if self.permutation_invariant
             else cast(Callable, tuple),
@@ -311,10 +311,10 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         )
         # Only include the other_params DataFrame if it is non-empty to avoid
         # pandas FutureWarning about concatenation with empty entries
-        parts = [censored_data[other_params]] if other_params else []
+        parts = [censored_df[other_params]] if other_params else []
         parts.append(invariant_indicator)
         df_eval = pd.concat(parts, axis=1)
-        inds_bad = data.index[df_eval.duplicated(keep="first")]
+        inds_bad = df.index[df_eval.duplicated(keep="first")]
 
         return inds_bad
 
@@ -357,8 +357,8 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         return len(available & set(self.parameters)) >= 2
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        cols = set(data.columns)
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        cols = set(df.columns)
         params = [p for p in self.parameters if p in cols]
         # When dependencies exist, permutation dedup on a partial set of
         # parameters is not safe because the dependency logic can change
@@ -368,30 +368,30 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
             if not self._required_parameters <= cols:
                 return DiscreteNoLabelDuplicatesConstraint(
                     parameters=params
-                ).get_invalid(data)
+                ).get_invalid(df)
 
         # Get indices of entries with duplicate label entries. These will also be
         # dropped by this constraint.
-        mask_duplicate_labels = pd.Series(False, index=data.index)
+        mask_duplicate_labels = pd.Series(False, index=df.index)
         mask_duplicate_labels[
-            DiscreteNoLabelDuplicatesConstraint(parameters=params).get_invalid(data)
+            DiscreteNoLabelDuplicatesConstraint(parameters=params).get_invalid(df)
         ] = True
 
         # Merge a permutation invariant representation of all affected parameters with
         # the other parameters and indicate duplicates. This ensures that variation in
         # other parameters is also accounted for.
-        other_params = data.columns.drop(params).tolist()
-        frozen = data[params].apply(cast(Callable, frozenset), axis=1)
-        parts = [data[other_params].copy(), frozen] if other_params else [frozen]
+        other_params = df.columns.drop(params).tolist()
+        frozen = df[params].apply(cast(Callable, frozenset), axis=1)
+        parts = [df[other_params].copy(), frozen] if other_params else [frozen]
         df_eval = pd.concat(parts, axis=1).loc[
             ~mask_duplicate_labels  # only consider label-duplicate-free part
         ]
         mask_duplicate_permutations = df_eval.duplicated(keep="first")
 
         # Indices of entries with label-duplicates
-        inds_duplicate_labels = data.index[mask_duplicate_labels]
+        inds_duplicate_labels = df.index[mask_duplicate_labels]
 
-        # Indices of duplicate permutations in the (already label-duplicate-free) data
+        # Indices of duplicate permutations in the (already label-duplicate-free) df
         inds_duplicate_permutations = df_eval.index[mask_duplicate_permutations]
 
         # If there are dependencies connected to the invariant parameters evaluate them
@@ -400,7 +400,7 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         if self.dependencies:
             self.dependencies.permutation_invariant = True
             inds_duplicate_independency_adjusted = self.dependencies.get_invalid(
-                data.drop(index=inds_invalid)
+                df.drop(index=inds_invalid)
             )
             inds_invalid = inds_invalid.union(inds_duplicate_independency_adjusted)
 
@@ -418,10 +418,10 @@ class DiscreteCustomConstraint(DiscreteConstraint):
     you want to keep/remove."""
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        mask_bad = ~self.validator(data[self.parameters])
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        mask_bad = ~self.validator(df[self.parameters])
 
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
 
 @define
@@ -439,11 +439,11 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
         return bool(available & set(self.parameters))
 
     @override
-    def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        params = [p for p in self.parameters if p in set(data.columns)]
+    def _get_invalid(self, df: pd.DataFrame) -> pd.Index:
+        params = [p for p in self.parameters if p in set(df.columns)]
         all_present = len(params) == len(self.parameters)
 
-        non_zeros = (data[params] != 0.0).sum(axis=1)
+        non_zeros = (df[params] != 0.0).sum(axis=1)
         # The max_cardinality check is safe on a partial subset: the nonzero
         # count can only increase as more parameters are added.
         mask_bad = non_zeros > self.max_cardinality
@@ -451,7 +451,7 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
         # are present, since missing parameters could still add nonzero values.
         if all_present:
             mask_bad |= non_zeros < self.min_cardinality
-        return data.index[mask_bad]
+        return df.index[mask_bad]
 
 
 # Constraints are approximately ordered according to increasing computational effort

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -42,16 +42,20 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
     """Operator encoding how to combine the individual conditions."""
 
     @override
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        # The OR combiner supports incremental filtering (a single true
+        # condition suffices to mark a row as invalid), so at least one
+        # parameter is enough. Other combiners need all parameters.
+        present = available & set(self.parameters)
+        if not present:
+            return False
+        if self.combiner != "OR" and present != set(self.parameters):
+            return False
+        return True
+
+    @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in data]
-        if not pairs:
-            return pd.Index([])
-
-        # Only the OR combiner supports incremental filtering: a single
-        # true condition is sufficient to mark a row as invalid.
-        if self.combiner != "OR" and len(pairs) < len(self.parameters):
-            return pd.Index([])
-
         satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
 
@@ -76,6 +80,11 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     # IMPROVE: refactor `SumConstraint` and `ProdConstraint` to avoid code copying
 
+    # IMPROVE: Look-ahead filtering would be possible if parameter
+    # value ranges (min/max) were available to the constraint, allowing
+    # bound-based pruning of partial sums before all parameters are
+    # present. This could be expressed via a _can_evaluate override.
+
     # class variables
     numerical_only: ClassVar[bool] = True
     # See base class.
@@ -86,12 +95,6 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        # IMPROVE: Look-ahead filtering would be possible if parameter
-        # value ranges (min/max) were available to the constraint, allowing
-        # bound-based pruning of partial sums before all parameters are
-        # present.
-        if not set(self.parameters) <= set(data.columns):
-            return pd.Index([])
         evaluate_data = data[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -118,14 +121,13 @@ class DiscreteProductConstraint(DiscreteConstraint):
     condition: ThresholdCondition = field()
     """The condition that is used for this constraint."""
 
+    # IMPROVE: Look-ahead filtering would be possible if parameter
+    # value ranges (min/max) were available to the constraint, allowing
+    # bound-based pruning of partial products before all parameters are
+    # present. This could be expressed via a _can_evaluate override.
+
     @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        # IMPROVE: Look-ahead filtering would be possible if parameter
-        # value ranges (min/max) were available to the constraint, allowing
-        # bound-based pruning of partial products before all parameters are
-        # present.
-        if not set(self.parameters) <= set(data.columns):
-            return pd.Index([])
         evaluate_data = data[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -159,10 +161,15 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
     """
 
     @override
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        # Duplicate detection is meaningful as soon as at least two of the
+        # constraint's parameters are available: duplicates in a subset
+        # will also be duplicates in the full set.
+        return len(available & set(self.parameters)) >= 2
+
+    @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         params = [p for p in self.parameters if p in data]
-        if len(params) < 2:
-            return pd.Index([])
         mask_bad = data[params].nunique(axis=1) != len(params)
 
         return data.index[mask_bad]
@@ -191,10 +198,15 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
     """
 
     @override
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        # Linked-parameter checking is meaningful as soon as at least two of
+        # the constraint's parameters are available: if values differ in a
+        # subset, they will also differ in the full set.
+        return len(available & set(self.parameters)) >= 2
+
+    @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         params = [p for p in self.parameters if p in set(data.columns)]
-        if len(params) < 2:
-            return pd.Index([])
         mask_bad = data[params].nunique(axis=1) != 1
 
         return data.index[mask_bad]
@@ -265,8 +277,6 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not self._required_parameters <= set(data.columns):
-            return pd.Index([])
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
@@ -340,11 +350,16 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
         return params
 
     @override
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        # At least two parameters are needed for any deduplication. When only a
+        # partial set is available, the constraint falls back to the always-safe
+        # label-dedup logic.
+        return len(available & set(self.parameters)) >= 2
+
+    @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
         cols = set(data.columns)
         params = [p for p in self.parameters if p in cols]
-        if len(params) < 2:
-            return pd.Index([])
         # When dependencies exist, permutation dedup on a partial set of
         # parameters is not safe because the dependency logic can change
         # which permutations are equivalent. In this case, only the
@@ -404,8 +419,6 @@ class DiscreteCustomConstraint(DiscreteConstraint):
 
     @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        if not set(self.parameters) <= set(data.columns):
-            return pd.Index([])
         mask_bad = ~self.validator(data[self.parameters])
 
         return data.index[mask_bad]
@@ -420,11 +433,14 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
     # See base class.
 
     @override
+    def _can_evaluate(self, available: set[str], /) -> bool:
+        # The max-cardinality check is safe on any non-empty subset: the
+        # nonzero count can only increase as more parameters are added.
+        return bool(available & set(self.parameters))
+
+    @override
     def _get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        cols = set(data.columns)
-        params = [p for p in self.parameters if p in cols]
-        if not params:
-            return pd.Index([])
+        params = [p for p in self.parameters if p in set(data.columns)]
         all_present = len(params) == len(self.parameters)
 
         non_zeros = (data[params] != 0.0).sum(axis=1)

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -19,6 +19,7 @@ from baybe.constraints.conditions import (
     _threshold_operators,
     _valid_logic_combiners,
 )
+from baybe.exceptions import UnsupportedEarlyFilteringError
 from baybe.serialization import (
     block_deserialization_hook,
     block_serialization_hook,
@@ -43,10 +44,24 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        satisfied = [
-            cond.evaluate(data[self.parameters[k]])
-            for k, cond in enumerate(self.conditions)
-        ]
+        cols = set(data.columns)
+        pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in cols]
+        if not pairs:
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' has no available parameters "
+                f"for filtering."
+            )
+        # Only the OR combiner supports incremental filtering: a single
+        # true condition is sufficient to mark a row as invalid.
+        if self.combiner != "OR" and len(pairs) < len(self.parameters):
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' with combiner "
+                f"'{self.combiner}' requires all parameters for filtering."
+            )
+        params_list = [p for p, _ in pairs]
+        conds_list = [c for _, c in pairs]
+
+        satisfied = [cond.evaluate(data[p]) for p, cond in zip(params_list, conds_list)]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
         return data.index[res]
 
@@ -79,6 +94,14 @@ class DiscreteSumConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not set(self.parameters) <= set(data.columns):
+            # IMPROVE: Look-ahead filtering would be possible if parameter
+            # value ranges (min/max) were available to the constraint, allowing
+            # bound-based pruning of partial sums before all parameters are
+            # present.
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires all parameters for filtering."
+            )
         evaluate_data = data[self.parameters].sum(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -107,6 +130,14 @@ class DiscreteProductConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not set(self.parameters) <= set(data.columns):
+            # IMPROVE: Look-ahead filtering would be possible if parameter
+            # value ranges (min/max) were available to the constraint, allowing
+            # bound-based pruning of partial products before all parameters are
+            # present.
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires all parameters for filtering."
+            )
         evaluate_data = data[self.parameters].prod(axis=1)
         mask_bad = ~self.condition.evaluate(evaluate_data)
 
@@ -141,7 +172,13 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        mask_bad = data[self.parameters].nunique(axis=1) != len(self.parameters)
+        params = [p for p in self.parameters if p in set(data.columns)]
+        if len(params) < 2:
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires at least 2 available "
+                f"parameters for filtering but got {len(params)}."
+            )
+        mask_bad = data[params].nunique(axis=1) != len(params)
 
         return data.index[mask_bad]
 
@@ -158,6 +195,7 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
         return expr
 
 
+@define
 class DiscreteLinkedParametersConstraint(DiscreteConstraint):
     """Constraint class for linking the values of parameters.
 
@@ -169,7 +207,13 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        mask_bad = data[self.parameters].nunique(axis=1) != 1
+        params = [p for p in self.parameters if p in set(data.columns)]
+        if len(params) < 2:
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires at least 2 available "
+                f"parameters for filtering but got {len(params)}."
+            )
+        mask_bad = data[params].nunique(axis=1) != 1
 
         return data.index[mask_bad]
 
@@ -228,8 +272,22 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
                 f"the conditions list."
             )
 
+    @property
+    @override
+    def _required_filtering_parameters(self) -> set[str]:
+        """See base class."""
+        params = set(self.parameters)
+        for group in self.affected_parameters:
+            params.update(group)
+        return params
+
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not self._required_filtering_parameters <= set(data.columns):
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires all parameters and "
+                f"affected parameters for filtering."
+            )
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
@@ -293,25 +351,49 @@ class DiscretePermutationInvarianceConstraint(DiscreteConstraint):
     dependencies: DiscreteDependenciesConstraint | None = field(default=None)
     """Dependencies connected with the invariant parameters."""
 
+    @property
+    @override
+    def _required_filtering_parameters(self) -> set[str]:
+        """See base class."""
+        params = set(self.parameters)
+        if self.dependencies:
+            params.update(self.dependencies._required_filtering_parameters)
+        return params
+
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        cols = set(data.columns)
+        params = [p for p in self.parameters if p in cols]
+        if len(params) < 2:
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires at least 2 available "
+                f"parameters for filtering but got {len(params)}."
+            )
+        # When dependencies exist, permutation dedup on a partial set of
+        # parameters is not safe because the dependency logic can change
+        # which permutations are equivalent. In this case, only the
+        # label-dedup part (which is always safe incrementally) is applied.
+        if self.dependencies:
+            if not self._required_filtering_parameters <= cols:
+                return DiscreteNoLabelDuplicatesConstraint(
+                    parameters=params
+                ).get_invalid(data)
+
         # Get indices of entries with duplicate label entries. These will also be
         # dropped by this constraint.
         mask_duplicate_labels = pd.Series(False, index=data.index)
         mask_duplicate_labels[
-            DiscreteNoLabelDuplicatesConstraint(parameters=self.parameters).get_invalid(
-                data
-            )
+            DiscreteNoLabelDuplicatesConstraint(parameters=params).get_invalid(data)
         ] = True
 
         # Merge a permutation invariant representation of all affected parameters with
         # the other parameters and indicate duplicates. This ensures that variation in
         # other parameters is also accounted for.
-        other_params = data.columns.drop(self.parameters).tolist()
+        other_params = data.columns.drop(params).tolist()
         df_eval = pd.concat(
             [
                 data[other_params].copy(),
-                data[self.parameters].apply(cast(Callable, frozenset), axis=1),
+                data[params].apply(cast(Callable, frozenset), axis=1),
             ],
             axis=1,
         ).loc[
@@ -350,6 +432,10 @@ class DiscreteCustomConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
+        if not set(self.parameters) <= set(data.columns):
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' requires all parameters for filtering."
+            )
         mask_bad = ~self.validator(data[self.parameters])
 
         return data.index[mask_bad]
@@ -365,9 +451,23 @@ class DiscreteCardinalityConstraint(CardinalityConstraint, DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        non_zeros = (data[self.parameters] != 0.0).sum(axis=1)
+        cols = set(data.columns)
+        params = [p for p in self.parameters if p in cols]
+        if not params:
+            raise UnsupportedEarlyFilteringError(
+                f"'{self.__class__.__name__}' has no available parameters "
+                f"for filtering."
+            )
+        all_present = len(params) == len(self.parameters)
+
+        non_zeros = (data[params] != 0.0).sum(axis=1)
+        # The max_cardinality check is safe on a partial subset: the nonzero
+        # count can only increase as more parameters are added.
         mask_bad = non_zeros > self.max_cardinality
-        mask_bad |= non_zeros < self.min_cardinality
+        # The min_cardinality check can only be applied when all parameters
+        # are present, since missing parameters could still add nonzero values.
+        if all_present:
+            mask_bad |= non_zeros < self.min_cardinality
         return data.index[mask_bad]
 
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -44,8 +44,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        cols = set(data.columns)
-        pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in cols]
+        pairs = [(p, c) for p, c in zip(self.parameters, self.conditions) if p in data]
         if not pairs:
             raise UnsupportedEarlyFilteringError(
                 f"'{self.__class__.__name__}' has no available parameters "
@@ -58,10 +57,7 @@ class DiscreteExcludeConstraint(DiscreteConstraint):
                 f"'{self.__class__.__name__}' with combiner "
                 f"'{self.combiner}' requires all parameters for filtering."
             )
-        params_list = [p for p, _ in pairs]
-        conds_list = [c for _, c in pairs]
-
-        satisfied = [cond.evaluate(data[p]) for p, cond in zip(params_list, conds_list)]
+       satisfied = [cond.evaluate(data[p]) for p, cond in pairs]
         res = reduce(_valid_logic_combiners[self.combiner], satisfied)
         return data.index[res]
 
@@ -172,7 +168,7 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
 
     @override
     def get_invalid(self, data: pd.DataFrame) -> pd.Index:
-        params = [p for p in self.parameters if p in set(data.columns)]
+        params = [p for p in self.parameters if p in data]
         if len(params) < 2:
             raise UnsupportedEarlyFilteringError(
                 f"'{self.__class__.__name__}' requires at least 2 available "

--- a/baybe/constraints/validation.py
+++ b/baybe/constraints/validation.py
@@ -54,29 +54,30 @@ def validate_constraints(  # noqa: DOC101, DOC103
     ]
 
     for constraint in constraints:
-        if not all(p in param_names_all for p in constraint.parameters):
+        if not all(p in param_names_all for p in constraint._required_parameters):
             raise ValueError(
                 f"You are trying to create a constraint with at least one parameter "
                 f"name that does not exist in the list of defined parameters. "
-                f"Parameter list of the affected constraint: {constraint.parameters}"
+                f"Parameter list of the affected constraint: "
+                f"{constraint._required_parameters}"
             )
 
         if constraint.is_continuous and any(
-            p in param_names_discrete for p in constraint.parameters
+            p in param_names_discrete for p in constraint._required_parameters
         ):
             raise ValueError(
                 f"You are trying to initialize a continuous constraint over a "
                 f"parameter that is discrete. Parameter list of the affected "
-                f"constraint: {constraint.parameters}"
+                f"constraint: {constraint._required_parameters}"
             )
 
         if constraint.is_discrete and any(
-            p in param_names_continuous for p in constraint.parameters
+            p in param_names_continuous for p in constraint._required_parameters
         ):
             raise ValueError(
                 f"You are trying to initialize a discrete constraint over a parameter "
                 f"that is continuous. Parameter list of the affected constraint: "
-                f"{constraint.parameters}"
+                f"{constraint._required_parameters}"
             )
 
         if constraint.numerical_only and any(

--- a/baybe/exceptions.py
+++ b/baybe/exceptions.py
@@ -175,5 +175,9 @@ class NotAllowedError(Exception):
     """An operation was attempted that is not allowed in the current context."""
 
 
+class UnsupportedEarlyFilteringError(Exception):
+    """A constraint does not support early filtering with the given parameters."""
+
+
 # Collect leftover original slotted classes processed by `attrs.define`
 gc.collect()

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -21,6 +21,7 @@ from baybe.constraints.base import ContinuousConstraint, ContinuousNonlinearCons
 from baybe.constraints.validation import (
     validate_cardinality_constraint_parameter_bounds,
     validate_cardinality_constraints_are_nonoverlapping,
+    validate_constraints,
 )
 from baybe.parameters import NumericalContinuousParameter
 from baybe.parameters.base import ContinuousParameter
@@ -201,6 +202,10 @@ class SubspaceContinuous(SerialMixin):
     ) -> SubspaceContinuous:
         """See :class:`baybe.searchspace.core.SearchSpace`."""
         constraints = constraints or []
+
+        if constraints:
+            validate_constraints(constraints, parameters)
+
         return SubspaceContinuous(
             parameters=[p for p in parameters if p.is_continuous],
             constraints_lin_eq=[

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -202,7 +202,7 @@ class SubspaceDiscrete(SerialMixin):
             # Determine which parameters are needed by Polars-capable constraints
             polars_param_names: set[str] = set()
             for c in polars_constraints:
-                polars_param_names.update(c._required_filtering_parameters)
+                polars_param_names.update(c._required_parameters)
             polars_params = [p for p in parameters if p.name in polars_param_names]
             remaining_params = [
                 p for p in parameters if p.name not in polars_param_names

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import warnings
 from collections.abc import Collection, Sequence
 from itertools import compress
 from math import prod
@@ -385,12 +386,16 @@ class SubspaceDiscrete(SerialMixin):
                 f"parameters: {overlap}."
             )
 
-        # Validate minimum number of simplex parameters
+        # Handle degenerate simplex cases
         if len(simplex_parameters) < 2:
-            raise ValueError(
-                f"'{cls.from_simplex.__name__}' requires at least 2 simplex "
-                f"parameters but got {len(simplex_parameters)}."
+            warnings.warn(
+                f"'{cls.from_simplex.__name__}' was called with less than 2 "
+                f"simplex parameters, so smart simplex construction has no effect."
+                f"Consider using '{cls.from_product.__name__}' instead.",
+                UserWarning,
             )
+            if len(simplex_parameters) < 1:
+                return cls.from_product(product_parameters, constraints)
 
         # Validate non-negativity
         min_values = [min(p.values) for p in simplex_parameters]

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -14,7 +14,7 @@ from attrs import define, field
 from cattrs import IterableValidationError
 from typing_extensions import override
 
-from baybe.constraints import validate_constraints
+from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
 from baybe.constraints.base import DiscreteConstraint
 from baybe.exceptions import DeprecationError
 from baybe.parameters import (
@@ -97,7 +97,13 @@ class SubspaceDiscrete(SerialMixin):
     """Flag encoding whether an empty encoding is used."""
 
     constraints: tuple[DiscreteConstraint, ...] = field(
-        converter=to_tuple, factory=tuple
+        converter=lambda x: to_tuple(
+            sorted(
+                x,
+                key=lambda c: DISCRETE_CONSTRAINTS_FILTERING_ORDER.index(c.__class__),
+            )
+        ),
+        factory=tuple,
     )
     """A list of constraints for restricting the space."""
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -24,6 +24,10 @@ from baybe.parameters import (
 )
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.utils import get_parameters_from_dataframe, sort_parameters
+from baybe.searchspace.utils import (
+    parameter_cartesian_prod_pandas_constrained,
+    parameter_cartesian_prod_polars,
+)
 from baybe.searchspace.validation import validate_parameter_names, validate_parameters
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.settings import active_settings
@@ -189,18 +193,41 @@ class SubspaceDiscrete(SerialMixin):
         )
 
         if active_settings.use_polars_for_constraints:
-            lazy_df = parameter_cartesian_prod_polars(parameters)
-            lazy_df, mask_missing = _apply_constraint_filter_polars(
-                lazy_df, constraints
-            )
-            df_records = lazy_df.collect().to_dicts()
-            df = pd.DataFrame.from_records(df_records)
-        else:
-            df = parameter_cartesian_prod_pandas(parameters)
-            mask_missing = [True] * len(constraints)
+            # Partition constraints by Polars support
+            polars_constraints = [c for c in constraints if c.has_polars_implementation]
+            pandas_constraints = [
+                c for c in constraints if not c.has_polars_implementation
+            ]
 
-        # Gather and use constraints not yet applied
-        _apply_constraint_filter_pandas(df, list(compress(constraints, mask_missing)))
+            # Determine which parameters are needed by Polars-capable constraints
+            polars_param_names: set[str] = set()
+            for c in polars_constraints:
+                polars_param_names.update(c._required_filtering_parameters)
+            polars_params = [p for p in parameters if p.name in polars_param_names]
+            remaining_params = [
+                p for p in parameters if p.name not in polars_param_names
+            ]
+
+            if polars_params:
+                # Build Polars product only for relevant parameters and filter
+                lazy_df = parameter_cartesian_prod_polars(polars_params)
+                lazy_df, mask_missing = _apply_constraint_filter_polars(
+                    lazy_df, polars_constraints
+                )
+                initial_df = lazy_df.collect().to_pandas()
+                # Apply Polars constraints that failed back via pandas
+                _apply_constraint_filter_pandas(
+                    initial_df, list(compress(polars_constraints, mask_missing))
+                )
+            else:
+                initial_df = None
+
+            # Merge remaining parameters with pandas-only constraint filtering
+            df = parameter_cartesian_prod_pandas_constrained(
+                remaining_params, pandas_constraints, initial_df=initial_df
+            )
+        else:
+            df = parameter_cartesian_prod_pandas_constrained(parameters, constraints)
 
         return SubspaceDiscrete(
             parameters=parameters,
@@ -358,10 +385,12 @@ class SubspaceDiscrete(SerialMixin):
                 f"parameters: {overlap}."
             )
 
-        # Construct the product part of the space
-        product_space = parameter_cartesian_prod_pandas(product_parameters)
-        if not simplex_parameters:
-            return cls(parameters=product_parameters, exp_rep=product_space)
+        # Validate minimum number of simplex parameters
+        if len(simplex_parameters) < 2:
+            raise ValueError(
+                f"'{cls.from_simplex.__name__}' requires at least 2 simplex "
+                f"parameters but got {len(simplex_parameters)}."
+            )
 
         # Validate non-negativity
         min_values = [min(p.values) for p in simplex_parameters]
@@ -471,12 +500,10 @@ class SubspaceDiscrete(SerialMixin):
         if boundary_only:
             drop_invalid(exp_rep, max_sum, boundary_only=True)
 
-        # Augment the Cartesian product created from all other parameter types
-        if product_parameters:
-            exp_rep = pd.merge(exp_rep, product_space, how="cross")
-
-        # Remove entries that violate parameter constraints:
-        _apply_constraint_filter_pandas(exp_rep, constraints)
+        # Merge product parameters and apply constraints incrementally
+        exp_rep = parameter_cartesian_prod_pandas_constrained(
+            product_parameters, constraints, initial_df=exp_rep
+        )
 
         return cls(
             parameters=[*simplex_parameters, *product_parameters],
@@ -686,59 +713,6 @@ def _apply_constraint_filter_polars(
             mask_missing.append(True)
 
     return ldf, mask_missing
-
-
-def parameter_cartesian_prod_polars(
-    parameters: Sequence[DiscreteParameter],
-) -> pl.LazyFrame:
-    """Create the Cartesian product of discrete parameter values using Polars.
-
-    Args:
-        parameters: List of discrete parameter objects.
-
-    Returns:
-        A lazy dataframe containing all possible discrete parameter value combinations.
-    """
-    from baybe._optional.polars import polars as pl
-
-    if not parameters:
-        return pl.LazyFrame()
-
-    # Convert each parameter to a lazy dataframe for cross-join operation
-    param_frames = [pl.LazyFrame({p.name: p.active_values}) for p in parameters]
-
-    # Handling edge cases
-    if len(param_frames) == 1:
-        return param_frames[0]
-
-    # Cross-join parameters
-    res = param_frames[0]
-    for frame in param_frames[1:]:
-        res = res.join(frame, how="cross", force_parallel=True)
-
-    return res
-
-
-def parameter_cartesian_prod_pandas(
-    parameters: Sequence[DiscreteParameter],
-) -> pd.DataFrame:
-    """Create the Cartesian product of discrete parameter values using Pandas.
-
-    Args:
-        parameters: List of discrete parameter objects.
-
-    Returns:
-        A dataframe containing all possible discrete parameter value combinations.
-    """
-    if not parameters:
-        return pd.DataFrame()
-
-    index = pd.MultiIndex.from_product(
-        [p.active_values for p in parameters], names=[p.name for p in parameters]
-    )
-    ret = pd.DataFrame(index=index).reset_index()
-
-    return ret
 
 
 def validate_simplex_subspace_from_config(specs: dict, _) -> None:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -14,7 +14,7 @@ from attrs import define, field
 from cattrs import IterableValidationError
 from typing_extensions import override
 
-from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
+from baybe.constraints import validate_constraints
 from baybe.constraints.base import DiscreteConstraint
 from baybe.exceptions import DeprecationError
 from baybe.parameters import (
@@ -24,10 +24,7 @@ from baybe.parameters import (
 )
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.utils import get_parameters_from_dataframe, sort_parameters
-from baybe.searchspace.utils import (
-    parameter_cartesian_prod_pandas_constrained,
-    parameter_cartesian_prod_polars,
-)
+from baybe.searchspace.utils import build_constrained_product
 from baybe.searchspace.validation import validate_parameter_names, validate_parameters
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.settings import active_settings
@@ -42,8 +39,6 @@ from baybe.utils.dataframe import (
 from baybe.utils.memory import bytes_to_human_readable
 
 if TYPE_CHECKING:
-    import polars as pl
-
     from baybe.searchspace.core import SearchSpace
 
 
@@ -185,45 +180,9 @@ class SubspaceDiscrete(SerialMixin):
         empty_encoding: bool = False,
     ) -> SubspaceDiscrete:
         """See :class:`baybe.searchspace.core.SearchSpace`."""
-        # Set defaults and order constraints
         constraints = constraints or []
-        constraints = sorted(
-            constraints,
-            key=lambda x: DISCRETE_CONSTRAINTS_FILTERING_ORDER.index(x.__class__),
-        )
 
-        if active_settings.use_polars_for_constraints:
-            # Partition constraints by Polars support
-            polars_constraints = [c for c in constraints if c.has_polars_implementation]
-            pandas_constraints = [
-                c for c in constraints if not c.has_polars_implementation
-            ]
-
-            # Determine which parameters are needed by Polars-capable constraints
-            polars_param_names: set[str] = set()
-            for c in polars_constraints:
-                polars_param_names.update(c._required_parameters)
-            polars_params = [p for p in parameters if p.name in polars_param_names]
-            remaining_params = [
-                p for p in parameters if p.name not in polars_param_names
-            ]
-
-            if polars_params:
-                # Build Polars product only for relevant parameters and filter
-                lazy_df = parameter_cartesian_prod_polars(polars_params)
-                lazy_df, _ = _apply_constraint_filter_polars(
-                    lazy_df, polars_constraints
-                )
-                initial_df = lazy_df.collect().to_pandas()
-            else:
-                initial_df = None
-
-            # Merge remaining parameters with pandas-only constraint filtering
-            df = parameter_cartesian_prod_pandas_constrained(
-                remaining_params, pandas_constraints, initial_df=initial_df
-            )
-        else:
-            df = parameter_cartesian_prod_pandas_constrained(parameters, constraints)
+        df = build_constrained_product(parameters, constraints)
 
         return SubspaceDiscrete(
             parameters=parameters,
@@ -501,7 +460,7 @@ class SubspaceDiscrete(SerialMixin):
             drop_invalid(exp_rep, max_sum, boundary_only=True)
 
         # Merge product parameters and apply constraints incrementally
-        exp_rep = parameter_cartesian_prod_pandas_constrained(
+        exp_rep = build_constrained_product(
             product_parameters, constraints, initial_df=exp_rep
         )
 
@@ -659,60 +618,6 @@ class SubspaceDiscrete(SerialMixin):
             The named parameters.
         """
         return tuple(p for p in self.parameters if p.name in names)
-
-
-def _apply_constraint_filter_pandas(
-    df: pd.DataFrame, constraints: Collection[DiscreteConstraint]
-) -> pd.DataFrame:
-    """Remove discrete search space entries based on constraints.
-
-    The filtering is done inplace, but the modified object is still returned.
-
-    Args:
-        df: The data in experimental representation to be modified inplace.
-        constraints: List of discrete constraints.
-
-    Returns:
-        The filtered dataframe.
-    """
-    # Remove entries that violate parameter constraints:
-    for constraint in (c for c in constraints if c.eval_during_creation):
-        idxs = constraint.get_invalid(df)
-        df.drop(index=idxs, inplace=True)
-    df.reset_index(inplace=True, drop=True)
-
-    return df
-
-
-def _apply_constraint_filter_polars(
-    ldf: pl.LazyFrame,
-    constraints: Sequence[DiscreteConstraint],
-) -> tuple[pl.LazyFrame, list[bool]]:
-    """Remove discrete search space entries based on constraints.
-
-    Note:
-        This will silently skip constraints that have no Polars implementation.
-
-    Args:
-        ldf: The data in experimental representation to be filtered.
-        constraints: Collection of discrete constraints.
-
-    Returns:
-        A tuple containing
-            * The Polars lazyframe with undesired rows removed
-            * A Boolean mask indicating which constraints have **not** been applied
-    """
-    mask_missing = []
-
-    for c in constraints:
-        try:
-            to_keep = c.get_invalid_polars().not_()
-            ldf = ldf.filter(to_keep)
-            mask_missing.append(False)
-        except NotImplementedError:
-            mask_missing.append(True)
-
-    return ldf, mask_missing
 
 
 def validate_simplex_subspace_from_config(specs: dict, _) -> None:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import gc
 import warnings
 from collections.abc import Collection, Sequence
-from itertools import compress
 from math import prod
 from typing import TYPE_CHECKING, Any
 
@@ -212,14 +211,10 @@ class SubspaceDiscrete(SerialMixin):
             if polars_params:
                 # Build Polars product only for relevant parameters and filter
                 lazy_df = parameter_cartesian_prod_polars(polars_params)
-                lazy_df, mask_missing = _apply_constraint_filter_polars(
+                lazy_df, _ = _apply_constraint_filter_polars(
                     lazy_df, polars_constraints
                 )
                 initial_df = lazy_df.collect().to_pandas()
-                # Apply Polars constraints that failed back via pandas
-                _apply_constraint_filter_pandas(
-                    initial_df, list(compress(polars_constraints, mask_missing))
-                )
             else:
                 initial_df = None
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -188,6 +188,9 @@ class SubspaceDiscrete(SerialMixin):
         """See :class:`baybe.searchspace.core.SearchSpace`."""
         constraints = constraints or []
 
+        if constraints:
+            validate_constraints(constraints, parameters)
+
         df = build_constrained_product(parameters, constraints)
 
         return SubspaceDiscrete(

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -37,7 +37,7 @@ def compute_parameter_order(
         return list(parameters)
 
     # Compute which parameter names each constraint needs
-    constraint_params = [c._required_filtering_parameters for c in constraints]
+    constraint_params = [c._required_parameters for c in constraints]
 
     # Separate constrained from unconstrained parameters
     all_constrained_names = set().union(*constraint_params)
@@ -169,7 +169,7 @@ def parameter_cartesian_prod_pandas_constrained(
 
     # Determine which parameter names each constraint needs for completion
     pending: list[tuple[DiscreteConstraint, set[str]]] = [
-        (c, c._required_filtering_parameters) for c in filtering_constraints
+        (c, c._required_parameters) for c in filtering_constraints
     ]
 
     # Initialize the dataframe

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 from baybe.constraints.base import DiscreteConstraint
-from baybe.exceptions import UnsupportedEarlyFilteringError
 from baybe.parameters.base import DiscreteParameter
 
 if TYPE_CHECKING:
@@ -195,11 +194,8 @@ def parameter_cartesian_prod_pandas_constrained(
         still_pending: list[tuple[DiscreteConstraint, set[str]]] = []
 
         for constraint, all_params in pending:
-            try:
-                idxs = constraint.get_invalid(df)
-                df.drop(index=idxs, inplace=True)
-            except UnsupportedEarlyFilteringError:
-                pass
+            idxs = constraint.get_invalid(df, allow_missing=True)
+            df.drop(index=idxs, inplace=True)
 
             if not (all_params <= available):
                 still_pending.append((constraint, all_params))

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
     import polars as pl
 
 
-def compute_parameter_order(
+def optimize_parameter_order(
     parameters: Sequence[DiscreteParameter],
     constraints: Sequence[DiscreteConstraint],
 ) -> list[DiscreteParameter]:
-    """Compute an optimal parameter ordering for incremental space construction.
+    """Determine a heuristic parameter ordering for incremental space construction.
 
     Parameters involved in constraints are placed first, ordered so that the
     parameters completing the most constraints come earliest. Parameters not
@@ -164,7 +164,7 @@ def parameter_cartesian_prod_pandas_constrained(
         return parameter_cartesian_prod_pandas(parameters)
 
     # Compute optimal parameter order
-    ordered_params = compute_parameter_order(parameters, filtering_constraints)
+    ordered_params = optimize_parameter_order(parameters, filtering_constraints)
 
     # Determine which parameter names each constraint needs for completion
     pending: list[tuple[DiscreteConstraint, set[str]]] = [

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -1,0 +1,223 @@
+"""Utilities for search space construction."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from baybe.constraints.base import DiscreteConstraint
+from baybe.exceptions import UnsupportedEarlyFilteringError
+from baybe.parameters.base import DiscreteParameter
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def compute_parameter_order(
+    parameters: Sequence[DiscreteParameter],
+    constraints: Sequence[DiscreteConstraint],
+) -> list[DiscreteParameter]:
+    """Compute an optimal parameter ordering for incremental space construction.
+
+    Parameters involved in constraints are placed first, ordered so that the
+    parameters completing the most constraints come earliest. Parameters not
+    involved in any constraint are placed last.
+
+    Args:
+        parameters: The discrete parameters.
+        constraints: The discrete constraints.
+
+    Returns:
+        The parameters in an order optimized for incremental constraint
+        filtering.
+    """
+    if not constraints:
+        return list(parameters)
+
+    # Compute which parameter names each constraint needs
+    constraint_params = [c._required_filtering_parameters for c in constraints]
+
+    # Separate constrained from unconstrained parameters
+    all_constrained_names = set().union(*constraint_params)
+    constrained = [p for p in parameters if p.name in all_constrained_names]
+    unconstrained = [p for p in parameters if p.name not in all_constrained_names]
+
+    # Greedy ordering: at each step, pick the parameter whose addition
+    # completes (is the last missing parameter for) the most constraints.
+    # Ties are broken by picking the parameter with fewest active values
+    # (smallest expansion factor during cross-merging).
+    ordered: list[DiscreteParameter] = []
+    available: set[str] = set()
+    remaining = list(constrained)
+
+    while remaining:
+        best_param = None
+        best_score = (-1, float("inf"))  # (completions, -active_values)
+
+        for param in remaining:
+            candidate_available = available | {param.name}
+            completions = sum(
+                1
+                for cp in constraint_params
+                if cp <= candidate_available and not cp <= available
+            )
+            n_values = len(param.active_values)
+            score = (completions, -n_values)
+            if score > best_score:
+                best_score = score
+                best_param = param
+
+        assert best_param is not None
+        ordered.append(best_param)
+        available.add(best_param.name)
+        remaining.remove(best_param)
+
+    # Unconstrained parameters go last
+    ordered.extend(unconstrained)
+    return ordered
+
+
+def parameter_cartesian_prod_polars(
+    parameters: Sequence[DiscreteParameter],
+) -> pl.LazyFrame:
+    """Create the Cartesian product of discrete parameter values using Polars.
+
+    Args:
+        parameters: List of discrete parameter objects.
+
+    Returns:
+        A lazy dataframe containing all possible discrete parameter value combinations.
+    """
+    from baybe._optional.polars import polars as pl
+
+    if not parameters:
+        return pl.LazyFrame()
+
+    # Convert each parameter to a lazy dataframe for cross-join operation
+    param_frames = [pl.LazyFrame({p.name: p.active_values}) for p in parameters]
+
+    # Handling edge cases
+    if len(param_frames) == 1:
+        return param_frames[0]
+
+    # Cross-join parameters
+    res = param_frames[0]
+    for frame in param_frames[1:]:
+        res = res.join(frame, how="cross", force_parallel=True)
+
+    return res
+
+
+def parameter_cartesian_prod_pandas(
+    parameters: Sequence[DiscreteParameter],
+) -> pd.DataFrame:
+    """Create the Cartesian product of discrete parameter values using Pandas.
+
+    Args:
+        parameters: List of discrete parameter objects.
+
+    Returns:
+        A dataframe containing all possible discrete parameter value combinations.
+    """
+    if not parameters:
+        return pd.DataFrame()
+
+    index = pd.MultiIndex.from_product(
+        [p.active_values for p in parameters], names=[p.name for p in parameters]
+    )
+    ret = pd.DataFrame(index=index).reset_index()
+
+    return ret
+
+
+def parameter_cartesian_prod_pandas_constrained(
+    parameters: Sequence[DiscreteParameter],
+    constraints: Sequence[DiscreteConstraint],
+    initial_df: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Build a Cartesian product of parameters with incremental constraint filtering.
+
+    Instead of creating the full Cartesian product and then filtering, this
+    function cross-merges parameters one by one, applying constraint filters
+    as early as possible. This significantly reduces memory usage and
+    construction time for highly constrained spaces.
+
+    Parameters are ordered so that constrained parameters come first, enabling
+    constraints to fire early when the intermediate dataframe is still small.
+
+    Args:
+        parameters: The discrete parameters to combine.
+        constraints: The discrete constraints to apply.
+        initial_df: An optional starting dataframe. When provided, the given
+            parameters are cross-merged into it (its columns count as already
+            available for constraint evaluation).
+
+    Returns:
+        A dataframe containing all valid parameter combinations.
+    """
+    # Filter to constraints that should be applied during creation
+    filtering_constraints = [c for c in constraints if c.eval_during_creation]
+
+    # Fast path: no constraints and no initial dataframe
+    if not filtering_constraints and initial_df is None:
+        return parameter_cartesian_prod_pandas(parameters)
+
+    # Compute optimal parameter order
+    ordered_params = compute_parameter_order(parameters, filtering_constraints)
+
+    # Determine which parameter names each constraint needs for completion
+    pending: list[tuple[DiscreteConstraint, set[str]]] = [
+        (c, c._required_filtering_parameters) for c in filtering_constraints
+    ]
+
+    # Initialize the dataframe
+    if initial_df is not None:
+        df = initial_df
+    else:
+        df = pd.DataFrame()
+
+    # Original column order for final reindexing
+    original_columns = (list(initial_df.columns) if initial_df is not None else []) + [
+        p.name for p in parameters
+    ]
+
+    # Incremental cross-merge loop
+    for param in ordered_params:
+        param_df = pd.DataFrame({param.name: param.active_values})
+        if df.empty:
+            df = param_df
+        else:
+            df = pd.merge(df, param_df, how="cross")
+
+        available = set(df.columns)
+        still_pending: list[tuple[DiscreteConstraint, set[str]]] = []
+
+        for constraint, all_params in pending:
+            try:
+                idxs = constraint.get_invalid(df)
+                df.drop(index=idxs, inplace=True)
+            except UnsupportedEarlyFilteringError:
+                pass
+
+            if not (all_params <= available):
+                still_pending.append((constraint, all_params))
+
+        pending = still_pending
+
+    # Apply any remaining constraints whose parameters were already present
+    # in the initial_df (i.e., no new parameters were needed to complete them)
+    if pending and not df.empty:
+        available = set(df.columns)
+        for constraint, all_params in pending:
+            if all_params <= available:
+                idxs = constraint.get_invalid(df)
+                df.drop(index=idxs, inplace=True)
+
+    # Reorder columns and reset index
+    if original_columns:
+        df = df[original_columns]
+    df.reset_index(drop=True, inplace=True)
+
+    return df

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -246,32 +246,21 @@ def _apply_constraint_filter_pandas(
 def _apply_constraint_filter_polars(
     ldf: pl.LazyFrame,
     constraints: Sequence[DiscreteConstraint],
-) -> tuple[pl.LazyFrame, list[bool]]:
+) -> pl.LazyFrame:
     """Remove discrete search space entries based on constraints.
-
-    Note:
-        This will silently skip constraints that have no Polars implementation.
 
     Args:
         ldf: The data in experimental representation to be filtered.
         constraints: Collection of discrete constraints.
 
     Returns:
-        A tuple containing
-            * The Polars lazyframe with undesired rows removed
-            * A Boolean mask indicating which constraints have **not** been applied
+        The Polars lazyframe with undesired rows removed.
     """
-    mask_missing = []
-
     for c in constraints:
-        try:
-            to_keep = c.get_invalid_polars().not_()
-            ldf = ldf.filter(to_keep)
-            mask_missing.append(False)
-        except NotImplementedError:
-            mask_missing.append(True)
+        to_keep = c.get_invalid_polars().not_()
+        ldf = ldf.filter(to_keep)
 
-    return ldf, mask_missing
+    return ldf
 
 
 def build_constrained_product(
@@ -323,7 +312,7 @@ def build_constrained_product(
             lazy_df = parameter_cartesian_prod_polars(
                 polars_params, initial_ldf=initial_ldf
             )
-            lazy_df, _ = _apply_constraint_filter_polars(lazy_df, polars_constraints)
+            lazy_df = _apply_constraint_filter_polars(lazy_df, polars_constraints)
             initial_df = lazy_df.collect().to_pandas()
 
             remaining_params = [

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -267,7 +267,7 @@ def build_constrained_product(
     constraints: Sequence[DiscreteConstraint],
     initial_df: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
-    """Build a constrained Cartesian product, using Polars when available.
+    """Build a constrained Cartesian product, using Polars if configured.
 
     Partitions constraints by Polars support and builds the product accordingly.
     Parameters covered by Polars-capable constraints are cross-joined and

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER
 from baybe.constraints.base import DiscreteConstraint
 from baybe.parameters.base import DiscreteParameter
 
@@ -80,30 +81,33 @@ def optimize_parameter_order(
 
 def parameter_cartesian_prod_polars(
     parameters: Sequence[DiscreteParameter],
+    initial_ldf: pl.LazyFrame | None = None,
 ) -> pl.LazyFrame:
     """Create the Cartesian product of discrete parameter values using Polars.
 
     Args:
         parameters: List of discrete parameter objects.
+        initial_ldf: An optional starting lazy dataframe. When provided, the
+            given parameters are cross-joined into it.
 
     Returns:
         A lazy dataframe containing all possible discrete parameter value combinations.
     """
     from baybe._optional.polars import polars as pl
 
-    if not parameters:
-        return pl.LazyFrame()
-
     # Convert each parameter to a lazy dataframe for cross-join operation
     param_frames = [pl.LazyFrame({p.name: p.active_values}) for p in parameters]
 
-    # Handling edge cases
-    if len(param_frames) == 1:
-        return param_frames[0]
+    # Determine the starting frame
+    if initial_ldf is not None:
+        res = initial_ldf
+    elif param_frames:
+        res = param_frames.pop(0)
+    else:
+        return pl.LazyFrame()
 
-    # Cross-join parameters
-    res = param_frames[0]
-    for frame in param_frames[1:]:
+    # Cross-join remaining parameter frames
+    for frame in param_frames:
         res = res.join(frame, how="cross", force_parallel=True)
 
     return res
@@ -214,3 +218,121 @@ def parameter_cartesian_prod_pandas_constrained(
     df.reset_index(drop=True, inplace=True)
 
     return df
+
+
+def _apply_constraint_filter_pandas(
+    df: pd.DataFrame, constraints: Collection[DiscreteConstraint]
+) -> pd.DataFrame:
+    """Remove discrete search space entries based on constraints.
+
+    The filtering is done inplace, but the modified object is still returned.
+
+    Args:
+        df: The data in experimental representation to be modified inplace.
+        constraints: List of discrete constraints.
+
+    Returns:
+        The filtered dataframe.
+    """
+    # Remove entries that violate parameter constraints:
+    for constraint in (c for c in constraints if c.eval_during_creation):
+        idxs = constraint.get_invalid(df)
+        df.drop(index=idxs, inplace=True)
+    df.reset_index(inplace=True, drop=True)
+
+    return df
+
+
+def _apply_constraint_filter_polars(
+    ldf: pl.LazyFrame,
+    constraints: Sequence[DiscreteConstraint],
+) -> tuple[pl.LazyFrame, list[bool]]:
+    """Remove discrete search space entries based on constraints.
+
+    Note:
+        This will silently skip constraints that have no Polars implementation.
+
+    Args:
+        ldf: The data in experimental representation to be filtered.
+        constraints: Collection of discrete constraints.
+
+    Returns:
+        A tuple containing
+            * The Polars lazyframe with undesired rows removed
+            * A Boolean mask indicating which constraints have **not** been applied
+    """
+    mask_missing = []
+
+    for c in constraints:
+        try:
+            to_keep = c.get_invalid_polars().not_()
+            ldf = ldf.filter(to_keep)
+            mask_missing.append(False)
+        except NotImplementedError:
+            mask_missing.append(True)
+
+    return ldf, mask_missing
+
+
+def build_constrained_product(
+    parameters: Sequence[DiscreteParameter],
+    constraints: Sequence[DiscreteConstraint],
+    initial_df: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Build a constrained Cartesian product, using Polars when available.
+
+    Partitions constraints by Polars support and builds the product accordingly.
+    Parameters covered by Polars-capable constraints are cross-joined and
+    filtered in Polars first, then the remaining parameters and constraints are
+    handled via incremental pandas filtering.
+
+    Args:
+        parameters: The discrete parameters to combine.
+        constraints: The discrete constraints to apply during construction.
+        initial_df: An optional starting dataframe whose columns count as
+            already available for constraint evaluation.
+
+    Returns:
+        A dataframe containing all valid parameter combinations.
+    """
+    from baybe.settings import active_settings
+
+    constraints = sorted(
+        constraints,
+        key=lambda x: DISCRETE_CONSTRAINTS_FILTERING_ORDER.index(x.__class__),
+    )
+
+    remaining_params = list(parameters)
+    remaining_constraints = list(constraints)
+
+    if active_settings.use_polars_for_constraints:
+        from baybe._optional.polars import polars as pl
+
+        polars_constraints = [c for c in constraints if c.has_polars_implementation]
+
+        # Determine which parameters are needed by Polars-capable constraints
+        polars_param_names: set[str] = set()
+        for c in polars_constraints:
+            polars_param_names.update(c._required_parameters)
+        polars_params = [p for p in parameters if p.name in polars_param_names]
+
+        if polars_params:
+            initial_ldf = (
+                pl.from_pandas(initial_df).lazy() if initial_df is not None else None
+            )
+            lazy_df = parameter_cartesian_prod_polars(
+                polars_params, initial_ldf=initial_ldf
+            )
+            lazy_df, _ = _apply_constraint_filter_polars(lazy_df, polars_constraints)
+            initial_df = lazy_df.collect().to_pandas()
+
+            remaining_params = [
+                p for p in parameters if p.name not in polars_param_names
+            ]
+            remaining_constraints = [
+                c for c in constraints if not c.has_polars_implementation
+            ]
+
+    return parameter_cartesian_prod_pandas_constrained(
+        remaining_params, remaining_constraints, initial_df=initial_df
+    )

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -41,7 +41,6 @@ def optimize_parameter_order(
 
     # Separate constrained from unconstrained parameters
     all_constrained_names = set().union(*constraint_params)
-    constrained = [p for p in parameters if p.name in all_constrained_names]
     unconstrained = [p for p in parameters if p.name not in all_constrained_names]
 
     # Greedy ordering: at each step, pick the parameter whose addition
@@ -50,7 +49,7 @@ def optimize_parameter_order(
     # (smallest expansion factor during cross-merging).
     ordered: list[DiscreteParameter] = []
     available: set[str] = set()
-    remaining = list(constrained)
+    remaining = [p for p in parameters if p.name in all_constrained_names]
 
     while remaining:
         best_param = None

--- a/baybe/searchspace/utils.py
+++ b/baybe/searchspace/utils.py
@@ -172,10 +172,7 @@ def parameter_cartesian_prod_pandas_constrained(
     ]
 
     # Initialize the dataframe
-    if initial_df is not None:
-        df = initial_df
-    else:
-        df = pd.DataFrame()
+    df = pd.DataFrame() if initial_df is None else initial_df
 
     # Original column order for final reindexing
     original_columns = (list(initial_df.columns) if initial_df is not None else []) + [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ nitpick_ignore_regex = [
     (r"py:obj", "baybe.acquisition.base.*.supports_multi_output"),
     (r"py:obj", "baybe.acquisition.base.*.is_analytic"),
     (r"py:obj", "baybe.surrogates.*.is_available"),
+    (r"py:obj", r"baybe.constraints.*.has_polars_implementation"),
     # KMedoids
     (r"py:.*", r".*clustering_algorithms.*KMedoids.*"),
     (r"ref:.*", r".*clustering_algorithms.*KMedoids.*"),

--- a/tests/constraints/test_constrained_cartesian_product.py
+++ b/tests/constraints/test_constrained_cartesian_product.py
@@ -23,8 +23,8 @@ from baybe.constraints import (
 from baybe.constraints.base import DiscreteConstraint
 from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
 from baybe.parameters.base import DiscreteParameter
-from baybe.searchspace.discrete import _apply_constraint_filter_pandas
 from baybe.searchspace.utils import (
+    _apply_constraint_filter_pandas,
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_pandas_constrained,
 )

--- a/tests/constraints/test_constrained_cartesian_product.py
+++ b/tests/constraints/test_constrained_cartesian_product.py
@@ -1,0 +1,245 @@
+"""Tests comparing naive vs incremental constrained Cartesian product construction."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import partial
+
+import numpy as np
+import pytest
+from pandas.testing import assert_frame_equal
+
+from baybe.constraints import (
+    DiscreteCardinalityConstraint,
+    DiscreteDependenciesConstraint,
+    DiscreteExcludeConstraint,
+    DiscreteLinkedParametersConstraint,
+    DiscreteNoLabelDuplicatesConstraint,
+    DiscretePermutationInvarianceConstraint,
+    DiscreteSumConstraint,
+    SubSelectionCondition,
+    ThresholdCondition,
+)
+from baybe.constraints.base import DiscreteConstraint
+from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
+from baybe.parameters.base import DiscreteParameter
+from baybe.searchspace.discrete import _apply_constraint_filter_pandas
+from baybe.searchspace.utils import (
+    parameter_cartesian_prod_pandas,
+    parameter_cartesian_prod_pandas_constrained,
+)
+
+
+def _no_constraints_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    params = [
+        CategoricalParameter(name="A", values=["a1", "a2"]),
+        CategoricalParameter(name="B", values=["b1", "b2", "b3"]),
+    ]
+    return params, []
+
+
+def _no_label_duplicates_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    values = ["x", "y", "z", "w"]
+    params = [CategoricalParameter(name=f"P{i}", values=values) for i in range(4)]
+    constraints = [
+        DiscreteNoLabelDuplicatesConstraint(parameters=[p.name for p in params])
+    ]
+    return params, constraints
+
+
+def _linked_parameters_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    values = ["a", "b", "c"]
+    params = [CategoricalParameter(name=f"P{i}", values=values) for i in range(3)]
+    constraints = [
+        DiscreteLinkedParametersConstraint(parameters=[p.name for p in params])
+    ]
+    return params, constraints
+
+
+def _exclude_scenario(
+    combiner: str,
+) -> tuple[Sequence[DiscreteParameter], Sequence[DiscreteConstraint]]:
+    params = [
+        CategoricalParameter(name="A", values=["a1", "a2", "a3"]),
+        CategoricalParameter(name="B", values=["b1", "b2", "b3"]),
+        CategoricalParameter(name="C", values=["c1", "c2", "c3"]),
+    ]
+    constraints = [
+        DiscreteExcludeConstraint(
+            parameters=["A", "B"],
+            conditions=[
+                SubSelectionCondition(selection=["a1"]),
+                SubSelectionCondition(selection=["b1"]),
+            ],
+            combiner=combiner,
+        )
+    ]
+    return params, constraints
+
+
+def _cardinality_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    params = [
+        NumericalDiscreteParameter(name=f"P{i}", values=[0.0, 1.0, 2.0])
+        for i in range(4)
+    ]
+    constraints = [
+        DiscreteCardinalityConstraint(
+            parameters=[p.name for p in params],
+            min_cardinality=1,
+            max_cardinality=2,
+        )
+    ]
+    return params, constraints
+
+
+def _sum_scenario() -> tuple[Sequence[DiscreteParameter], Sequence[DiscreteConstraint]]:
+    params = [
+        NumericalDiscreteParameter(name=f"P{i}", values=[0.0, 25.0, 50.0, 75.0, 100.0])
+        for i in range(3)
+    ]
+    constraints = [
+        DiscreteSumConstraint(
+            parameters=[p.name for p in params],
+            condition=ThresholdCondition(threshold=100, operator="=", tolerance=0.1),
+        )
+    ]
+    return params, constraints
+
+
+def _dependencies_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    params = [
+        CategoricalParameter(name="Switch", values=["on", "off"]),
+        CategoricalParameter(name="Label", values=["a", "b", "c"]),
+        NumericalDiscreteParameter(name="Amount", values=[1.0, 2.0, 3.0]),
+    ]
+    constraints = [
+        DiscreteDependenciesConstraint(
+            parameters=["Switch"],
+            conditions=[SubSelectionCondition(selection=["on"])],
+            affected_parameters=[["Label"]],
+        )
+    ]
+    return params, constraints
+
+
+def _permutation_invariance_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    values = ["a", "b", "c", "d"]
+    params = [CategoricalParameter(name=f"P{i}", values=values) for i in range(3)]
+    constraints = [
+        DiscretePermutationInvarianceConstraint(parameters=[p.name for p in params])
+    ]
+    return params, constraints
+
+
+def _permutation_invariance_with_dependencies_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    solvents = ["water", "ethanol", "methanol", "acetone"]
+    labels = [
+        CategoricalParameter(name=f"Slot{i}_Label", values=solvents) for i in range(3)
+    ]
+    amounts = [
+        NumericalDiscreteParameter(
+            name=f"Slot{i}_Amount", values=list(np.linspace(0, 100, 5))
+        )
+        for i in range(3)
+    ]
+    params = labels + amounts
+    label_names = [lbl.name for lbl in labels]
+    amount_names = [amt.name for amt in amounts]
+
+    constraints = [
+        DiscretePermutationInvarianceConstraint(
+            parameters=label_names,
+            dependencies=DiscreteDependenciesConstraint(
+                parameters=amount_names,
+                conditions=[
+                    ThresholdCondition(threshold=0.0, operator=">"),
+                    ThresholdCondition(threshold=0.0, operator=">"),
+                    ThresholdCondition(threshold=0.0, operator=">"),
+                ],
+                affected_parameters=[[n] for n in label_names],
+            ),
+        ),
+        DiscreteSumConstraint(
+            parameters=amount_names,
+            condition=ThresholdCondition(threshold=100, operator="=", tolerance=0.1),
+        ),
+        DiscreteNoLabelDuplicatesConstraint(parameters=label_names),
+    ]
+    return params, constraints
+
+
+def _mixed_scenario() -> tuple[
+    Sequence[DiscreteParameter], Sequence[DiscreteConstraint]
+]:
+    params = [
+        CategoricalParameter(name="Cat1", values=["a", "b", "c"]),
+        CategoricalParameter(name="Cat2", values=["a", "b", "c"]),
+        CategoricalParameter(name="Cat3", values=["a", "b", "c"]),
+        NumericalDiscreteParameter(name="Num1", values=[0.0, 50.0, 100.0]),
+        NumericalDiscreteParameter(name="Num2", values=[0.0, 50.0, 100.0]),
+    ]
+    constraints = [
+        DiscreteNoLabelDuplicatesConstraint(parameters=["Cat1", "Cat2", "Cat3"]),
+        DiscreteSumConstraint(
+            parameters=["Num1", "Num2"],
+            condition=ThresholdCondition(threshold=100, operator="<="),
+        ),
+    ]
+    return params, constraints
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        pytest.param(_no_constraints_scenario, id="no_constraints"),
+        pytest.param(_no_label_duplicates_scenario, id="no_label_duplicates"),
+        pytest.param(_linked_parameters_scenario, id="linked_parameters"),
+        pytest.param(partial(_exclude_scenario, "OR"), id="exclude_or"),
+        pytest.param(partial(_exclude_scenario, "AND"), id="exclude_and"),
+        pytest.param(_cardinality_scenario, id="cardinality"),
+        pytest.param(_sum_scenario, id="sum"),
+        pytest.param(_dependencies_scenario, id="dependencies"),
+        pytest.param(_permutation_invariance_scenario, id="permutation_invariance"),
+        pytest.param(
+            _permutation_invariance_with_dependencies_scenario,
+            id="permutation_invariance_with_deps",
+        ),
+        pytest.param(_mixed_scenario, id="mixed"),
+    ],
+)
+def test_constrained_cartesian_product(scenario):
+    """Verify incremental and naive product construction produce identical results."""
+    parameters, constraints = scenario()
+
+    # Naive approach: full product then filter
+    df_naive = parameter_cartesian_prod_pandas(parameters)
+    _apply_constraint_filter_pandas(df_naive, constraints)
+
+    # Incremental approach
+    df_incremental = parameter_cartesian_prod_pandas_constrained(
+        parameters, constraints
+    )
+
+    # Column order must be identical
+    assert list(df_incremental.columns) == list(df_naive.columns)
+
+    # Content must be identical (row order may differ)
+    cols = df_naive.columns.tolist()
+    assert_frame_equal(
+        df_incremental.sort_values(cols).reset_index(drop=True),
+        df_naive.sort_values(cols).reset_index(drop=True),
+    )

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -4,9 +4,16 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 from baybe._optional.info import POLARS_INSTALLED
+from baybe.constraints import (
+    DiscreteLinkedParametersConstraint,
+    DiscreteSumConstraint,
+    ThresholdCondition,
+)
+from baybe.parameters import NumericalDiscreteParameter
 from baybe.searchspace.utils import (
     _apply_constraint_filter_pandas,
     _apply_constraint_filter_polars,
+    build_constrained_product,
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )
@@ -203,4 +210,40 @@ def test_polars_product(constraints, parameters):
     assert_frame_equal(
         df_pd_filtered.sort_values(cols).reset_index(drop=True),
         df_pl_filtered.sort_values(cols).reset_index(drop=True),
+    )
+
+
+def test_mixed_polars_pandas_constraints():
+    """build_constrained_product with Polars active matches naive pandas result.
+
+    Verifies that parameters shared between Polars and pandas constraints are
+    handled correctly — parameters in the Polars product remain available for
+    subsequent pandas constraint filtering.
+    """
+    parameters = [
+        NumericalDiscreteParameter(name="A", values=[0.0, 50.0, 100.0]),
+        NumericalDiscreteParameter(name="B", values=[0.0, 50.0, 100.0]),
+        NumericalDiscreteParameter(name="C", values=[0.0, 50.0, 100.0]),
+    ]
+    constraints = [
+        # Polars-capable: operates on [A, B]
+        DiscreteSumConstraint(
+            parameters=["A", "B"],
+            condition=ThresholdCondition(threshold=100, operator="="),
+        ),
+        # Pandas-only: operates on [B, C] — B is shared with the Polars constraint
+        DiscreteLinkedParametersConstraint(parameters=["B", "C"]),
+    ]
+
+    # Naive reference: full product then filter
+    df_naive = parameter_cartesian_prod_pandas(parameters)
+    _apply_constraint_filter_pandas(df_naive, constraints)
+
+    # Under test: build_constrained_product routes through Polars partitioning
+    df_result = build_constrained_product(parameters, constraints)
+
+    cols = df_naive.columns.tolist()
+    assert_frame_equal(
+        df_result.sort_values(cols).reset_index(drop=True),
+        df_naive.sort_values(cols).reset_index(drop=True),
     )

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -41,7 +41,7 @@ def _lazyframe_from_product(parameters):
 def test_polars_prodsum1(parameters, constraints):
     """Tests Polars implementation of sum constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with 1,2-sum above 150
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -56,7 +56,7 @@ def test_polars_prodsum1(parameters, constraints):
 def test_polars_prodsum2(parameters, constraints):
     """Tests Polars implementation of product constrain."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with product under 30
     df = ldf.filter(
@@ -75,7 +75,7 @@ def test_polars_prodsum2(parameters, constraints):
 def test_polars_prodsum3(parameters, constraints):
     """Tests Polars implementation of exact sum constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with sum unequal to 100
     ldf = ldf.with_columns(sum=pl.sum_horizontal(["Fraction_1", "Fraction_2"]))
@@ -96,7 +96,7 @@ def test_polars_prodsum3(parameters, constraints):
 def test_polars_exclusion(mock_substances, parameters, constraints):
     """Tests Polars implementation of exclusion constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     # Number of entries with either first/second substance and a temperature above 151
     df = ldf.filter(
@@ -125,7 +125,7 @@ def test_polars_exclusion(mock_substances, parameters, constraints):
 def test_polars_label_duplicates(parameters, constraints):
     """Tests Polars implementation of no-label duplicates constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -144,7 +144,7 @@ def test_polars_label_duplicates(parameters, constraints):
 def test_polars_linked_parameters(parameters, constraints):
     """Tests Polars implementation of linked parameters constraint."""
     ldf = _lazyframe_from_product(parameters)
-    ldf, _ = _apply_constraint_filter_polars(ldf, constraints)
+    ldf = _apply_constraint_filter_polars(ldf, constraints)
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
@@ -195,7 +195,7 @@ def test_polars_product(constraints, parameters):
     # Apply constraints
     df_pd_filtered = _apply_constraint_filter_pandas(df_pd, constraints)
     df_pl_filtered = (
-        _apply_constraint_filter_polars(ldf, constraints)[0].collect().to_pandas()
+        _apply_constraint_filter_polars(ldf, constraints).collect().to_pandas()
     )
 
     # Assert order-agnostic equality of the two dataframes

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -27,6 +27,14 @@ if POLARS_INSTALLED:
     import polars as pl
 
 
+@pytest.fixture(autouse=True)
+def _assert_polars_active():
+    """Assert that polars is enabled in the active settings."""
+    from baybe.settings import active_settings
+
+    assert active_settings.use_polars_for_constraints
+
+
 def _lazyframe_from_product(parameters):
     """Create a Polars lazyframe from the product of given parameters and return it."""
     param_frames = [pl.LazyFrame({p.name: p.values}) for p in parameters]

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -7,6 +7,8 @@ from baybe._optional.info import POLARS_INSTALLED
 from baybe.searchspace.discrete import (
     _apply_constraint_filter_pandas,
     _apply_constraint_filter_polars,
+)
+from baybe.searchspace.utils import (
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -4,11 +4,9 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 from baybe._optional.info import POLARS_INSTALLED
-from baybe.searchspace.discrete import (
+from baybe.searchspace.utils import (
     _apply_constraint_filter_pandas,
     _apply_constraint_filter_polars,
-)
-from baybe.searchspace.utils import (
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -116,7 +116,7 @@ def test_discrete_searchspace_creation_from_degenerate_dataframe():
 @given(
     parameters=st.lists(
         numerical_discrete_parameters(min_value=0.0, max_value=1.0),
-        min_size=1,
+        min_size=2,
         max_size=5,
         unique_by=lambda x: x.name,
     )
@@ -157,7 +157,6 @@ p_t2 = TaskParameter(name="t2", values=["A", "B"])
     [
         param([p_d1, p_d2], [p_t1, p_t2], 6 * 4, id="both"),
         param([p_d1, p_d2], [], 6, id="simplex-only"),
-        param([], [p_t1, p_t2], 4, id="task_only"),
     ],
 )
 def test_discrete_space_creation_from_simplex_mixed(

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -139,6 +139,35 @@ def test_invalid_simplex_creating_with_overlapping_parameters():
         )
 
 
+@pytest.mark.parametrize(
+    ("simplex_parameters", "expected_len"),
+    [
+        pytest.param([], 3, id="zero_simplex"),
+        pytest.param(
+            [NumericalDiscreteParameter("x", values=[0.0, 0.5, 1.0, 1.5, 2.0])],
+            9,
+            id="one_simplex",
+        ),
+    ],
+)
+def test_from_simplex_with_degenerate_parameter_count(simplex_parameters, expected_len):
+    """Calling from_simplex with less than 2 simplex parameters emits a warning."""
+    product_parameters = [CategoricalParameter(name="C", values=["a", "b", "c"])]
+
+    with pytest.warns(UserWarning, match="less than 2 simplex parameters"):
+        subspace = SubspaceDiscrete.from_simplex(
+            max_sum=1.0,
+            simplex_parameters=simplex_parameters,
+            product_parameters=product_parameters,
+        )
+
+    assert len(subspace.exp_rep) == expected_len
+
+    if simplex_parameters:
+        simplex_cols = [p.name for p in simplex_parameters]
+        assert all(subspace.exp_rep[simplex_cols].sum(axis=1) <= 1.0)
+
+
 def test_continuous_searchspace_creation_from_bounds():
     """A purely continuous search space is created from example bounds."""
     parameters = (

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -29,7 +29,7 @@ from baybe.searchspace import (
     SubspaceContinuous,
     SubspaceDiscrete,
 )
-from baybe.searchspace.discrete import (
+from baybe.searchspace.utils import (
     parameter_cartesian_prod_pandas,
     parameter_cartesian_prod_polars,
 )


### PR DESCRIPTION
This PR implements a more optimized Cartesian product creation in the presence of constraints which can result in memory and time gains of many orders of magnitude (see mini benchmark below).

### Rationale
- Currently constraint filtering is done only after the entire search space has been created. This means the memory needed for the intermediate df is potentially huge even if the final df is tiny. In practice this had led to many problems when working with slot based mixtures, even if the optimized `from_simplex` constructor was used
- Instead, any given cosntraint can be applied early during the parameter-by-parameter cross join operations. There are three tiers of applying this:
  1) `As soon as possible filter`: A constraint can be applied as soon as all of its affected parameters are in the current crossjoin-df. After this application the constraint is fully ensured and does not have to be applied again. If the order in which cross join goes over the parameters is optimized this would already lead to an improvement as subsequent operations "see" much smaller left-dataframes.
  2) `Partial/early filter`: 
    - Some constraints can be applied even if not all affected parameters are present yet.
    - Example: no label duplicates - even if there are just 2 out of 7 parameters present, we can remove the rows that have duplicates in the 2 parameters.
    - This filter has to be repeated in every loop iteration until it ran with all affected parameters present. However, the cost of multiple filter applications are dwarfed by the savings from smaller cross join operations.
    - Whether a constraint supports early filtering might depend on its configuration, example: exclude constraint with combiner (early filter supported for OR, not for AND or XOR) 
  3) `Look ahead`: Some constraints can look ahead based on the possible parameter values that might be incoming and recognize that constraints cannot be fulfilled even in future crossjoin iterations.
    - This is essentially what `from_simplex` implements for the very special case of 1 global sum constraint and 1 cardinality constraint. If we ever implement look-ahead filters for all constraints the `from_simplex` constructor might become obsolete 
    - For this we would need access to the parameter values inside the constraint logic, which might be easier to implement once the constraints have been refactored #517  
- This PR implements smart filtering for tiers 1 and 2. I left `IMPROVE` notes to remember about tier 3. To achieve this
  - `Constraint.get_invalid` was extended to handle situations where not all parameters are in the df to be filtered. The constraint can the decide whether it can apply early filtering or returns the new `UnsupportedEarlyFilteringError` if it needs all parameters present
  - The crossjoin is done in a custom loop inside `parameter_cartesian_prod_pandas_constrained` which itself performs the process described above after deciding on a smart parameter order for the crossjoin

### Good To Know
- new Constraint method `has_polars_implementation`, discussion [here](https://github.com/emdgroup/baybe/pull/773#discussion_r3025273969)
- new Constraint property `_filtering_parameters`, discussion [here](https://github.com/emdgroup/baybe/pull/773#discussion_r3025277306) 
- strange appearance of `DiscreteNoLabelDuplicatesConstraint` in `DiscretePermutationInvarianceConstraint .get_invalid` explained [here](https://github.com/emdgroup/baybe/pull/773#discussion_r3025283126)

### Mini Benchmark:
- Scenario 1: 7 categoricals with 8 values each and a no label dupe constraint
- Scenario 2: complex slot-based mixture with 4 slots, 2 subgroups, sum constraints and additional product parameters
- Scenario 3: like scenario 2 but with 6 slots and 3 subgroups
- tested on (old main vs this branch) x (polars on/off) 
- 30min as max runtime for a quick test 

| Scenario | Polars | main | feature | Speedup | Memory reduction |
|---|---|---|---|---|---|
| **1**: `from_product`, 7×8 cat, NoLabelDuplicates (2M→40K rows) | OFF | 61.4s / 636 MB | 6.6s / 48 MB | **9.3x** | **13.2x** |
| | ON | 1.8s / 73 MB | 1.6s / 47 MB | 1.1x | 1.6x |
| **2**: `from_simplex`, 4-slot mixture + 3 extras (~4.5M→2.4K rows) | OFF | 14.7s / 62MB | 0.09s / 1.5 MB | **163x** | **41x** |
| | ON | 14.8s / 62MB | 0.53s / 7.3 MB | **28x** | **8.5x** |
| **3**: `from_simplex`, 6-slot mixture + 3 extras (~12B→22K rows) | OFF | >30min | 0.5s / 17 MB | **>3600x** | — |
| | ON | >30min | 0.5s / 17 MB | **>3600x** | — |