### PR TITLE
Transfer Learning Decorator

### DIFF
--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -306,12 +306,6 @@ class SearchSpace(SerialMixin):
             name_or_selector: Either the name of a single parameter or a selector
                 that filters parameters to be included.
 
-        Raises:
-            ValueError: If a parameter name is provided but no matching parameter
-                exists.
-            ValueError: If a parameter name is provided but multiple matches are
-                found.
-
         Returns:
             A tuple containing the integer indices of the columns in the computational
             representation associated with the selected parameter(s). When a selected
@@ -319,18 +313,9 @@ class SearchSpace(SerialMixin):
             no indices.
         """
         if isinstance(name_or_selector, str):
-            matched = self.get_parameters_by_name([name_or_selector])
-            if len(matched) < 1:
-                raise ValueError(
-                    f"There exists no parameter named '{name_or_selector}' in the "
-                    f"search space."
-                )
-            if len(matched) > 1:
-                raise ValueError(
-                    f"There exist multiple parameter matches for "
-                    f"'{name_or_selector}' in the search space."
-                )
-            params: list[Parameter] = list(matched)
+            params: list[Parameter] = [
+                p for p in self.parameters if p.name == name_or_selector
+            ]
         else:
             params = [p for p in self.parameters if name_or_selector(p)]
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 from collections.abc import Iterable, Sequence
 from enum import Enum
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import pandas as pd
 from attrs import define, field
@@ -27,6 +27,9 @@ from baybe.searchspace.validation import (
 )
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.conversion import to_string
+
+if TYPE_CHECKING:
+    from baybe.parameters.selectors import ParameterSelectorProtocol
 
 
 class SearchSpaceType(Enum):
@@ -287,35 +290,53 @@ class SearchSpace(SerialMixin):
             return 1
         return len(task_param.values)
 
-    def get_comp_rep_parameter_indices(self, name: str, /) -> tuple[int, ...]:
-        """Find a parameter's column indices in the computational representation.
+    def get_comp_rep_parameter_indices(
+        self,
+        name_or_selector: str | ParameterSelectorProtocol,
+        /,
+    ) -> tuple[int, ...]:
+        """Find comp-rep column indices for a parameter selection.
+
+        When called with a parameter name, returns the indices for that single
+        parameter. When called with a
+        :class:`~baybe.parameters.selectors.ParameterSelectorProtocol`,
+        returns the combined indices for all matching parameters.
 
         Args:
-            name: The name of the parameter whose columns indices are to be retrieved.
+            name_or_selector: Either the name of a single parameter or a selector
+                that filters parameters to be included.
 
         Raises:
-            ValueError: If no parameter with the provided name exists.
-            ValueError: If more than one parameter with the provided name exists.
+            ValueError: If a parameter name is provided but no matching parameter
+                exists.
+            ValueError: If a parameter name is provided but multiple matches are
+                found.
 
         Returns:
             A tuple containing the integer indices of the columns in the computational
-            representation associated with the parameter. When the parameter is not part
-            of the computational representation, an empty tuple is returned.
+            representation associated with the selected parameter(s). When a selected
+            parameter is not part of the computational representation, it contributes
+            no indices.
         """
-        params = self.get_parameters_by_name([name])
-        if len(params) < 1:
-            raise ValueError(
-                f"There exists no parameter named '{name}' in the search space."
-            )
-        if len(params) > 1:
-            raise ValueError(
-                f"There exist multiple parameter matches for '{name}' in the search "
-                f"space."
-            )
-        p = params[0]
+        if isinstance(name_or_selector, str):
+            matched = self.get_parameters_by_name([name_or_selector])
+            if len(matched) < 1:
+                raise ValueError(
+                    f"There exists no parameter named '{name_or_selector}' in the "
+                    f"search space."
+                )
+            if len(matched) > 1:
+                raise ValueError(
+                    f"There exist multiple parameter matches for "
+                    f"'{name_or_selector}' in the search space."
+                )
+            params: list[Parameter] = list(matched)
+        else:
+            params = [p for p in self.parameters if name_or_selector(p)]
 
         return tuple(
             i
+            for p in params
             for i, col in enumerate(self.comp_rep_columns)
             if col in p.comp_rep_columns
         )

--- a/baybe/serialization/mixin.py
+++ b/baybe/serialization/mixin.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 from baybe.serialization.core import _add_type_to_dict, converter
 
 _T = TypeVar("_T", bound="SerialMixin")
+_T_co = TypeVar("_T_co", covariant=True)
+_T_contra = TypeVar("_T_contra", contravariant=True)
 
-if TYPE_CHECKING:
-    from _typeshed import SupportsRead, SupportsWrite
+
+class SupportsRead(Protocol[_T_co]):
+    """Runtime equivalent of `_typeshed.SupportsRead`."""
+
+    def read(self, length: int = ..., /) -> _T_co: ...  # noqa
+
+
+class SupportsWrite(Protocol[_T_contra]):
+    """Runtime equivalent of `_typeshed.SupportsWrite`."""
+
+    def write(self, s: _T_contra, /) -> object: ...  # noqa
 
 
 class SerialMixin:

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
-from attrs import define, field
+from attrs import define, field, fields
 from attrs.converters import optional
 from attrs.validators import is_callable
 from typing_extensions import override
@@ -257,10 +257,6 @@ class ICMKernelFactory(_MetaKernelFactory):
             _BayBENumericalKernelFactory,
         )
 
-        assert (
-            _BayBENumericalKernelFactory._supported_parameter_kinds
-            is _ParameterKind.REGULAR
-        )
         return _BayBENumericalKernelFactory(
             TypeSelector((TaskParameter,), exclude=True)
         )
@@ -271,8 +267,29 @@ class ICMKernelFactory(_MetaKernelFactory):
             _BayBETaskKernelFactory,
         )
 
-        assert _BayBETaskKernelFactory._supported_parameter_kinds is _ParameterKind.TASK
         return _BayBETaskKernelFactory()
+
+    @base_kernel_factory.validator
+    def _validate_base_kernel_factory(self, _, factory: KernelFactoryProtocol):
+        if (
+            isinstance(factory, _PureKernelFactory)
+            and factory._supported_parameter_kinds & _ParameterKind.TASK
+        ):
+            raise TypeError(
+                f"The specified '{fields(ICMKernelFactory).base_kernel_factory.alias}' "
+                f"must not support task parameters."
+            )
+
+    @task_kernel_factory.validator
+    def _validate_task_kernel_factory(self, _, factory: KernelFactoryProtocol):
+        if (
+            isinstance(factory, _PureKernelFactory)
+            and factory._supported_parameter_kinds is not _ParameterKind.TASK
+        ):
+            raise TypeError(
+                f"The specified '{fields(ICMKernelFactory).task_kernel_factory.alias}' "
+                f"must support only task parameters."
+            )
 
     @override
     def __call__(

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -126,7 +126,7 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
 
 
 def _enable_transfer_learning(
-    cls: type[_PureKernelFactory], /
+    cls: type[_PureKernelFactory], name: str | None = None, /
 ) -> type[_PureKernelFactory]:
     """Class decorator enabling BayBE's default transfer learning mechanism.
 
@@ -136,6 +136,9 @@ def _enable_transfer_learning(
 
     Args:
         cls: The kernel factory class to decorate.
+        name: Optional name for the created class. Defaults to ``cls.__name__``.
+            Useful when calling the function directly (as opposed to using it as a
+            decorator) and assigning the result to a different name.
 
     Raises:
         TypeError: If the factory already supports task parameters.
@@ -147,7 +150,7 @@ def _enable_transfer_learning(
         raise TypeError(f"'{cls.__name__}' already supports task parameters.")
 
     # Create a subclass so the original class remains unmodified
-    new_cls = type(cls.__name__, (cls,), {"__doc__": cls.__doc__})
+    new_cls = type(name or cls.__name__, (cls,), {"__doc__": cls.__doc__})
 
     original_call = cls.__call__
     original_supported_kinds = cls._supported_parameter_kinds

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -156,12 +156,20 @@ def _enable_transfer_learning(
     # This distinction is important for serialization so that the classes can be
     # correctly identified by their names in the subclass registry
     if name is not None:
-        # Create a subclass so the original class remains unmodified.
+        # Create a sibling class so the original class remains unmodified.
+        # We use cls.__bases__ (not (cls,)) because the new class is conceptually
+        # an equivalent variant, not a specialization. Concrete (non-dunder)
+        # attributes are copied so the sibling has the same behavior.
         # __module__ must be set explicitly because the Protocol metaclass
         # would otherwise default it to "abc".
-        target_cls = type(
-            name, (cls,), {"__doc__": cls.__doc__, "__module__": cls.__module__}
-        )
+        ns = {
+            k: v
+            for k, v in cls.__dict__.items()
+            if not (k.startswith("__") and k.endswith("__"))
+        }
+        ns["__doc__"] = cls.__doc__
+        ns["__module__"] = cls.__module__
+        target_cls = type(name, cls.__bases__, ns)
     else:
         # Modify the class in-place (avoids name collision in subclass registry)
         target_cls = cls

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -79,11 +79,10 @@ class _PureKernelFactory(KernelFactoryProtocol, SerialMixin, ABC):
 
     def _get_effective_dimensionality(self, searchspace: SearchSpace) -> int:
         """Get the number of computational columns for the selected parameters."""
-        names = self.get_parameter_names(searchspace)
-        if names is None:
-            return len(searchspace.comp_rep_columns)
-        return sum(
-            len(searchspace.get_comp_rep_parameter_indices(name)) for name in names
+        return len(
+            searchspace.get_comp_rep_parameter_indices(
+                self.parameter_selector or (lambda _: True)
+            )
         )
 
     def _validate_parameter_kinds(self, parameters: Iterable[Parameter]) -> None:

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -157,8 +157,12 @@ def _enable_transfer_learning(
     # This distinction is important for serialization so that the classes can be
     # correctly identified by their names in the subclass registry
     if name is not None:
-        # Create a subclass so the original class remains unmodified
-        target_cls = type(name, (cls,), {"__doc__": cls.__doc__})
+        # Create a subclass so the original class remains unmodified.
+        # __module__ must be set explicitly because the Protocol metaclass
+        # would otherwise default it to "abc".
+        target_cls = type(
+            name, (cls,), {"__doc__": cls.__doc__, "__module__": cls.__module__}
+        )
     else:
         # Modify the class in-place (avoids name collision in subclass registry)
         target_cls = cls

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -23,6 +23,7 @@ from baybe.parameters.selectors import (
     to_parameter_selector,
 )
 from baybe.searchspace.core import SearchSpace
+from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.gaussian_process.components.generic import (
     GPComponentFactoryProtocol,
     GPComponentType,
@@ -45,7 +46,7 @@ else:
 
 
 @define
-class _PureKernelFactory(KernelFactoryProtocol, ABC):
+class _PureKernelFactory(KernelFactoryProtocol, SerialMixin, ABC):
     """Base class for pure kernel factories."""
 
     # For internal use only: sanity check mechanism to remind developers of new

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -155,13 +155,22 @@ def _enable_transfer_learning(
 
     # This distinction is important for serialization so that the classes can be
     # correctly identified by their names in the subclass registry
-    if name is not None:
+    if name is None:
+        # Modify the class in-place (avoids name collision in subclass registry)
+        # -> For the use with `@` syntax, where the original class gets overridden by
+        #    the decorated version, i.e., no references to the original class remain.
+        target_cls = cls
+    else:
         # Create a sibling class so the original class remains unmodified.
         # We use cls.__bases__ (not (cls,)) because the new class is conceptually
         # an equivalent variant, not a specialization. Concrete (non-dunder)
         # attributes are copied so the sibling has the same behavior.
         # __module__ must be set explicitly because the Protocol metaclass
         # would otherwise default it to "abc".
+        # -> For the assignment-based used, i.e.,
+        #   `DecoratedX = enable_transfer_learning(X, name="DecoratedX")`,
+        #    where both the original and decorated versions remain accessible and
+        #    are intended to be used independently.
         ns = {
             k: v
             for k, v in cls.__dict__.items()
@@ -170,9 +179,6 @@ def _enable_transfer_learning(
         ns["__doc__"] = cls.__doc__
         ns["__module__"] = cls.__module__
         target_cls = type(name, cls.__bases__, ns)
-    else:
-        # Modify the class in-place (avoids name collision in subclass registry)
-        target_cls = cls
 
     original_call = cls.__call__
     original_supported_kinds = cls._supported_parameter_kinds

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from functools import partial
@@ -115,6 +116,47 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
         """Construct the kernel."""
 
 
+def _enable_transfer_learning(
+    cls: type[_PureKernelFactory], /
+) -> type[_PureKernelFactory]:
+    """Class decorator enabling BayBE's default transfer learning mechanism.
+
+    When the search space contains a task parameter, the decorated factory
+    automatically composes its kernel with BayBE's default task kernel.
+    Otherwise, the factory behaves unchanged.
+
+    Args:
+        cls: The kernel factory class to decorate.
+
+    Raises:
+        TypeError: If the factory already supports task parameters.
+
+    Returns:
+        The decorated kernel factory class with transfer learning enabled.
+    """
+    if cls._supported_parameter_kinds & _ParameterKind.TASK:
+        raise TypeError(f"'{cls.__name__}' already supports task parameters.")
+
+    # Create a subclass so the original class remains unmodified
+    new_cls = type(cls.__name__, (cls,), {"__doc__": cls.__doc__})
+
+    original_call = cls.__call__
+
+    @functools.wraps(original_call)
+    def __call__(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor):
+        base_kernel = original_call(self, searchspace, train_x, train_y)
+        if searchspace.task_idx is not None:
+            icm = ICMKernelFactory(base_kernel_or_factory=base_kernel)
+            return icm(searchspace, train_x, train_y)
+        return base_kernel
+
+    new_cls.__call__ = __call__  # type: ignore[method-assign]
+    new_cls._supported_parameter_kinds = (
+        cls._supported_parameter_kinds | _ParameterKind.TASK
+    )
+    return new_cls
+
+
 @define
 class _MetaKernelFactory(KernelFactoryProtocol, ABC):
     """Base class for meta kernel factories that orchestrate other kernel factories."""
@@ -150,18 +192,25 @@ class ICMKernelFactory(_MetaKernelFactory):
     @base_kernel_factory.default
     def _default_base_kernel_factory(self) -> KernelFactoryProtocol:
         from baybe.surrogates.gaussian_process.presets.baybe import (
-            BayBENumericalKernelFactory,
+            _BayBENumericalKernelFactory,
         )
 
-        return BayBENumericalKernelFactory(TypeSelector((TaskParameter,), exclude=True))
+        assert (
+            _BayBENumericalKernelFactory._supported_parameter_kinds
+            is _ParameterKind.REGULAR
+        )
+        return _BayBENumericalKernelFactory(
+            TypeSelector((TaskParameter,), exclude=True)
+        )
 
     @task_kernel_factory.default
     def _default_task_kernel_factory(self) -> KernelFactoryProtocol:
         from baybe.surrogates.gaussian_process.presets.baybe import (
-            BayBETaskKernelFactory,
+            _BayBETaskKernelFactory,
         )
 
-        return BayBETaskKernelFactory(TypeSelector((TaskParameter,)))
+        assert _BayBETaskKernelFactory._supported_parameter_kinds is _ParameterKind.TASK
+        return _BayBETaskKernelFactory()
 
     @override
     def __call__(

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -134,11 +134,15 @@ def _enable_transfer_learning(
     automatically composes its kernel with BayBE's default task kernel.
     Otherwise, the factory behaves unchanged.
 
+    When used as a decorator (without ``name``), the class is modified in-place.
+    When called with a ``name`` argument, a new subclass is created so that the
+    original class remains unmodified. The latter form is intended for cases where
+    the original class is reused independently elsewhere.
+
     Args:
         cls: The kernel factory class to decorate.
-        name: Optional name for the created class. Defaults to ``cls.__name__``.
-            Useful when calling the function directly (as opposed to using it as a
-            decorator) and assigning the result to a different name.
+        name: Optional name for the created class. If provided, a new subclass is
+            created instead of modifying ``cls`` in-place.
 
     Raises:
         TypeError: If the factory already supports task parameters.
@@ -149,8 +153,14 @@ def _enable_transfer_learning(
     if cls._supported_parameter_kinds & _ParameterKind.TASK:
         raise TypeError(f"'{cls.__name__}' already supports task parameters.")
 
-    # Create a subclass so the original class remains unmodified
-    new_cls = type(name or cls.__name__, (cls,), {"__doc__": cls.__doc__})
+    # This distinction is important for serialization so that the classes can be
+    # correctly identified by their names in the subclass registry
+    if name is not None:
+        # Create a subclass so the original class remains unmodified
+        target_cls = type(name, (cls,), {"__doc__": cls.__doc__})
+    else:
+        # Modify the class in-place (avoids name collision in subclass registry)
+        target_cls = cls
 
     original_call = cls.__call__
     original_supported_kinds = cls._supported_parameter_kinds
@@ -161,8 +171,8 @@ def _enable_transfer_learning(
         # Temporarily narrow the supported parameter kinds to those of the original
         # class. If the decorator logic is correct, the original factory should never
         # see the extended scope, but this acts as a sanity check to prevent regressions
-        broadened_kinds = new_cls._supported_parameter_kinds
-        new_cls._supported_parameter_kinds = original_supported_kinds
+        broadened_kinds = target_cls._supported_parameter_kinds
+        target_cls._supported_parameter_kinds = original_supported_kinds
 
         # Split off the task parameters
         original_selector = self.parameter_selector
@@ -175,7 +185,7 @@ def _enable_transfer_learning(
         try:
             base_kernel = original_call(self, searchspace, train_x, train_y)
         finally:
-            new_cls._supported_parameter_kinds = broadened_kinds
+            target_cls._supported_parameter_kinds = broadened_kinds
             self.parameter_selector = original_selector
 
         if searchspace.task_idx is not None:
@@ -183,11 +193,11 @@ def _enable_transfer_learning(
             return icm(searchspace, train_x, train_y)
         return base_kernel
 
-    new_cls.__call__ = __call__  # type: ignore[method-assign]
-    new_cls._supported_parameter_kinds = (
+    target_cls.__call__ = __call__  # type: ignore[method-assign]
+    target_cls._supported_parameter_kinds = (
         cls._supported_parameter_kinds | _ParameterKind.TASK
     )
-    return new_cls
+    return target_cls
 
 
 @define

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -176,8 +176,8 @@ def _enable_transfer_learning(
         # Temporarily narrow the supported parameter kinds to those of the original
         # class. If the decorator logic is correct, the original factory should never
         # see the extended scope, but this acts as a sanity check to prevent regressions
-        broadened_kinds = target_cls._supported_parameter_kinds
-        target_cls._supported_parameter_kinds = original_supported_kinds
+        broadened_kinds = target_cls._supported_parameter_kinds  # type: ignore[attr-defined]
+        target_cls._supported_parameter_kinds = original_supported_kinds  # type: ignore[attr-defined]
 
         # Split off the task parameters
         original_selector = self.parameter_selector
@@ -190,7 +190,7 @@ def _enable_transfer_learning(
         try:
             base_kernel = original_call(self, searchspace, train_x, train_y)
         finally:
-            target_cls._supported_parameter_kinds = broadened_kinds
+            target_cls._supported_parameter_kinds = broadened_kinds  # type: ignore[attr-defined]
             self.parameter_selector = original_selector
 
         if searchspace.task_idx is not None:
@@ -199,7 +199,7 @@ def _enable_transfer_learning(
         return base_kernel
 
     target_cls.__call__ = __call__  # type: ignore[method-assign]
-    target_cls._supported_parameter_kinds = (
+    target_cls._supported_parameter_kinds = (  # type: ignore[attr-defined]
         cls._supported_parameter_kinds | _ParameterKind.TASK
     )
     return target_cls

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -186,6 +186,7 @@ def _enable_transfer_learning(
             self.parameter_selector = lambda p: (
                 _task_exclude_selector(p) and original_selector(p)
             )
+
         try:
             base_kernel = original_call(self, searchspace, train_x, train_y)
         finally:

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -76,6 +76,15 @@ class _PureKernelFactory(KernelFactoryProtocol, ABC):
         selector = self.parameter_selector or (lambda _: True)
         return tuple(p.name for p in searchspace.parameters if selector(p))
 
+    def _get_effective_dimensionality(self, searchspace: SearchSpace) -> int:
+        """Get the number of computational columns for the selected parameters."""
+        names = self.get_parameter_names(searchspace)
+        if names is None:
+            return len(searchspace.comp_rep_columns)
+        return sum(
+            len(searchspace.get_comp_rep_parameter_indices(name)) for name in names
+        )
+
     def _validate_parameter_kinds(self, parameters: Iterable[Parameter]) -> None:
         """Validate that the given parameters are supported by the factory.
 
@@ -141,10 +150,31 @@ def _enable_transfer_learning(
     new_cls = type(cls.__name__, (cls,), {"__doc__": cls.__doc__})
 
     original_call = cls.__call__
+    original_supported_kinds = cls._supported_parameter_kinds
+    _task_exclude_selector = TypeSelector((TaskParameter,), exclude=True)
 
     @functools.wraps(original_call)
     def __call__(self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor):
-        base_kernel = original_call(self, searchspace, train_x, train_y)
+        # Temporarily narrow the supported parameter kinds to those of the original
+        # class. If the decorator logic is correct, the original factory should never
+        # see the extended scope, but this acts as a sanity check to prevent regressions
+        broadened_kinds = new_cls._supported_parameter_kinds
+        new_cls._supported_parameter_kinds = original_supported_kinds
+
+        # Split off the task parameters
+        original_selector = self.parameter_selector
+        if original_selector is None:
+            self.parameter_selector = _task_exclude_selector
+        else:
+            self.parameter_selector = lambda p: (
+                _task_exclude_selector(p) and original_selector(p)
+            )
+        try:
+            base_kernel = original_call(self, searchspace, train_x, train_y)
+        finally:
+            new_cls._supported_parameter_kinds = broadened_kinds
+            self.parameter_selector = original_selector
+
         if searchspace.task_idx is not None:
             icm = ICMKernelFactory(base_kernel_or_factory=base_kernel)
             return icm(searchspace, train_x, train_y)

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -189,8 +189,8 @@ def _enable_transfer_learning(
         # Temporarily narrow the supported parameter kinds to those of the original
         # class. If the decorator logic is correct, the original factory should never
         # see the extended scope, but this acts as a sanity check to prevent regressions
-        broadened_kinds = target_cls._supported_parameter_kinds  # type: ignore[attr-defined]
-        target_cls._supported_parameter_kinds = original_supported_kinds  # type: ignore[attr-defined]
+        broadened_kinds = target_cls._supported_parameter_kinds
+        target_cls._supported_parameter_kinds = original_supported_kinds
 
         # Split off the task parameters
         original_selector = self.parameter_selector
@@ -204,7 +204,7 @@ def _enable_transfer_learning(
         try:
             base_kernel = original_call(self, searchspace, train_x, train_y)
         finally:
-            target_cls._supported_parameter_kinds = broadened_kinds  # type: ignore[attr-defined]
+            target_cls._supported_parameter_kinds = broadened_kinds
             self.parameter_selector = original_selector
 
         if searchspace.task_idx is not None:
@@ -213,7 +213,7 @@ def _enable_transfer_learning(
         return base_kernel
 
     target_cls.__call__ = __call__  # type: ignore[method-assign]
-    target_cls._supported_parameter_kinds = (  # type: ignore[attr-defined]
+    target_cls._supported_parameter_kinds = (
         cls._supported_parameter_kinds | _ParameterKind.TASK
     )
     return target_cls

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -33,17 +33,17 @@ if TYPE_CHECKING:
     from torch import Tensor
 
 
-_BayBENumericalKernelFactory = _SmoothedEDBONumericalKernelFactory
-"""The factory providing the default numerical kernel for Gaussian process surrogates."""  # noqa: E501
+class _BayBENumericalKernelFactory(_SmoothedEDBONumericalKernelFactory):
+    """The default numerical kernel factory for GP surrogates."""
 
 
-BayBEKernelFactory = SmoothedEDBOKernelFactory
-"""The default kernel factory for Gaussian process surrogates."""
+class BayBEKernelFactory(SmoothedEDBOKernelFactory):
+    """The default kernel factory for GP surrogates."""
 
 
 @define
 class _BayBETaskKernelFactory(_PureKernelFactory):
-    """The factory providing the default task kernel for Gaussian process surrogates."""
+    """The default task kernel factory for GP surrogates."""
 
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
@@ -68,11 +68,12 @@ class _BayBETaskKernelFactory(_PureKernelFactory):
         )
 
 
-BayBEMeanFactory = LazyConstantMeanFactory
-"""The factory providing the default mean function for Gaussian process surrogates."""
+class BayBEMeanFactory(LazyConstantMeanFactory):
+    """The default mean factory for GP surrogates."""
 
-BayBELikelihoodFactory = SmoothedEDBOLikelihoodFactory
-"""The factory providing the default likelihood for Gaussian process surrogates."""
+
+class BayBELikelihoodFactory(SmoothedEDBOLikelihoodFactory):
+    """The default likelihood factory for GP surrogates."""
 
 
 @define

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -26,38 +26,23 @@ from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFa
 from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
     SmoothedEDBOKernelFactory,
     SmoothedEDBOLikelihoodFactory,
+    _SmoothedEDBONumericalKernelFactory,
 )
 
 if TYPE_CHECKING:
     from torch import Tensor
 
 
-@define
-class BayBEKernelFactory(_PureKernelFactory):
-    """The default kernel factory for Gaussian process surrogates."""
-
-    _supported_parameter_kinds: ClassVar[_ParameterKind] = (
-        _ParameterKind.REGULAR | _ParameterKind.TASK
-    )
-    # See base class.
-
-    @override
-    def _make(
-        self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
-    ) -> Kernel:
-        from baybe.surrogates.gaussian_process.components.kernel import ICMKernelFactory
-
-        is_multitask = searchspace.task_idx is not None
-        factory = ICMKernelFactory if is_multitask else BayBENumericalKernelFactory
-        return factory()(searchspace, train_x, train_y)
-
-
-BayBENumericalKernelFactory = SmoothedEDBOKernelFactory
+_BayBENumericalKernelFactory = _SmoothedEDBONumericalKernelFactory
 """The factory providing the default numerical kernel for Gaussian process surrogates."""  # noqa: E501
 
 
+BayBEKernelFactory = SmoothedEDBOKernelFactory
+"""The default kernel factory for Gaussian process surrogates."""
+
+
 @define
-class BayBETaskKernelFactory(_PureKernelFactory):
+class _BayBETaskKernelFactory(_PureKernelFactory):
     """The factory providing the default task kernel for Gaussian process surrogates."""
 
     _uses_parameter_names: ClassVar[bool] = True

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -37,7 +37,7 @@ class _BayBENumericalKernelFactory(_SmoothedEDBONumericalKernelFactory):
     """The default numerical kernel factory for GP surrogates."""
 
 
-class BayBEKernelFactory(SmoothedEDBOKernelFactory):
+class BayBEKernelFactory(SmoothedEDBOKernelFactory):  # type: ignore[valid-type, misc]
     """The default kernel factory for GP surrogates."""
 
 

--- a/baybe/surrogates/gaussian_process/presets/chen.py
+++ b/baybe/surrogates/gaussian_process/presets/chen.py
@@ -6,22 +6,17 @@ import gc
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-from attrs import define, field
+from attrs import define
 from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
-from baybe.parameters.categorical import TaskParameter
-from baybe.parameters.selectors import (
-    ParameterSelectorProtocol,
-    TypeSelector,
-    to_parameter_selector,
-)
 from baybe.priors.basic import GammaPrior
 from baybe.surrogates.gaussian_process.components.fit_criterion import (
     _MLLForNonTLFitCriterionFactory,
 )
 from baybe.surrogates.gaussian_process.components.kernel import (
+    _enable_transfer_learning,
     _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
@@ -36,18 +31,13 @@ if TYPE_CHECKING:
     from baybe.searchspace.core import SearchSpace
 
 
+@_enable_transfer_learning
 @define
 class CHENKernelFactory(_PureKernelFactory):
     """A factory providing adaptive hyperprior kernels as proposed by :cite:p:`Chen2026`."""  # noqa: E501
 
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
-
-    parameter_selector: ParameterSelectorProtocol | None = field(
-        factory=lambda: TypeSelector([TaskParameter], exclude=True),
-        converter=to_parameter_selector,
-    )
-    # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
     def _make(

--- a/baybe/surrogates/gaussian_process/presets/chen.py
+++ b/baybe/surrogates/gaussian_process/presets/chen.py
@@ -43,7 +43,8 @@ class CHENKernelFactory(_PureKernelFactory):
     def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        lengthscale = 0.4 * math.sqrt(train_x.shape[-1]) + 4.0
+        n_dimensions = self._get_effective_dimensionality(searchspace)
+        lengthscale = 0.4 * math.sqrt(n_dimensions) + 4.0
         lengthscale_prior = GammaPrior(2.0 * lengthscale, 2.0)
         lengthscale_initial_value = lengthscale
         outputscale_prior = GammaPrior(1.0 * lengthscale, 1.0)

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -6,18 +6,13 @@ import gc
 from collections.abc import Collection
 from typing import TYPE_CHECKING, ClassVar
 
-from attrs import define, field
+from attrs import define
 from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
 from baybe.parameters import TaskParameter
 from baybe.parameters.enum import SubstanceEncoding
-from baybe.parameters.selectors import (
-    ParameterSelectorProtocol,
-    TypeSelector,
-    to_parameter_selector,
-)
 from baybe.parameters.substance import SubstanceParameter
 from baybe.priors.basic import GammaPrior
 from baybe.searchspace.discrete import SubspaceDiscrete
@@ -25,6 +20,7 @@ from baybe.surrogates.gaussian_process.components.fit_criterion import (
     _MLLForNonTLFitCriterionFactory,
 )
 from baybe.surrogates.gaussian_process.components.kernel import (
+    _enable_transfer_learning,
     _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
@@ -59,6 +55,7 @@ _EDBO_ENCODINGS = (
 """Encodings relevant to EDBO logic."""
 
 
+@_enable_transfer_learning
 @define
 class EDBOKernelFactory(_PureKernelFactory):
     """A factory providing EDBO kernels, as proposed by :cite:p:`Shields2021`.
@@ -69,12 +66,6 @@ class EDBOKernelFactory(_PureKernelFactory):
 
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
-
-    parameter_selector: ParameterSelectorProtocol | None = field(
-        factory=lambda: TypeSelector([TaskParameter], exclude=True),
-        converter=to_parameter_selector,
-    )
-    # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
     def _make(

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -116,8 +116,8 @@ class EDBOKernelFactory(_PureKernelFactory):
         )
 
 
-EDBOMeanFactory = LazyConstantMeanFactory
-"""A factory providing mean functions for the EDBO preset."""
+class EDBOMeanFactory(LazyConstantMeanFactory):
+    """A factory providing mean functions for the EDBO preset."""
 
 
 @define

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -135,10 +135,10 @@ class EDBOLikelihoodFactory(LikelihoodFactoryProtocol):
         import torch
         from gpytorch.likelihoods import GaussianLikelihood
 
-        effective_dims = sum(
-            len(searchspace.get_comp_rep_parameter_indices(p.name))
-            for p in searchspace.parameters
-            if p._kind & _ParameterKind.REGULAR
+        effective_dims = len(
+            searchspace.get_comp_rep_parameter_indices(
+                lambda p: bool(p._kind & _ParameterKind.REGULAR)
+            )
         )
 
         switching_condition = _contains_encoding(

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -11,8 +11,7 @@ from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
-from baybe.parameters import TaskParameter
-from baybe.parameters.enum import SubstanceEncoding
+from baybe.parameters.enum import SubstanceEncoding, _ParameterKind
 from baybe.parameters.substance import SubstanceParameter
 from baybe.priors.basic import GammaPrior
 from baybe.searchspace.discrete import SubspaceDiscrete
@@ -71,7 +70,7 @@ class EDBOKernelFactory(_PureKernelFactory):
     def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        effective_dims = train_x.shape[-1]
+        effective_dims = self._get_effective_dimensionality(searchspace)
 
         switching_condition = _contains_encoding(
             searchspace.discrete, _EDBO_ENCODINGS
@@ -136,8 +135,10 @@ class EDBOLikelihoodFactory(LikelihoodFactoryProtocol):
         import torch
         from gpytorch.likelihoods import GaussianLikelihood
 
-        effective_dims = train_x.shape[-1] - len(
-            [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
+        effective_dims = sum(
+            len(searchspace.get_comp_rep_parameter_indices(p.name))
+            for p in searchspace.parameters
+            if p._kind & _ParameterKind.REGULAR
         )
 
         switching_condition = _contains_encoding(

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -6,22 +6,18 @@ import gc
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
-from attrs import define, field
+from attrs import define
 from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
 from baybe.parameters import TaskParameter
-from baybe.parameters.selectors import (
-    ParameterSelectorProtocol,
-    TypeSelector,
-    to_parameter_selector,
-)
 from baybe.priors.basic import GammaPrior
 from baybe.surrogates.gaussian_process.components.fit_criterion import (
     _MLLForNonTLFitCriterionFactory,
 )
 from baybe.surrogates.gaussian_process.components.kernel import (
+    _enable_transfer_learning,
     _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.components.likelihood import (
@@ -42,22 +38,11 @@ _DIM_LIMITS = (8, 75)
 
 
 @define
-class SmoothedEDBOKernelFactory(_PureKernelFactory):
-    """A factory providing smoothed versions of EDBO kernels (adapted from :cite:p:`Shields2021`).
-
-    Takes the low and high dimensional limits of
-    :class:`baybe.surrogates.gaussian_process.presets.edbo.EDBOKernelFactory`
-    and interpolates the prior moments linearly in between.
-    """  # noqa: E501
+class _SmoothedEDBONumericalKernelFactory(_PureKernelFactory):
+    """A factory providing the core numerical kernel for the smoothed EDBO preset."""
 
     _uses_parameter_names: ClassVar[bool] = True
     # See base class.
-
-    parameter_selector: ParameterSelectorProtocol | None = field(
-        factory=lambda: TypeSelector([TaskParameter], exclude=True),
-        converter=to_parameter_selector,
-    )
-    # TODO: Reuse base attribute (https://github.com/python-attrs/attrs/pull/1429)
 
     @override
     def _make(
@@ -90,6 +75,16 @@ class SmoothedEDBOKernelFactory(_PureKernelFactory):
             outputscale_initial_value=outputscale_initial_value,
         )
 
+
+SmoothedEDBOKernelFactory = _enable_transfer_learning(
+    _SmoothedEDBONumericalKernelFactory
+)
+"""A factory providing smoothed versions of EDBO kernels (adapted from :cite:p:`Shields2021`).
+
+Takes the low and high dimensional limits of
+:class:`baybe.surrogates.gaussian_process.presets.edbo.EDBOKernelFactory`
+and interpolates the prior moments linearly in between.
+"""  # noqa: E501
 
 SmoothedEDBOMeanFactory = LazyConstantMeanFactory
 """A factory providing mean functions for the smoothed EDBO preset."""

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -77,7 +77,7 @@ class _SmoothedEDBONumericalKernelFactory(_PureKernelFactory):
 
 
 SmoothedEDBOKernelFactory = _enable_transfer_learning(
-    _SmoothedEDBONumericalKernelFactory
+    _SmoothedEDBONumericalKernelFactory, "SmoothedEDBOKernelFactory"
 )
 """A factory providing smoothed versions of EDBO kernels (adapted from :cite:p:`Shields2021`).
 

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -86,8 +86,9 @@ Takes the low and high dimensional limits of
 and interpolates the prior moments linearly in between.
 """  # noqa: E501
 
-SmoothedEDBOMeanFactory = LazyConstantMeanFactory
-"""A factory providing mean functions for the smoothed EDBO preset."""
+
+class SmoothedEDBOMeanFactory(LazyConstantMeanFactory):
+    """A factory providing mean functions for the smoothed EDBO preset."""
 
 
 @define

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 
 from baybe.kernels.basic import MaternKernel
 from baybe.kernels.composite import ScaleKernel
-from baybe.parameters import TaskParameter
+from baybe.parameters.enum import _ParameterKind
 from baybe.priors.basic import GammaPrior
 from baybe.surrogates.gaussian_process.components.fit_criterion import (
     _MLLForNonTLFitCriterionFactory,
@@ -48,7 +48,7 @@ class _SmoothedEDBONumericalKernelFactory(_PureKernelFactory):
     def _make(
         self, searchspace: SearchSpace, train_x: Tensor, train_y: Tensor
     ) -> Kernel:
-        effective_dims = train_x.shape[-1]
+        effective_dims = self._get_effective_dimensionality(searchspace)
 
         # Interpolate prior moments linearly between low D and high D regime.
         # The high D regime itself is the average of the EDBO OHE and Mordred regime.
@@ -109,8 +109,10 @@ class SmoothedEDBOLikelihoodFactory(LikelihoodFactoryProtocol):
         # Interpolate prior moments linearly between low D and high D regime.
         # The high D regime itself is the average of the EDBO OHE and Mordred regime.
         # Values outside the dimension limits will get the border value assigned.
-        effective_dims = train_x.shape[-1] - len(
-            [p for p in searchspace.parameters if isinstance(p, TaskParameter)]
+        effective_dims = sum(
+            len(searchspace.get_comp_rep_parameter_indices(p.name))
+            for p in searchspace.parameters
+            if p._kind & _ParameterKind.REGULAR
         )
 
         prior = GammaPrior(

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -110,10 +110,10 @@ class SmoothedEDBOLikelihoodFactory(LikelihoodFactoryProtocol):
         # Interpolate prior moments linearly between low D and high D regime.
         # The high D regime itself is the average of the EDBO OHE and Mordred regime.
         # Values outside the dimension limits will get the border value assigned.
-        effective_dims = sum(
-            len(searchspace.get_comp_rep_parameter_indices(p.name))
-            for p in searchspace.parameters
-            if p._kind & _ParameterKind.REGULAR
+        effective_dims = len(
+            searchspace.get_comp_rep_parameter_indices(
+                lambda p: bool(p._kind & _ParameterKind.REGULAR)
+            )
         )
 
         prior = GammaPrior(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,8 @@ nitpick_ignore_regex = [
     (r"py:obj", "baybe.utils.boolean.UncertainBool.*"),
     ("py:obj", "baybe.targets.botorch.*"),
     ("py:obj", "baybe.objectives.botorch.*"),
+    ("py:obj", "baybe.serialization.mixin.SupportsRead.read"),
+    ("py:obj", "baybe.serialization.mixin.SupportsWrite.write"),
     ("py:class", "baybe.surrogates.gaussian_process.components.PlainKernelFactory"),
     # Private classes
     (r"py:class", r"baybe\..*\._.*"),

--- a/tests/serialization/test_kernel_factory_serialization.py
+++ b/tests/serialization/test_kernel_factory_serialization.py
@@ -1,0 +1,23 @@
+"""Kernel factory serialization tests."""
+
+import pytest
+
+from baybe.surrogates.gaussian_process.components.kernel import _PureKernelFactory
+from baybe.surrogates.gaussian_process.presets import *  # noqa: F401, F403
+from baybe.utils.basic import get_subclasses
+from tests.serialization.utils import assert_roundtrip_consistency
+
+_KERNEL_FACTORIES = [
+    cls
+    for cls in get_subclasses(_PureKernelFactory)
+    if not cls.__name__.startswith("_")
+]
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [pytest.param(cls(), id=cls.__name__) for cls in _KERNEL_FACTORIES],
+)
+def test_roundtrip(factory):
+    """A serialization roundtrip yields an equivalent object."""
+    assert_roundtrip_consistency(factory)

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -13,16 +13,10 @@ from baybe.parameters.numerical import (
     NumericalDiscreteParameter,
 )
 from baybe.searchspace.core import SearchSpace
-from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.surrogates.gaussian_process.presets.baybe import (
     BayBEKernelFactory,
     _BayBENumericalKernelFactory,
     _BayBETaskKernelFactory,
-)
-from baybe.surrogates.gaussian_process.presets.chen import CHENKernelFactory
-from baybe.surrogates.gaussian_process.presets.edbo import EDBOKernelFactory
-from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
-    SmoothedEDBOKernelFactory,
 )
 
 # A selector that accepts all parameters
@@ -79,21 +73,3 @@ def test_factory_parameter_kind_validation(factory, parameters, error):
         else pytest.raises(error, match="does not support")
     ):
         factory(ss, train_x, train_y)
-
-
-@pytest.mark.parametrize(
-    "factory",
-    [
-        param(BayBEKernelFactory(), id="BayBEKernelFactory"),
-        param(SmoothedEDBOKernelFactory(), id="SmoothedEDBOKernelFactory"),
-        param(EDBOKernelFactory(), id="EDBOKernelFactory"),
-        param(CHENKernelFactory(), id="CHENKernelFactory"),
-    ],
-)
-def test_kernel_factory_serialization_roundtrip(factory):
-    """Kernel factories survive a serialization roundtrip via a GP surrogate."""
-    gp = GaussianProcessSurrogate(kernel_or_factory=factory)
-    json_str = gp.to_json()
-    gp_roundtrip = GaussianProcessSurrogate.from_json(json_str)
-    assert type(gp.kernel_factory) is type(gp_roundtrip.kernel_factory)
-    assert gp == gp_roundtrip

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -15,8 +15,8 @@ from baybe.parameters.numerical import (
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.gaussian_process.presets.baybe import (
     BayBEKernelFactory,
-    BayBENumericalKernelFactory,
-    BayBETaskKernelFactory,
+    _BayBENumericalKernelFactory,
+    _BayBETaskKernelFactory,
 )
 
 # A selector that accepts all parameters
@@ -27,25 +27,25 @@ _SELECT_ALL = lambda parameter: True  # noqa: E731
     ("factory", "parameters", "error"),
     [
         param(
-            BayBENumericalKernelFactory(parameter_selector=_SELECT_ALL),
+            _BayBENumericalKernelFactory(parameter_selector=_SELECT_ALL),
             [TaskParameter("task", ["t1", "t2"])],
             IncompatibleSearchSpaceError,
             id="regular_rejects_task",
         ),
         param(
-            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            _BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
             [CategoricalParameter("cat", ["a", "b"])],
             IncompatibleSearchSpaceError,
             id="task_rejects_categorical",
         ),
         param(
-            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            _BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
             [NumericalDiscreteParameter("num", [1, 2, 3])],
             IncompatibleSearchSpaceError,
             id="task_rejects_numerical_discrete",
         ),
         param(
-            BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
+            _BayBETaskKernelFactory(parameter_selector=_SELECT_ALL),
             [NumericalContinuousParameter("cont", (0, 1))],
             IncompatibleSearchSpaceError,
             id="task_rejects_numerical_continuous",

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -13,10 +13,16 @@ from baybe.parameters.numerical import (
     NumericalDiscreteParameter,
 )
 from baybe.searchspace.core import SearchSpace
+from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.surrogates.gaussian_process.presets.baybe import (
     BayBEKernelFactory,
     _BayBENumericalKernelFactory,
     _BayBETaskKernelFactory,
+)
+from baybe.surrogates.gaussian_process.presets.chen import CHENKernelFactory
+from baybe.surrogates.gaussian_process.presets.edbo import EDBOKernelFactory
+from baybe.surrogates.gaussian_process.presets.edbo_smoothed import (
+    SmoothedEDBOKernelFactory,
 )
 
 # A selector that accepts all parameters
@@ -73,3 +79,21 @@ def test_factory_parameter_kind_validation(factory, parameters, error):
         else pytest.raises(error, match="does not support")
     ):
         factory(ss, train_x, train_y)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        param(BayBEKernelFactory(), id="BayBEKernelFactory"),
+        param(SmoothedEDBOKernelFactory(), id="SmoothedEDBOKernelFactory"),
+        param(EDBOKernelFactory(), id="EDBOKernelFactory"),
+        param(CHENKernelFactory(), id="CHENKernelFactory"),
+    ],
+)
+def test_kernel_factory_serialization_roundtrip(factory):
+    """Kernel factories survive a serialization roundtrip via a GP surrogate."""
+    gp = GaussianProcessSurrogate(kernel_or_factory=factory)
+    json_str = gp.to_json()
+    gp_roundtrip = GaussianProcessSurrogate.from_json(json_str)
+    assert type(gp.kernel_factory) is type(gp_roundtrip.kernel_factory)
+    assert gp == gp_roundtrip


### PR DESCRIPTION
DevPR, parent is https://github.com/emdgroup/baybe/pull/745

Last piece to the puzzle:
Presets (i.e. papers, packages, etc) can dictate certain aspects of the GP model while not saying anything about other aspects. For example, both EDBO and CHEN focus on the kernel priors but don't even consider transfer learning at all. This is a general issue, and can also cover other things like multi-fidelity etc. 

For these cases, we want to follow the approach `if not defined, use BayBE default mechanism/setting`. However, this requires to abstract these settings/mechanism into reusable structures. This PR takes care of this step for transfer learning (which is currently the only mechanism that needs to be ported) in the form of a class decorator. Because other mechanisms will follow in the future and their extent isn't yet fully clear (e.g. multi-fidelity or transfer learning via mean injection), we keep this decorator private for now. A possible future extension of the decorator could have the form `@enable_mechanism(transfer_learning=True, multi_fidelity=True)` that then accepts any existing GP component and makes the necessary adjustments.

### Technical Details

The decorator supports two application modes to avoid name collisions in the subclass registry (used for serialization/deserialization):

1. `@` syntax (`@_enable_transfer_learning`): The decorated version replaces the original class entirely, so no two references coexist. The class is modified in-place, preserving its registry name.

2. Assignment syntax (`DecoratedX = _enable_transfer_learning(X, name="DecoratedX")`): Both the original and the decorated class must remain accessible and independently usable. A sibling class is created so both variants can coexist in the registry under distinct names.