### PR TITLE
Parameter validation for kernel factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EDBO` and `EDBO_SMOOTHED` presets for `GaussianProcessSurrogate`
 - `TypeSelector` and `NameSelector` classes for parameter selection in kernel factories
 - `parameter_names` attribute to basic kernels for controlling the considered parameters
+- `ParameterKind` flag enum for classifying parameters by their role and automatic
+  parameter kind validation in kernel factories
 - `IndexKernel` and `PositiveIndexKernel` classes
 - Interpoint constraints for continuous search spaces
 - `IndexKernel` and `PositiveIndexKernel` classes

--- a/baybe/parameters/__init__.py
+++ b/baybe/parameters/__init__.py
@@ -5,6 +5,7 @@ from baybe.parameters.custom import CustomDiscreteParameter
 from baybe.parameters.enum import (
     CategoricalEncoding,
     CustomEncoding,
+    ParameterKind,
     SubstanceEncoding,
 )
 from baybe.parameters.numerical import (
@@ -22,6 +23,7 @@ __all__ = [
     "MeasurableMetadata",
     "NumericalContinuousParameter",
     "NumericalDiscreteParameter",
+    "ParameterKind",
     "SubstanceEncoding",
     "SubstanceParameter",
     "TaskParameter",

--- a/baybe/parameters/__init__.py
+++ b/baybe/parameters/__init__.py
@@ -5,7 +5,6 @@ from baybe.parameters.custom import CustomDiscreteParameter
 from baybe.parameters.enum import (
     CategoricalEncoding,
     CustomEncoding,
-    ParameterKind,
     SubstanceEncoding,
 )
 from baybe.parameters.numerical import (
@@ -23,7 +22,6 @@ __all__ = [
     "MeasurableMetadata",
     "NumericalContinuousParameter",
     "NumericalDiscreteParameter",
-    "ParameterKind",
     "SubstanceEncoding",
     "SubstanceParameter",
     "TaskParameter",

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -21,6 +21,7 @@ from baybe.utils.basic import to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
+    from baybe.parameters.enum import ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
     from baybe.searchspace.core import SearchSpace
     from baybe.searchspace.discrete import SubspaceDiscrete
@@ -76,6 +77,13 @@ class Parameter(ABC, SerialMixin):
     def is_discrete(self) -> bool:
         """Boolean indicating if this is a discrete parameter."""
         return isinstance(self, DiscreteParameter)
+
+    @property
+    def kind(self) -> ParameterKind:
+        """The kind of the parameter."""
+        from baybe.parameters.enum import ParameterKind
+
+        return ParameterKind.from_parameter(self)
 
     @property
     @abstractmethod

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -21,7 +21,7 @@ from baybe.utils.basic import to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
-    from baybe.parameters.enum import ParameterKind
+    from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
     from baybe.searchspace.core import SearchSpace
     from baybe.searchspace.discrete import SubspaceDiscrete
@@ -79,11 +79,11 @@ class Parameter(ABC, SerialMixin):
         return isinstance(self, DiscreteParameter)
 
     @property
-    def kind(self) -> ParameterKind:
+    def _kind(self) -> _ParameterKind:
         """The kind of the parameter."""
-        from baybe.parameters.enum import ParameterKind
+        from baybe.parameters.enum import _ParameterKind
 
-        return ParameterKind.from_parameter(self)
+        return _ParameterKind.from_parameter(self)
 
     @property
     @abstractmethod

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from baybe.parameters.base import Parameter
 
 
-class ParameterKind(Flag):
+class _ParameterKind(Flag):
     """Flag enum encoding the kind of a parameter.
 
     Can be used to express compatibility (e.g. Gaussian process kernel factories)
@@ -26,13 +26,13 @@ class ParameterKind(Flag):
     """Fidelity parameter for multi-fidelity modelling."""
 
     @staticmethod
-    def from_parameter(parameter: Parameter) -> ParameterKind:
+    def from_parameter(parameter: Parameter) -> _ParameterKind:
         """Determine the kind of a parameter from its type."""
         from baybe.parameters.categorical import TaskParameter
 
         if isinstance(parameter, TaskParameter):
-            return ParameterKind.TASK
-        return ParameterKind.REGULAR
+            return _ParameterKind.TASK
+        return _ParameterKind.REGULAR
 
 
 class ParameterEncoding(Enum):

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -1,6 +1,38 @@
 """Parameter-related enumerations."""
 
-from enum import Enum
+from __future__ import annotations
+
+from enum import Enum, Flag, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from baybe.parameters.base import Parameter
+
+
+class ParameterKind(Flag):
+    """Flag enum encoding the kind of a parameter.
+
+    Can be used to express compatibility (e.g. Gaussian process kernel factories)
+    with different parameter types via bitwise combination of flags.
+    """
+
+    REGULAR = auto()
+    """Regular parameter undergoing no special treatment."""
+
+    TASK = auto()
+    """Task parameter for transfer learning."""
+
+    FIDELITY = auto()
+    """Fidelity parameter for multi-fidelity modelling."""
+
+    @staticmethod
+    def from_parameter(parameter: Parameter) -> ParameterKind:
+        """Determine the kind of a parameter from its type."""
+        from baybe.parameters.categorical import TaskParameter
+
+        if isinstance(parameter, TaskParameter):
+            return ParameterKind.TASK
+        return ParameterKind.REGULAR
 
 
 class ParameterEncoding(Enum):

--- a/baybe/parameters/selectors.py
+++ b/baybe/parameters/selectors.py
@@ -3,15 +3,13 @@
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Collection
-from typing import ClassVar, Protocol
+from typing import Protocol
 
 from attrs import Converter, define, field
-from attrs.converters import optional
 from attrs.validators import deep_iterable, instance_of, min_len
 from typing_extensions import override
 
 from baybe.parameters.base import Parameter
-from baybe.searchspace.core import SearchSpace
 from baybe.utils.basic import to_tuple
 from baybe.utils.conversion import nonstring_to_tuple
 
@@ -131,37 +129,3 @@ def to_parameter_selector(
         return TypeSelector(items)
 
     raise TypeError(f"Cannot convert {x!r} to a parameter selector.")
-
-
-@define
-class _ParameterSelectorMixin:
-    """A mixin class to enable parameter selection."""
-
-    # For internal use only: sanity check mechanism to remind developers of new
-    # subclasses to actually use the parameter selector when it is provided
-    # TODO: Perhaps we can find a more elegant way to enforce this by design
-    _uses_parameter_names: ClassVar[bool] = False
-
-    parameter_selector: ParameterSelectorProtocol | None = field(
-        default=None, converter=optional(to_parameter_selector), kw_only=True
-    )
-    """An optional selector to specify which parameters are to be considered."""
-
-    def get_parameter_names(self, searchspace: SearchSpace) -> tuple[str, ...] | None:
-        """Get the names of the parameters to be considered."""
-        if self.parameter_selector is None:
-            return None
-
-        return tuple(
-            p.name for p in searchspace.parameters if self.parameter_selector(p)
-        )
-
-    def __attrs_post_init__(self):
-        if self.parameter_selector is not None and not self._uses_parameter_names:
-            raise AssertionError(
-                f"A `parameter_selector` was provided to "
-                f"`{type(self).__name__}`, but the class does not set "
-                f"`_uses_parameter_names = True`. Subclasses that accept a "
-                f"parameter selector must explicitly set this flag to confirm "
-                f"they actually use the selected parameter names."
-            )

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -44,8 +44,8 @@ else:
 
 
 @define
-class _KernelFactory(KernelFactoryProtocol, ABC):
-    """Base class for kernel factories."""
+class _PureKernelFactory(KernelFactoryProtocol, ABC):
+    """Base class for pure kernel factories."""
 
     # For internal use only: sanity check mechanism to remind developers of new
     # factories to actually use the parameter selector when it is provided

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -60,6 +60,16 @@ class _KernelFactory(KernelFactoryProtocol, ABC):
     )
     """An optional selector to specify which parameters are considered by the kernel."""
 
+    def __attrs_post_init__(self):
+        if self.parameter_selector is not None and not self._uses_parameter_names:
+            raise AssertionError(
+                f"A `parameter_selector` was provided to "
+                f"`{type(self).__name__}`, but the class does not set "
+                f"`_uses_parameter_names = True`. Subclasses that accept a "
+                f"parameter selector must explicitly set this flag to confirm "
+                f"they actually use the selected parameter names."
+            )
+
     def get_parameter_names(self, searchspace: SearchSpace) -> tuple[str, ...] | None:
         """Get the names of the parameters to be considered by the kernel."""
         if self.parameter_selector is None:
@@ -105,16 +115,6 @@ class _KernelFactory(KernelFactoryProtocol, ABC):
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         """Construct the kernel."""
-
-    def __attrs_post_init__(self):
-        if self.parameter_selector is not None and not self._uses_parameter_names:
-            raise AssertionError(
-                f"A `parameter_selector` was provided to "
-                f"`{type(self).__name__}`, but the class does not set "
-                f"`_uses_parameter_names = True`. Subclasses that accept a "
-                f"parameter selector must explicitly set this flag to confirm "
-                f"they actually use the selected parameter names."
-            )
 
 
 @define

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from attrs import define, field
+from attrs.converters import optional
 from attrs.validators import is_callable
 from typing_extensions import override
 
@@ -13,7 +14,9 @@ from baybe.kernels.base import Kernel
 from baybe.kernels.composite import ProductKernel
 from baybe.parameters.categorical import TaskParameter
 from baybe.parameters.selectors import (
+    ParameterSelectorProtocol,
     TypeSelector,
+    to_parameter_selector,
 )
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.gaussian_process.components.generic import (
@@ -33,6 +36,40 @@ else:
     # At runtime, we use only the BayBE type for serialization compatibility
     KernelFactoryProtocol = GPComponentFactoryProtocol[Kernel]
     PlainKernelFactory = PlainGPComponentFactory[Kernel]
+
+
+@define
+class _ParameterSelectorMixin:
+    """A mixin class to enable parameter selection."""
+
+    # For internal use only: sanity check mechanism to remind developers of new
+    # subclasses to actually use the parameter selector when it is provided
+    # TODO: Perhaps we can find a more elegant way to enforce this by design
+    _uses_parameter_names: ClassVar[bool] = False
+
+    parameter_selector: ParameterSelectorProtocol | None = field(
+        default=None, converter=optional(to_parameter_selector), kw_only=True
+    )
+    """An optional selector to specify which parameters are to be considered."""
+
+    def get_parameter_names(self, searchspace: SearchSpace) -> tuple[str, ...] | None:
+        """Get the names of the parameters to be considered."""
+        if self.parameter_selector is None:
+            return None
+
+        return tuple(
+            p.name for p in searchspace.parameters if self.parameter_selector(p)
+        )
+
+    def __attrs_post_init__(self):
+        if self.parameter_selector is not None and not self._uses_parameter_names:
+            raise AssertionError(
+                f"A `parameter_selector` was provided to "
+                f"`{type(self).__name__}`, but the class does not set "
+                f"`_uses_parameter_names = True`. Subclasses that accept a "
+                f"parameter selector must explicitly set this flag to confirm "
+                f"they actually use the selected parameter names."
+            )
 
 
 @define

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -14,7 +14,6 @@ from typing_extensions import override
 
 from baybe.exceptions import IncompatibleSearchSpaceError
 from baybe.kernels.base import Kernel
-from baybe.kernels.composite import ProductKernel
 from baybe.parameters.categorical import TaskParameter
 from baybe.parameters.enum import ParameterKind
 from baybe.parameters.selectors import (
@@ -161,4 +160,8 @@ class ICMKernelFactory(KernelFactoryProtocol):
     ) -> Kernel:
         base_kernel = self.base_kernel_factory(searchspace, train_x, train_y)
         task_kernel = self.task_kernel_factory(searchspace, train_x, train_y)
-        return ProductKernel([base_kernel, task_kernel])
+        if isinstance(base_kernel, Kernel):
+            base_kernel = base_kernel.to_gpytorch(searchspace)
+        if isinstance(task_kernel, Kernel):
+            task_kernel = task_kernel.to_gpytorch(searchspace)
+        return base_kernel * task_kernel

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -118,7 +118,18 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
 
 
 @define
-class ICMKernelFactory(KernelFactoryProtocol):
+class _MetaKernelFactory(KernelFactoryProtocol, ABC):
+    """Base class for meta kernel factories that orchestrate other kernel factories."""
+
+    @override
+    @abstractmethod
+    def __call__(
+        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> Kernel: ...
+
+
+@define
+class ICMKernelFactory(_MetaKernelFactory):
     """A kernel factory that constructs an ICM kernel for transfer learning.
 
     ICM: Intrinsic Coregionalization Model :cite:p:`NIPS2007_66368270`

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 from baybe.exceptions import IncompatibleSearchSpaceError
 from baybe.kernels.base import Kernel
 from baybe.parameters.categorical import TaskParameter
-from baybe.parameters.enum import ParameterKind
+from baybe.parameters.enum import _ParameterKind
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
@@ -52,7 +52,7 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
     # TODO: Perhaps we can find a more elegant way to enforce this by design
     _uses_parameter_names: ClassVar[bool] = False
 
-    supported_parameter_kinds: ClassVar[ParameterKind] = ParameterKind.REGULAR
+    _supported_parameter_kinds: ClassVar[_ParameterKind] = _ParameterKind.REGULAR
     """The parameter kinds supported by the kernel factory."""
 
     parameter_selector: ParameterSelectorProtocol | None = field(
@@ -89,12 +89,14 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
             IncompatibleSearchSpaceError: If unsupported parameter kinds are found.
         """
         if unsupported := [
-            p.name for p in parameters if not (p.kind & self.supported_parameter_kinds)
+            p.name
+            for p in parameters
+            if not (p._kind & self._supported_parameter_kinds)
         ]:
             raise IncompatibleSearchSpaceError(
                 f"'{type(self).__name__}' does not support parameter kind(s) for "
                 f"parameter(s) {unsupported}. Supported kinds: "
-                f"{self.supported_parameter_kinds}."
+                f"{self._supported_parameter_kinds}."
             )
 
     @override

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
@@ -39,21 +40,21 @@ else:
 
 
 @define
-class _ParameterSelectorMixin:
-    """A mixin class to enable parameter selection."""
+class _KernelFactory(KernelFactoryProtocol, ABC):
+    """Base class for kernel factories."""
 
     # For internal use only: sanity check mechanism to remind developers of new
-    # subclasses to actually use the parameter selector when it is provided
+    # factories to actually use the parameter selector when it is provided
     # TODO: Perhaps we can find a more elegant way to enforce this by design
     _uses_parameter_names: ClassVar[bool] = False
 
     parameter_selector: ParameterSelectorProtocol | None = field(
-        default=None, converter=optional(to_parameter_selector), kw_only=True
+        default=None, converter=optional(to_parameter_selector)
     )
-    """An optional selector to specify which parameters are to be considered."""
+    """An optional selector to specify which parameters are considered by the kernel."""
 
     def get_parameter_names(self, searchspace: SearchSpace) -> tuple[str, ...] | None:
-        """Get the names of the parameters to be considered."""
+        """Get the names of the parameters to be considered by the kernel."""
         if self.parameter_selector is None:
             return None
 
@@ -70,6 +71,13 @@ class _ParameterSelectorMixin:
                 f"parameter selector must explicitly set this flag to confirm "
                 f"they actually use the selected parameter names."
             )
+
+    @override
+    @abstractmethod
+    def __call__(
+        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> Kernel | GPyTorchKernel:
+        pass
 
 
 @define

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
@@ -11,9 +12,11 @@ from attrs.converters import optional
 from attrs.validators import is_callable
 from typing_extensions import override
 
+from baybe.exceptions import IncompatibleSearchSpaceError
 from baybe.kernels.base import Kernel
 from baybe.kernels.composite import ProductKernel
 from baybe.parameters.categorical import TaskParameter
+from baybe.parameters.enum import ParameterKind
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
@@ -30,6 +33,8 @@ from baybe.surrogates.gaussian_process.components.generic import (
 if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
     from torch import Tensor
+
+    from baybe.parameters.base import Parameter
 
     KernelFactoryProtocol = GPComponentFactoryProtocol[Kernel | GPyTorchKernel]
     PlainKernelFactory = PlainGPComponentFactory[Kernel | GPyTorchKernel]
@@ -48,6 +53,9 @@ class _KernelFactory(KernelFactoryProtocol, ABC):
     # TODO: Perhaps we can find a more elegant way to enforce this by design
     _uses_parameter_names: ClassVar[bool] = False
 
+    supported_parameter_kinds: ClassVar[ParameterKind] = ParameterKind.REGULAR
+    """The parameter kinds supported by the kernel factory."""
+
     parameter_selector: ParameterSelectorProtocol | None = field(
         default=None, converter=optional(to_parameter_selector)
     )
@@ -62,6 +70,43 @@ class _KernelFactory(KernelFactoryProtocol, ABC):
             p.name for p in searchspace.parameters if self.parameter_selector(p)
         )
 
+    def _validate_parameter_kinds(self, parameters: Iterable[Parameter]) -> None:
+        """Validate that the given parameters are supported by the factory.
+
+        Args:
+            parameters: The parameters to validate.
+
+        Raises:
+            IncompatibleSearchSpaceError: If unsupported parameter kinds are found.
+        """
+        if unsupported := [
+            p.name for p in parameters if not (p.kind & self.supported_parameter_kinds)
+        ]:
+            raise IncompatibleSearchSpaceError(
+                f"'{type(self).__name__}' does not support parameter kind(s) for "
+                f"parameter(s) {unsupported}. Supported kinds: "
+                f"{self.supported_parameter_kinds}."
+            )
+
+    @override
+    def __call__(
+        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> Kernel:
+        """Construct the kernel, validating parameter kinds before construction."""
+        if self.parameter_selector is not None:
+            params = [p for p in searchspace.parameters if self.parameter_selector(p)]
+        else:
+            params = list(searchspace.parameters)
+        self._validate_parameter_kinds(params)
+
+        return self._make(searchspace, train_x, train_y)
+
+    @abstractmethod
+    def _make(
+        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> Kernel:
+        """Construct the kernel."""
+
     def __attrs_post_init__(self):
         if self.parameter_selector is not None and not self._uses_parameter_names:
             raise AssertionError(
@@ -71,13 +116,6 @@ class _KernelFactory(KernelFactoryProtocol, ABC):
                 f"parameter selector must explicitly set this flag to confirm "
                 f"they actually use the selected parameter names."
             )
-
-    @override
-    @abstractmethod
-    def __call__(
-        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
-    ) -> Kernel | GPyTorchKernel:
-        pass
 
 
 @define

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -18,7 +18,7 @@ from baybe.parameters.selectors import (
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.gaussian_process.components.kernel import (
     KernelFactoryProtocol,
-    _ParameterSelectorMixin,
+    _KernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFactory
 from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
@@ -50,7 +50,7 @@ BayBENumericalKernelFactory = SmoothedEDBOKernelFactory
 
 
 @define
-class BayBETaskKernelFactory(KernelFactoryProtocol, _ParameterSelectorMixin):
+class BayBETaskKernelFactory(_KernelFactory):
     """The factory providing the default task kernel for Gaussian process surrogates."""
 
     _uses_parameter_names: ClassVar[bool] = True

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 from baybe.kernels.base import Kernel
 from baybe.kernels.basic import IndexKernel
 from baybe.parameters.categorical import TaskParameter
-from baybe.parameters.enum import ParameterKind
+from baybe.parameters.enum import _ParameterKind
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
@@ -32,8 +32,8 @@ if TYPE_CHECKING:
 class BayBEKernelFactory(_PureKernelFactory):
     """The default kernel factory for Gaussian process surrogates."""
 
-    supported_parameter_kinds: ClassVar[ParameterKind] = (
-        ParameterKind.REGULAR | ParameterKind.TASK
+    _supported_parameter_kinds: ClassVar[_ParameterKind] = (
+        _ParameterKind.REGULAR | _ParameterKind.TASK
     )
     # See base class.
 
@@ -59,7 +59,7 @@ class BayBETaskKernelFactory(_PureKernelFactory):
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
 
-    supported_parameter_kinds: ClassVar[ParameterKind] = ParameterKind.TASK
+    _supported_parameter_kinds: ClassVar[_ParameterKind] = _ParameterKind.TASK
     # See base class.
 
     parameter_selector: ParameterSelectorProtocol | None = field(

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -10,16 +10,14 @@ from typing_extensions import override
 from baybe.kernels.base import Kernel
 from baybe.kernels.basic import IndexKernel
 from baybe.parameters.categorical import TaskParameter
+from baybe.parameters.enum import ParameterKind
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
     to_parameter_selector,
 )
 from baybe.searchspace.core import SearchSpace
-from baybe.surrogates.gaussian_process.components.kernel import (
-    KernelFactoryProtocol,
-    _KernelFactory,
-)
+from baybe.surrogates.gaussian_process.components.kernel import _KernelFactory
 from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFactory
 from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
     SmoothedEDBOKernelFactory,
@@ -31,11 +29,16 @@ if TYPE_CHECKING:
 
 
 @define
-class BayBEKernelFactory(KernelFactoryProtocol):
+class BayBEKernelFactory(_KernelFactory):
     """The default kernel factory for Gaussian process surrogates."""
 
+    supported_parameter_kinds: ClassVar[ParameterKind] = (
+        ParameterKind.REGULAR | ParameterKind.TASK
+    )
+    # See base class.
+
     @override
-    def __call__(
+    def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         from baybe.surrogates.gaussian_process.components.kernel import ICMKernelFactory
@@ -56,6 +59,9 @@ class BayBETaskKernelFactory(_KernelFactory):
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
 
+    supported_parameter_kinds: ClassVar[ParameterKind] = ParameterKind.TASK
+    # See base class.
+
     parameter_selector: ParameterSelectorProtocol | None = field(
         factory=lambda: TypeSelector([TaskParameter]),
         converter=to_parameter_selector,
@@ -63,7 +69,7 @@ class BayBETaskKernelFactory(_KernelFactory):
     # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
-    def __call__(
+    def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         return IndexKernel(

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -17,7 +17,7 @@ from baybe.parameters.selectors import (
     to_parameter_selector,
 )
 from baybe.searchspace.core import SearchSpace
-from baybe.surrogates.gaussian_process.components.kernel import _KernelFactory
+from baybe.surrogates.gaussian_process.components.kernel import _PureKernelFactory
 from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFactory
 from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
     SmoothedEDBOKernelFactory,
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 @define
-class BayBEKernelFactory(_KernelFactory):
+class BayBEKernelFactory(_PureKernelFactory):
     """The default kernel factory for Gaussian process surrogates."""
 
     supported_parameter_kinds: ClassVar[ParameterKind] = (
@@ -53,7 +53,7 @@ BayBENumericalKernelFactory = SmoothedEDBOKernelFactory
 
 
 @define
-class BayBETaskKernelFactory(_KernelFactory):
+class BayBETaskKernelFactory(_PureKernelFactory):
     """The factory providing the default task kernel for Gaussian process surrogates."""
 
     _uses_parameter_names: ClassVar[bool] = True

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -13,11 +13,13 @@ from baybe.parameters.categorical import TaskParameter
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
-    _ParameterSelectorMixin,
     to_parameter_selector,
 )
 from baybe.searchspace.core import SearchSpace
-from baybe.surrogates.gaussian_process.components.kernel import KernelFactoryProtocol
+from baybe.surrogates.gaussian_process.components.kernel import (
+    KernelFactoryProtocol,
+    _ParameterSelectorMixin,
+)
 from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFactory
 from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
     SmoothedEDBOKernelFactory,

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -16,13 +16,15 @@ from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
-    _ParameterSelectorMixin,
     to_parameter_selector,
 )
 from baybe.parameters.substance import SubstanceParameter
 from baybe.priors.basic import GammaPrior
 from baybe.searchspace.discrete import SubspaceDiscrete
-from baybe.surrogates.gaussian_process.components.kernel import KernelFactoryProtocol
+from baybe.surrogates.gaussian_process.components.kernel import (
+    KernelFactoryProtocol,
+    _ParameterSelectorMixin,
+)
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
 )

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -22,7 +22,7 @@ from baybe.parameters.substance import SubstanceParameter
 from baybe.priors.basic import GammaPrior
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.surrogates.gaussian_process.components.kernel import (
-    _KernelFactory,
+    _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
@@ -57,7 +57,7 @@ _EDBO_ENCODINGS = (
 
 
 @define
-class EDBOKernelFactory(_KernelFactory):
+class EDBOKernelFactory(_PureKernelFactory):
     """A factory providing EDBO kernels.
 
     References:

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -78,9 +78,7 @@ class EDBOKernelFactory(_KernelFactory):
     def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        effective_dims = train_x.shape[-1] - len(
-            [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
-        )
+        effective_dims = train_x.shape[-1]
 
         switching_condition = _contains_encoding(
             searchspace.discrete, _EDBO_ENCODINGS

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -75,7 +75,7 @@ class EDBOKernelFactory(_KernelFactory):
     # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
-    def __call__(
+    def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         effective_dims = train_x.shape[-1] - len(

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -22,8 +22,7 @@ from baybe.parameters.substance import SubstanceParameter
 from baybe.priors.basic import GammaPrior
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.surrogates.gaussian_process.components.kernel import (
-    KernelFactoryProtocol,
-    _ParameterSelectorMixin,
+    _KernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
@@ -58,7 +57,7 @@ _EDBO_ENCODINGS = (
 
 
 @define
-class EDBOKernelFactory(KernelFactoryProtocol, _ParameterSelectorMixin):
+class EDBOKernelFactory(_KernelFactory):
     """A factory providing EDBO kernels.
 
     References:

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -19,7 +19,7 @@ from baybe.parameters.selectors import (
 )
 from baybe.priors.basic import GammaPrior
 from baybe.surrogates.gaussian_process.components.kernel import (
-    _KernelFactory,
+    _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
@@ -39,7 +39,7 @@ _DIM_LIMITS = (8, 75)
 
 
 @define
-class SmoothedEDBOKernelFactory(_KernelFactory):
+class SmoothedEDBOKernelFactory(_PureKernelFactory):
     """A factory providing smoothed versions of EDBO kernels.
 
     Takes the low and high dimensional limits of

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -19,8 +19,7 @@ from baybe.parameters.selectors import (
 )
 from baybe.priors.basic import GammaPrior
 from baybe.surrogates.gaussian_process.components.kernel import (
-    KernelFactoryProtocol,
-    _ParameterSelectorMixin,
+    _KernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
@@ -40,7 +39,7 @@ _DIM_LIMITS = (8, 75)
 
 
 @define
-class SmoothedEDBOKernelFactory(KernelFactoryProtocol, _ParameterSelectorMixin):
+class SmoothedEDBOKernelFactory(_KernelFactory):
     """A factory providing smoothed versions of EDBO kernels.
 
     Takes the low and high dimensional limits of

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -60,9 +60,7 @@ class SmoothedEDBOKernelFactory(_KernelFactory):
     def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        effective_dims = train_x.shape[-1] - len(
-            [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
-        )
+        effective_dims = train_x.shape[-1]
 
         # Interpolate prior moments linearly between low D and high D regime.
         # The high D regime itself is the average of the EDBO OHE and Mordred regime.

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -15,11 +15,13 @@ from baybe.parameters import TaskParameter
 from baybe.parameters.selectors import (
     ParameterSelectorProtocol,
     TypeSelector,
-    _ParameterSelectorMixin,
     to_parameter_selector,
 )
 from baybe.priors.basic import GammaPrior
-from baybe.surrogates.gaussian_process.components.kernel import KernelFactoryProtocol
+from baybe.surrogates.gaussian_process.components.kernel import (
+    KernelFactoryProtocol,
+    _ParameterSelectorMixin,
+)
 from baybe.surrogates.gaussian_process.components.likelihood import (
     LikelihoodFactoryProtocol,
 )

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -57,7 +57,7 @@ class SmoothedEDBOKernelFactory(_KernelFactory):
     # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
-    def __call__(
+    def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
         effective_dims = train_x.shape[-1] - len(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,11 +146,9 @@ nitpick_ignore_regex = [
     (r"py:obj", "baybe.utils.boolean.UncertainBool.*"),
     ("py:obj", "baybe.targets.botorch.*"),
     ("py:obj", "baybe.objectives.botorch.*"),
-    ("py:class", "baybe.parameters.base._DiscreteLabelLikeParameter"),
-    ("py:class", "baybe.acquisition.acqfs._ExpectedHypervolumeImprovement"),
-    ("py:class", "baybe.settings._SlottedContextDecorator"),
     ("py:class", "baybe.surrogates.gaussian_process.components.PlainKernelFactory"),
-    ("py:class", "baybe.surrogates.gaussian_process.components.kernel._KernelFactory"),
+    # Private classes
+    (r"py:class", r"baybe\..*\._.*"),
     # Deprecation
     ("py:.*", "baybe.targets._deprecated.*"),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,7 @@ nitpick_ignore_regex = [
     ("py:class", "baybe.acquisition.acqfs._ExpectedHypervolumeImprovement"),
     ("py:class", "baybe.settings._SlottedContextDecorator"),
     ("py:class", "baybe.surrogates.gaussian_process.components.PlainKernelFactory"),
-    ("py:class", "baybe.parameters.selectors._ParameterSelectorMixin"),
+    ("py:class", "baybe.surrogates.gaussian_process.components.kernel._KernelFactory"),
     # Deprecation
     ("py:.*", "baybe.targets._deprecated.*"),
 ]

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -1,0 +1,75 @@
+"""Tests for kernel factories."""
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+from pytest import param
+
+from baybe.exceptions import IncompatibleSearchSpaceError
+from baybe.parameters.categorical import CategoricalParameter, TaskParameter
+from baybe.parameters.numerical import (
+    NumericalContinuousParameter,
+    NumericalDiscreteParameter,
+)
+from baybe.searchspace.core import SearchSpace
+from baybe.surrogates.gaussian_process.presets.baybe import (
+    BayBEKernelFactory,
+    BayBENumericalKernelFactory,
+    BayBETaskKernelFactory,
+)
+
+# A selector that accepts all parameters
+_SELECT_ALL = lambda parameter: True  # noqa: E731
+
+
+@pytest.mark.parametrize(
+    ("factory", "parameters", "error"),
+    [
+        param(
+            BayBENumericalKernelFactory(parameter_selector=_SELECT_ALL),
+            [TaskParameter("task", ["t1", "t2"])],
+            IncompatibleSearchSpaceError,
+            id="regular_rejects_task",
+        ),
+        param(
+            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            [CategoricalParameter("cat", ["a", "b"])],
+            IncompatibleSearchSpaceError,
+            id="task_rejects_categorical",
+        ),
+        param(
+            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            [NumericalDiscreteParameter("num", [1, 2, 3])],
+            IncompatibleSearchSpaceError,
+            id="task_rejects_numerical_discrete",
+        ),
+        param(
+            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            [NumericalContinuousParameter("cont", (0, 1))],
+            IncompatibleSearchSpaceError,
+            id="task_rejects_numerical_continuous",
+        ),
+        param(
+            BayBEKernelFactory(),
+            [
+                NumericalContinuousParameter("cont", (0, 1)),
+                TaskParameter("task", ["t1", "t2"]),
+            ],
+            None,
+            id="combined_accepts_both",
+        ),
+    ],
+)
+def test_factory_parameter_kind_validation(factory, parameters, error):
+    """Factories reject unsupported parameter kinds and accept supported ones."""
+    ss = SearchSpace.from_product(parameters)
+    train_x = torch.zeros(2, len(ss.comp_rep_columns))
+    train_y = torch.zeros(2, 1)
+
+    with (
+        nullcontext()
+        if error is None
+        else pytest.raises(error, match="does not support")
+    ):
+        factory(ss, train_x, train_y)


### PR DESCRIPTION
DevPR, parent is https://github.com/emdgroup/baybe/pull/745

Adds a validation mechanism to ensure kernel factories only produce kernels for search spaces they are intended for.
This is achieved via a new `_ParameterKind` flag enum that factories can use to signal which parameter types they support.