### PR TITLE
Lock docs pipeline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ setenv =
     SMOKE_TEST = true
 commands =
     python --version
-    uv run --extra docs docs/scripts/build_documentation.py {posargs}
+    uv run --locked --extra docs docs/scripts/build_documentation.py {posargs}
 
 [testenv:docs-quickbuild]
 description = Force-build documentation, ignoring links and examples
@@ -102,4 +102,4 @@ setenv =
     SMOKE_TEST = true
 commands = 
     python --version
-    uv run --extra docs docs/scripts/build_documentation.py -f -l
+    uv run --locked --extra docs docs/scripts/build_documentation.py -f -l


### PR DESCRIPTION
Enforce lockfile consistency in the docs tox pipeline by passing `--locked` to `uv run`, preventing silent use of stale dependency pins.