### PR TITLE
Add _ReducedSearchSpace for parameter-only reduced search spaces

### DIFF
--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import gc
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from enum import Enum
 from itertools import product
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -433,6 +433,23 @@ class SearchSpace(SerialMixin):
             if col in p.comp_rep_columns
         )
 
+    def _get_n_comp_rep_columns(
+        self,
+        name_or_selector: str | ParameterSelectorProtocol,
+        /,
+    ) -> int:
+        """Get the number of comp-rep columns for a parameter selection.
+
+        Args:
+            name_or_selector: Either the name of a single parameter or a selector
+                that filters parameters to be included.
+
+        Returns:
+            The number of columns in the computational representation associated
+            with the selected parameter(s).
+        """
+        return len(self.get_comp_rep_parameter_indices(name_or_selector))
+
     @staticmethod
     def estimate_product_space_size(parameters: Iterable[Parameter]) -> MemorySize:
         """Estimate an upper bound for the memory size of a product space.
@@ -514,6 +531,124 @@ class SearchSpace(SerialMixin):
         return self.discrete.get_parameters_by_name(
             names
         ) + self.continuous.get_parameters_by_name(names)
+
+    def _drop_parameters(self, names: Collection[str], /) -> _ReducedSearchSpace:
+        """Return a reduced search space without the named parameters.
+
+        The returned object exposes only parameter information and blocks
+        access to constraints, subspaces, and transformation.
+
+        Args:
+            names: The names of the parameters to remove.
+
+        Raises:
+            ValueError: If any name does not match a parameter in the space.
+
+        Returns:
+            A reduced search space containing only parameter information.
+        """
+        current_names = {p.name for p in self.parameters}
+        names_set = set(names)
+        if unknown := names_set - current_names:
+            raise ValueError(
+                f"Parameter name(s) {unknown} not found in the search space. "
+                f"Available: {current_names}."
+            )
+        remaining = [p for p in self.parameters if p.name not in names_set]
+
+        disc_params = [p for p in remaining if p.is_discrete]
+        cont_params = [p for p in remaining if p.is_continuous]
+
+        # Explicit comp_rep needed because transform() drops columns for empty inputs.
+        discrete = (
+            SubspaceDiscrete(
+                parameters=disc_params,
+                exp_rep=pd.DataFrame(columns=[p.name for p in disc_params]),
+                comp_rep=pd.DataFrame(
+                    columns=[c for p in disc_params for c in p.comp_rep_columns]
+                ),
+            )
+            if disc_params
+            else SubspaceDiscrete.empty()
+        )
+
+        continuous = (
+            SubspaceContinuous(
+                parameters=cont_params,
+            )
+            if cont_params
+            else SubspaceContinuous.empty()
+        )
+
+        return _ReducedSearchSpace(discrete=discrete, continuous=continuous)
+
+
+@define(slots=False)
+class _ReducedSearchSpace(SearchSpace):
+    """A lightweight search space exposing only parameter information.
+
+    Provides access to parameter-related properties needed by kernel factory
+    calls. Blocks access to transformation, index-based lookups, and other
+    functionality requiring actual candidate data.
+
+    This class is not intended for direct construction. Use
+    :meth:`SearchSpace._drop_parameters` instead.
+    """
+
+    _ALLOWED_ATTRIBUTES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "discrete",
+            "continuous",
+            "parameters",
+            "parameter_names",
+            "comp_rep_columns",
+            "constraints",
+            "type",
+            "_task_parameter",
+            "n_tasks",
+            "_get_n_comp_rep_columns",
+            "get_parameters_by_name",
+            "_ALLOWED_ATTRIBUTES",
+        }
+    )
+    """Attributes accessible on this reduced search space."""
+
+    @override
+    def __getattribute__(self, name: str):
+        """Guard attribute access, allowing only parameter-related attributes."""
+        if name.startswith("__"):
+            return object.__getattribute__(self, name)
+        allowed = object.__getattribute__(self, "_ALLOWED_ATTRIBUTES")
+        if name in allowed:
+            return object.__getattribute__(self, name)
+        raise AttributeError(
+            f"'{object.__getattribute__(self, '__class__').__name__}' does not "
+            f"support attribute '{name}'. Only parameter information is available."
+        )
+
+    @override
+    def _get_n_comp_rep_columns(
+        self,
+        name_or_selector: str | ParameterSelectorProtocol,
+        /,
+    ) -> int:
+        """Get the number of comp-rep columns for a parameter selection.
+
+        Args:
+            name_or_selector: Either the name of a single parameter or a selector
+                that filters parameters to be included.
+
+        Returns:
+            The number of columns in the computational representation associated
+            with the selected parameter(s).
+        """
+        if isinstance(name_or_selector, str):
+            params: list[Parameter] = [
+                p for p in self.parameters if p.name == name_or_selector
+            ]
+        else:
+            params = [p for p in self.parameters if name_or_selector(p)]
+        return sum(len(p.comp_rep_columns) for p in params)
 
 
 def to_searchspace(

--- a/baybe/surrogates/gaussian_process/components/fit_criterion.py
+++ b/baybe/surrogates/gaussian_process/components/fit_criterion.py
@@ -66,7 +66,7 @@ class _MLLForNonTLFitCriterionFactory(FitCriterionFactoryProtocol):
     def __call__(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> FitCriterion:
-        if searchspace.task_idx is None:
+        if searchspace.n_tasks == 1:
             return FitCriterion.MARGINAL_LOG_LIKELIHOOD
 
         from baybe.surrogates.gaussian_process.presets.baybe import (

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -83,10 +83,8 @@ class _PureKernelFactory(KernelFactoryProtocol, SerialMixin, ABC):
 
     def _get_effective_dimensionality(self, searchspace: SearchSpace) -> int:
         """Get the number of computational columns for the selected parameters."""
-        return len(
-            searchspace.get_comp_rep_parameter_indices(
-                self.parameter_selector or (lambda _: True)
-            )
+        return searchspace._get_n_comp_rep_columns(
+            self.parameter_selector or (lambda _: True)
         )
 
     def _validate_parameter_kinds(self, parameters: Iterable[Parameter]) -> None:
@@ -213,7 +211,7 @@ def _enable_transfer_learning(
             target_cls._supported_parameter_kinds = broadened_kinds
             self.parameter_selector = original_selector
 
-        if searchspace.task_idx is not None:
+        if searchspace.n_tasks > 1:
             icm = ICMKernelFactory(base_kernel_or_factory=base_kernel)
             return icm(searchspace, objective, measurements)
         return base_kernel
@@ -301,7 +299,7 @@ class ICMKernelFactory(_MetaKernelFactory):
     def __call__(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel | GPyTorchKernel:
-        if searchspace.task_idx is None:
+        if searchspace.n_tasks == 1:
             raise IncompatibleSearchSpaceError(
                 f"'{type(self).__name__}' can only be used with a searchspace that "
                 f"contains a '{TaskParameter.__name__}'."

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -276,7 +276,7 @@ class BayBEFitCriterionFactory(FitCriterionFactoryProtocol):
     ) -> FitCriterion:
         return (
             FitCriterion.MARGINAL_LOG_LIKELIHOOD
-            if searchspace.task_idx is None
+            if searchspace.n_tasks == 1
             else FitCriterion.LEAVE_ONE_OUT_PSEUDOLIKELIHOOD
         )
 

--- a/tests/test_reduced_searchspace.py
+++ b/tests/test_reduced_searchspace.py
@@ -1,0 +1,132 @@
+"""Tests for _ReducedSearchSpace and SearchSpace._drop_parameters."""
+
+import pytest
+
+from baybe.parameters import (
+    CategoricalParameter,
+    NumericalContinuousParameter,
+    TaskParameter,
+)
+from baybe.searchspace import SearchSpace
+
+
+@pytest.fixture(name="reduced_searchspace")
+def fixture_reduced_searchspace():
+    """A reduced search space with the task parameter removed."""
+    ss = SearchSpace.from_product(
+        [
+            CategoricalParameter("Color", ["red", "blue"]),
+            NumericalContinuousParameter("x", (0.0, 1.0)),
+            TaskParameter("Task", ["A", "B"]),
+        ]
+    )
+    return ss._drop_parameters({"Task"})
+
+
+def test_reduced_parameters(reduced_searchspace):
+    """Verify that the reduced space exposes only the remaining parameters."""
+    names = {p.name for p in reduced_searchspace.parameters}
+    assert names == {"Color", "x"}
+
+
+def test_reduced_parameter_names(reduced_searchspace):
+    """Verify that parameter_names derives from the remaining parameters."""
+    assert set(reduced_searchspace.parameter_names) == {"Color", "x"}
+
+
+def test_reduced_comp_rep_columns(reduced_searchspace):
+    """Verify that comp_rep_columns matches the remaining parameters' columns."""
+    expected = set()
+    for p in reduced_searchspace.parameters:
+        expected.update(p.comp_rep_columns)
+    assert set(reduced_searchspace.comp_rep_columns) == expected
+
+
+def test_reduced_n_tasks(reduced_searchspace):
+    """Verify that n_tasks is 1 when no task parameter is present."""
+    assert reduced_searchspace.n_tasks == 1
+
+
+def test_reduced_get_n_comp_rep_columns(reduced_searchspace):
+    """Verify that _get_n_comp_rep_columns works on the reduced space."""
+    from baybe.parameters.selectors import TypeSelector
+
+    # String-based selection
+    assert reduced_searchspace._get_n_comp_rep_columns("x") == 1
+    assert reduced_searchspace._get_n_comp_rep_columns("Color") == 2
+
+    # Selector-based selection
+    assert (
+        reduced_searchspace._get_n_comp_rep_columns(
+            TypeSelector([NumericalContinuousParameter])
+        )
+        == 1
+    )
+    assert reduced_searchspace._get_n_comp_rep_columns(lambda _: True) == 3
+
+
+def test_reduced_blocked_attributes(reduced_searchspace):
+    """Verify that all non-allowed attributes raise NotImplementedError."""
+    from baybe.searchspace.core import _ReducedSearchSpace
+
+    allowed = _ReducedSearchSpace._ALLOWED_ATTRIBUTES
+
+    # All public non-dunder attributes of SearchSpace
+    all_attrs = {name for name in dir(SearchSpace) if not name.startswith("_")}
+
+    # Attributes that should be blocked (not in allowlist)
+    blocked = all_attrs - allowed
+
+    for attr in sorted(blocked):
+        with pytest.raises(AttributeError, match=attr):
+            getattr(reduced_searchspace, attr)
+
+
+def test_reduced_repr(reduced_searchspace):
+    """Verify that repr does not crash on a reduced search space."""
+    result = repr(reduced_searchspace)
+    assert "_ReducedSearchSpace" in result
+
+
+def test_reduced_str(reduced_searchspace):
+    """Verify that str does not crash on a reduced search space."""
+    result = str(reduced_searchspace)
+    assert isinstance(result, str)
+
+
+def test_reduced_eq(reduced_searchspace):
+    """Verify that equality comparison works on reduced search spaces."""
+    ss = SearchSpace.from_product(
+        [
+            CategoricalParameter("Color", ["red", "blue"]),
+            NumericalContinuousParameter("x", (0.0, 1.0)),
+            TaskParameter("Task", ["A", "B"]),
+        ]
+    )
+    other = ss._drop_parameters({"Task"})
+    assert reduced_searchspace == other
+
+
+def test_reduced_unknown_parameter_raises():
+    """Verify that removing a nonexistent parameter raises an error."""
+    ss = SearchSpace.from_product(
+        [
+            CategoricalParameter("Color", ["red", "blue"]),
+            NumericalContinuousParameter("x", (0.0, 1.0)),
+        ]
+    )
+    with pytest.raises(ValueError, match="not found"):
+        ss._drop_parameters({"nonexistent"})
+
+
+def test_reduced_multiple_parameters_removed():
+    """Verify that multiple parameters can be removed at once."""
+    ss = SearchSpace.from_product(
+        [
+            CategoricalParameter("Color", ["red", "blue"]),
+            NumericalContinuousParameter("x", (0.0, 1.0)),
+            TaskParameter("Task", ["A", "B"]),
+        ]
+    )
+    reduced = ss._drop_parameters({"Task", "Color"})
+    assert reduced.parameter_names == ("x",)


### PR DESCRIPTION
Introduces `_ReducedSearchSpace` (private `SearchSpace` subclass) that exposes only parameter information without building the expensive discrete Cartesian product. This is constructed via `SearchSpace._drop_parameters(names)`, which returns a reduced version with the specified parameters removed.

 The class blocks access to anything beyond parameter-related properties.

  **Motivation**

  When building composite GP kernels, we need to call kernel factories on search spaces with certain parameters stripped away. A full `SearchSpace.from_product()` would rebuild the entire discrete candidate set. `_ReducedSearchSpace` avoids this by storing the parameter tuple directly and computing everything from it.

  **Changes to `SearchSpace` and kernel factories**

 The reduced search space exposes only name-based properties, no integer indices. To support this, we made two changes to existing code:

  - **Replaced `task_idx` sentinel checks** with `n_tasks > 1` / `n_tasks == 1` in kernel factories and fit criterion factories. (Equivalent because `TaskParameter` requires a minimum of 2 values).
  - **Added `SearchSpace._get_n_comp_rep_columns(selector)`** that returns the number of comp-rep columns for a parameter selection. This replaces the previous `len(get_comp_rep_parameter_indices(...))` in `_get_effective_dimensionality`, avoiding the need to expose index-returning methods on the reduced space. Uses `sum(len(p.comp_rep_columns) for p in params)` instead of delegating to `get_comp_rep_parameter_indices`.

  **Design of `_ReducedSearchSpace`**

  - Subclasses `SearchSpace` so it passes type checks and works with existing factory signatures
- Builds real `SubspaceDiscrete`/`SubspaceContinuous` instances with zero-row DataFrames so that `parameters`, `parameter_names`, and `comp_rep_columns` work correctly
  - Overrides `__getattribute__` with an allowlist — accessing `transform`, `index`, etc. raises `AttributeError` 

  **Allowed attributes**

  ```python
  _ALLOWED_ATTRIBUTES: ClassVar[frozenset[str]] = frozenset({
      "discrete",
      "continuous",
      "parameters",
      "parameter_names",
      "comp_rep_columns",
      "constraints",
      "type",
      "_task_parameter",
      "n_tasks",
      "_get_n_comp_rep_columns",
      "get_parameters_by_name",
      "_ALLOWED_ATTRIBUTES",
  })
  ```
**Outlook**

  This class is a building block for kernel override dispatching in the GP surrogate. The dispatching logic will:
  - Strip the task parameter from the search space
  - Call kernel factories on the reduced space to obtain a base kernel
  - Separately construct the task kernel
  - Multiply both at the gpytorch level after resolving indices against the full search space
  - Ensure that factories called on a reduced search space return BayBE Kernel objects (which use parameter names) rather than raw gpytorch kernels (which bake in integer indices)
