### PR TITLE
Refactor Campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.0] - 2026-06-11
 ### Added
 - Support for Python 3.14
 - Support for pandas 3
 - `Settings` class for unified and streamlined settings management
 - Settings options to (de-)activate recommendation caching / dataframe preprocessing
 - Settings option for random seed control
-- `identify_non_dominated_configurations` method to `Campaign` and `Objective`
-  for determining the Pareto front
 - Gaussian process component factories
 - Support for GPyTorch objects (kernels, means, likelihood) as Gaussian process
   components, enabling full low-level customization
@@ -20,12 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Factories for all Gaussian process components
 - `BOTORCH`, `CHEN`, `EDBO`, `EDBO_SMOOTHED` and `HVARFNER` presets for
   `GaussianProcessSurrogate`
+- `DiscreteBatchConstraint` for ensuring all recommendations in a batch share
+  the same value for a specified discrete parameter
+- Interpoint constraints for continuous search spaces
+- `identify_non_dominated_configurations` method to `Campaign` and `Objective`
+  for determining the Pareto front
 - `TypeSelector` and `NameSelector` classes for parameter selection in kernel factories
 - `parameter_names` attribute to basic kernels for controlling the considered parameters
 - `ParameterKind` flag enum for classifying parameters by their role and automatic
   parameter kind validation in kernel factories
 - `IndexKernel` and `PositiveIndexKernel` classes
-- Interpoint constraints for continuous search spaces
 - Addition and multiplication operators for kernel objects, enabling kernel
   composition via `+` (sum) and `*` (product), as well as `constant * kernel`
   for creating a `ScaleKernel` with a fixed output scale
@@ -34,10 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `has_polars_implementation` property on `DiscreteConstraint`
 - `allow_missing` flag on `DiscreteConstraint.get_invalid` and `get_valid`
 - `zizmor` pre-commit hook for static analysis of GitHub Actions workflows
-- `DiscreteBatchConstraint` for ensuring all recommendations in a batch share
-  the same value for a specified discrete parameter
 
 ### Breaking Changes
+- `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task
+  scenarios. Custom kernel architectures must now explicitly include the task kernel,
+  e.g. via `ICMKernelFactory`
 - `parameter_cartesian_prod_pandas` and `parameter_cartesian_prod_polars` moved
   from `baybe.searchspace.discrete` to `baybe.searchspace.utils`
 - `ContinuousLinearConstraint.to_botorch` now returns a collection of constraint tuples
@@ -45,32 +48,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Kernel.to_gpytorch` now takes a `SearchSpace` instead of explicit `ard_num_dims`,
   `batch_shape` and `active_dims` arguments, as kernels now automatically adjust this
   configuration to the given search space
-- `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task
-  scenarios. Custom kernel architectures must now explicitly include the task kernel,
-  e.g. via `ICMKernelFactory`
 - `KernelFactory` now obeys the more general `GPComponentFactoryProtocol`
 
 ### Fixed
 - Broken cache validation for certain `Campaign.recommend` cases
 - `ContinuousCardinalityConstraint` now works in hybrid search spaces
-- Typo in `_FixedNumericalContinuousParameter` where `is_numeric` was used
-  instead of `is_numerical`
 - `SHAPInsight` breaking with `numpy>=2.4` due to no longer accepted implicit array to 
   scalar conversion
 - Using `np.isclose` for assessing equality of `Interval` bounds instead of hard
   equality check
+- Typo in `_FixedNumericalContinuousParameter` where `is_numeric` was used
+  instead of `is_numerical`
 
 ### Changed
 - The `BAYBE` GP preset now dispatches between the `CHEN` preset (when a
   `SubstanceParameter` is present) and custom dimension-scaled Gamma priors (otherwise)
-- "User Guide" section has been split into "Components" and "Concepts" 
 - Default transfer learning kernel changed from `IndexKernel` to `PositiveIndexKernel`,
   enforcing positive task correlations
-- The `Campaign.allow_*` flag mechanism is now based on `AutoBool` logic, providing
-  well-defined Boolean values at query time while exposing the `AUTO` option to the user
 - Discrete search space construction now applies constraints incrementally during
   Cartesian product building, significantly reducing memory usage and construction
   time for constrained spaces
+- "User Guide" section has been split into "Components" and "Concepts"
+- The `Campaign.allow_*` flag mechanism is now based on `AutoBool` logic, providing
+  well-defined Boolean values at query time while exposing the `AUTO` option to the user
 - Polars path in discrete search space construction now builds the Cartesian product
   only for parameters involved in Polars-capable constraints, merging the rest
   incrementally via pandas
@@ -84,11 +84,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 - `BotorchRecommender.max_n_subspaces` has been renamed to `max_n_subsets`
+- `set_random_seed` and `temporary_seed` utility functions
 - Using a custom kernel with `GaussianProcessSurrogate` in a multi-task context now
   raises a `DeprecationError` to alert users about the changed kernel logic. This can
   be suppressed by setting the `BAYBE_DISABLE_CUSTOM_KERNEL_WARNING` environment
   variable to a truthy value
-- `set_random_seed` and `temporary_seed` utility functions
 - The environment variables
   `BAYBE_NUMPY_USE_SINGLE_PRECISION`/`BAYBE_TORCH_USE_SINGLE_PRECISION` have been
   replaced with the variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Breaking Changes
+- `Campaign.measurements` no longer contains `FitNr` or `BatchNr` metadata columns
+
+### Changed
+- Internal `Campaign` state model simplified: recommended and excluded experiments
+  are now stored as dataframes instead of being tracked as metadata flags
+
+### Deprecations
+- `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes 
+
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes
 - `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task
@@ -83,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GaussianProcessSurrogate.from_preset` 
 
 ### Deprecations
+- `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
 - `BotorchRecommender.max_n_subspaces` has been renamed to `max_n_subsets`
 - `set_random_seed` and `temporary_seed` utility functions
 - Using a custom kernel with `GaussianProcessSurrogate` in a multi-task context now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.15.0] - 2026-06-11
+### Breaking Changes
+- `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task
+  scenarios. Custom kernel architectures must now explicitly include the task kernel,
+  e.g. via `ICMKernelFactory`.
+- `parameter_cartesian_prod_pandas` and `parameter_cartesian_prod_polars` moved
+  from `baybe.searchspace.discrete` to `baybe.searchspace.utils`
+- `ContinuousLinearConstraint.to_botorch` now returns a collection of constraint tuples
+  instead of a single tuple (needed for interpoint constraints)
+- `Kernel.to_gpytorch` now takes a `SearchSpace` instead of explicit `ard_num_dims`,
+  `batch_shape` and `active_dims` arguments, as kernels now automatically adjust this
+  configuration to the given search space
+- `KernelFactory` now obeys the more general `GPComponentFactoryProtocol`
+
 ### Added
 - Support for Python 3.14
 - Support for pandas 3
@@ -37,29 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `allow_missing` flag on `DiscreteConstraint.get_invalid` and `get_valid`
 - `zizmor` pre-commit hook for static analysis of GitHub Actions workflows
 
-### Breaking Changes
-- `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task
-  scenarios. Custom kernel architectures must now explicitly include the task kernel,
-  e.g. via `ICMKernelFactory`
-- `parameter_cartesian_prod_pandas` and `parameter_cartesian_prod_polars` moved
-  from `baybe.searchspace.discrete` to `baybe.searchspace.utils`
-- `ContinuousLinearConstraint.to_botorch` now returns a collection of constraint tuples
-  instead of a single tuple (needed for interpoint constraints)
-- `Kernel.to_gpytorch` now takes a `SearchSpace` instead of explicit `ard_num_dims`,
-  `batch_shape` and `active_dims` arguments, as kernels now automatically adjust this
-  configuration to the given search space
-- `KernelFactory` now obeys the more general `GPComponentFactoryProtocol`
-
-### Fixed
-- Broken cache validation for certain `Campaign.recommend` cases
-- `ContinuousCardinalityConstraint` now works in hybrid search spaces
-- `SHAPInsight` breaking with `numpy>=2.4` due to no longer accepted implicit array to 
-  scalar conversion
-- Using `np.isclose` for assessing equality of `Interval` bounds instead of hard
-  equality check
-- Typo in `_FixedNumericalContinuousParameter` where `is_numeric` was used
-  instead of `is_numerical`
-
 ### Changed
 - The `BAYBE` GP preset now dispatches between the `CHEN` preset (when a
   `SubstanceParameter` is present) and custom dimension-scaled Gamma priors (otherwise)
@@ -75,6 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only for parameters involved in Polars-capable constraints, merging the rest
   incrementally via pandas
 - Minimum required pandas version increased to `2.1.0`
+
+### Fixed
+- Broken cache validation for certain `Campaign.recommend` cases
+- `ContinuousCardinalityConstraint` now works in hybrid search spaces
+- `SHAPInsight` breaking with `numpy>=2.4` due to no longer accepted implicit array to 
+  scalar conversion
+- Using `np.isclose` for assessing equality of `Interval` bounds instead of hard
+  equality check
+- Typo in `_FixedNumericalContinuousParameter` where `is_numeric` was used
+  instead of `is_numerical`
 
 ### Removed
 - `parallel_runs` argument from `simulate_scenarios`, since parallelization

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -7,10 +7,9 @@ import json
 import warnings
 from collections.abc import Collection, Sequence
 from functools import reduce
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import cattrs
-import numpy as np
 import pandas as pd
 from attrs import Attribute, define, evolve, field, fields, setters
 from attrs.converters import optional
@@ -19,6 +18,7 @@ from typing_extensions import override
 
 from baybe.constraints.base import DiscreteConstraint
 from baybe.exceptions import (
+    DeprecationError,
     IncompatibilityError,
     NoMeasurementsError,
     NotEnoughPointsLeftError,
@@ -178,9 +178,6 @@ class Campaign(SerialMixin):
     n_batches_done: int = field(default=0, init=False)
     """The number of already processed batches."""
 
-    n_fits_done: int = field(default=0, init=False)
-    """The number of fits already done."""
-
     # Private
     _measurements_exp: pd.DataFrame = field(
         factory=pd.DataFrame, eq=eq_dataframe, init=False
@@ -228,7 +225,6 @@ class Campaign(SerialMixin):
         ]
         metadata_fields = [
             to_string("Batches done", self.n_batches_done, single_line=True),
-            to_string("Fits done", self.n_fits_done, single_line=True),
             to_string("Discrete Subspace Meta Data", *searchspace_fields),
         ]
         metadata = to_string("Meta Data", *metadata_fields)
@@ -240,6 +236,11 @@ class Campaign(SerialMixin):
     def measurements(self) -> pd.DataFrame:
         """The experimental data added to the Campaign."""
         return self._measurements_exp
+
+    @property
+    def n_fits_done(self) -> NoReturn:
+        """Deprecated!"""
+        raise DeprecationError("'n_fits_done' is no longer available.")
 
     @property
     def parameters(self) -> tuple[Parameter, ...]:
@@ -356,7 +357,6 @@ class Campaign(SerialMixin):
         self.n_batches_done += 1
         to_insert = data.copy()
         to_insert["BatchNr"] = self.n_batches_done
-        to_insert["FitNr"] = np.nan
 
         self._measurements_exp = pd.concat(
             [self._measurements_exp, to_insert], axis=0, ignore_index=True
@@ -378,7 +378,7 @@ class Campaign(SerialMixin):
 
         This can be useful to correct mistakes or update target measurements. The
         match to existing data entries is made based on the index. This will reset
-        the `FitNr` of the corresponding measurement and reset cached recommendations.
+        cached recommendations.
 
         Args:
             data: The measurement data to be updated (with filled values for targets).
@@ -420,9 +420,6 @@ class Campaign(SerialMixin):
         # Perform the update
         cols = [p.name for p in self.parameters] + [t.name for t in self.targets]
         self._measurements_exp.loc[data.index, cols] = data[cols]
-
-        # Reset fit number
-        self._measurements_exp.loc[data.index, "FitNr"] = np.nan
 
     def toggle_discrete_candidates(  # noqa: DOC501
         self,
@@ -539,11 +536,6 @@ class Campaign(SerialMixin):
             and len(cache) == batch_size
         ):
             return cache
-
-        # Update recommendation meta data
-        if len(self._measurements_exp) > 0:
-            self.n_fits_done += 1
-            self._measurements_exp.fillna({"FitNr": self.n_fits_done}, inplace=True)
 
         # Prepare the search space according to the current campaign state
         if self.searchspace.type is SearchSpaceType.DISCRETE:
@@ -976,6 +968,33 @@ def _drop_version(dict_: dict) -> dict:
     return dict_
 
 
+# >>>>>>>>>> Deprecation
+def _discard_legacy_fields(dict_: dict, /) -> dict:
+    """Discard legacy fields from a Campaign dictionary during structuring."""
+    dict_.pop("n_fits_done", None)
+
+    # Strip FitNr column from legacy measurements
+    if "measurements_exp" in dict_:
+        meas = converter.structure(dict_["measurements_exp"], pd.DataFrame)
+        if "FitNr" in meas.columns:
+            dict_["measurements_exp"] = converter.unstructure(
+                meas.drop(columns="FitNr")
+            )
+
+    return dict_
+
+
+# <<<<<<<<<< Deprecation
+
+
+def _prepare_for_structuring(dict_: dict, /) -> dict:
+    """Prepare a Campaign dictionary for structuring."""
+    dict_ = dict_.copy()
+    _drop_version(dict_)
+    _discard_legacy_fields(dict_)
+    return dict_
+
+
 # Register (un-)structure hooks
 unstructure_hook = cattrs.gen.make_dict_unstructure_fn(
     Campaign, converter, _cattrs_include_init_false=True
@@ -987,7 +1006,7 @@ converter.register_unstructure_hook(
     Campaign, lambda x: _add_version(unstructure_hook(x))
 )
 converter.register_structure_hook(
-    Campaign, lambda d, cl: structure_hook(_drop_version(d), cl)
+    Campaign, lambda d, cl: structure_hook(_prepare_for_structuring(d), cl)
 )
 
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -60,11 +60,8 @@ if TYPE_CHECKING:
 
     _T = TypeVar("_T")
 
-# Metadata columns
-_EXCLUDED = "excluded"
-_METADATA_COLUMNS = [_EXCLUDED]
-
 # Legacy constants kept for deserialization migration only
+_EXCLUDED = "excluded"
 _MEASURED = "measured"
 _RECOMMENDED = "recommended"
 
@@ -173,11 +170,10 @@ class Campaign(SerialMixin):
     )
     """Allow recommending pending experiments."""
 
-    # Metadata
-    _searchspace_metadata: pd.DataFrame = field(init=False, eq=eq_dataframe)
-    """Metadata tracking the experimentation status of the search space."""
-
     # Private
+    _excluded_experiments: pd.DataFrame = field(eq=eq_dataframe, init=False)
+    """The parameter configurations that have been excluded from recommendations."""
+
     _measurements: pd.DataFrame = field(eq=eq_dataframe, init=False)
     """The measurements added to the campaign."""
 
@@ -197,22 +193,17 @@ class Campaign(SerialMixin):
         ]
         return pd.DataFrame(columns=cols)
 
+    @_excluded_experiments.default
+    def _default_excluded_experiments(self) -> pd.DataFrame:
+        """Create an empty excluded experiments DataFrame with correct schema."""
+        cols = [p.name for p in self.searchspace.parameters]
+        return pd.DataFrame(columns=cols)
+
     @_recommended_experiments.default
     def _default_recommended_experiments(self) -> pd.DataFrame:
         """Create an empty recommended experiments DataFrame with correct schema."""
         cols = [p.name for p in self.searchspace.parameters]
         return pd.DataFrame(columns=cols)
-
-    @_searchspace_metadata.default
-    def _default_searchspace_metadata(self) -> pd.DataFrame:
-        """Create a fresh metadata object."""
-        df = pd.DataFrame(
-            False,
-            index=self.searchspace.discrete.exp_rep.index,
-            columns=_METADATA_COLUMNS,
-        )
-
-        return df
 
     @override
     def __str__(self) -> str:
@@ -224,8 +215,8 @@ class Campaign(SerialMixin):
             measured_count = len(
                 fuzzy_row_match(exp_rep, self._measurements, self.parameters)
             )
-        excluded_count = sum(self._searchspace_metadata[_EXCLUDED])
-        n_elements = len(self._searchspace_metadata)
+        excluded_count = len(self._excluded_experiments)
+        n_elements = len(exp_rep)
         searchspace_fields = [
             to_string(
                 "Recommended:",
@@ -497,7 +488,25 @@ class Campaign(SerialMixin):
             )
 
         if not dry_run:
-            self._searchspace_metadata.loc[points.index, _EXCLUDED] = exclude
+            if exclude:
+                # Add the toggled points (avoid duplicates)
+                frames = [
+                    f for f in (self._excluded_experiments, points) if not f.empty
+                ]
+                self._excluded_experiments = (
+                    pd.concat(frames, axis=0).drop_duplicates().reset_index(drop=True)
+                )
+            # Remove the re-included points
+            elif not self._excluded_experiments.empty:
+                merged = pd.merge(
+                    self._excluded_experiments,
+                    points,
+                    indicator=True,
+                    how="left",
+                )
+                self._excluded_experiments = self._excluded_experiments[
+                    merged["_merge"].eq("left_only").values
+                ].reset_index(drop=True)
 
         return points
 
@@ -553,13 +562,21 @@ class Campaign(SerialMixin):
         if self.searchspace.type is SearchSpaceType.DISCRETE:
             # TODO: This implementation should at some point be hidden behind an
             #   appropriate public interface, like `SubspaceDiscrete.filter()`
-            mask_todrop = self._searchspace_metadata[_EXCLUDED].astype(bool)
+            exp_rep = self.searchspace.discrete.exp_rep
+            mask_todrop = pd.Series(False, index=exp_rep.index)
+            if not self._excluded_experiments.empty:
+                mask_todrop |= pd.merge(
+                    exp_rep,
+                    self._excluded_experiments,
+                    indicator=True,
+                    how="left",
+                )["_merge"].eq("both")
             if (
                 not self.allow_recommending_already_recommended
                 and not self._recommended_experiments.empty
             ):
                 mask_todrop |= pd.merge(
-                    self.searchspace.discrete.exp_rep,
+                    exp_rep,
                     self._recommended_experiments,
                     indicator=True,
                     how="left",
@@ -569,9 +586,7 @@ class Campaign(SerialMixin):
                 and not self._measurements.empty
             ):
                 measured_idxs = fuzzy_row_match(
-                    self.searchspace.discrete.exp_rep,
-                    self._measurements,
-                    self.parameters,
+                    exp_rep, self._measurements, self.parameters
                 )
                 mask_todrop.loc[measured_idxs] = True
             if (
@@ -579,7 +594,7 @@ class Campaign(SerialMixin):
                 and pending_experiments is not None
             ):
                 mask_todrop |= pd.merge(
-                    self.searchspace.discrete.exp_rep,
+                    exp_rep,
                     pending_experiments,
                     indicator=True,
                     how="left",
@@ -1025,20 +1040,19 @@ def _discard_legacy_fields(dict_: dict, /) -> dict:
                 meas.drop(columns=cols_to_drop)
             )
 
-    # Strip legacy columns from _searchspace_metadata
+    # Migrate legacy _searchspace_metadata to new fields
     if "searchspace_metadata" in dict_:
-        metadata = converter.structure(dict_["searchspace_metadata"], pd.DataFrame)
-        legacy_cols = [c for c in (_RECOMMENDED, _MEASURED) if c in metadata.columns]
+        metadata = converter.structure(dict_.pop("searchspace_metadata"), pd.DataFrame)
         if _RECOMMENDED in metadata.columns:
             if "recommended_experiments" not in dict_:
                 recommended_idxs = metadata.index[metadata[_RECOMMENDED]]
-                # Store indices for post-structure reconstruction
                 if len(recommended_idxs) > 0:
                     dict_["_legacy_recommended_idxs"] = recommended_idxs
-        if legacy_cols:
-            dict_["searchspace_metadata"] = converter.unstructure(
-                metadata.drop(columns=legacy_cols)
-            )
+        if _EXCLUDED in metadata.columns:
+            if "excluded_experiments" not in dict_:
+                excluded_idxs = metadata.index[metadata[_EXCLUDED]]
+                if len(excluded_idxs) > 0:
+                    dict_["_legacy_excluded_idxs"] = excluded_idxs
 
     return dict_
 
@@ -1069,15 +1083,23 @@ converter.register_unstructure_hook(
 def _structure_campaign(d: dict, cl: type) -> Campaign:
     """Structure a Campaign from a dictionary, handling legacy migrations."""
     prepared = _prepare_for_structuring(d)
-    legacy_idxs = prepared.pop("_legacy_recommended_idxs", None)
+    legacy_recommended_idxs = prepared.pop("_legacy_recommended_idxs", None)
+    legacy_excluded_idxs = prepared.pop("_legacy_excluded_idxs", None)
     campaign = structure_hook(prepared, cl)
 
     # >>>>>>>>>> Deprecation
-    # Post-structure reconstruction of _recommended_experiments from legacy metadata
-    if legacy_idxs is not None:
+    # Post-structure reconstruction from legacy metadata indices
+    if legacy_recommended_idxs is not None:
         try:
-            rec_df = campaign.searchspace.discrete.exp_rep.loc[legacy_idxs]
+            rec_df = campaign.searchspace.discrete.exp_rep.loc[legacy_recommended_idxs]
             campaign._recommended_experiments = rec_df.reset_index(drop=True)
+        except Exception:
+            pass
+
+    if legacy_excluded_idxs is not None:
+        try:
+            excl_df = campaign.searchspace.discrete.exp_rep.loc[legacy_excluded_idxs]
+            campaign._excluded_experiments = excl_df.reset_index(drop=True)
         except Exception:
             pass
 
@@ -1089,6 +1111,11 @@ def _structure_campaign(d: dict, cl: type) -> Campaign:
         and campaign._recommended_experiments.empty
     ):
         campaign._recommended_experiments = campaign._default_recommended_experiments()
+    if (
+        campaign._excluded_experiments.columns.empty
+        and campaign._excluded_experiments.empty
+    ):
+        campaign._excluded_experiments = campaign._default_excluded_experiments()
     # <<<<<<<<<< Deprecation
 
     return campaign

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -175,9 +175,6 @@ class Campaign(SerialMixin):
     _searchspace_metadata: pd.DataFrame = field(init=False, eq=eq_dataframe)
     """Metadata tracking the experimentation status of the search space."""
 
-    n_batches_done: int = field(default=0, init=False)
-    """The number of already processed batches."""
-
     # Private
     _measurements_exp: pd.DataFrame = field(
         factory=pd.DataFrame, eq=eq_dataframe, init=False
@@ -224,7 +221,6 @@ class Campaign(SerialMixin):
             ),
         ]
         metadata_fields = [
-            to_string("Batches done", self.n_batches_done, single_line=True),
             to_string("Discrete Subspace Meta Data", *searchspace_fields),
         ]
         metadata = to_string("Meta Data", *metadata_fields)
@@ -236,6 +232,11 @@ class Campaign(SerialMixin):
     def measurements(self) -> pd.DataFrame:
         """The experimental data added to the Campaign."""
         return self._measurements_exp
+
+    @property
+    def n_batches_done(self) -> NoReturn:
+        """Deprecated!"""
+        raise DeprecationError("'n_batches_done' is no longer available.")
 
     @property
     def n_fits_done(self) -> NoReturn:
@@ -354,12 +355,8 @@ class Campaign(SerialMixin):
         self.clear_cache()
 
         # Read in measurements and add them to the database
-        self.n_batches_done += 1
-        to_insert = data.copy()
-        to_insert["BatchNr"] = self.n_batches_done
-
         self._measurements_exp = pd.concat(
-            [self._measurements_exp, to_insert], axis=0, ignore_index=True
+            [self._measurements_exp, data], axis=0, ignore_index=True
         )
 
         # Update metadata
@@ -972,13 +969,15 @@ def _drop_version(dict_: dict) -> dict:
 def _discard_legacy_fields(dict_: dict, /) -> dict:
     """Discard legacy fields from a Campaign dictionary during structuring."""
     dict_.pop("n_fits_done", None)
+    dict_.pop("n_batches_done", None)
 
-    # Strip FitNr column from legacy measurements
+    # Strip FitNr/BatchNr columns from legacy measurements
     if "measurements_exp" in dict_:
         meas = converter.structure(dict_["measurements_exp"], pd.DataFrame)
-        if "FitNr" in meas.columns:
+        cols_to_drop = [c for c in ("FitNr", "BatchNr") if c in meas.columns]
+        if cols_to_drop:
             dict_["measurements_exp"] = converter.unstructure(
-                meas.drop(columns="FitNr")
+                meas.drop(columns=cols_to_drop)
             )
 
     return dict_

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -496,8 +496,8 @@ class Campaign(SerialMixin):
                 self._excluded_experiments = (
                     pd.concat(frames, axis=0).drop_duplicates().reset_index(drop=True)
                 )
-            # Remove the re-included points
-            elif not self._excluded_experiments.empty:
+            elif not exclude and not self._excluded_experiments.empty:
+                # Remove the re-included points
                 merged = pd.merge(
                     self._excluded_experiments,
                     points,

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -178,20 +178,30 @@ class Campaign(SerialMixin):
     """Metadata tracking the experimentation status of the search space."""
 
     # Private
-    _measurements: pd.DataFrame = field(
-        factory=pd.DataFrame, eq=eq_dataframe, init=False
-    )
+    _measurements: pd.DataFrame = field(eq=eq_dataframe, init=False)
     """The measurements added to the campaign."""
 
-    _recommended_experiments: pd.DataFrame = field(
-        factory=pd.DataFrame, eq=eq_dataframe, init=False
-    )
+    _recommended_experiments: pd.DataFrame = field(eq=eq_dataframe, init=False)
     """The (deduplicated) parameter configurations that have been recommended."""
 
     _cached_recommendation: pd.DataFrame | None = field(
         default=None, init=False, eq=False
     )
     """The cached recommendations."""
+
+    @_measurements.default
+    def _default_measurements(self) -> pd.DataFrame:
+        """Create an empty measurements DataFrame with the correct schema."""
+        cols = [p.name for p in self.searchspace.parameters] + [
+            t.name for t in (self.objective.targets if self.objective else ())
+        ]
+        return pd.DataFrame(columns=cols)
+
+    @_recommended_experiments.default
+    def _default_recommended_experiments(self) -> pd.DataFrame:
+        """Create an empty recommended experiments DataFrame with correct schema."""
+        cols = [p.name for p in self.searchspace.parameters]
+        return pd.DataFrame(columns=cols)
 
     @_searchspace_metadata.default
     def _default_searchspace_metadata(self) -> pd.DataFrame:
@@ -362,9 +372,8 @@ class Campaign(SerialMixin):
         self.clear_cache()
 
         # Read in measurements and add them to the database
-        self._measurements = pd.concat(
-            [self._measurements, data], axis=0, ignore_index=True
-        )
+        frames = [f for f in (self._measurements, data) if not f.empty]
+        self._measurements = pd.concat(frames, axis=0, ignore_index=True)
 
         # Update metadata
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
@@ -642,12 +651,13 @@ class Campaign(SerialMixin):
         # Track recommended experiments (deduplicated)
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
             param_cols = [p.name for p in self.parameters]
+            frames = [
+                f
+                for f in (self._recommended_experiments, rec[param_cols])
+                if not f.empty
+            ]
             self._recommended_experiments = (
-                pd.concat(
-                    [self._recommended_experiments, rec[param_cols]],
-                    axis=0,
-                    ignore_index=True,
-                )
+                pd.concat(frames, axis=0, ignore_index=True)
                 .drop_duplicates()
                 .reset_index(drop=True)
             )
@@ -1062,6 +1072,15 @@ def _structure_campaign(d: dict, cl: type) -> Campaign:
             campaign._recommended_experiments = rec_df.reset_index(drop=True)
         except Exception:
             pass
+
+    # Fix schema of empty DataFrames from legacy serialization
+    if campaign._measurements.columns.empty and campaign._measurements.empty:
+        campaign._measurements = campaign._default_measurements()
+    if (
+        campaign._recommended_experiments.columns.empty
+        and campaign._recommended_experiments.empty
+    ):
+        campaign._recommended_experiments = campaign._default_recommended_experiments()
     # <<<<<<<<<< Deprecation
 
     return campaign

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -61,11 +61,11 @@ if TYPE_CHECKING:
     _T = TypeVar("_T")
 
 # Metadata columns
-_MEASURED = "measured"
 _EXCLUDED = "excluded"
-_METADATA_COLUMNS = [_MEASURED, _EXCLUDED]
+_METADATA_COLUMNS = [_EXCLUDED]
 
-# Legacy constant kept for deserialization migration only
+# Legacy constants kept for deserialization migration only
+_MEASURED = "measured"
 _RECOMMENDED = "recommended"
 
 
@@ -217,7 +217,13 @@ class Campaign(SerialMixin):
     @override
     def __str__(self) -> str:
         recommended_count = len(self._recommended_experiments)
-        measured_count = sum(self._searchspace_metadata[_MEASURED])
+        exp_rep = self.searchspace.discrete.exp_rep
+        if self._measurements.empty or exp_rep.empty:
+            measured_count = 0
+        else:
+            measured_count = len(
+                fuzzy_row_match(exp_rep, self._measurements, self.parameters)
+            )
         excluded_count = sum(self._searchspace_metadata[_EXCLUDED])
         n_elements = len(self._searchspace_metadata)
         searchspace_fields = [
@@ -374,13 +380,6 @@ class Campaign(SerialMixin):
         # Read in measurements and add them to the database
         frames = [f for f in (self._measurements, data) if not f.empty]
         self._measurements = pd.concat(frames, axis=0, ignore_index=True)
-
-        # Update metadata
-        if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            idxs_matched = fuzzy_row_match(
-                self.searchspace.discrete.exp_rep, data, self.parameters
-            )
-            self._searchspace_metadata.loc[idxs_matched, _MEASURED] = True
 
     def update_measurements(
         self,
@@ -565,8 +564,16 @@ class Campaign(SerialMixin):
                     indicator=True,
                     how="left",
                 )["_merge"].eq("both")
-            if not self.allow_recommending_already_measured:
-                mask_todrop |= self._searchspace_metadata[_MEASURED]
+            if (
+                not self.allow_recommending_already_measured
+                and not self._measurements.empty
+            ):
+                measured_idxs = fuzzy_row_match(
+                    self.searchspace.discrete.exp_rep,
+                    self._measurements,
+                    self.parameters,
+                )
+                mask_todrop.loc[measured_idxs] = True
             if (
                 not self.allow_recommending_pending_experiments
                 and pending_experiments is not None
@@ -1018,18 +1025,19 @@ def _discard_legacy_fields(dict_: dict, /) -> dict:
                 meas.drop(columns=cols_to_drop)
             )
 
-    # Reconstruct _recommended_experiments from legacy _searchspace_metadata
+    # Strip legacy columns from _searchspace_metadata
     if "searchspace_metadata" in dict_:
         metadata = converter.structure(dict_["searchspace_metadata"], pd.DataFrame)
+        legacy_cols = [c for c in (_RECOMMENDED, _MEASURED) if c in metadata.columns]
         if _RECOMMENDED in metadata.columns:
             if "recommended_experiments" not in dict_:
                 recommended_idxs = metadata.index[metadata[_RECOMMENDED]]
                 # Store indices for post-structure reconstruction
                 if len(recommended_idxs) > 0:
                     dict_["_legacy_recommended_idxs"] = recommended_idxs
-            # Strip the legacy column
+        if legacy_cols:
             dict_["searchspace_metadata"] = converter.unstructure(
-                metadata.drop(columns=[_RECOMMENDED])
+                metadata.drop(columns=legacy_cols)
             )
 
     return dict_

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -565,22 +565,30 @@ class Campaign(SerialMixin):
             exp_rep = self.searchspace.discrete.exp_rep
             mask_todrop = pd.Series(False, index=exp_rep.index)
             if not self._excluded_experiments.empty:
-                mask_todrop |= pd.merge(
-                    exp_rep,
-                    self._excluded_experiments,
-                    indicator=True,
-                    how="left",
-                )["_merge"].eq("both")
+                mask_todrop |= (
+                    pd.merge(
+                        exp_rep,
+                        self._excluded_experiments,
+                        indicator=True,
+                        how="left",
+                    )["_merge"]
+                    .eq("both")
+                    .to_numpy()
+                )
             if (
                 not self.allow_recommending_already_recommended
                 and not self._recommended_experiments.empty
             ):
-                mask_todrop |= pd.merge(
-                    exp_rep,
-                    self._recommended_experiments,
-                    indicator=True,
-                    how="left",
-                )["_merge"].eq("both")
+                mask_todrop |= (
+                    pd.merge(
+                        exp_rep,
+                        self._recommended_experiments,
+                        indicator=True,
+                        how="left",
+                    )["_merge"]
+                    .eq("both")
+                    .to_numpy()
+                )
             if (
                 not self.allow_recommending_already_measured
                 and not self._measurements.empty
@@ -593,12 +601,16 @@ class Campaign(SerialMixin):
                 not self.allow_recommending_pending_experiments
                 and pending_experiments is not None
             ):
-                mask_todrop |= pd.merge(
-                    exp_rep,
-                    pending_experiments,
-                    indicator=True,
-                    how="left",
-                )["_merge"].eq("both")
+                mask_todrop |= (
+                    pd.merge(
+                        exp_rep,
+                        pending_experiments,
+                        indicator=True,
+                        how="left",
+                    )["_merge"]
+                    .eq("both")
+                    .to_numpy()
+                )
             searchspace = evolve(
                 self.searchspace,
                 discrete=FilteredSubspaceDiscrete.from_subspace(

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -488,7 +488,7 @@ class Campaign(SerialMixin):
             )
 
         if not dry_run:
-            if exclude:
+            if exclude and not points.empty:
                 # Add the toggled points (avoid duplicates)
                 frames = [
                     f for f in (self._excluded_experiments, points) if not f.empty

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -176,10 +176,10 @@ class Campaign(SerialMixin):
     """Metadata tracking the experimentation status of the search space."""
 
     # Private
-    _measurements_exp: pd.DataFrame = field(
+    _measurements: pd.DataFrame = field(
         factory=pd.DataFrame, eq=eq_dataframe, init=False
     )
-    """The experimental representation of the conducted experiments."""
+    """The measurements added to the campaign."""
 
     _cached_recommendation: pd.DataFrame | None = field(
         default=None, init=False, eq=False
@@ -231,7 +231,7 @@ class Campaign(SerialMixin):
     @property
     def measurements(self) -> pd.DataFrame:
         """The experimental data added to the Campaign."""
-        return self._measurements_exp
+        return self._measurements
 
     @property
     def n_batches_done(self) -> NoReturn:
@@ -355,8 +355,8 @@ class Campaign(SerialMixin):
         self.clear_cache()
 
         # Read in measurements and add them to the database
-        self._measurements_exp = pd.concat(
-            [self._measurements_exp, data], axis=0, ignore_index=True
+        self._measurements = pd.concat(
+            [self._measurements, data], axis=0, ignore_index=True
         )
 
         # Update metadata
@@ -407,7 +407,7 @@ class Campaign(SerialMixin):
             )
 
         # Allow only existing indices
-        if nonmatching_idxs := set(data.index).difference(self._measurements_exp.index):
+        if nonmatching_idxs := set(data.index).difference(self._measurements.index):
             raise ValueError(
                 f"Updating measurements requires indices matching the "
                 f"existing measurements. The following indices were in the input, but "
@@ -416,7 +416,7 @@ class Campaign(SerialMixin):
 
         # Perform the update
         cols = [p.name for p in self.parameters] + [t.name for t in self.targets]
-        self._measurements_exp.loc[data.index, cols] = data[cols]
+        self._measurements.loc[data.index, cols] = data[cols]
 
     def toggle_discrete_candidates(  # noqa: DOC501
         self,
@@ -571,7 +571,7 @@ class Campaign(SerialMixin):
                 batch_size,
                 searchspace,
                 self.objective,
-                self._measurements_exp,
+                self._measurements,
                 pending_experiments,
             )
         is_nonpredictive = isinstance(recommender, NonPredictiveRecommender)
@@ -585,7 +585,7 @@ class Campaign(SerialMixin):
                     batch_size,
                     searchspace,
                     self.objective,
-                    self._measurements_exp,
+                    self._measurements,
                     None if is_nonpredictive else pending_experiments,
                 )
         except NotEnoughPointsLeftError as ex:
@@ -971,12 +971,16 @@ def _discard_legacy_fields(dict_: dict, /) -> dict:
     dict_.pop("n_fits_done", None)
     dict_.pop("n_batches_done", None)
 
-    # Strip FitNr/BatchNr columns from legacy measurements
+    # Migrate legacy "measurements_exp" key to "measurements"
     if "measurements_exp" in dict_:
-        meas = converter.structure(dict_["measurements_exp"], pd.DataFrame)
+        dict_["measurements"] = dict_.pop("measurements_exp")
+
+    # Strip FitNr/BatchNr columns from legacy measurements
+    if "measurements" in dict_:
+        meas = converter.structure(dict_["measurements"], pd.DataFrame)
         cols_to_drop = [c for c in ("FitNr", "BatchNr") if c in meas.columns]
         if cols_to_drop:
-            dict_["measurements_exp"] = converter.unstructure(
+            dict_["measurements"] = converter.unstructure(
                 meas.drop(columns=cols_to_drop)
             )
 

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -1102,18 +1102,12 @@ def _structure_campaign(d: dict, cl: type) -> Campaign:
     # >>>>>>>>>> Deprecation
     # Post-structure reconstruction from legacy metadata indices
     if legacy_recommended_idxs is not None:
-        try:
-            rec_df = campaign.searchspace.discrete.exp_rep.loc[legacy_recommended_idxs]
-            campaign._recommended_experiments = rec_df.reset_index(drop=True)
-        except Exception:
-            pass
+        rec_df = campaign.searchspace.discrete.exp_rep.loc[legacy_recommended_idxs]
+        campaign._recommended_experiments = rec_df.reset_index(drop=True)
 
     if legacy_excluded_idxs is not None:
-        try:
-            excl_df = campaign.searchspace.discrete.exp_rep.loc[legacy_excluded_idxs]
-            campaign._excluded_experiments = excl_df.reset_index(drop=True)
-        except Exception:
-            pass
+        excl_df = campaign.searchspace.discrete.exp_rep.loc[legacy_excluded_idxs]
+        campaign._excluded_experiments = excl_df.reset_index(drop=True)
 
     # Fix schema of empty DataFrames from legacy serialization
     if campaign._measurements.columns.empty and campaign._measurements.empty:

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -61,10 +61,12 @@ if TYPE_CHECKING:
     _T = TypeVar("_T")
 
 # Metadata columns
-_RECOMMENDED = "recommended"
 _MEASURED = "measured"
 _EXCLUDED = "excluded"
-_METADATA_COLUMNS = [_RECOMMENDED, _MEASURED, _EXCLUDED]
+_METADATA_COLUMNS = [_MEASURED, _EXCLUDED]
+
+# Legacy constant kept for deserialization migration only
+_RECOMMENDED = "recommended"
 
 
 def _set_with_cache_cleared(instance: Campaign, attribute: Attribute, value: _T) -> _T:
@@ -181,6 +183,11 @@ class Campaign(SerialMixin):
     )
     """The measurements added to the campaign."""
 
+    _recommended_experiments: pd.DataFrame = field(
+        factory=pd.DataFrame, eq=eq_dataframe, init=False
+    )
+    """The (deduplicated) parameter configurations that have been recommended."""
+
     _cached_recommendation: pd.DataFrame | None = field(
         default=None, init=False, eq=False
     )
@@ -199,7 +206,7 @@ class Campaign(SerialMixin):
 
     @override
     def __str__(self) -> str:
-        recommended_count = sum(self._searchspace_metadata[_RECOMMENDED])
+        recommended_count = len(self._recommended_experiments)
         measured_count = sum(self._searchspace_metadata[_MEASURED])
         excluded_count = sum(self._searchspace_metadata[_EXCLUDED])
         n_elements = len(self._searchspace_metadata)
@@ -539,8 +546,16 @@ class Campaign(SerialMixin):
             # TODO: This implementation should at some point be hidden behind an
             #   appropriate public interface, like `SubspaceDiscrete.filter()`
             mask_todrop = self._searchspace_metadata[_EXCLUDED].astype(bool)
-            if not self.allow_recommending_already_recommended:
-                mask_todrop |= self._searchspace_metadata[_RECOMMENDED]
+            if (
+                not self.allow_recommending_already_recommended
+                and not self._recommended_experiments.empty
+            ):
+                mask_todrop |= pd.merge(
+                    self.searchspace.discrete.exp_rep,
+                    self._recommended_experiments,
+                    indicator=True,
+                    how="left",
+                )["_merge"].eq("both")
             if not self.allow_recommending_already_measured:
                 mask_todrop |= self._searchspace_metadata[_MEASURED]
             if (
@@ -624,9 +639,18 @@ class Campaign(SerialMixin):
         ):
             self._cache_recommendation(rec)
 
-        # Update metadata
+        # Track recommended experiments (deduplicated)
         if self.searchspace.type in (SearchSpaceType.DISCRETE, SearchSpaceType.HYBRID):
-            self._searchspace_metadata.loc[rec.index, _RECOMMENDED] = True
+            param_cols = [p.name for p in self.parameters]
+            self._recommended_experiments = (
+                pd.concat(
+                    [self._recommended_experiments, rec[param_cols]],
+                    axis=0,
+                    ignore_index=True,
+                )
+                .drop_duplicates()
+                .reset_index(drop=True)
+            )
 
         return rec
 
@@ -984,6 +1008,20 @@ def _discard_legacy_fields(dict_: dict, /) -> dict:
                 meas.drop(columns=cols_to_drop)
             )
 
+    # Reconstruct _recommended_experiments from legacy _searchspace_metadata
+    if "searchspace_metadata" in dict_:
+        metadata = converter.structure(dict_["searchspace_metadata"], pd.DataFrame)
+        if _RECOMMENDED in metadata.columns:
+            if "recommended_experiments" not in dict_:
+                recommended_idxs = metadata.index[metadata[_RECOMMENDED]]
+                # Store indices for post-structure reconstruction
+                if len(recommended_idxs) > 0:
+                    dict_["_legacy_recommended_idxs"] = recommended_idxs
+            # Strip the legacy column
+            dict_["searchspace_metadata"] = converter.unstructure(
+                metadata.drop(columns=[_RECOMMENDED])
+            )
+
     return dict_
 
 
@@ -1008,9 +1046,28 @@ structure_hook = cattrs.gen.make_dict_structure_fn(
 converter.register_unstructure_hook(
     Campaign, lambda x: _add_version(unstructure_hook(x))
 )
-converter.register_structure_hook(
-    Campaign, lambda d, cl: structure_hook(_prepare_for_structuring(d), cl)
-)
+
+
+def _structure_campaign(d: dict, cl: type) -> Campaign:
+    """Structure a Campaign from a dictionary, handling legacy migrations."""
+    prepared = _prepare_for_structuring(d)
+    legacy_idxs = prepared.pop("_legacy_recommended_idxs", None)
+    campaign = structure_hook(prepared, cl)
+
+    # >>>>>>>>>> Deprecation
+    # Post-structure reconstruction of _recommended_experiments from legacy metadata
+    if legacy_idxs is not None:
+        try:
+            rec_df = campaign.searchspace.discrete.exp_rep.loc[legacy_idxs]
+            campaign._recommended_experiments = rec_df.reset_index(drop=True)
+        except Exception:
+            pass
+    # <<<<<<<<<< Deprecation
+
+    return campaign
+
+
+converter.register_structure_hook(Campaign, _structure_campaign)
 
 
 # Converter for config validation

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -1110,18 +1110,8 @@ def _structure_campaign(d: dict, cl: type) -> Campaign:
         campaign._excluded_experiments = excl_df.reset_index(drop=True)
 
     # Fix schema of empty DataFrames from legacy serialization
-    if campaign._measurements.columns.empty and campaign._measurements.empty:
+    if campaign._measurements.columns.empty:
         campaign._measurements = campaign._default_measurements()
-    if (
-        campaign._recommended_experiments.columns.empty
-        and campaign._recommended_experiments.empty
-    ):
-        campaign._recommended_experiments = campaign._default_recommended_experiments()
-    if (
-        campaign._excluded_experiments.columns.empty
-        and campaign._excluded_experiments.empty
-    ):
-        campaign._excluded_experiments = campaign._default_excluded_experiments()
     # <<<<<<<<<< Deprecation
 
     return campaign

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -423,7 +423,7 @@ class Campaign(SerialMixin):
             )
 
         # Allow only existing indices
-        if nonmatching_idxs := set(data.index).difference(self._measurements.index):
+        if nonmatching_idxs := set(data.index).difference(self.measurements.index):
             raise ValueError(
                 f"Updating measurements requires indices matching the "
                 f"existing measurements. The following indices were in the input, but "
@@ -595,7 +595,7 @@ class Campaign(SerialMixin):
                 batch_size,
                 searchspace,
                 self.objective,
-                self._measurements,
+                self.measurements,
                 pending_experiments,
             )
         is_nonpredictive = isinstance(recommender, NonPredictiveRecommender)
@@ -609,7 +609,7 @@ class Campaign(SerialMixin):
                     batch_size,
                     searchspace,
                     self.objective,
-                    self._measurements,
+                    self.measurements,
                     None if is_nonpredictive else pending_experiments,
                 )
         except NotEnoughPointsLeftError as ex:

--- a/tests/constraints/test_constraints_continuous.py
+++ b/tests/constraints/test_constraints_continuous.py
@@ -7,6 +7,7 @@ from pytest import param
 
 from baybe.constraints import ContinuousLinearConstraint
 from baybe.parameters.numerical import NumericalContinuousParameter
+from baybe.utils.dataframe import add_fake_measurements
 from tests.conftest import run_iterations
 
 TOLERANCE = 0.01
@@ -116,18 +117,22 @@ def test_interpoint_linear_constraints(
     check_type,
 ):
     """Test interpoint linear constraints with various operators and parameters."""
-    run_iterations(campaign_non_sequential, n_iterations, batch_size, add_noise=False)
-    res = campaign_non_sequential.measurements
+    batches = []
+    for _ in range(n_iterations):
+        rec = campaign_non_sequential.recommend(batch_size=batch_size)
+        batches.append(rec)
+        add_fake_measurements(rec, campaign_non_sequential.targets)
+        campaign_non_sequential.add_measurements(rec)
 
-    res_grouped = res.groupby("BatchNr")
-    interpoint_result = calculation(res_grouped)
+    for batch in batches:
+        interpoint_result = calculation(batch)
 
-    if check_type == "eq":
-        assert np.allclose(interpoint_result, expected_value, atol=TOLERANCE)
-    elif check_type == "ge":
-        assert interpoint_result.ge(expected_value - TOLERANCE).all()
-    elif check_type == "le":
-        assert interpoint_result.le(expected_value + TOLERANCE).all()
+        if check_type == "eq":
+            assert np.isclose(interpoint_result, expected_value, atol=TOLERANCE)
+        elif check_type == "ge":
+            assert interpoint_result >= expected_value - TOLERANCE
+        elif check_type == "le":
+            assert interpoint_result <= expected_value + TOLERANCE
 
 
 @pytest.mark.parametrize("parameter_names", [["Conti_finite1", "Conti_finite2"]])
@@ -140,11 +145,20 @@ def test_interpoint_intrapoint_mix(
     batch_size,
 ):
     """Test mixing interpoint and intrapoint inequality constraints."""
-    run_iterations(campaign_non_sequential, n_iterations, batch_size, add_noise=False)
-    res = campaign_non_sequential.measurements
+    batches = []
+    for _ in range(n_iterations):
+        rec = campaign_non_sequential.recommend(batch_size=batch_size)
+        batches.append(rec)
+        add_fake_measurements(rec, campaign_non_sequential.targets)
+        campaign_non_sequential.add_measurements(rec)
 
-    interpoint_result = 2 * res.groupby("BatchNr")["Conti_finite1"].sum()
-    assert interpoint_result.ge(0.3 - TOLERANCE).all()
+    # Interpoint constraint: sum across each batch
+    for batch in batches:
+        interpoint_result = 2 * batch["Conti_finite1"].sum()
+        assert interpoint_result >= 0.3 - TOLERANCE
+
+    # Intrapoint constraint: each row individually
+    res = campaign_non_sequential.measurements
     assert (
         (1.0 * res["Conti_finite1"] + 3.0 * res["Conti_finite2"])
         .ge(0.3 - TOLERANCE)

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_index_equal
 from pytest import param
 
 from baybe.acquisition import qLogEI, qLogNEHVI, qTS, qUCB
-from baybe.campaign import _EXCLUDED, Campaign
+from baybe.campaign import Campaign
 from baybe.constraints.conditions import SubSelectionCondition
 from baybe.constraints.discrete import DiscreteExcludeConstraint
 from baybe.exceptions import IncompatibilityError, NotEnoughPointsLeftError
@@ -91,7 +91,7 @@ def test_get_surrogate(campaign, n_iterations, batch_size):
     ids=["dataframe", "constraints"],
 )
 def test_candidate_toggling(constraints, exclude, complement):
-    """Toggling discrete candidates updates the campaign metadata accordingly."""
+    """Toggling discrete candidates updates the exclusion state accordingly."""
     subspace = SubspaceDiscrete.from_product(
         [
             NumericalDiscreteParameter("a", [0, 1]),
@@ -99,22 +99,30 @@ def test_candidate_toggling(constraints, exclude, complement):
         ]
     )
     campaign = Campaign(subspace)
+    all_candidates = campaign.searchspace.discrete.exp_rep
 
-    # Set metadata to opposite of targeted value so that we can verify the effect later
-    campaign._searchspace_metadata[_EXCLUDED] = not exclude
+    # Set initial state to the opposite of the targeted value
+    if not exclude:
+        # Pre-exclude all candidates so that we can test re-inclusion
+        campaign.toggle_discrete_candidates(all_candidates, exclude=True)
 
     # Toggle the candidates
     campaign.toggle_discrete_candidates(constraints, exclude, complement=complement)
 
-    # Extract row indices of candidates whose metadata should have been toggled
-    matches = campaign.searchspace.discrete.exp_rep["a"] == 0
-    idx = matches.index[~matches if complement else matches]
+    # Determine which candidates should be affected by the toggle
+    matches = all_candidates["a"] == 0
+    toggled_idx = matches.index[~matches if complement else matches]
+    toggled_rows = all_candidates.loc[toggled_idx]
 
-    # Assert that metadata is set correctly
-    target = campaign._searchspace_metadata.loc[idx, _EXCLUDED]
-    other = campaign._searchspace_metadata[_EXCLUDED].drop(index=idx)
-    assert all(target == exclude)  # must contain the updated values
-    assert all(other != exclude)  # must contain the original values
+    if exclude:
+        # The toggled rows should be excluded, the rest should not
+        assert len(campaign._excluded_experiments) == len(toggled_rows)
+        merged = pd.merge(campaign._excluded_experiments, toggled_rows, how="inner")
+        assert len(merged) == len(toggled_rows)
+    else:
+        # The toggled rows should be re-included, the rest should remain excluded
+        expected_remaining = len(all_candidates) - len(toggled_rows)
+        assert len(campaign._excluded_experiments) == expected_remaining
 
 
 @pytest.mark.parametrize(

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -276,7 +276,6 @@ def test_update_measurements(ongoing_campaign):
     meas = ongoing_campaign.measurements
     assert meas.iloc[0, updated.columns.get_loc(p_name)] == 1337
     assert meas.iloc[0, updated.columns.get_loc(t_name)] == 1337
-    assert meas.iloc[[0], updated.columns.get_loc("FitNr")].isna().all()
     assert ongoing_campaign._cached_recommendation is None
 
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -629,3 +629,27 @@ def test_legacy_recommended_metadata_deserialization(ongoing_campaign):
         drop=True
     )
     pd.testing.assert_frame_equal(restored_sorted, expected_sorted)
+
+
+def test_legacy_empty_dataframe_schema_deserialization():
+    """Legacy campaigns with schema-less empty DataFrames get correct columns."""
+    from baybe.campaign import Campaign
+    from baybe.parameters.numerical import NumericalDiscreteParameter
+    from baybe.serialization import converter
+    from baybe.targets.numerical import NumericalTarget
+
+    p = NumericalDiscreteParameter("x", [1, 2, 3])
+    t = NumericalTarget("y")
+    campaign = Campaign(p.to_searchspace(), t.to_objective())
+
+    # Simulate legacy serialization: replace with column-less empty DataFrames
+    data = campaign.to_dict()
+    data["measurements"] = converter.unstructure(pd.DataFrame())
+    data["recommended_experiments"] = converter.unstructure(pd.DataFrame())
+
+    restored = Campaign.from_dict(data)
+    assert restored._measurements.columns.tolist() == ["x", "y"]
+    assert restored._recommended_experiments.columns.tolist() == ["x"]
+    assert restored._measurements.empty
+    assert restored._recommended_experiments.empty
+    assert restored == campaign

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -605,22 +605,21 @@ def test_legacy_recommended_metadata_deserialization(ongoing_campaign):
     rec = ongoing_campaign.recommend(batch_size=2)
     n_recommended = len(rec)
 
-    # Serialize and simulate legacy format (no recommended_experiments field)
+    # Serialize and simulate legacy format (no recommended/excluded_experiments)
     data = ongoing_campaign.to_dict()
     del data["recommended_experiments"]
+    del data["excluded_experiments"]
 
-    # Inject legacy recommended column into searchspace_metadata
-    metadata = converter.structure(data["searchspace_metadata"], pd.DataFrame)
-    assert _RECOMMENDED not in metadata.columns
-    # Add the recommended column as it would have been in legacy format
-    metadata[_RECOMMENDED] = False
+    # Construct legacy searchspace_metadata with a "recommended" column
+    exp_rep = ongoing_campaign.searchspace.discrete.exp_rep
+    metadata = pd.DataFrame(False, index=exp_rep.index, columns=[_RECOMMENDED])
     idxs = rec.index[:n_recommended]
     metadata.loc[idxs, _RECOMMENDED] = True
     data["searchspace_metadata"] = converter.unstructure(metadata)
 
     # Deserialization must reconstruct _recommended_experiments with correct content
     restored = Campaign.from_dict(data)
-    expected = ongoing_campaign.searchspace.discrete.exp_rep.loc[idxs]
+    expected = exp_rep.loc[idxs]
     # Compare as sets of rows (order may differ)
     restored_sorted = restored._recommended_experiments.sort_values(
         restored._recommended_experiments.columns.tolist()
@@ -656,7 +655,7 @@ def test_legacy_empty_dataframe_schema_deserialization():
 
 
 def test_legacy_measured_metadata_deserialization():
-    """Legacy searchspace_metadata 'measured' column is stripped during loading."""
+    """Legacy searchspace_metadata 'measured' column is discarded during loading."""
     from baybe.campaign import _MEASURED, Campaign
     from baybe.parameters.numerical import NumericalDiscreteParameter
     from baybe.serialization import converter
@@ -668,11 +667,46 @@ def test_legacy_measured_metadata_deserialization():
 
     # Simulate legacy format: searchspace_metadata with a "measured" column
     data = campaign.to_dict()
-    metadata = converter.structure(data["searchspace_metadata"], pd.DataFrame)
-    metadata[_MEASURED] = [True, False, False]
+    metadata = pd.DataFrame(
+        {_MEASURED: [True, False, False]},
+        index=campaign.searchspace.discrete.exp_rep.index,
+    )
     data["searchspace_metadata"] = converter.unstructure(metadata)
 
-    # Deserialization must strip the legacy column without errors
+    # Deserialization must handle the legacy column without errors
     restored = Campaign.from_dict(data)
-    assert _MEASURED not in restored._searchspace_metadata.columns
     assert restored == campaign
+
+
+def test_legacy_excluded_metadata_deserialization():
+    """Legacy searchspace_metadata 'excluded' column migrates to new field."""
+    from baybe.campaign import _EXCLUDED, Campaign
+    from baybe.parameters.numerical import NumericalDiscreteParameter
+    from baybe.serialization import converter
+    from baybe.targets.numerical import NumericalTarget
+
+    p = NumericalDiscreteParameter("x", [1, 2, 3])
+    t = NumericalTarget("y")
+    campaign = Campaign(p.to_searchspace(), t.to_objective())
+
+    # Simulate legacy format: searchspace_metadata with an "excluded" column,
+    # and no excluded_experiments field
+    data = campaign.to_dict()
+    del data["excluded_experiments"]
+    exp_rep = campaign.searchspace.discrete.exp_rep
+    metadata = pd.DataFrame(
+        {_EXCLUDED: [True, False, True]},
+        index=exp_rep.index,
+    )
+    data["searchspace_metadata"] = converter.unstructure(metadata)
+
+    # Deserialization must reconstruct _excluded_experiments
+    restored = Campaign.from_dict(data)
+    excluded_idxs = metadata.index[metadata[_EXCLUDED]]
+    expected = exp_rep.loc[excluded_idxs].reset_index(drop=True)
+    pd.testing.assert_frame_equal(
+        restored._excluded_experiments.sort_values(
+            restored._excluded_experiments.columns.tolist()
+        ).reset_index(drop=True),
+        expected.sort_values(expected.columns.tolist()).reset_index(drop=True),
+    )

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -644,7 +644,6 @@ def test_legacy_empty_dataframe_schema_deserialization():
     # Simulate legacy serialization: replace with column-less empty DataFrames
     data = campaign.to_dict()
     data["measurements"] = converter.unstructure(pd.DataFrame())
-    data["recommended_experiments"] = converter.unstructure(pd.DataFrame())
 
     restored = Campaign.from_dict(data)
     assert restored._measurements.columns.tolist() == ["x", "y"]

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -582,12 +582,13 @@ def test_legacy_campaign_counter_deserialization(ongoing_campaign):
     data["n_batches_done"] = 2
 
     # Inject legacy columns into measurements
-    meas = converter.structure(data["measurements_exp"], pd.DataFrame)
+    # (use legacy key name "measurements_exp" to test migration hook)
+    meas = converter.structure(data.pop("measurements"), pd.DataFrame)
     meas["FitNr"] = 1.0
     meas["BatchNr"] = 1
     data["measurements_exp"] = converter.unstructure(meas)
 
     # Deserialization must not raise and legacy columns must be stripped
     restored = Campaign.from_dict(data)
-    assert "FitNr" not in restored._measurements_exp.columns
-    assert "BatchNr" not in restored._measurements_exp.columns
+    assert "FitNr" not in restored._measurements.columns
+    assert "BatchNr" not in restored._measurements.columns

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -592,3 +592,40 @@ def test_legacy_campaign_counter_deserialization(ongoing_campaign):
     restored = Campaign.from_dict(data)
     assert "FitNr" not in restored._measurements.columns
     assert "BatchNr" not in restored._measurements.columns
+
+
+@pytest.mark.parametrize("batch_size", [3], ids=["b3"])
+@pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
+def test_legacy_recommended_metadata_deserialization(ongoing_campaign):
+    """Legacy searchspace_metadata 'recommended' column migrates to new field."""
+    from baybe.campaign import _RECOMMENDED, Campaign
+    from baybe.serialization import converter
+
+    # Recommend to mark some entries as recommended
+    rec = ongoing_campaign.recommend(batch_size=2)
+    n_recommended = len(rec)
+
+    # Serialize and simulate legacy format (no recommended_experiments field)
+    data = ongoing_campaign.to_dict()
+    del data["recommended_experiments"]
+
+    # Inject legacy recommended column into searchspace_metadata
+    metadata = converter.structure(data["searchspace_metadata"], pd.DataFrame)
+    assert _RECOMMENDED not in metadata.columns
+    # Add the recommended column as it would have been in legacy format
+    metadata[_RECOMMENDED] = False
+    idxs = rec.index[:n_recommended]
+    metadata.loc[idxs, _RECOMMENDED] = True
+    data["searchspace_metadata"] = converter.unstructure(metadata)
+
+    # Deserialization must reconstruct _recommended_experiments with correct content
+    restored = Campaign.from_dict(data)
+    expected = ongoing_campaign.searchspace.discrete.exp_rep.loc[idxs]
+    # Compare as sets of rows (order may differ)
+    restored_sorted = restored._recommended_experiments.sort_values(
+        restored._recommended_experiments.columns.tolist()
+    ).reset_index(drop=True)
+    expected_sorted = expected.sort_values(expected.columns.tolist()).reset_index(
+        drop=True
+    )
+    pd.testing.assert_frame_equal(restored_sorted, expected_sorted)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -556,3 +556,31 @@ def test_multitask_kernel_deprecation(monkeypatch, custom: bool, env: bool, task
     )
     with context:
         GaussianProcessSurrogate(*args).fit(searchspace, objective, measurements)
+
+
+def test_deprecated_n_fits_done(campaign):
+    """Accessing the deprecated n_fits_done property raises an error."""
+    with pytest.raises(DeprecationError, match="n_fits_done"):
+        campaign.n_fits_done
+
+
+@pytest.mark.parametrize("batch_size", [3], ids=["b3"])
+@pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
+def test_legacy_n_fits_done_deserialization(ongoing_campaign):
+    """Deserializing a campaign with legacy n_fits_done and FitNr still works."""
+    from baybe.campaign import Campaign
+    from baybe.serialization import converter
+
+    # Serialize, then inject legacy fields
+    data = ongoing_campaign.to_dict()
+    assert "n_fits_done" not in data
+    data["n_fits_done"] = 3
+
+    # Inject FitNr column into measurements
+    meas = converter.structure(data["measurements_exp"], pd.DataFrame)
+    meas["FitNr"] = 1.0
+    data["measurements_exp"] = converter.unstructure(meas)
+
+    # Deserialization must not raise and FitNr must be stripped
+    restored = Campaign.from_dict(data)
+    assert "FitNr" not in restored._measurements_exp.columns

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -558,29 +558,36 @@ def test_multitask_kernel_deprecation(monkeypatch, custom: bool, env: bool, task
         GaussianProcessSurrogate(*args).fit(searchspace, objective, measurements)
 
 
-def test_deprecated_n_fits_done(campaign):
-    """Accessing the deprecated n_fits_done property raises an error."""
-    with pytest.raises(DeprecationError, match="n_fits_done"):
-        campaign.n_fits_done
+@pytest.mark.parametrize(
+    "attr", ["n_fits_done", "n_batches_done"], ids=["fits", "batches"]
+)
+def test_deprecated_campaign_counters(campaign, attr):
+    """Accessing the deprecated campaign counter properties raises an error."""
+    with pytest.raises(DeprecationError, match=attr):
+        getattr(campaign, attr)
 
 
 @pytest.mark.parametrize("batch_size", [3], ids=["b3"])
 @pytest.mark.parametrize("n_iterations", [1], ids=["i1"])
-def test_legacy_n_fits_done_deserialization(ongoing_campaign):
-    """Deserializing a campaign with legacy n_fits_done and FitNr still works."""
+def test_legacy_campaign_counter_deserialization(ongoing_campaign):
+    """Deserializing a campaign with legacy counter fields and columns still works."""
     from baybe.campaign import Campaign
     from baybe.serialization import converter
 
     # Serialize, then inject legacy fields
     data = ongoing_campaign.to_dict()
     assert "n_fits_done" not in data
+    assert "n_batches_done" not in data
     data["n_fits_done"] = 3
+    data["n_batches_done"] = 2
 
-    # Inject FitNr column into measurements
+    # Inject legacy columns into measurements
     meas = converter.structure(data["measurements_exp"], pd.DataFrame)
     meas["FitNr"] = 1.0
+    meas["BatchNr"] = 1
     data["measurements_exp"] = converter.unstructure(meas)
 
-    # Deserialization must not raise and FitNr must be stripped
+    # Deserialization must not raise and legacy columns must be stripped
     restored = Campaign.from_dict(data)
     assert "FitNr" not in restored._measurements_exp.columns
+    assert "BatchNr" not in restored._measurements_exp.columns

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -653,3 +653,26 @@ def test_legacy_empty_dataframe_schema_deserialization():
     assert restored._measurements.empty
     assert restored._recommended_experiments.empty
     assert restored == campaign
+
+
+def test_legacy_measured_metadata_deserialization():
+    """Legacy searchspace_metadata 'measured' column is stripped during loading."""
+    from baybe.campaign import _MEASURED, Campaign
+    from baybe.parameters.numerical import NumericalDiscreteParameter
+    from baybe.serialization import converter
+    from baybe.targets.numerical import NumericalTarget
+
+    p = NumericalDiscreteParameter("x", [1, 2, 3])
+    t = NumericalTarget("y")
+    campaign = Campaign(p.to_searchspace(), t.to_objective())
+
+    # Simulate legacy format: searchspace_metadata with a "measured" column
+    data = campaign.to_dict()
+    metadata = converter.structure(data["searchspace_metadata"], pd.DataFrame)
+    metadata[_MEASURED] = [True, False, False]
+    data["searchspace_metadata"] = converter.unstructure(metadata)
+
+    # Deserialization must strip the legacy column without errors
+    restored = Campaign.from_dict(data)
+    assert _MEASURED not in restored._searchspace_metadata.columns
+    assert restored == campaign


### PR DESCRIPTION
## Removed Features
- `n_fits_done` and `FitNr` column tracking removed from `Campaign`; `n_fits_done` is now a deprecated property raising `DeprecationError`
- `n_batches_done` and `BatchNr` column tracking removed from `Campaign`; `n_batches_done` is now a deprecated property raising `DeprecationError`
- `_searchspace_metadata` field removed entirely (constants kept only for legacy deserialization)

## Renames
- `_measurements_exp` → `_measurements` (serialized key: `"measurements_exp"` → `"measurements"`)

## New Internal State Model
- `_recommended_experiments: pd.DataFrame` replaces `_searchspace_metadata["recommended"]`; filtering uses merge-based matching
- `_excluded_experiments: pd.DataFrame` replaces `_searchspace_metadata["excluded"]`; `toggle_discrete_candidates` adds/removes rows
- Measured state is now computed on-the-fly via `fuzzy_row_match` instead of persisted
- Empty DataFrames initialized with correct column schemas via `@field.default`

## Serialization
- Legacy `n_fits_done`, `n_batches_done`, `FitNr`, `BatchNr` fields silently discarded on load
- Legacy `"measurements_exp"` key migrated to `"measurements"`
- Legacy `searchspace_metadata` columns migrated:
  - `"recommended"` → `_recommended_experiments`
  - `"excluded"` → `_excluded_experiments`
  - `"measured"` discarded (since info already contained in `measurements`)

## Tests
- Removed `FitNr`/`BatchNr` assertions; refactored affected tests to use new state model
- Added deprecation tests for counters and legacy deserialization scenarios
