### PR TITLE
Fix Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parameter and constraint validation has been streamlined, using `validate_parameters`
   and `validate_constraints` as the only remaining public entry points
 
+### Fixed
+- Deserialization with constructor selection now correctly respects converter settings
+
 ### Deprecations
 - `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
 - `SubspaceDiscrete` ignores any `empty_encoding` when provided

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -18,6 +18,7 @@ from typing import (
 import attrs
 import cattrs
 import pandas as pd
+from cattrs.gen import make_dict_structure_fn
 from cattrs.strategies import configure_union_passthrough
 
 from baybe.utils.basic import find_subclass
@@ -229,8 +230,8 @@ def select_constructor_hook(specs: dict, cls: type[_T]) -> _T:
         # Call the constructor with the deserialized arguments
         return constructor(**specs)
 
-    # Otherwise, use the regular __init__ method
-    return converter.structure_attrs_fromdict(specs, cls)
+    # Otherwise, structure using the regular mechanism
+    return make_dict_structure_fn(cls, converter)(specs, cls)
 
 
 # Register custom (un-)structure hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ['version']
 dependencies = [
     "attrs>=26.1.0",
     "botorch>=0.13.0,<1",
-    "cattrs>=25.2.0",
+    "cattrs>=26.1.0",
     "exceptiongroup",
     "gpytorch>=1.9.1,<2",
     "joblib>1.4.0,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-22T09:27:47.33792Z"
+exclude-newer = "2026-06-12T12:57:26.466234Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -419,7 +419,7 @@ requires-dist = [
     { name = "baybe", extras = ["test"], marker = "extra == 'dev'" },
     { name = "boto3", marker = "extra == 'benchmarking'", specifier = ">=1.0.0,<2" },
     { name = "botorch", specifier = ">=0.13.0,<1" },
-    { name = "cattrs", specifier = ">=25.2.0" },
+    { name = "cattrs", specifier = ">=26.1.0" },
     { name = "exceptiongroup" },
     { name = "flake8", marker = "extra == 'lint'", specifier = "==7.3.0" },
     { name = "fpsample", marker = "extra == 'extras'", specifier = ">=1.0.1" },
@@ -609,16 +609,16 @@ wheels = [
 
 [[package]]
 name = "cattrs"
-version = "25.3.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- `select_constructor_hook` was using `structure_attrs_fromdict` to instantiate attrs classes, which hardcodes field name lookups and ignores converter settings such as `use_alias`. This caused serialization roundtrips to break for classes with aliased private fields. The fix replaces the call with `make_dict_structure_fn`, which correctly inherits the converter's configuration.
- The cattrs requirement is also bumped to 26.1.0 to support the `Annotated[T, cattrs.override(...)]` pattern used for deprecation fields.