### PR TITLE
Enable Pandas 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for Python 3.14
+- Support for pandas 3
 - `Settings` class for unified and streamlined settings management
 - Settings options to (de-)activate recommendation caching / dataframe preprocessing
 - Settings option for random seed control
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Polars path in discrete search space construction now builds the Cartesian product
   only for parameters involved in Polars-capable constraints, merging the rest
   incrementally via pandas
+- Minimum required pandas version increased to `2.1.0`
 
 ### Removed
 - `parallel_runs` argument from `simulate_scenarios`, since parallelization

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -289,7 +289,7 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
                 censored_df[affected_param] = [
                     (None if inv else val, dep)
                     for val, dep, inv in zip(
-                        df[affected_param], censored_df[param], invalid
+                        censored_df[affected_param], censored_df[param], invalid
                     )
                 ]
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -24,7 +24,6 @@ from baybe.serialization import (
     block_serialization_hook,
     converter,
 )
-from baybe.utils.basic import Dummy
 
 if TYPE_CHECKING:
     import polars as pl
@@ -277,25 +276,22 @@ class DiscreteDependenciesConstraint(DiscreteConstraint):
 
     @override
     def _get_invalid(self, df: pd.DataFrame, /) -> pd.Index:
-        # Create df copy and mark entries where the dependency conditions are negative
-        # with a dummy value to cause degeneracy.
+        # Build an invariant indicator for each affected parameter: pair each value
+        # with the value of the parameter it depends on. For rows where the dependency
+        # condition is not met, use None as a sentinel so that all such rows with the
+        # same dependency value appear identical, causing them to be detected as
+        # duplicates. The indicator tuples are constructed directly without storing
+        # any intermediate sentinel in the typed columns.
         censored_df = df.copy()
-        for k, _ in enumerate(self.parameters):
-            # .loc assignments are not supported by mypy + pandas-stubs yet
-            # See https://github.com/pandas-dev/pandas-stubs/issues/572
-            censored_df.loc[  # type: ignore[call-overload]
-                ~self.conditions[k].evaluate(df[self.parameters[k]]),
-                self.affected_parameters[k],
-            ] = Dummy()
-
-        # Create an invariant indicator: pair each value of an affected parameter with
-        # the corresponding value of the parameter it depends on. These indicators
-        # will become invariant when frozenset is applied to them.
         for k, param in enumerate(self.parameters):
+            invalid = ~self.conditions[k].evaluate(df[self.parameters[k]])
             for affected_param in self.affected_parameters[k]:
-                censored_df[affected_param] = list(
-                    zip(censored_df[affected_param], censored_df[param])
-                )
+                censored_df[affected_param] = [
+                    (None if inv else val, dep)
+                    for val, dep, inv in zip(
+                        df[affected_param], censored_df[param], invalid
+                    )
+                ]
 
         # Merge the invariant indicator with all other parameters (i.e. neither the
         # affected nor the dependency-causing ones) and detect duplicates in that space.

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -368,7 +368,7 @@ class BotorchRecommender(BayesianRecommender):
         #   For details: https://github.com/pytorch/botorch/issues/2042
         points, acqf_values = optimize_acqf(
             acq_function=self._botorch_acqf,
-            bounds=torch.from_numpy(subspace_continuous.comp_rep_bounds.values),
+            bounds=torch.tensor(subspace_continuous.comp_rep_bounds.to_numpy()),
             q=batch_size,
             num_restarts=self.n_restarts,
             raw_samples=self.n_raw_samples,
@@ -471,7 +471,7 @@ class BotorchRecommender(BayesianRecommender):
         #   For details: https://github.com/pytorch/botorch/issues/2042
         points, _ = optimize_acqf_mixed(
             acq_function=self._botorch_acqf,
-            bounds=torch.from_numpy(searchspace.comp_rep_bounds.values),
+            bounds=torch.tensor(searchspace.comp_rep_bounds.to_numpy()),
             q=batch_size,
             num_restarts=self.n_restarts,
             raw_samples=self.n_raw_samples,

--- a/baybe/recommenders/pure/bayesian/botorch.py
+++ b/baybe/recommenders/pure/bayesian/botorch.py
@@ -368,7 +368,9 @@ class BotorchRecommender(BayesianRecommender):
         #   For details: https://github.com/pytorch/botorch/issues/2042
         points, acqf_values = optimize_acqf(
             acq_function=self._botorch_acqf,
-            bounds=torch.tensor(subspace_continuous.comp_rep_bounds.to_numpy()),
+            bounds=torch.from_numpy(
+                subspace_continuous.comp_rep_bounds.to_numpy(copy=True)
+            ),
             q=batch_size,
             num_restarts=self.n_restarts,
             raw_samples=self.n_raw_samples,
@@ -471,7 +473,7 @@ class BotorchRecommender(BayesianRecommender):
         #   For details: https://github.com/pytorch/botorch/issues/2042
         points, _ = optimize_acqf_mixed(
             acq_function=self._botorch_acqf,
-            bounds=torch.tensor(searchspace.comp_rep_bounds.to_numpy()),
+            bounds=torch.from_numpy(searchspace.comp_rep_bounds.to_numpy(copy=True)),
             q=batch_size,
             num_restarts=self.n_restarts,
             raw_samples=self.n_raw_samples,

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -479,10 +479,12 @@ class SubspaceContinuous(SerialMixin):
             return pd.DataFrame(index=pd.RangeIndex(0, batch_size))
 
         if not self.is_constrained:
-            return self._sample_from_bounds(batch_size, self.comp_rep_bounds.values)
+            return self._sample_from_bounds(batch_size, self.comp_rep_bounds.to_numpy())
 
         if len(self.constraints_cardinality) == 0:
-            return self._sample_from_polytope(batch_size, self.comp_rep_bounds.values)
+            return self._sample_from_polytope(
+                batch_size, self.comp_rep_bounds.to_numpy()
+            )
 
         return self._sample_from_polytope_with_cardinality_constraints(batch_size)
 
@@ -501,6 +503,9 @@ class SubspaceContinuous(SerialMixin):
         import torch
         from botorch.utils.sampling import get_polytope_samples
 
+        # pandas 3 with Copy-on-Write may pass a read-only array; copy only if needed
+        if not bounds.flags.writeable:
+            bounds = bounds.copy()
         bounds_tensor = torch.from_numpy(bounds)
         if not self.has_interpoint_constraints:
             points = get_polytope_samples(

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -67,7 +67,7 @@ class _ModelContext:
         """Get the search space parameter bounds in BoTorch Format."""
         import torch
 
-        return torch.tensor(self.searchspace.scaling_bounds.to_numpy())
+        return torch.from_numpy(self.searchspace.scaling_bounds.to_numpy(copy=True))
 
     def get_numerical_indices(self, n_inputs: int) -> tuple[int, ...]:
         """Get the indices of the regular numerical model inputs."""

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -67,7 +67,7 @@ class _ModelContext:
         """Get the search space parameter bounds in BoTorch Format."""
         import torch
 
-        return torch.from_numpy(self.searchspace.scaling_bounds.values)
+        return torch.tensor(self.searchspace.scaling_bounds.to_numpy())
 
     def get_numerical_indices(self, n_inputs: int) -> tuple[int, ...]:
         """Get the indices of the regular numerical model inputs."""

--- a/baybe/utils/basic.py
+++ b/baybe/utils/basic.py
@@ -7,7 +7,6 @@ import functools
 import inspect
 import itertools
 from collections.abc import Callable, Collection, Iterable, Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeGuard, TypeVar
 
 import cattrs
@@ -40,19 +39,6 @@ class UnspecifiedType(enum.Enum):
 
 UNSPECIFIED = UnspecifiedType.UNSPECIFIED
 """Sentinel indicating an unspecified value when `None` is ambiguous."""
-
-
-@dataclass(frozen=True, repr=False)
-class Dummy:
-    """Placeholder element for array-like data types.
-
-    Useful e.g. for detecting duplicates in constraints.
-    """
-
-    @override
-    def __repr__(self):
-        """Return a representation of the placeholder."""
-        return "<dummy>"
 
 
 def is_all_instance(

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -261,9 +261,7 @@ def df_drop_string_columns(
         The cleaned dataframe.
     """
     ignore_list = ignore_list or []
-    # applymap was removed in pandas 3.0; map() is the replacement (added in 2.1)
-    _df_map = df.map if hasattr(df, "map") else df.applymap
-    no_string = ~_df_map(lambda x: isinstance(x, str)).any()
+    no_string = ~df.map(lambda x: isinstance(x, str)).any()
     no_string = no_string[no_string].index
     to_keep = set(no_string).union(set(ignore_list))
     ordered_cols = [col for col in df if col in to_keep]

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -255,7 +255,9 @@ def df_drop_string_columns(
         The cleaned dataframe.
     """
     ignore_list = ignore_list or []
-    no_string = ~df.applymap(lambda x: isinstance(x, str)).any()
+    # applymap was removed in pandas 3.0; map() is the replacement (added in 2.1)
+    _df_map = getattr(df, "map", df.applymap)
+    no_string = ~_df_map(lambda x: isinstance(x, str)).any()
     no_string = no_string[no_string].index
     to_keep = set(no_string).union(set(ignore_list))
     ordered_cols = [col for col in df if col in to_keep]

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -262,7 +262,7 @@ def df_drop_string_columns(
     """
     ignore_list = ignore_list or []
     # applymap was removed in pandas 3.0; map() is the replacement (added in 2.1)
-    _df_map = getattr(df, "map", df.applymap)
+    _df_map = df.map if hasattr(df, "map") else df.applymap
     no_string = ~_df_map(lambda x: isinstance(x, str)).any()
     no_string = no_string[no_string].index
     to_keep = set(no_string).union(set(ignore_list))

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -421,12 +421,16 @@ def fuzzy_row_match(
     for col in cat_cols:
         # Per categorical parameter, this identifies matches between all elements of
         # left and right and stores them in a matrix.
-        match_matrix &= right_df[col].values[:, None] == left_df[col].values[None, :]
+        match_matrix &= (
+            np.asarray(right_df[col])[:, None] == np.asarray(left_df[col])[None, :]
+        )
 
     # Match numerical parameters
     for col in num_cols:
         # Compute absolute differences and find the minimum difference
-        abs_diff = np.abs(right_df[col].values[:, None] - left_df[col].values[None, :])
+        abs_diff = np.abs(
+            np.asarray(right_df[col])[:, None] - np.asarray(left_df[col])[None, :]
+        )
         min_diff = abs_diff.min(axis=1, keepdims=True)
         match_matrix &= abs_diff == min_diff
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -61,6 +61,9 @@ def to_tensor(*x: _ConvertibleToTensor) -> Tensor | tuple[Tensor, ...]:
                 # tensors with negative strides are not supported by PyTorch
                 fix_strides = any(s < 0 for s in x.strides)
                 x = x.astype(numpy_dtype, copy=fix_strides)
+                # Copy if read-only (possible under pandas 3 Copy-on-Write)
+                if not x.flags.writeable:
+                    x = x.copy()
                 tensor = torch.from_numpy(x)
             case pd.Series() | pd.DataFrame():
                 # We already coerce to the target dtype during the dataframe-to-numpy
@@ -72,6 +75,9 @@ def to_tensor(*x: _ConvertibleToTensor) -> Tensor | tuple[Tensor, ...]:
                 # tensors with negative strides are not supported by PyTorch
                 fix_strides = any(s < 0 for s in x.to_numpy().strides)
                 array = x.to_numpy(numpy_dtype, copy=fix_strides)
+                # Copy if read-only (possible under pandas 3 Copy-on-Write)
+                if not array.flags.writeable:
+                    array = array.copy()
                 tensor = torch.from_numpy(array)
             case _:
                 assert_never(x)
@@ -695,6 +701,9 @@ def arrays_to_dataframes(
             if use_torch:
                 import torch
 
+                # Copy if read-only (possible under pandas 3 Copy-on-Write)
+                if not array_in.flags.writeable:
+                    array_in = array_in.copy()
                 with torch.no_grad():
                     array_out = fn(torch.from_numpy(array_in)).numpy()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "gpytorch>=1.9.1,<2",
     "joblib>1.4.0,<2",
     "numpy>=1.24.1,<3",
-    "pandas>=1.4.2,<3",
+    "pandas>=1.4.2,<4",
     "scikit-learn>=1.1.1,<2",
     "scipy>=1.10.1",
     "torch>=1.13.1,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "gpytorch>=1.9.1,<2",
     "joblib>1.4.0,<2",
     "numpy>=1.24.1,<3",
-    "pandas>=1.4.2,<4",
+    "pandas>=2.1.0,<4",
     "scikit-learn>=1.1.1,<2",
     "scipy>=1.10.1",
     "torch>=1.13.1,<3",

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,8 +30,6 @@ filterwarnings =
     ignore:.*invalid escape sequence.*:DeprecationWarning
     ; https://github.com/meta-pytorch/botorch/pull/3279
     ignore:chol argument to CholLinearOperator should be a TriangularLinearOperator.*:DeprecationWarning:linear_operator.operators.chol_linear_operator
-    ; Needs proper fix for pandas 3.0 compatibility
-    ignore:Setting an item of incompatible dtype is deprecated:FutureWarning:baybe.constraints.discrete
     ; https://github.com/shap/shap/issues/4280 (fixed in shap>=0.51.0, but only available for Python 3.11+)
     ignore:Conversion of an array with ndim > 0 to a scalar is deprecated:DeprecationWarning:shap.explainers.other._maple
 

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -197,7 +197,7 @@ def custom_parameters(draw: st.DrawFn):
     name = draw(parameter_names)
     data = draw(custom_descriptors())
     decorrelate = draw(decorrelations)
-    active_values = draw(_active_values(data.index.values))
+    active_values = draw(_active_values(list(data.index)))
     param_metadata = draw(measurable_metadata())
     return CustomDiscreteParameter(
         name=name,

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,7 +1,5 @@
 """Tests for basic input-output and iterative loop."""
 
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -34,10 +32,9 @@ from baybe.utils.dataframe import add_fake_measurements
 def test_bad_parameter_input_value(campaign, bad_val, fake_measurements):
     """Test attempting to read in an invalid parameter value."""
     col = campaign.parameters[0].name
-    with warnings.catch_warnings():
-        # Suppress FutureWarning from deliberately assigning invalid dtypes
-        warnings.simplefilter("ignore", FutureWarning)
-        fake_measurements.loc[fake_measurements.index[0], col] = bad_val
+    # Ensure assignment succeeds in pandas 3 where incompatible dtypes raise
+    fake_measurements[col] = fake_measurements[col].astype(object)
+    fake_measurements.loc[fake_measurements.index[0], col] = bad_val
     with pytest.raises((ValueError, TypeError)):
         campaign.add_measurements(fake_measurements)
 
@@ -56,10 +53,9 @@ def test_bad_target_input_value(campaign, bad_val):
     add_fake_measurements(rec, campaign.targets)
 
     col = campaign.targets[0].name
-    with warnings.catch_warnings():
-        # Suppress FutureWarning from deliberately assigning invalid dtypes
-        warnings.simplefilter("ignore", FutureWarning)
-        rec.loc[rec.index[0], col] = bad_val
+    # Ensure assignment succeeds in pandas 3 where incompatible dtypes raise
+    rec[col] = rec[col].astype(object)
+    rec.loc[rec.index[0], col] = bad_val
     with pytest.raises((ValueError, TypeError)):
         campaign.add_measurements(rec)
 

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.15.1" },
     { name = "onnxruntime", marker = "python_full_version < '3.11' and extra == 'onnx'", specifier = ">=1.15.1,<1.24" },
     { name = "openpyxl", marker = "extra == 'examples'", specifier = ">=3.0.9" },
-    { name = "pandas", specifier = ">=1.4.2,<3" },
+    { name = "pandas", specifier = ">=1.4.2,<4" },
     { name = "pandas-stubs", marker = "extra == 'mypy'", specifier = ">=2.2.2.240603" },
     { name = "pillow", marker = "extra == 'examples'", specifier = ">=10.0.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.5.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-20T18:46:58.35845Z"
+exclude-newer = "2026-05-22T09:27:47.33792Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -436,7 +436,7 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.15.1" },
     { name = "onnxruntime", marker = "python_full_version < '3.11' and extra == 'onnx'", specifier = ">=1.15.1,<1.24" },
     { name = "openpyxl", marker = "extra == 'examples'", specifier = ">=3.0.9" },
-    { name = "pandas", specifier = ">=1.4.2,<4" },
+    { name = "pandas", specifier = ">=2.1.0,<4" },
     { name = "pandas-stubs", marker = "extra == 'mypy'", specifier = ">=2.2.2.240603" },
     { name = "pillow", marker = "extra == 'examples'", specifier = ">=10.0.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.5.5" },


### PR DESCRIPTION
Main changes explained:
- pandas 3 now uses `Copy on Write` (CoW) which can cause trouble in some code parts, mostly where we used `df.values` before by causing torch warnings about undefined behavior on read-only arrays. I've generally followed different approaches depending on the context:
  - where we previously used `torch.from_numpy(df.values)` or similar, we cant do this any longer because `values` might be read-only. In places where the array is definitely small (eg when talking about bounds) I am using now `df.to_numpy(copy=True)` as it always ensures a copy and thus writeability
  - other places deal with potentially large arrays. Here I am reading out this pattern `if not array.flags.writeable: array = array.copy()`
- `df.values` apparently can now also return something of type `ArrowStringArray` (eg for strings). This cannot be handled in some downsteam parts etc, so it is converted (eg to list) where needed
- The `Dummy` class that was used in the invariance constraint was remove and a different approach that uses `None` as sentinel is used now

Pandas 3 is only supported for Python 3.11+ so the 3.10 test serves as a verification that everything (still) works in Pandas 2