### PR TITLE
Create GP from prior with mean factory

### DIFF
--- a/baybe/surrogates/gaussian_process/components/__init__.py
+++ b/baybe/surrogates/gaussian_process/components/__init__.py
@@ -17,6 +17,7 @@ from baybe.surrogates.gaussian_process.components.mean import (
     LazyConstantMeanFactory,
     MeanFactoryProtocol,
     PlainMeanFactory,
+    PriorMeanFactory,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "LazyConstantMeanFactory",
     "MeanFactoryProtocol",
     "PlainMeanFactory",
+    "PriorMeanFactory",
 ]

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -79,12 +79,12 @@ class PriorMeanFactory(MeanFactoryProtocol):
                 self.gp: SingleTaskGP = deepcopy(gp)
                 for param in self.gp.parameters():
                     param.requires_grad = False
+                self.gp.eval()
+                self.gp.likelihood.eval()
                 self.input_transform = input_transform
 
             def forward(self, x: Tensor) -> Tensor:
                 """Compute the mean using the wrapped GP's posterior."""
-                self.gp.eval()
-                self.gp.likelihood.eval()
                 with gpytorch.settings.fast_pred_var():
                     # Unnormalize to raw physical space so that posterior()
                     # can apply the prior GP's own input normalization.

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -10,6 +10,11 @@ from attrs import define, field
 from typing_extensions import override
 
 from baybe.searchspace.core import SearchSpace
+from baybe.serialization.core import (
+    block_deserialization_hook,
+    block_serialization_hook,
+    converter,
+)
 from baybe.surrogates.gaussian_process.components.generic import (
     GPComponentFactoryProtocol,
     PlainGPComponentFactory,
@@ -47,6 +52,9 @@ class PriorMeanFactory(MeanFactoryProtocol):
 
     The mean function uses the trained GP's posterior mean predictions.
     The provided model is deep-copied and its parameters are frozen.
+
+    Surrogates using this factory are not serializable because the underlying
+    BoTorch model is not covered by BayBE's serialization system.
     """
 
     _prior_model: SingleTaskGP = field()
@@ -93,5 +101,9 @@ class PriorMeanFactory(MeanFactoryProtocol):
 
         return PriorMean(self._prior_model, input_transform)
 
+
+# Prevent (de-)serialization of PriorMeanFactory since it contains a BoTorch model
+converter.register_unstructure_hook(PriorMeanFactory, block_serialization_hook)
+converter.register_structure_hook(PriorMeanFactory, block_deserialization_hook)
 
 gc.collect()  # Collect leftover original slotted classes created by attrs

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -57,24 +57,42 @@ class PriorMeanFactory(MeanFactoryProtocol):
     ) -> GPyTorchMean:
         import gpytorch
         import torch
+        from botorch.models.transforms.input import Normalize
+
+        from baybe.surrogates.gaussian_process.core import _ModelContext
+
+        context = _ModelContext(searchspace)
+
+        # Build the same normalization used by _fit for the new GP.
+        # In eval mode, untransform reverses the normalization.
+        input_transform = Normalize(
+            train_x.shape[-1],
+            bounds=context.parameter_bounds,
+            indices=context.numerical_indices,
+        )
+        input_transform.eval()
 
         class PriorMean(gpytorch.means.Mean):
             """GPyTorch mean using a trained GP's posterior as the mean function."""
 
-            def __init__(self, gp: SingleTaskGP) -> None:
+            def __init__(self, gp: SingleTaskGP, input_transform: Normalize) -> None:
                 super().__init__()
                 self.gp: SingleTaskGP = deepcopy(gp)
                 for param in self.gp.parameters():
                     param.requires_grad = False
+                self.input_transform = input_transform
 
             def forward(self, x: Tensor) -> Tensor:
                 """Compute the mean using the wrapped GP's posterior."""
                 self.gp.eval()
                 self.gp.likelihood.eval()
                 with torch.no_grad(), gpytorch.settings.fast_pred_var():
-                    return self.gp(x).mean.detach()
+                    # Unnormalize to raw physical space so that posterior()
+                    # can apply the prior GP's own input normalization.
+                    x_raw = self.input_transform.untransform(x)
+                    return self.gp.posterior(x_raw).mean.squeeze(-1).detach()
 
-        return PriorMean(self._prior_model)
+        return PriorMean(self._prior_model, input_transform)
 
 
 gc.collect()  # Collect leftover original slotted classes created by attrs

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import gc
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
-from attrs import define
+from attrs import define, field
 from typing_extensions import override
 
 from baybe.searchspace.core import SearchSpace
@@ -14,6 +16,7 @@ from baybe.surrogates.gaussian_process.components.generic import (
 )
 
 if TYPE_CHECKING:
+    from botorch.models import SingleTaskGP
     from gpytorch.means import Mean as GPyTorchMean
     from torch import Tensor
 
@@ -36,3 +39,42 @@ class LazyConstantMeanFactory(MeanFactoryProtocol):
         from gpytorch.means import ConstantMean
 
         return ConstantMean()
+
+
+@define
+class PriorMeanFactory(MeanFactoryProtocol):
+    """A factory that creates a prior mean from a trained botorch GP model.
+
+    The mean function uses the trained GP's posterior mean predictions.
+    The provided model is deep-copied and its parameters are frozen.
+    """
+
+    _prior_model: SingleTaskGP = field()
+
+    @override
+    def __call__(
+        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
+    ) -> GPyTorchMean:
+        import gpytorch
+        import torch
+
+        class PriorMean(gpytorch.means.Mean):
+            """GPyTorch mean using a trained GP's posterior as the mean function."""
+
+            def __init__(self, gp: SingleTaskGP) -> None:
+                super().__init__()
+                self.gp: SingleTaskGP = deepcopy(gp)
+                for param in self.gp.parameters():
+                    param.requires_grad = False
+
+            def forward(self, x: Tensor) -> Tensor:
+                """Compute the mean using the wrapped GP's posterior."""
+                self.gp.eval()
+                self.gp.likelihood.eval()
+                with torch.no_grad(), gpytorch.settings.fast_pred_var():
+                    return self.gp(x).mean.detach()
+
+        return PriorMean(self._prior_model)
+
+
+gc.collect()  # Collect leftover original slotted classes created by attrs

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -56,7 +56,6 @@ class PriorMeanFactory(MeanFactoryProtocol):
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> GPyTorchMean:
         import gpytorch
-        import torch
         from botorch.models.transforms.input import Normalize
 
         from baybe.surrogates.gaussian_process.core import _ModelContext
@@ -86,11 +85,11 @@ class PriorMeanFactory(MeanFactoryProtocol):
                 """Compute the mean using the wrapped GP's posterior."""
                 self.gp.eval()
                 self.gp.likelihood.eval()
-                with torch.no_grad(), gpytorch.settings.fast_pred_var():
+                with gpytorch.settings.fast_pred_var():
                     # Unnormalize to raw physical space so that posterior()
                     # can apply the prior GP's own input normalization.
                     x_raw = self.input_transform.untransform(x)
-                    return self.gp.posterior(x_raw).mean.squeeze(-1).detach()
+                    return self.gp.posterior(x_raw).mean.squeeze(-1)
 
         return PriorMean(self._prior_model, input_transform)
 

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -258,7 +258,9 @@ class GaussianProcessSurrogate(Surrogate):
                 new GP. Defaults to the BayBE default fit criterion factory.
 
         Returns:
-            A new :class:`GaussianProcessSurrogate` instance.
+            A new :class:`GaussianProcessSurrogate` instance. The returned surrogate
+            is not serializable. Calling ``to_json`` on a campaign using this
+            surrogate will raise an error.
 
         Raises:
             TypeError: If ``prior_gp`` is not a :class:`GaussianProcessSurrogate`.

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -232,6 +232,59 @@ class GaussianProcessSurrogate(Surrogate):
 
         return cls(kernel, mean, likelihood, criterion)
 
+    @classmethod
+    def from_prior(
+        cls,
+        prior_gp: GaussianProcessSurrogate,
+        kernel_or_factory: KernelFactoryProtocol
+        | Kernel
+        | GPyTorchKernel
+        | None = None,
+        likelihood_or_factory: LikelihoodFactoryProtocol
+        | GPyTorchLikelihood
+        | None = None,
+        criterion_or_factory: FitCriterion | FitCriterionFactoryProtocol | None = None,
+    ) -> Self:
+        """Create a GP using a fitted GP's posterior mean as the mean function.
+
+        Args:
+            prior_gp: A fitted :class:`GaussianProcessSurrogate` whose posterior
+                mean will serve as the mean function of the new GP.
+            kernel_or_factory: Kernel or kernel factory for the new GP.
+                Defaults to the BayBE default kernel factory.
+            likelihood_or_factory: Likelihood or likelihood factory for the new GP.
+                Defaults to the BayBE default likelihood factory.
+            criterion_or_factory: Fit criterion or fit criterion factory for the
+                new GP. Defaults to the BayBE default fit criterion factory.
+
+        Returns:
+            A new :class:`GaussianProcessSurrogate` instance.
+
+        Raises:
+            TypeError: If ``prior_gp`` is not a :class:`GaussianProcessSurrogate`.
+            ModelNotTrainedError: If the prior GP has not been fitted.
+        """
+        from baybe.exceptions import ModelNotTrainedError
+        from baybe.surrogates.gaussian_process.components.mean import PriorMeanFactory
+
+        if not isinstance(prior_gp, cls):
+            raise TypeError(
+                f"prior_gp must be a {cls.__name__} instance, "
+                f"got {type(prior_gp).__name__}"
+            )
+        if prior_gp._model is None:
+            raise ModelNotTrainedError("Prior GP must be fitted before use.")
+
+        kwargs: dict = {"mean_or_factory": PriorMeanFactory(prior_gp._model)}
+        if kernel_or_factory is not None:
+            kwargs["kernel_or_factory"] = kernel_or_factory
+        if likelihood_or_factory is not None:
+            kwargs["likelihood_or_factory"] = likelihood_or_factory
+        if criterion_or_factory is not None:
+            kwargs["criterion_or_factory"] = criterion_or_factory
+
+        return cls(**kwargs)
+
     @override
     def to_botorch(self) -> GPyTorchModel:
         return self._model

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -130,3 +130,73 @@ def test_invalid_components():
         )
     with pytest.raises(TypeError, match="Component must be one of"):
         GaussianProcessSurrogate(criterion_or_factory=MaternKernel())
+
+
+def test_prior_mean_correct_under_different_bounds():
+    """PriorMean evaluates at correct physical points when bounds differ."""
+    import pandas as pd
+    import torch
+
+    from baybe.parameters.numerical import NumericalDiscreteParameter
+    from baybe.searchspace.core import SearchSpace
+
+    # Train a prior GP on a narrow search space [0, 5]
+    prior_params = [NumericalDiscreteParameter("x1", values=[0.0, 2.5, 5.0])]
+    prior_ss = SearchSpace.from_product(prior_params)
+    obj = NumericalTarget(name="y").to_objective()
+
+    prior_surrogate = GaussianProcessSurrogate()
+    prior_measurements = pd.DataFrame({"x1": [0.0, 2.5, 5.0], "y": [0.0, 5.0, 10.0]})
+    prior_surrogate.fit(prior_ss, obj, prior_measurements)
+
+    # Get the prior's prediction at a known physical point (x1=2.5)
+    prior_posterior = prior_surrogate.posterior(pd.DataFrame({"x1": [2.5]}))
+    expected_mean = prior_posterior.mean.item()
+
+    # Create a new GP with from_prior on a WIDER search space [0, 10]
+    new_params = [NumericalDiscreteParameter("x1", values=[0.0, 2.5, 5.0, 7.5, 10.0])]
+    new_ss = SearchSpace.from_product(new_params)
+
+    new_surrogate = GaussianProcessSurrogate.from_prior(prior_gp=prior_surrogate)
+    new_measurements = pd.DataFrame({"x1": [0.0, 10.0], "y": [0.0, 20.0]})
+    new_surrogate.fit(new_ss, obj, new_measurements)
+
+    # Extract the mean module and evaluate it at x1=2.5's normalized position
+    # In the new space [0,10], x1=2.5 normalizes to 0.25
+    mean_module = new_surrogate._model.mean_module
+    x_normalized = torch.tensor([[0.25]])
+    with torch.no_grad():
+        actual_mean = mean_module(x_normalized).item()
+
+    assert abs(actual_mean - expected_mean) < 1e-4
+
+
+def test_prior_mean_same_bounds():
+    """PriorMean is correct when prior and new search spaces have same bounds."""
+    import pandas as pd
+    import torch
+
+    from baybe.parameters.numerical import NumericalDiscreteParameter
+    from baybe.searchspace.core import SearchSpace
+
+    params = [NumericalDiscreteParameter("x1", values=[0.0, 2.5, 5.0])]
+    ss = SearchSpace.from_product(params)
+    obj = NumericalTarget(name="y").to_objective()
+
+    prior_surrogate = GaussianProcessSurrogate()
+    meas = pd.DataFrame({"x1": [0.0, 2.5, 5.0], "y": [0.0, 5.0, 10.0]})
+    prior_surrogate.fit(ss, obj, meas)
+
+    prior_posterior = prior_surrogate.posterior(pd.DataFrame({"x1": [2.5]}))
+    expected_mean = prior_posterior.mean.item()
+
+    new_surrogate = GaussianProcessSurrogate.from_prior(prior_gp=prior_surrogate)
+    new_surrogate.fit(ss, obj, meas)
+
+    # x1=2.5 normalizes to 0.5 in [0,5]
+    mean_module = new_surrogate._model.mean_module
+    x_normalized = torch.tensor([[0.5]])
+    with torch.no_grad():
+        actual_mean = mean_module(x_normalized).item()
+
+    assert abs(actual_mean - expected_mean) < 1e-4


### PR DESCRIPTION
New constructor method that enables transfer learning for Gaussian Process surrogates

```
# Train source GP
source_gp = GaussianProcessSurrogate()
source_gp.fit(source_space, source_objective, source_data)

# Transfer mean
target_gp = GaussianProcessSurrogate.from_prior(
      prior_gp=source_gp,  # Use source GP as prior
  )
```

Mean Function Transfer:
  - Implements full mean transfer from the prior GP to the new GP
  - The posterior mean predictions of the pre-trained GP used as the mean module for the new GP
  - Frozen hyperparameters 
  - Mean function is evaluated at source training points
  - New `PriorMeanFactory` in the GP component factory system (lazily constructs a PriorMean module)                                                                                                                                       