### PR TITLE
Use `PositiveIndexKernel` as default transfer learning kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   equality check
 
 ### Changed
+- Default transfer learning kernel changed from `IndexKernel` to `PositiveIndexKernel`,
+  enforcing positive task correlations
 - The `Campaign.allow_*` flag mechanism is now based on `AutoBool` logic, providing
   well-defined Boolean values at query time while exposing the `AUTO` option to the user
 - Discrete search space construction now applies constraints incrementally during

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -105,12 +105,9 @@ class Kernel(ABC, SerialMixin):
     ) -> tuple[tuple[int, ...] | None, int | None]:
         """Get the active dimensions and the number of ARD dimensions."""
 
+    @property
     def _extra_gpytorch_kwargs(self) -> dict[str, Any]:
-        """Extra keyword arguments injected into the gpytorch kernel constructor.
-
-        Returns:
-            A dictionary of keyword arguments.
-        """
+        """Extra keyword arguments injected into the gpytorch kernel constructor."""
         return {}
 
     def to_gpytorch(self, searchspace: SearchSpace):
@@ -175,7 +172,7 @@ class Kernel(ABC, SerialMixin):
         kernel_attrs.update(prior_dict)
         gpytorch_kernel = kernel_cls(
             **kernel_attrs,
-            **self._extra_gpytorch_kwargs(),
+            **self._extra_gpytorch_kwargs,
             ard_num_dims=ard_num_dims,
             active_dims=active_dims,
         )

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -105,6 +105,14 @@ class Kernel(ABC, SerialMixin):
     ) -> tuple[tuple[int, ...] | None, int | None]:
         """Get the active dimensions and the number of ARD dimensions."""
 
+    def _extra_gpytorch_kwargs(self) -> dict[str, Any]:
+        """Extra keyword arguments injected into the gpytorch kernel constructor.
+
+        Returns:
+            A dictionary of keyword arguments.
+        """
+        return {}
+
     def to_gpytorch(self, searchspace: SearchSpace):
         """Create the gpytorch representation of the kernel."""
         import gpytorch.kernels
@@ -166,7 +174,10 @@ class Kernel(ABC, SerialMixin):
         kernel_attrs.update(kernel_dict)
         kernel_attrs.update(prior_dict)
         gpytorch_kernel = kernel_cls(
-            **kernel_attrs, ard_num_dims=ard_num_dims, active_dims=active_dims
+            **kernel_attrs,
+            **self._extra_gpytorch_kwargs(),
+            ard_num_dims=ard_num_dims,
+            active_dims=active_dims,
         )
 
         # If the kernel has a lengthscale, set its initial value

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -1,6 +1,7 @@
 """Collection of basic kernels."""
 
 import gc
+from typing import Any
 
 from attrs import define, field
 from attrs.converters import optional as optional_c
@@ -236,7 +237,15 @@ class IndexKernel(BasicKernel):
 
 @define(frozen=True)
 class PositiveIndexKernel(IndexKernel):
-    """A positive index kernel for transfer learning across tasks."""
+    """A positive index kernel for transfer learning across tasks.
+
+    Enforces strictly positive correlations between tasks. BayBE always
+    disables botorch's target-task normalization.
+    """
+
+    @override
+    def _extra_gpytorch_kwargs(self) -> dict[str, Any]:
+        return {"unit_scale_for_target": False}
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -239,8 +239,7 @@ class IndexKernel(BasicKernel):
 class PositiveIndexKernel(IndexKernel):
     """A positive index kernel for transfer learning across tasks.
 
-    Enforces strictly positive correlations between tasks. BayBE always
-    disables botorch's target-task normalization.
+    Enforces strictly positive correlations between tasks.
     """
 
     @override

--- a/baybe/kernels/basic.py
+++ b/baybe/kernels/basic.py
@@ -244,6 +244,7 @@ class PositiveIndexKernel(IndexKernel):
     """
 
     @override
+    @property
     def _extra_gpytorch_kwargs(self) -> dict[str, Any]:
         return {"unit_scale_for_target": False}
 

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -9,7 +9,7 @@ from attrs import define, field
 from typing_extensions import override
 
 from baybe.kernels.base import Kernel
-from baybe.kernels.basic import IndexKernel
+from baybe.kernels.basic import PositiveIndexKernel
 from baybe.objectives.base import Objective
 from baybe.parameters.categorical import TaskParameter
 from baybe.parameters.enum import _ParameterKind
@@ -60,7 +60,7 @@ class _BayBETaskKernelFactory(_PureKernelFactory):
     def _make(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel:
-        return IndexKernel(
+        return PositiveIndexKernel(
             num_tasks=searchspace.n_tasks,
             rank=searchspace.n_tasks,
             parameter_names=self.get_parameter_names(searchspace),

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -135,6 +135,14 @@ def validate_gpytorch_kernel_components(  # noqa: DOC501
         else:
             assert component == mapped_component
 
+    # Validate extra kwargs injected via the _extra_gpytorch_kwargs hook
+    if isinstance(obj, Kernel):
+        for name, value in obj._extra_gpytorch_kwargs().items():
+            mapped_value = getattr(mapped, name, None)
+            assert mapped_value == value, (
+                f"Extra gpytorch kwarg '{name}' expected {value}, got {mapped_value}"
+            )
+
 
 @given(kernels())
 def test_kernel_assembly(kernel: Kernel):

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -137,7 +137,7 @@ def validate_gpytorch_kernel_components(  # noqa: DOC501
 
     # Validate extra kwargs injected via the _extra_gpytorch_kwargs hook
     if isinstance(obj, Kernel):
-        for name, value in obj._extra_gpytorch_kwargs().items():
+        for name, value in obj._extra_gpytorch_kwargs.items():
             mapped_value = getattr(mapped, name, None)
             assert mapped_value == value, (
                 f"Extra gpytorch kwarg '{name}' expected {value}, got {mapped_value}"


### PR DESCRIPTION
  - Add `_extra_gpytorch_kwargs` hook to Kernel base class for injecting hardcoded constructor arguments (without exposing them as attrs fields)
  - Set `unit_scale_for_target=False` via hook in `PositiveIndexKernel` to disable botorch's target-task normalization (this way `PositiveIndexKernel` can work with an arbitrary number of tasks)
  - Switch `BayBETaskKernelFactory` from `IndexKernel` to `PositiveIndexKernel`
  - Extend `validate_gpytorch_kernel_components` to verify extra kwargs