### PR TITLE
Include `__call__` function as `special-member` in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,10 +8,23 @@ import os
 import shutil
 
 from gpytorch.kernels import Kernel as GPyTorchKernel
+from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
+from gpytorch.means import Mean as GPyTorchMean
 
 from baybe.surrogates.gaussian_process.components import kernel as _kernel
+from baybe.surrogates.gaussian_process.components import likelihood as _likelihood
+from baybe.surrogates.gaussian_process.components import mean as _mean
+from baybe.surrogates.gaussian_process.presets import botorch as _botorch
+from baybe.surrogates.gaussian_process.presets import edbo as _edbo
+from baybe.surrogates.gaussian_process.presets import edbo_smoothed as _edbo_smoothed
 
 _kernel.GPyTorchKernel = GPyTorchKernel
+_likelihood.GPyTorchLikelihood = GPyTorchLikelihood
+_mean.GPyTorchMean = GPyTorchMean
+_botorch.GPyTorchLikelihood = GPyTorchLikelihood
+_botorch.GPyTorchMean = GPyTorchMean
+_edbo.GPyTorchLikelihood = GPyTorchLikelihood
+_edbo_smoothed.GPyTorchLikelihood = GPyTorchLikelihood
 
 # -- Path setup --------------------------------------------------------------
 
@@ -276,7 +289,12 @@ html_theme_options = {
     "dark_logo": "logo1.svg",  # Logo for dark mode
 }
 
-autodoc_type_aliases = {"Smiles": "Smiles"}
+autodoc_type_aliases = {
+    "GPyTorchKernel": "GPyTorchKernel",
+    "GPyTorchLikelihood": "GPyTorchLikelihood",
+    "GPyTorchMean": "GPyTorchMean",
+    "Smiles": "Smiles",
+}
 
 # Everything in the module has the prefix baybe
 modindex_common_prefix = ["baybe."]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,15 @@ from gpytorch.kernels import Kernel as GPyTorchKernel
 from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
 from gpytorch.means import Mean as GPyTorchMean
 
+# >>>>>>>>>> NOTE ON THE FOLLOWING IMPORTS AND ALIASES <<<<<<<<<<
+# This is a hack to make the GPyTorch components available in the docs
+# Without those specific imports, the corresponding references cannot be resolved.
+# As a consequence, the __call__ functions that the factories use would not be part
+# of the documentation. Having those explicit imports here are the only solution
+# that two members of the core team were able to find, and it was agreed that even
+# though not pretty, it is the best solution to this problem.
+# If future implementations of the corresponding factories rely on different imports
+# not listed here, this will be flagged by the docs pipeline.
 from baybe.surrogates.gaussian_process.components import kernel as _kernel
 from baybe.surrogates.gaussian_process.components import likelihood as _likelihood
 from baybe.surrogates.gaussian_process.components import mean as _mean
@@ -25,6 +34,19 @@ _botorch.GPyTorchLikelihood = GPyTorchLikelihood
 _botorch.GPyTorchMean = GPyTorchMean
 _edbo.GPyTorchLikelihood = GPyTorchLikelihood
 _edbo_smoothed.GPyTorchLikelihood = GPyTorchLikelihood
+
+# It is also necessary to add those aliases here, otherwise the references in the
+# documentation resolve to the original name of the classes, i.e., we would have the
+# type hint `Kernel | Kernel` instead of `Kernel | GPyTorchKernel`.
+
+autodoc_type_aliases = {
+    "GPyTorchKernel": "GPyTorchKernel",
+    "GPyTorchLikelihood": "GPyTorchLikelihood",
+    "GPyTorchMean": "GPyTorchMean",
+    "Smiles": "Smiles",
+}
+
+# >>>>>>>>>> NOTE END <<<<<<<<<<
 
 # -- Path setup --------------------------------------------------------------
 
@@ -289,12 +311,6 @@ html_theme_options = {
     "dark_logo": "logo1.svg",  # Logo for dark mode
 }
 
-autodoc_type_aliases = {
-    "GPyTorchKernel": "GPyTorchKernel",
-    "GPyTorchLikelihood": "GPyTorchLikelihood",
-    "GPyTorchMean": "GPyTorchMean",
-    "Smiles": "Smiles",
-}
 
 # Everything in the module has the prefix baybe
 modindex_common_prefix = ["baybe."]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,12 @@ from __future__ import annotations
 import os
 import shutil
 
+from gpytorch.kernels import Kernel as GPyTorchKernel
+
+from baybe.surrogates.gaussian_process.components import kernel as _kernel
+
+_kernel.GPyTorchKernel = GPyTorchKernel
+
 # -- Path setup --------------------------------------------------------------
 
 __location__ = os.path.dirname(__file__)

--- a/docs/templates/custom-class-template.rst
+++ b/docs/templates/custom-class-template.rst
@@ -15,10 +15,10 @@
    .. autosummary::
    {% for item in methods %}
       ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% if "__call__" in all_methods %}
+   {% if item == "__init__" and "__call__" in all_methods %}
       ~{{ name }}.__call__
    {% endif %}
+   {%- endfor %}
    {% endif %}
    {% endblock %}
 

--- a/docs/templates/custom-class-template.rst
+++ b/docs/templates/custom-class-template.rst
@@ -16,6 +16,9 @@
    {% for item in methods %}
       ~{{ name }}.{{ item }}
    {%- endfor %}
+   {% if "__call__" in all_methods %}
+      ~{{ name }}.__call__
+   {% endif %}
    {% endif %}
    {% endblock %}
 

--- a/docs/templates/custom-class-template.rst
+++ b/docs/templates/custom-class-template.rst
@@ -4,6 +4,7 @@
 
 .. autoclass:: {{ objname }}
    :members:                              
+   :special-members: __call__
    :show-inheritance:                 
    :inherited-members:
 


### PR DESCRIPTION
This PR adds the `:special-member: __call__` directive to the class template used for doc building.

This was attempted earlier, but could not be implemented due to `sphinx` not being able to resolve the forward reference to the `GPyTorchKernel` as this is imported lazily. This PR attempts to fix that by having this import directly in `docs./conf.py`.