### PR TITLE
Goodbye pytest warnings

### DIFF
--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import warnings
 from collections.abc import Callable
 from functools import reduce
 from typing import TYPE_CHECKING, Any, ClassVar, cast
@@ -233,13 +234,18 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
-        for k, _ in enumerate(self.parameters):
-            # .loc assignments are not supported by mypy + pandas-stubs yet
-            # See https://github.com/pandas-dev/pandas-stubs/issues/572
-            censored_data.loc[  # type: ignore[call-overload]
-                ~self.conditions[k].evaluate(data[self.parameters[k]]),
-                self.affected_parameters[k],
-            ] = Dummy()
+        with warnings.catch_warnings():
+            # Suppress pandas FutureWarning about setting incompatible dtype.
+            # TODO: Needs proper fix for pandas 3.0 compatibility.
+            warnings.simplefilter("ignore", FutureWarning)
+
+            for k, _ in enumerate(self.parameters):
+                # .loc assignments are not supported by mypy + pandas-stubs yet
+                # See https://github.com/pandas-dev/pandas-stubs/issues/572
+                censored_data.loc[  # type: ignore[call-overload]
+                    ~self.conditions[k].evaluate(data[self.parameters[k]]),
+                    self.affected_parameters[k],
+                ] = Dummy()
 
         # Create an invariant indicator: pair each value of an affected parameter with
         # the corresponding value of the parameter it depends on. These indicators

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import gc
-import warnings
 from collections.abc import Callable
 from functools import reduce
 from typing import TYPE_CHECKING, Any, ClassVar, cast
@@ -234,18 +233,13 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
         # Create data copy and mark entries where the dependency conditions are negative
         # with a dummy value to cause degeneracy.
         censored_data = data.copy()
-        with warnings.catch_warnings():
-            # Suppress pandas FutureWarning about setting incompatible dtype.
-            # TODO: Needs proper fix for pandas 3.0 compatibility.
-            warnings.simplefilter("ignore", FutureWarning)
-
-            for k, _ in enumerate(self.parameters):
-                # .loc assignments are not supported by mypy + pandas-stubs yet
-                # See https://github.com/pandas-dev/pandas-stubs/issues/572
-                censored_data.loc[  # type: ignore[call-overload]
-                    ~self.conditions[k].evaluate(data[self.parameters[k]]),
-                    self.affected_parameters[k],
-                ] = Dummy()
+        for k, _ in enumerate(self.parameters):
+            # .loc assignments are not supported by mypy + pandas-stubs yet
+            # See https://github.com/pandas-dev/pandas-stubs/issues/572
+            censored_data.loc[  # type: ignore[call-overload]
+                ~self.conditions[k].evaluate(data[self.parameters[k]]),
+                self.affected_parameters[k],
+            ] = Dummy()
 
         # Create an invariant indicator: pair each value of an affected parameter with
         # the corresponding value of the parameter it depends on. These indicators

--- a/baybe/surrogates/linear.py
+++ b/baybe/surrogates/linear.py
@@ -71,7 +71,9 @@ class BayesianLinearSurrogate(IndependentGaussianSurrogate):
         import torch
 
         # Get predictions
-        dists = self._model.predict(candidates_comp_scaled.numpy(), return_std=True)
+        dists = self._model.predict(
+            candidates_comp_scaled.detach().numpy(), return_std=True
+        )
 
         # Split into posterior mean and variance
         mean = torch.from_numpy(dists[0])

--- a/baybe/surrogates/ngboost.py
+++ b/baybe/surrogates/ngboost.py
@@ -98,7 +98,7 @@ class NGBoostSurrogate(IndependentGaussianSurrogate):
         import torch
 
         # Get predictions
-        dists = self._model.pred_dist(candidates_comp_scaled)
+        dists = self._model.pred_dist(candidates_comp_scaled.detach().numpy())
 
         # Split into posterior mean and variance
         mean = torch.from_numpy(dists.mean())

--- a/baybe/surrogates/random_forest.py
+++ b/baybe/surrogates/random_forest.py
@@ -109,7 +109,7 @@ class RandomForestSurrogate(Surrogate):
 
             return torch.from_numpy(
                 self._predict_ensemble(
-                    self._model.estimators_, candidates_comp_scaled.numpy()
+                    self._model.estimators_, candidates_comp_scaled.detach().numpy()
                 )
             )
 

--- a/baybe/utils/clustering_algorithms/third_party/kmedoids.py
+++ b/baybe/utils/clustering_algorithms/third_party/kmedoids.py
@@ -46,7 +46,6 @@ from sklearn.metrics.pairwise import (
     pairwise_distances_argmin,
 )
 from sklearn.utils import check_array, check_random_state
-from sklearn.utils.extmath import stable_cumsum
 from sklearn.utils.validation import check_is_fitted
 
 from baybe.settings import active_settings
@@ -485,7 +484,9 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         # pick the remaining n_clusters-1 points
         for cluster_index in range(1, n_clusters):
             rand_vals = random_state_.random_sample(n_local_trials) * current_pot
-            candidate_ids = np.searchsorted(stable_cumsum(closest_dist_sq), rand_vals)
+            candidate_ids = np.searchsorted(
+                np.cumulative_sum(closest_dist_sq), rand_vals
+            )
 
             # Compute distances to center candidates
             distance_to_candidates = D[candidate_ids, :] ** 2

--- a/baybe/utils/clustering_algorithms/third_party/kmedoids.py
+++ b/baybe/utils/clustering_algorithms/third_party/kmedoids.py
@@ -484,9 +484,7 @@ class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
         # pick the remaining n_clusters-1 points
         for cluster_index in range(1, n_clusters):
             rand_vals = random_state_.random_sample(n_local_trials) * current_pot
-            candidate_ids = np.searchsorted(
-                np.cumulative_sum(closest_dist_sq), rand_vals
-            )
+            candidate_ids = np.searchsorted(np.cumsum(closest_dist_sq), rand_vals)
 
             # Compute distances to center candidates
             distance_to_candidates = D[candidate_ids, :] ** 2

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,18 +20,21 @@ filterwarnings =
     ; Treat warnings as errors
     error
 
+    ; Temporary ignores
+    ; -----------------
+    ; Torch JIT deprecation warning triggered during linear_operator import
+    ignore:.*torch.jit.script.*is deprecated:DeprecationWarning
+    ; https://github.com/meta-pytorch/botorch/pull/3279
+    ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
+    ; Needs proper fix for pandas 3.0 compatibility
+    ignore:Setting an item of incompatible dtype is deprecated:FutureWarning:baybe.constraints.discrete
+
     ; Numerics/optimization
     ; ---------------------
     ignore:.*add(ed|ing) jitter.*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
-    ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit  
+    ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
     ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
     
-    ; Temporary ignores
-    ; -----------------
-    ; https://github.com/meta-pytorch/botorch/pull/3279
-    ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
-    ; Needs proper fix for pandas 3.0 compatibility
-    ignore:Setting an item of incompatible dtype is deprecated:FutureWarning:baybe.constraints.discrete

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,8 @@ filterwarnings =
     ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
     ; Needs proper fix for pandas 3.0 compatibility
     ignore:Setting an item of incompatible dtype is deprecated:FutureWarning:baybe.constraints.discrete
+    ; https://github.com/shap/shap/issues/4280 (fixed in shap>=0.51.0, but only available for Python 3.11+)
+    ignore:Conversion of an array with ndim > 0 to a scalar is deprecated:DeprecationWarning:shap.explainers.other._maple
 
     ; Numerics/optimization
     ; ---------------------

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,5 @@ xfail_strict=true
 
 filterwarnings =
     error
+    ; Numerics
+    ignore:A not p.d., added jitter of .*:linear_operator.utils.warnings.NumericalWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,3 +18,5 @@ filterwarnings =
     ; Numerics/optimization
     ignore:A not p.d., added jitter of .*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
+    ; BoTorch warning recommending to switch to log-versions of acquisition functions
+    ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,12 @@ addopts =
     
     ; Avoids import errors due to optional dependencies
     --doctest-ignore-import-errors  
+
 testpaths = 
     baybe
     tests
+
 xfail_strict=true
+
+filterwarnings =
+    error

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,10 +4,6 @@ strict = true
 markers =
     filterwarnings: Apply warning filters to a test
 
-# Currently blocked by test_iterations.py. Should be activated once that test module
-# has been properly refactored.
-strict_parametrization_ids=false
-
 addopts = 
     --doctest-modules 
     --ignore=examples

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,14 +21,21 @@ testpaths =
     tests
 
 filterwarnings =
+    ; Treat warnings as errors
     error
+
     ; Numerics/optimization
+    ; ---------------------
     ignore:.*add(ed|ing) jitter.*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
     ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit  
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
     ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
+    
     ; Temporary ignores
+    ; -----------------
     ; https://github.com/meta-pytorch/botorch/pull/3279
     ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
+    ; Needs proper fix for pandas 3.0 compatibility
+    ignore:Setting an item of incompatible dtype is deprecated:FutureWarning:baybe.constraints.discrete

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,7 +16,7 @@ xfail_strict=true
 filterwarnings =
     error
     ; Numerics/optimization
-    ignore:A not p.d., added jitter of .*:linear_operator.utils.warnings.NumericalWarning
+    ignore:.*add(ed|ing) jitter.*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
     ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit  

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,7 +23,7 @@ filterwarnings =
     ; Temporary ignores
     ; -----------------
     ; Torch JIT deprecation warning triggered during linear_operator import
-    ignore:.*torch.jit.script.*is deprecated:DeprecationWarning
+    ignore:.*torch.jit.script.*:DeprecationWarning
     ; Invalid escape sequence in pyro.ops.stats docstring
     ; Fixed upstream but unreleased: https://github.com/pyro-ppl/pyro/issues/3450
     ignore:.*invalid escape sequence.*:SyntaxWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,10 @@
 [pytest]
 strict = true
 
+# Currently blocked by test_iterations.py. Should be activated once that test module
+# has been properly refactored.
+strict_parametrization_ids=false
+
 addopts = 
     --doctest-modules 
     --ignore=examples

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,8 @@ filterwarnings =
     ; Numerics/optimization
     ignore:A not p.d., added jitter of .*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
+    ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
+    ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit  
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
     ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
     ; Temporary ignores

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,10 @@ filterwarnings =
     ; -----------------
     ; Torch JIT deprecation warning triggered during linear_operator import
     ignore:.*torch.jit.script.*is deprecated:DeprecationWarning
+    ; Invalid escape sequence in pyro.ops.stats docstring
+    ; Fixed upstream but unreleased: https://github.com/pyro-ppl/pyro/issues/3450
+    ignore:.*invalid escape sequence.*:SyntaxWarning
+    ignore:.*invalid escape sequence.*:DeprecationWarning
     ; https://github.com/meta-pytorch/botorch/pull/3279
     ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
     ; Needs proper fix for pandas 3.0 compatibility
@@ -31,15 +35,10 @@ filterwarnings =
 
     ; Numerics/optimization
     ; ---------------------
-    ; NOTE: Using built-in base categories instead of fully-qualified third-party
-    ; warning classes (e.g. linear_operator.utils.warnings.NumericalWarning) to
-    ; avoid triggering third-party imports at pytest config time. Such imports can
-    ; fail when transitive dependencies contain invalid escape sequences
-    ; (cf. pyro.ops.stats on Python>=3.12 with -W error).
-    ignore:.*add(ed|ing) jitter.*:RuntimeWarning
+    ignore:.*add(ed|ing) jitter.*:linear_operator.utils.warnings.NumericalWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
-    ignore:`scipy_minimize` terminated with status .*::.*botorch/fit
+    ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
-    ignore:.*has known numerical issues that lead to suboptimal optimization performance.*::botorch.acquisition
+    ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
     

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,10 +31,15 @@ filterwarnings =
 
     ; Numerics/optimization
     ; ---------------------
-    ignore:.*add(ed|ing) jitter.*:linear_operator.utils.warnings.NumericalWarning
+    ; NOTE: Using built-in base categories instead of fully-qualified third-party
+    ; warning classes (e.g. linear_operator.utils.warnings.NumericalWarning) to
+    ; avoid triggering third-party imports at pytest config time. Such imports can
+    ; fail when transitive dependencies contain invalid escape sequences
+    ; (cf. pyro.ops.stats on Python>=3.12 with -W error).
+    ignore:.*add(ed|ing) jitter.*:RuntimeWarning
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; Note: File format instead of module format needed due to BoTorch reraising using `warn_explicit` without `module` argument
-    ignore:`scipy_minimize` terminated with status .*:botorch.exceptions.warnings.OptimizationWarning:.*botorch/fit
+    ignore:`scipy_minimize` terminated with status .*::.*botorch/fit
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
-    ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
+    ignore:.*has known numerical issues that lead to suboptimal optimization performance.*::botorch.acquisition
     

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,6 @@ xfail_strict=true
 
 filterwarnings =
     error
-    ; Numerics
+    ; Numerics/optimization
     ignore:A not p.d., added jitter of .*:linear_operator.utils.warnings.NumericalWarning
+    ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,6 @@ filterwarnings =
     ignore:Optimization failed.*:RuntimeWarning:botorch.optim.optimize
     ; BoTorch warning recommending to switch to log-versions of acquisition functions
     ignore:.*has known numerical issues that lead to suboptimal optimization performance.*:botorch.exceptions.warnings.NumericsWarning:botorch.acquisition
+    ; Temporary ignores
+    ; https://github.com/meta-pytorch/botorch/pull/3279
+    ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,9 @@
 [pytest]
 strict = true
 
+markers =
+    filterwarnings: Apply warning filters to a test
+
 # Currently blocked by test_iterations.py. Should be activated once that test module
 # has been properly refactored.
 strict_parametrization_ids=false

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+strict = true
+
 addopts = 
     --doctest-modules 
     --ignore=examples
@@ -10,8 +12,6 @@ addopts =
 testpaths = 
     baybe
     tests
-
-xfail_strict=true
 
 filterwarnings =
     error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import time
-import warnings
 from copy import deepcopy
 from itertools import chain
 from unittest.mock import Mock
@@ -81,13 +80,6 @@ from baybe.utils.dataframe import (
     add_fake_measurements,
     add_parameter_noise,
     create_fake_input,
-)
-
-# TODO: Remove when https://github.com/cornellius-gp/linear_operator/pull/129 is ready
-warnings.filterwarnings(
-    "ignore",
-    message=".*torch.jit.script.*is deprecated",
-    category=DeprecationWarning,
 )
 
 # Hypothesis settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -958,9 +958,6 @@ def fixture_default_onnx_surrogate(onnx_str) -> CustomONNXSurrogate:
             match=r".*Expected value argument.*to be within the support.*"
         ),
     ),
-    before_sleep=lambda x: warnings.warn(
-        f"Retrying iteration test due to '{x.outcome.exception()}'"
-    ),
 )
 def run_iterations(
     campaign: Campaign, n_iterations: int, batch_size: int, add_noise: bool = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,13 @@ from baybe.utils.dataframe import (
     create_fake_input,
 )
 
+# TODO: Remove when https://github.com/cornellius-gp/linear_operator/pull/129 is ready
+warnings.filterwarnings(
+    "ignore",
+    message=".*torch.jit.script.*is deprecated",
+    category=DeprecationWarning,
+)
+
 # Hypothesis settings
 hypothesis_settings.register_profile("ci", deadline=500, max_examples=100)
 if strtobool(os.getenv("CI", "false")):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -925,7 +925,7 @@ def fixture_default_onnx_str() -> bytes:
 
     # Train sklearn model
     train_x = torch.arange(10).view(-1, 1)
-    train_y = torch.arange(10).view(-1, 1)
+    train_y = torch.arange(10)
     model = BayesianRidge()
     model.fit(train_x, train_y)
 

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -231,6 +231,7 @@ def test_min_cardinality_warning():
         )
 
     with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.filterwarnings("always", category=MinimumCardinalityViolatedWarning)
         BotorchRecommender().recommend(
             BATCH_SIZE, searchspace, objective, prepare_measurements()
         )

--- a/tests/constraints/test_constraints_continuous.py
+++ b/tests/constraints/test_constraints_continuous.py
@@ -221,7 +221,7 @@ def test_hybridspace_ineq(campaign, n_iterations, batch_size):
         param(["A", "B"], [1.0, 2.0, 3.0], 0.0, ">=", id="ineq_too_many_coeffs"),
         param(["A", "B"], [1.0, 2.0], "bla", ">=", id="ineq_invalid_rhs"),
         param(["A", "B"], [1.0, 2.0], 0.0, "invalid", id="ineq_invalid_operator1"),
-        param(["A", "B"], [1.0, 2.0], 0.0, 2.0, id="ineq_invalid_operator1"),
+        param(["A", "B"], [1.0, 2.0], 0.0, 2.0, id="ineq_invalid_operator2"),
     ],
 )
 def test_invalid_constraints(parameters, coefficients, rhs, op):

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -12,7 +12,7 @@ abbreviations = [
     if hasattr(cl, "abbreviation")
 ]
 fullnames = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
-combined = set(abbreviations + fullnames)
+combined = sorted(set(abbreviations + fullnames))
 
 
 @pytest.mark.parametrize("acqf", combined)

--- a/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_acquisition.py
@@ -6,22 +6,22 @@ from baybe.acquisition.base import AcquisitionFunction
 from baybe.recommenders import BotorchRecommender
 from baybe.utils.basic import get_subclasses
 
-abbreviation_list = [
+abbreviations = [
     cl.abbreviation
     for cl in get_subclasses(AcquisitionFunction)
     if hasattr(cl, "abbreviation")
 ]
+fullnames = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
+combined = set(abbreviations + fullnames)
 
-fullname_list = [cl.__name__ for cl in get_subclasses(AcquisitionFunction)]
 
-
-@pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
+@pytest.mark.parametrize("acqf", combined)
 def test_creation_from_string(acqf):
     """Tests the creation from strings."""
     AcquisitionFunction.from_dict({"type": acqf})
 
 
-@pytest.mark.parametrize("acqf", abbreviation_list + fullname_list)
+@pytest.mark.parametrize("acqf", combined)
 def test_string_usage_in_recommender(acqf):
     """Tests the recommender initialization with acqfs as string."""
     BotorchRecommender(acquisition_function=acqf)

--- a/tests/insights/test_shap.py
+++ b/tests/insights/test_shap.py
@@ -126,6 +126,9 @@ _desirabilty_targets = [
 
 
 @mark.slow
+@pytest.mark.filterwarnings(
+    "ignore::botorch.exceptions.warnings.BadInitialCandidatesWarning",
+)
 @mark.parametrize(
     "objective",
     [

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -340,9 +340,13 @@ def test_constructor_equivalence_match(transformation):
         assert t1 == t2
 
 
-@pytest.mark.parametrize(
-    ("legacy", "deprecation", "modern", "expected"),
-    [
+# NOTE: The parametrize values below use the deprecated legacy interface of
+# ModernTarget (e.g. ModernTarget("t", "MAX")), which emits DeprecationWarning.
+# Since these are evaluated at module/collection time, we suppress the warning here
+# to avoid failures when running with `-W error`.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    _target_transformation_params = [
         param(
             LegacyTarget("t", "MAX"),
             ModernTarget("t", "MAX"),
@@ -464,7 +468,12 @@ def test_constructor_equivalence_match(transformation):
             triangular_transform(sample_input(), 2, 6),
             id="match_triangular_scaled_shifted",
         ),
-    ],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("legacy", "deprecation", "modern", "expected"),
+    _target_transformation_params,
 )
 def test_target_transformation(
     series,

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -243,6 +243,7 @@ def test_target_deprecation_helpers():
         NumericalTarget.from_modern_interface("t", minimize=True)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_target_legacy_deserialization():
     """Deserialization also works from legacy arguments."""
     actual = NumericalTarget.from_dict({"name": "t", "mode": "MATCH", "bounds": (1, 2)})
@@ -259,6 +260,7 @@ def series() -> pd.Series:
     return sample_input()
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("mode", ["MAX", "MIN"])
 def test_constructor_equivalence_min_max(mode):
     """
@@ -300,6 +302,7 @@ def test_constructor_equivalence_min_max(mode):
             assert t1 == t2
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("transformation", ["TRIANGULAR", "BELL"])
 def test_constructor_equivalence_match(transformation):
     """
@@ -491,6 +494,7 @@ def test_target_transformation(
     assert_series_equal(modern.transform(series), expected)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_deserialization_using_constructor():
     """Deserialization using the 'constructor' field works despite having other
     deprecation mechanisms in place."""  # noqa

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -125,6 +125,81 @@ acqfs_single_output_batching = [
 acqfs_multi_output_batching = [a for a in acqfs_batching if a.supports_multi_output]
 
 
+def _make_acqf_id(acqf) -> str:
+    """Return a unique strict_parametrization_ids-compatible ID for an acqf.
+
+    Disambiguates multiple instances of the same class (e.g. qNIPV variants) by
+    appending their sampling configuration to the abbreviation.
+    """
+    if isinstance(acqf, qNIPV):
+        method = acqf.sampling_method.value
+        if acqf.sampling_n_points is not None:
+            return f"{acqf.abbreviation}_n{acqf.sampling_n_points}_{method}"
+        frac = str(acqf.sampling_fraction).replace(".", "p")
+        return f"{acqf.abbreviation}_frac{frac}_{method}"
+    return acqf.abbreviation
+
+
+def _make_kernel_id(kernel) -> str:
+    """Return a unique strict_parametrization_ids-compatible ID for a kernel.
+
+    Disambiguates same-class instances by incorporating the prior type (base kernels),
+    the wrapped kernel (ScaleKernel), or the component class names (composite kernels).
+    """
+    cls_name = kernel.__class__.__name__
+    # Base kernels: disambiguate by the prior attribute that varies across instances
+    for attr in ("lengthscale_prior", "variance_prior", "offset_prior"):
+        prior = getattr(kernel, attr, None)
+        if prior is not None:
+            return f"{cls_name}_{prior.__class__.__name__}"
+    # ScaleKernel wraps a single base_kernel
+    base = getattr(kernel, "base_kernel", None)
+    if base is not None:
+        return f"{cls_name}_{_make_kernel_id(base)}"
+    # Composite kernels (AdditiveKernel, ProductKernel) have a base_kernels collection
+    base_kernels = getattr(kernel, "base_kernels", None)
+    if base_kernels is not None:
+        inner = "_".join(k.__class__.__name__ for k in base_kernels)
+        return f"{cls_name}_{inner}"
+    return cls_name
+
+
+def _make_recommender_id(recommender) -> str:
+    """Return a unique strict_parametrization_ids-compatible ID for a recommender.
+
+    For TwoPhaseMetaRecommender wrappers, the inner recommender type (and its key
+    config for BotorchRecommender / NaiveHybridSpaceRecommender) is used to produce
+    a more informative ID than the outer wrapper class name alone.
+    """
+    if isinstance(recommender, TwoPhaseMetaRecommender):
+        inner = recommender.recommender
+        if isinstance(inner, NaiveHybridSpaceRecommender):
+            return f"Naive_{inner.disc_recommender.__class__.__name__}"
+        if isinstance(inner, BotorchRecommender):
+            sampler = inner.hybrid_sampler or "None"
+            pct = str(inner.sampling_percentage).replace(".", "p")
+            return f"Botorch_{sampler}_{pct}"
+        return inner.__class__.__name__
+    return recommender.__class__.__name__
+
+
+def _dedup_ids(ids: list[str]) -> list[str]:
+    """Append a numeric suffix to duplicate IDs to ensure uniqueness."""
+    from collections import Counter
+
+    totals = Counter(ids)
+    counts: dict[str, int] = {}
+    result = []
+    for id_ in ids:
+        if totals[id_] > 1:
+            n = counts.get(id_, 0) + 1
+            counts[id_] = n
+            result.append(f"{id_}_{n}")
+        else:
+            result.append(id_)
+    return result
+
+
 # List of all hybrid recommenders with default attributes. Is extended with other lists
 # of hybrid recommenders like naive ones or recommenders not using default arguments
 # TODO the TwoPhaseMetaRecommender below can be removed if the SeqGreedy recommender
@@ -250,7 +325,7 @@ test_targets = [
 @pytest.mark.parametrize(
     "acqf",
     acqfs_single_output_batching,
-    ids=[a.abbreviation for a in acqfs_single_output_batching],
+    ids=[_make_acqf_id(a) for a in acqfs_single_output_batching],
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_single_output_batching_acqfs(ongoing_campaign, n_iterations, batch_size, acqf):
@@ -275,7 +350,7 @@ def test_single_output_batching_acqfs(ongoing_campaign, n_iterations, batch_size
 @pytest.mark.parametrize(
     "acqf",
     acqfs_multi_output_batching,
-    ids=[a.abbreviation for a in acqfs_multi_output_batching],
+    ids=[_make_acqf_id(a) for a in acqfs_multi_output_batching],
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_multi_output_batching_acqfs(ongoing_campaign, n_iterations, batch_size):
@@ -284,7 +359,7 @@ def test_multi_output_batching_acqfs(ongoing_campaign, n_iterations, batch_size)
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "acqf", acqfs_non_batching, ids=[a.abbreviation for a in acqfs_non_batching]
+    "acqf", acqfs_non_batching, ids=[_make_acqf_id(a) for a in acqfs_non_batching]
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 @pytest.mark.parametrize("batch_size", [1], ids=["b1"])
@@ -294,7 +369,7 @@ def test_non_batching_acqfs(ongoing_campaign, n_iterations, batch_size):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "kernel", valid_kernels, ids=[c.__class__.__name__ for c in valid_kernels]
+    "kernel", valid_kernels, ids=[_make_kernel_id(c) for c in valid_kernels]
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_kernels(ongoing_campaign, n_iterations, batch_size):
@@ -334,7 +409,7 @@ def test_surrogate_models(ongoing_campaign, n_iterations, batch_size, surrogate_
 @pytest.mark.parametrize(
     "recommender",
     valid_initial_recommenders,
-    ids=[c.__class__.__name__ for c in valid_initial_recommenders],
+    ids=_dedup_ids([c.__class__.__name__ for c in valid_initial_recommenders]),
 )
 def test_initial_recommenders(ongoing_campaign, n_iterations, batch_size):
     with pytest.warns(UnusedObjectWarning):
@@ -354,7 +429,7 @@ def test_targets(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_discrete_recommenders,
-    ids=[c.__class__.__name__ for c in valid_discrete_recommenders],
+    ids=_dedup_ids([_make_recommender_id(c) for c in valid_discrete_recommenders]),
 )
 def test_recommenders_discrete(ongoing_campaign, n_iterations, batch_size):
     try:
@@ -367,7 +442,7 @@ def test_recommenders_discrete(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_continuous_recommenders,
-    ids=[c.__class__.__name__ for c in valid_continuous_recommenders],
+    ids=_dedup_ids([_make_recommender_id(c) for c in valid_continuous_recommenders]),
 )
 @pytest.mark.parametrize(
     "parameter_names", [["Conti_finite1", "Conti_finite2"]], ids=["conti_params"]
@@ -380,7 +455,7 @@ def test_recommenders_continuous(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_hybrid_recommenders,
-    ids=[c.__class__.__name__ for c in valid_hybrid_recommenders],
+    ids=_dedup_ids([_make_recommender_id(c) for c in valid_hybrid_recommenders]),
 )
 @pytest.mark.parametrize(
     "parameter_names",

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -124,6 +124,7 @@ acqfs_single_output_batching = [
 ]
 acqfs_multi_output_batching = [a for a in acqfs_batching if a.supports_multi_output]
 
+
 # List of all hybrid recommenders with default attributes. Is extended with other lists
 # of hybrid recommenders like naive ones or recommenders not using default arguments
 # TODO the TwoPhaseMetaRecommender below can be removed if the SeqGreedy recommender
@@ -269,6 +270,7 @@ def test_single_output_batching_acqfs(ongoing_campaign, n_iterations, batch_size
 @pytest.mark.parametrize(
     "objective",
     [ParetoObjective([NumericalTarget("t1"), NumericalTarget("t2", minimize=True)])],
+    ids=["pareto_objective"],
 )
 @pytest.mark.parametrize(
     "acqf",
@@ -292,7 +294,7 @@ def test_non_batching_acqfs(ongoing_campaign, n_iterations, batch_size):
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "kernel", valid_kernels, ids=[c.__class__ for c in valid_kernels]
+    "kernel", valid_kernels, ids=[c.__class__.__name__ for c in valid_kernels]
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_kernels(ongoing_campaign, n_iterations, batch_size):
@@ -332,7 +334,7 @@ def test_surrogate_models(ongoing_campaign, n_iterations, batch_size, surrogate_
 @pytest.mark.parametrize(
     "recommender",
     valid_initial_recommenders,
-    ids=[c.__class__ for c in valid_initial_recommenders],
+    ids=[c.__class__.__name__ for c in valid_initial_recommenders],
 )
 def test_initial_recommenders(ongoing_campaign, n_iterations, batch_size):
     with pytest.warns(UnusedObjectWarning):
@@ -352,7 +354,7 @@ def test_targets(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_discrete_recommenders,
-    ids=[c.__class__ for c in valid_discrete_recommenders],
+    ids=[c.__class__.__name__ for c in valid_discrete_recommenders],
 )
 def test_recommenders_discrete(ongoing_campaign, n_iterations, batch_size):
     try:
@@ -365,7 +367,7 @@ def test_recommenders_discrete(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_continuous_recommenders,
-    ids=[c.__class__ for c in valid_continuous_recommenders],
+    ids=[c.__class__.__name__ for c in valid_continuous_recommenders],
 )
 @pytest.mark.parametrize(
     "parameter_names", [["Conti_finite1", "Conti_finite2"]], ids=["conti_params"]
@@ -378,7 +380,7 @@ def test_recommenders_continuous(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_hybrid_recommenders,
-    ids=[c.__class__ for c in valid_hybrid_recommenders],
+    ids=[c.__class__.__name__ for c in valid_hybrid_recommenders],
 )
 @pytest.mark.parametrize(
     "parameter_names",
@@ -410,7 +412,7 @@ def test_recommenders_hybrid(ongoing_campaign, n_iterations, batch_size):
 @pytest.mark.parametrize(
     "recommender",
     valid_meta_recommenders,
-    ids=[c.__class__ for c in valid_meta_recommenders],
+    ids=[c.__name__ for c in valid_meta_recommenders],
     indirect=True,
 )
 def test_meta_recommenders(ongoing_campaign, n_iterations, batch_size):

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -163,6 +163,10 @@ def test_invalid_model_params(model_cls, params):
         model_cls(model_params=params)
 
 
+@pytest.mark.skipif(
+    os.environ.get("BAYBE_TEST_ENV") != "FULLTEST",
+    reason="Most surrogates are only available in FULLTEST environment.",
+)
 @pytest.mark.parametrize(
     "target_names",
     [["Target_max"], ["Target_max_bounded", "Target_min_bounded"]],

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -167,6 +167,9 @@ def test_invalid_model_params(model_cls, params):
     os.environ.get("BAYBE_TEST_ENV") != "FULLTEST",
     reason="Most surrogates are only available in FULLTEST environment.",
 )
+@pytest.mark.filterwarnings(
+    "ignore::botorch.exceptions.warnings.BadInitialCandidatesWarning",
+)
 @pytest.mark.parametrize(
     "target_names",
     [["Target_max"], ["Target_max_bounded", "Target_min_bounded"]],
@@ -189,7 +192,7 @@ def test_invalid_model_params(model_cls, params):
 )
 def test_continuous_incompatibility(campaign):
     """Using surrogates without gradients on continuous spaces fails expectedly."""
-    data = create_fake_input(campaign.parameters, campaign.targets, n_rows=3)
+    data = create_fake_input(campaign.parameters, campaign.targets, n_rows=2)
     campaign.add_measurements(data)
 
     skip = False

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -185,7 +185,7 @@ def test_invalid_model_params(model_cls, params):
 )
 def test_continuous_incompatibility(campaign):
     """Using surrogates without gradients on continuous spaces fails expectedly."""
-    data = create_fake_input(campaign.parameters, campaign.targets)
+    data = create_fake_input(campaign.parameters, campaign.targets, n_rows=3)
     campaign.add_measurements(data)
 
     skip = False

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
     BAYBE_TEST_ENV = FULLTEST
 commands =
     python --version
-    pytest -p no:warnings --cov=baybe --durations=5 {posargs}
+    pytest --cov=baybe --durations=5 {posargs}
 
 [testenv:gputest,gputest-py{310,311,312,313,314}]
 description = Runs GPU tests
@@ -45,7 +45,7 @@ setenv =
     BAYBE_TEST_ENV = CORETEST
 commands =
     python --version
-    pytest -p no:warnings --cov=baybe --durations=5 {posargs}
+    pytest --cov=baybe --durations=5 {posargs}
 
 [testenv:lint,lint-py{310,311,312,313,314}]
 description = Run linters and format checkers


### PR DESCRIPTION
Say goodbye to all pytest warnings, once and for all. This is achieved but turning the warnings into errors using the `-W error` mode, requiring us to fix the causing issues. Generally good practice since:
* it finds more issues in our own code base (see changes)
* and also prevents us from running e.g. into deprecated features from third-party code (see changes)

So the PR essentially finalizes the work from #766. In addition, it enables the `--strict` mode.