### PR TITLE
Update import whitelist

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -81,8 +81,7 @@ WHITELISTS = {
         "baybe.utils.clustering_algorithms",
         "baybe.utils.clustering_algorithms.third_party",
         "baybe.utils.clustering_algorithms.third_party.kmedoids",
-    ]
-    + (["baybe._optional.simulation"] if sys.version_info >= (3, 11) else []),
+    ],
     "sklearn": [
         "baybe._optional.chem",
         "baybe._optional.insights",


### PR DESCRIPTION
Some of our dependencies seem to have dropped scipy from their own deps, meaning that the whitelist entry is no longer needed. Which dependency it was (probably xyzpy, xarray or related) is not important at this point.