### PR TITLE
Ignore Benchmarking Env Var

### DIFF
--- a/baybe/settings.py
+++ b/baybe/settings.py
@@ -50,6 +50,9 @@ def _validate_whitelist_env_vars(vars: dict[str, str], /) -> None:
                 f"Allowed values for 'BAYBE_TEST_ENV' are "
                 f"'CORETEST', 'FULLTEST', and 'GPUTEST'. Given: '{value}'"
             )
+    for var in list(vars):
+        if var.startswith("BAYBE_BENCHMARKING_"):
+            vars.pop(var)
     if vars:
         raise RuntimeError(f"Unknown 'BAYBE_*' environment variables: {set(vars)}")
 


### PR DESCRIPTION
The benchmarking submodule currently maintains a single environment variable for the CI to set the S3-Bucket name and was unknown to the Setting validation class. To prevent a runtime error, env variables from the benchmarking submodule are now ignored and maintained by the module itself.