### PR TITLE
Fix Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,4 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "quarterly"
     cooldown:
       default-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
- Remove unsupported `semver-major/minor/patch-days` sub-keys, which are not applicable to the github-actions ecosystem (actions don't use SemVer)
- Increase default-days from 7 to 14 to provide a longer stabilization window against potential supply chain attacks
- Group updates into a single PR