### PR TITLE
Use `BetaPrior` in MultiTask Botorch Preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance
+  kernel in multi-task scenarios, matching BoTorch's `MultiTaskGP` defaults introduced
+  in version `0.18.0`.
+
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes
 - `GaussianProcessSurrogate` no longer automatically adds a task kernel in multi-task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `BOTORCH` GP preset now requires BoTorch `>= 0.18.0` and raises an
+  `IncompatibilityError` if an older version is installed.
+
 ### Fixed
 - `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance
   kernel in multi-task scenarios, matching BoTorch's `MultiTaskGP` defaults introduced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- The `BOTORCH` GP preset now requires BoTorch `>= 0.18.0` and raises an
-  `IncompatibilityError` if an older version is installed.
-
-### Fixed
 - `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance
   kernel in multi-task scenarios, matching BoTorch's `MultiTaskGP` defaults introduced
-  in version `0.18.0`.
+  in version `0.18.0`
+- The `BOTORCH` GP preset now requires BoTorch `>= 0.18.0` and raises an
+  `IncompatibilityError` if an older version is installed
 
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -1,16 +1,26 @@
-"""BoTorch preset for Gaussian process surrogates.
+"""BoTorch preset for Gaussian process surrogates."""
 
-Currently mimics the Hvarfner preset :cite:p:`Hvarfner2024`.
-"""
+from __future__ import annotations
 
-from baybe.surrogates.gaussian_process.presets.hvarfner import (
-    FIT_CRITERION_FACTORY,
-    KERNEL_FACTORY,
-    LIKELIHOOD_FACTORY,
-    MEAN_FACTORY,
+import gc
+from itertools import chain
+from typing import TYPE_CHECKING, ClassVar
+
+import pandas as pd
+from attrs import define
+from typing_extensions import override
+
+from baybe.kernels.base import Kernel
+from baybe.objectives.base import Objective
+from baybe.parameters.enum import _ParameterKind
+from baybe.searchspace.core import SearchSpace
+from baybe.surrogates.gaussian_process.components.fit_criterion import (
+    FitCriterion,
+    PlainFitCriterionFactory,
 )
-from baybe.surrogates.gaussian_process.presets.hvarfner import (
-    HvarfnerKernelFactory as BotorchKernelFactory,
+from baybe.surrogates.gaussian_process.components.kernel import (
+    ICMKernelFactory,
+    _PureKernelFactory,
 )
 from baybe.surrogates.gaussian_process.presets.hvarfner import (
     HvarfnerLikelihoodFactory as BotorchLikelihoodFactory,
@@ -18,6 +28,84 @@ from baybe.surrogates.gaussian_process.presets.hvarfner import (
 from baybe.surrogates.gaussian_process.presets.hvarfner import (
     HvarfnerMeanFactory as BotorchMeanFactory,
 )
+
+if TYPE_CHECKING:
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
+
+@define
+class BotorchKernelFactory(_PureKernelFactory):
+    """A factory providing kernels matching BoTorch's :class:`~botorch.models.MultiTaskGP` defaults."""  # noqa: E501
+
+    _uses_parameter_names: ClassVar[bool] = True
+    # See base class.
+
+    _supported_parameter_kinds: ClassVar[_ParameterKind] = (
+        _ParameterKind.REGULAR | _ParameterKind.TASK
+    )
+    # See base class.
+
+    @override
+    def _make(
+        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+    ) -> Kernel | GPyTorchKernel:
+        from botorch.models.kernels.positive_index import PositiveIndexKernel
+        from botorch.models.utils.gpytorch_modules import (
+            get_covar_module_with_dim_scaled_prior,
+        )
+
+        parameter_names = self.get_parameter_names(searchspace)
+
+        # For regular parameters, resolve parameter names to active dimension indices
+        active_dims = list(
+            chain.from_iterable(
+                searchspace.get_comp_rep_parameter_indices(name)
+                for name in parameter_names
+                if searchspace.get_parameters_by_name([name])[0]._kind
+                is _ParameterKind.REGULAR
+            )
+        )
+        ard_num_dims = len(active_dims)
+
+        # Create the base kernel for the regular parameters
+        base_kernel = get_covar_module_with_dim_scaled_prior(
+            ard_num_dims=ard_num_dims, active_dims=active_dims
+        )
+
+        # Single-task case
+        if (task_idx := searchspace.task_idx) is None:
+            return base_kernel
+
+        # BoTorch's MultiTaskGP added BetaPrior(2.5, 1.5) as the default task
+        # covariance prior starting from version 0.18.0. For older versions, the
+        # prior is not available and we fall back to no prior (matching that version's
+        # MultiTaskGP behavior).
+        try:
+            from botorch.models.utils.priors import BetaPrior
+
+            task_prior = BetaPrior(concentration1=2.5, concentration0=1.5)
+        except ImportError:
+            task_prior = None
+
+        index_kernel = PositiveIndexKernel(
+            num_tasks=searchspace.n_tasks,
+            rank=searchspace.n_tasks,
+            task_prior=task_prior,
+            active_dims=[task_idx],
+        )
+        return ICMKernelFactory(base_kernel, index_kernel)(
+            searchspace, objective, measurements
+        )
+
+
+# Collect leftover original slotted classes processed by `attrs.define`
+gc.collect()
+
+# Aliases for generic preset imports
+KERNEL_FACTORY = BotorchKernelFactory()
+MEAN_FACTORY = BotorchMeanFactory()
+LIKELIHOOD_FACTORY = BotorchLikelihoodFactory()
+FIT_CRITERION_FACTORY = PlainFitCriterionFactory(FitCriterion.MARGINAL_LOG_LIKELIHOOD)
 
 __all__ = [
     "BotorchKernelFactory",

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -45,14 +45,20 @@ class BotorchKernelFactory(_PureKernelFactory):
     )
     # See base class.
 
+    #: The minimum BoTorch version required for this preset.
+    _MIN_BOTORCH_VERSION: ClassVar[str] = "0.18.0"
+
     @override
     def _make(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel | GPyTorchKernel:
+        self._check_botorch_version()
+
         from botorch.models.kernels.positive_index import PositiveIndexKernel
         from botorch.models.utils.gpytorch_modules import (
             get_covar_module_with_dim_scaled_prior,
         )
+        from botorch.models.utils.priors import BetaPrior
 
         parameter_names = self.get_parameter_names(searchspace)
 
@@ -76,17 +82,7 @@ class BotorchKernelFactory(_PureKernelFactory):
         if (task_idx := searchspace.task_idx) is None:
             return base_kernel
 
-        # BoTorch's MultiTaskGP added BetaPrior(2.5, 1.5) as the default task
-        # covariance prior starting from version 0.18.0. For older versions, the
-        # prior is not available and we fall back to no prior (matching that version's
-        # MultiTaskGP behavior).
-        try:
-            from botorch.models.utils.priors import BetaPrior
-
-            task_prior = BetaPrior(concentration1=2.5, concentration0=1.5)
-        except ImportError:
-            task_prior = None
-
+        task_prior = BetaPrior(concentration1=2.5, concentration0=1.5)
         index_kernel = PositiveIndexKernel(
             num_tasks=searchspace.n_tasks,
             rank=searchspace.n_tasks,
@@ -96,6 +92,27 @@ class BotorchKernelFactory(_PureKernelFactory):
         return ICMKernelFactory(base_kernel, index_kernel)(
             searchspace, objective, measurements
         )
+
+    def _check_botorch_version(self) -> None:
+        """Verify that the installed BoTorch version meets the minimum requirement.
+
+        Raises:
+            IncompatibilityError: If the installed BoTorch version is too old.
+        """
+        from importlib.metadata import version
+
+        from packaging.version import Version
+
+        from baybe.exceptions import IncompatibilityError
+
+        installed = version("botorch")
+        if Version(installed) < Version(self._MIN_BOTORCH_VERSION):
+            raise IncompatibilityError(
+                f"The '{self.__class__.__name__}' requires BoTorch >= "
+                f"{self._MIN_BOTORCH_VERSION}, but version {installed} is installed. "
+                f"Please upgrade BoTorch: pip install 'botorch>="
+                f"{self._MIN_BOTORCH_VERSION}'."
+            )
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -48,11 +48,13 @@ class BotorchKernelFactory(_PureKernelFactory):
     )
     # See base class.
 
+    def __attrs_pre_init__(self) -> None:
+        self._validate_botorch_version()
+
     @override
     def _make(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel | GPyTorchKernel:
-        self._validate_botorch_version()
 
         from botorch.models.kernels.positive_index import PositiveIndexKernel
         from botorch.models.utils.gpytorch_modules import (

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -110,9 +110,9 @@ class BotorchKernelFactory(_PureKernelFactory):
         installed = version("botorch")
         if Version(installed) < Version(_MIN_BOTORCH_VERSION):
             raise IncompatibilityError(
-                f"The '{self.__class__.__name__}' requires BoTorch >= "
+                f"The '{self.__class__.__name__}' requires botorch>="
                 f"{_MIN_BOTORCH_VERSION}, but version {installed} is installed. "
-                f"Please upgrade BoTorch: pip install 'botorch>="
+                f"Please upgrade: pip install 'botorch>="
                 f"{_MIN_BOTORCH_VERSION}'."
             )
 

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -52,7 +52,7 @@ class BotorchKernelFactory(_PureKernelFactory):
     def _make(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel | GPyTorchKernel:
-        self._check_botorch_version()
+        self._validate_botorch_version()
 
         from botorch.models.kernels.positive_index import PositiveIndexKernel
         from botorch.models.utils.gpytorch_modules import (
@@ -93,7 +93,7 @@ class BotorchKernelFactory(_PureKernelFactory):
             searchspace, objective, measurements
         )
 
-    def _check_botorch_version(self) -> None:
+    def _validate_botorch_version(self) -> None:
         """Verify that the installed BoTorch version meets the minimum requirement.
 
         Raises:

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -32,6 +32,9 @@ from baybe.surrogates.gaussian_process.presets.hvarfner import (
 if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
 
+# The minimum BoTorch version required for the preset
+_MIN_BOTORCH_VERSION = "0.18.0"
+
 
 @define
 class BotorchKernelFactory(_PureKernelFactory):
@@ -44,9 +47,6 @@ class BotorchKernelFactory(_PureKernelFactory):
         _ParameterKind.REGULAR | _ParameterKind.TASK
     )
     # See base class.
-
-    #: The minimum BoTorch version required for this preset.
-    _MIN_BOTORCH_VERSION: ClassVar[str] = "0.18.0"
 
     @override
     def _make(
@@ -106,12 +106,12 @@ class BotorchKernelFactory(_PureKernelFactory):
         from baybe.exceptions import IncompatibilityError
 
         installed = version("botorch")
-        if Version(installed) < Version(self._MIN_BOTORCH_VERSION):
+        if Version(installed) < Version(_MIN_BOTORCH_VERSION):
             raise IncompatibilityError(
                 f"The '{self.__class__.__name__}' requires BoTorch >= "
-                f"{self._MIN_BOTORCH_VERSION}, but version {installed} is installed. "
+                f"{_MIN_BOTORCH_VERSION}, but version {installed} is installed. "
                 f"Please upgrade BoTorch: pip install 'botorch>="
-                f"{self._MIN_BOTORCH_VERSION}'."
+                f"{_MIN_BOTORCH_VERSION}'."
             )
 
 

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -48,13 +48,11 @@ class BotorchKernelFactory(_PureKernelFactory):
     )
     # See base class.
 
-    def __attrs_pre_init__(self) -> None:
-        self._validate_botorch_version()
-
     @override
     def _make(
         self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
     ) -> Kernel | GPyTorchKernel:
+        self._validate_botorch_version()
 
         from botorch.models.kernels.positive_index import PositiveIndexKernel
         from botorch.models.utils.gpytorch_modules import (

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -200,10 +200,9 @@ def test_invalid_components():
 # NOTE: The BOTORCH preset tracks BoTorch's GP defaults while the HVARFNER preset
 #   implements BoTorch's static Hvarfner et al. (2024) parametrization. Therefore, the
 #   presets diverge as BoTorch evolves (e.g., BetaPrior added in 0.18.0).
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     sys.version_info < (3, 11),
     reason="BoTorch >=0.18.0 requires Python >=3.11.",
-    strict=True,
 )
 @pytest.mark.parametrize("multitask", [False, True], ids=["single-task", "multi-task"])
 def test_botorch_preset(multitask: bool):

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -195,9 +195,9 @@ def test_invalid_components():
         GaussianProcessSurrogate(fit_criterion_or_factory=MaternKernel())
 
 
-# NOTE: The BOTORCH preset tracks BoTorch's MultiTaskGP defaults. The HVARFNER preset
-#   implements the fixed Hvarfner et al. (2024) parametrization and may diverge from
-#   BoTorch's defaults as BoTorch evolves (e.g., BetaPrior added in 0.18.0).
+# NOTE: The BOTORCH preset tracks BoTorch's GP defaults while the HVARFNER preset
+#   implements BoTorch's static Hvarfner et al. (2024) parametrization. Therefore, the
+#   presets diverge as BoTorch evolves (e.g., BetaPrior added in 0.18.0).
 @pytest.mark.parametrize("multitask", [False, True], ids=["single-task", "multi-task"])
 def test_botorch_preset(multitask: bool):
     """The BoTorch preset exactly mimics BoTorch's MultiTaskGP/SingleTaskGP behavior."""

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -1,5 +1,7 @@
 """Tests for the Gaussian Process surrogate."""
 
+import sys
+
 import pandas as pd
 import pytest
 import torch
@@ -198,6 +200,11 @@ def test_invalid_components():
 # NOTE: The BOTORCH preset tracks BoTorch's GP defaults while the HVARFNER preset
 #   implements BoTorch's static Hvarfner et al. (2024) parametrization. Therefore, the
 #   presets diverge as BoTorch evolves (e.g., BetaPrior added in 0.18.0).
+@pytest.mark.xfail(
+    sys.version_info < (3, 11),
+    reason="BoTorch >=0.18.0 requires Python >=3.11.",
+    strict=True,
+)
 @pytest.mark.parametrize("multitask", [False, True], ids=["single-task", "multi-task"])
 def test_botorch_preset(multitask: bool):
     """The BoTorch preset exactly mimics BoTorch's MultiTaskGP/SingleTaskGP behavior."""

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -195,13 +195,12 @@ def test_invalid_components():
         GaussianProcessSurrogate(fit_criterion_or_factory=MaternKernel())
 
 
-# NOTE: BOTORCH and HVARFNER presets coincide at the moment but BOTORCH settings can
-#   change in the future. If that happens, the test below will start to fail and the
-#   HVARFNER parametrization needs to be dropped.
-@pytest.mark.parametrize("preset", ["BOTORCH", "HVARFNER"], ids=["botorch", "hvarfner"])
+# NOTE: The BOTORCH preset tracks BoTorch's MultiTaskGP defaults. The HVARFNER preset
+#   implements the fixed Hvarfner et al. (2024) parametrization and may diverge from
+#   BoTorch's defaults as BoTorch evolves (e.g., BetaPrior added in 0.18.0).
 @pytest.mark.parametrize("multitask", [False, True], ids=["single-task", "multi-task"])
-def test_botorch_preset(multitask: bool, preset: str):
-    """The BoTorch/Hvarfner presets exactly mimic BoTorch's behavior."""
+def test_botorch_preset(multitask: bool):
+    """The BoTorch preset exactly mimics BoTorch's MultiTaskGP/SingleTaskGP behavior."""
     if multitask:
         sp = searchspace_mt
         data = measurements_mt
@@ -210,7 +209,7 @@ def test_botorch_preset(multitask: bool, preset: str):
         data = measurements
 
     active_settings.random_seed = 1337
-    gp = GaussianProcessSurrogate.from_preset(preset)
+    gp = GaussianProcessSurrogate.from_preset("BOTORCH")
     gp.fit(sp, objective, data)
     posterior1 = gp.posterior_stats(data)
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ isolated_build = True
 [testenv:fulltest,fulltest-py{310,311,312,313,314}]
 description = Run PyTest with all extra functionality
 extras = extras,examples,lint,test
+deps =
+    py311,py312,py313,py314: botorch>=0.18.0,<1
 passenv =
     CI
     BAYBE_USE_SINGLE_PRECISION_NUMPY 
@@ -21,6 +23,8 @@ commands =
 [testenv:gputest,gputest-py{310,311,312,313,314}]
 description = Runs GPU tests
 extras = test
+deps =
+    py311,py312,py313,py314: botorch>=0.18.0,<1
 passenv =
     CI
     BAYBE_USE_SINGLE_PRECISION_NUMPY
@@ -35,6 +39,8 @@ commands =
 [testenv:coretest,coretest-py{310,311,312,313,314}]
 description = Run PyTest with core functionality
 extras = test
+deps =
+    py311,py312,py313,py314: botorch>=0.18.0,<1
 passenv =
     CI
     BAYBE_USE_SINGLE_PRECISION_NUMPY


### PR DESCRIPTION
This PR changes the `BOTORCH` preset to use the `BetaPrior(2.5, 1.5)` in the multi task case.

This change was introduced in Botorch v.0.18.0 (see https://github.com/meta-pytorch/botorch/releases/tag/v0.18.0). Consequently, our `BOTORCH` preset no longer reflected the actual botorch defaults and failed.

This PR thus updates the `BotorchKernelFactory` to not simply use `HVARFNER` but to use the new prior in the multi task case instead.