### PR TITLE
Sigstore attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          attestations: true
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
@@ -95,3 +96,5 @@ jobs:
           path: dist
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
Adds Sigstore attestations to PyPI releases, enabling users to cryptographically verify that published packages were built directly from the repository's CI pipeline.