### PR TITLE
Fix minor bugs on current `dev/mfbo` branch

### DIFF
--- a/baybe/parameters/fidelity.py
+++ b/baybe/parameters/fidelity.py
@@ -21,8 +21,8 @@ from baybe.parameters.validation import (
     validate_is_finite,
     validate_unique_values,
 )
+from baybe.settings import active_settings
 from baybe.utils.conversion import nonstring_to_tuple
-from baybe.utils.numerical import DTypeFloatNumpy
 
 
 def _convert_zeta(
@@ -107,7 +107,9 @@ class CategoricalFidelityParameter(_DiscreteLabelLikeParameter):
     @cached_property
     def comp_df(self) -> pd.DataFrame:
         return pd.DataFrame(
-            range(len(self.values)), dtype=DTypeFloatNumpy, columns=[self.name]
+            range(len(self.values)),
+            dtype=active_settings.DTypeFloatNumpy,
+            columns=[self.name],
         )
 
 
@@ -159,5 +161,7 @@ class NumericalDiscreteFidelityParameter(DiscreteParameter):
     @cached_property
     def comp_df(self) -> pd.DataFrame:
         return pd.DataFrame(
-            {self.name: self.values}, index=self.values, dtype=DTypeFloatNumpy
+            {self.name: self.values},
+            index=self.values,
+            dtype=active_settings.DTypeFloatNumpy,
         )

--- a/baybe/parameters/fidelity.py
+++ b/baybe/parameters/fidelity.py
@@ -110,6 +110,7 @@ class CategoricalFidelityParameter(_DiscreteLabelLikeParameter):
             range(len(self.values)),
             dtype=active_settings.DTypeFloatNumpy,
             columns=[self.name],
+            index=self.values,
         )
 
 

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,5 +1,9 @@
 """Tests for fidelity parameters."""
 
+import pandas as pd
+import pytest
+from pytest import param
+
 from baybe.parameters.fidelity import (
     CategoricalFidelityParameter,
     NumericalDiscreteFidelityParameter,
@@ -18,3 +22,38 @@ def test_numerical_discrete_fidelity_parameter_construction():
     p1 = NumericalDiscreteFidelityParameter("p", values=[0, 0.5, 1], costs=[1, 2, 3])
     p2 = NumericalDiscreteFidelityParameter("p", values=[0.5, 1, 0], costs=[2, 3, 1])
     assert p1 == p2
+
+
+@pytest.mark.parametrize(
+    ("param", "series", "expected"),
+    [
+        param(
+            CategoricalFidelityParameter(
+                "fidelity", values=["low", "high"], costs=[1, 2], zeta=[1, 0]
+            ),
+            pd.Series(["low", "high", "low"], name="fidelity"),
+            [1.0, 0.0, 1.0],
+            id="categorical",
+        ),
+        param(
+            CategoricalFidelityParameter(
+                "fidelity", values=["low", "high"], costs=[1, 2], zeta=5
+            ),
+            pd.Series(["low", "high", "low"], name="fidelity"),
+            [1.0, 0.0, 1.0],
+            id="categorical_scalar_zeta",
+        ),
+        param(
+            NumericalDiscreteFidelityParameter(
+                "fidelity", values=[0, 0.5, 1], costs=[1, 2, 3]
+            ),
+            pd.Series([0.5, 1.0, 0.0], name="fidelity"),
+            [0.5, 1.0, 0.0],
+            id="numerical_discrete",
+        ),
+    ],
+)
+def test_fidelity_parameter_transform(param, series, expected):
+    """Transform must correctly map fidelity values to computational representation."""
+    result = param.transform(series)
+    assert list(result["fidelity"]) == expected

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -25,7 +25,7 @@ def test_numerical_discrete_fidelity_parameter_construction():
 
 
 @pytest.mark.parametrize(
-    ("param", "series", "expected"),
+    ("parameter", "series", "expected"),
     [
         param(
             CategoricalFidelityParameter(
@@ -53,7 +53,7 @@ def test_numerical_discrete_fidelity_parameter_construction():
         ),
     ],
 )
-def test_fidelity_parameter_transform(param, series, expected):
+def test_fidelity_parameter_transform(parameter, series, expected):
     """Transform must correctly map fidelity values to computational representation."""
-    result = param.transform(series)
+    result = parameter.transform(series)
     assert list(result["fidelity"]) == expected


### PR DESCRIPTION
This PR fixes two minor bugs on the `dev/mfbo` branch that have not been detected previously resp. have probably been included during the previous rebase process.
1. `comp_df` of `CategoricalFidelityParameter` did not set the index correctly: Previously, the code did not set the index at all when creating the computational representation, failing with the following error when trying to call `.transform`: `ValueError: You are trying to merge on object and int64 columns for key 'Labels'. If you wish to proceed you should use pd.concat`. This has now been fixed in 6f4ddf328718eaf6112461f9d473a16d55fc7c55 and corresponding tests for all types of fidelity parameter have been added in 9fcd0b55ec8c5cd7d0d122b7df4c78bfa3d8c4f9
2. There was still an old import of `DTypeFloatNumy` which did not use the `active_settings`. This was already identified in one of the follow up PRs, but I decided to already include this now as I wanted to have a clean `dev/mfbo` branch. This has been fixed in 84fb01aa6ca907d38e38e6bc3c4a6347d5b92a99.