### PR TITLE
Deprecate `SubspaceDiscrete.constraints`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,17 @@ Every module using `@define` must end with:
 Name descriptively: `from_product`, `from_dataframe`, `from_parameter`, `from_config`,
 `from_json`, `from_dict`, `from_preset`.
 
+Use `Self` return type and `cls()` construction for proper subclass support:
+```python
+from typing_extensions import Self
+
+@classmethod
+def from_parameter(cls, parameter: DiscreteParameter) -> Self:
+    """Create a subspace from a single parameter."""
+    return cls(parameters=[parameter], ...)  # Use cls(), not ClassName()
+```
+This ensures subclasses return their own type, not the base class type.
+
 ### classproperty
 Custom `@classproperty` from `baybe.utils.basic` for class-level computed properties.
 
@@ -319,6 +330,7 @@ For a full list of available tox environments and developer commands, see
 - No hardcoded enum values in comments — link the enum.
 - No private field names in user-facing messages — use public alias.
 - No hardcoded class names in repr/errors — use `self.__class__.__name__`.
+- No hardcoded class names in classmethods — use `cls()` and return `Self`.
 - No silent errors. No mutation of caller-provided dicts.
 - No silent defaults or "best effort" fallbacks — if input is invalid, raise.
 - No proceeding past failed preconditions into expensive computation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `validate_parameter_names`, `validate_cardinality_constraints_are_nonoverlapping`
   and `validate_cardinality_constraint_parameter_bounds` are no longer available
   as public utilities
+- `is_constrained` property removed from `SubspaceDiscrete`, `SubspaceContinuous`,
+  and `SearchSpace`
 
 ### Added
 - `narwhals` as a hard dependency
 - `CandidatesProtocol` as an interface for candidates generation
 - `TableCandidates` and `ProductCandidates` classes implementing `CandidatesProtocol`
 - `DiscreteParameter.is_finite` property
+- `SubspaceDiscrete.batch_constraints` field for storing batch-level constraints
+- `SubspaceDiscrete.from_dataframe` now accepts `batch_constraints`
 
 ### Changed
 - Internal `Campaign` state model simplified: recommended and excluded experiments
@@ -26,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `validate_constraints` as the only remaining public entry points
 - `_recommend_discrete` and kin now return a `pd.DataFrame` subselection of the
   candidates instead of a `pd.Index`
+- `SubspaceDiscrete.from_product` and `SubspaceDiscrete.from_simplex` now split
+  their `constraints` argument into filtering constraints (applied during construction)
+  and batch constraints (stored in `batch_constraints`)
 
 ### Fixed
 - Deserialization with constructor selection now correctly respects converter settings
@@ -34,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
 - `SubspaceDiscrete` ignores any `empty_encoding` when provided
 - `SubspaceDiscrete` no longer accepts a `comp_rep` argument
+- `SubspaceDiscrete.constraints` field
 
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubspaceDiscrete` ignores any `empty_encoding` when provided
 - `SubspaceDiscrete` no longer accepts a `comp_rep` argument
 - `SubspaceDiscrete.constraints` field
+- `SubspaceDiscrete.constraints_batch` property (use `batch_constraints` instead)
 
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
 - `SubspaceDiscrete` ignores any `empty_encoding` when provided
 - `SubspaceDiscrete` no longer accepts a `comp_rep` argument
-- `SubspaceDiscrete.constraints` field
+- `SubspaceDiscrete.constraints` attribute (use `batch_constraints` to provide and
+  access batch-level constraints; filtering constraints are only needed during subspace
+  construction and are thus no longer stored).
 - `SubspaceDiscrete.constraints_batch` property (use `batch_constraints` instead)
 
 ## [0.15.0] - 2026-06-11

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -273,7 +273,7 @@ class PureRecommender(ABC, RecommenderProtocol):
             and not self.supports_discrete_subset_generating_constraints
         ):
             constraint_types = {
-                type(c).__name__ for c in searchspace.discrete.constraints_batch
+                type(c).__name__ for c in searchspace.discrete.batch_constraints
             }
             raise IncompatibilityError(
                 f"'{self.__class__.__name__}' does not support discrete "

--- a/baybe/searchspace/_filtered.py
+++ b/baybe/searchspace/_filtered.py
@@ -37,6 +37,7 @@ class FilteredSubspaceDiscrete(SubspaceDiscrete):
 
         # >>>>> Deprecation
         kwargs.pop("_empty_encoding", None)
+        kwargs.pop("_constraints", None)
         kwargs.pop("_comp_rep", None)
         # <<<<< Deprecation
 

--- a/baybe/searchspace/continuous.py
+++ b/baybe/searchspace/continuous.py
@@ -418,11 +418,6 @@ class SubspaceContinuous(SerialMixin):
         )
 
     @property
-    def is_constrained(self) -> bool:
-        """Boolean indicating if the subspace is constrained in any way."""
-        return bool(self.constraints)
-
-    @property
     def has_interpoint_constraints(self) -> bool:
         """Boolean indicating if the subspace has any interpoint constraints."""
         return any(
@@ -536,7 +531,7 @@ class SubspaceContinuous(SerialMixin):
         if not self.parameters:
             return pd.DataFrame(index=pd.RangeIndex(0, batch_size))
 
-        if not self.is_constrained:
+        if not self.constraints:
             return self._sample_from_bounds(batch_size, self.comp_rep_bounds.to_numpy())
 
         if len(self.constraints_cardinality) == 0:

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -198,7 +198,7 @@ class SearchSpace(SerialMixin):
     def constraints(self) -> tuple[Constraint, ...]:
         """Return the constraints of the search space."""
         return (
-            *self.discrete.constraints,
+            *self.discrete.batch_constraints,
             *self.continuous.constraints,
         )
 

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -203,11 +203,6 @@ class SearchSpace(SerialMixin):
         )
 
     @property
-    def is_constrained(self) -> bool:
-        """Boolean indicating if the search space has any constraints."""
-        return self.discrete.is_constrained or self.continuous.is_constrained
-
-    @property
     def type(self) -> SearchSpaceType:
         """Return the type of the search space."""
         if self.discrete.is_empty and not self.continuous.is_empty:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -49,19 +49,28 @@ if TYPE_CHECKING:
     from baybe.searchspace.core import SearchSpace
 
 
-def _deprecate_argument(error: bool):
+_CONSTRAINTS_DEPRECATION_MSG = (
+    "Providing 'constraints' to 'SubspaceDiscrete' is no longer supported. "
+    "Use 'batch_constraints' for any 'DiscreteBatchConstraint' instances. "
+    "Filtering constraints can simply be dropped. For now, we took care of "
+    "these steps, but please familiarize yourself with the new API and update "
+    "your code accordingly."
+)
+
+
+def _deprecate_argument(error: bool, msg: str | None = None):
     """Helper for deprecating legacy arguments."""  # noqa: D401
 
     def validator(self, attribute, value):
         if value is not None:
-            msg = (
+            warning_msg = msg or (
                 f"Providing '{attribute.alias}' to '{self.__class__.__name__}' is no "
                 f"longer supported. To proceed, simply drop the argument."
             )
             if error:
-                raise DeprecationError(msg)
+                raise DeprecationError(warning_msg)
             else:
-                warnings.warn(msg, DeprecationWarning, stacklevel=3)
+                warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
 
     return validator
 
@@ -124,21 +133,37 @@ class SubspaceDiscrete(SerialMixin):
     )
     "Ignore! For backwards compatibility only."
 
-    constraints: tuple[DiscreteConstraint, ...] = field(
-        default=(),
-        converter=lambda x: to_tuple(
-            sorted(
-                x,
-                key=lambda c: DISCRETE_CONSTRAINTS_FILTERING_ORDER.index(c.__class__),
-            )
-        ),
+    _constraints: Annotated[
+        tuple[DiscreteConstraint, ...], cattrs.override(omit=True)
+    ] = field(
+        alias="constraints",
+        default=None,
+        validator=_deprecate_argument(error=False, msg=_CONSTRAINTS_DEPRECATION_MSG),
     )
-    """Optional constraints filtering the subspace."""
+    "Ignore! For backwards compatibility only."
 
     _comp_rep: Annotated[pd.DataFrame, cattrs.override(omit=True)] = field(
         alias="comp_rep", default=None, validator=_deprecate_argument(error=True)
     )
     "Ignore! For backwards compatibility only."
+
+    batch_constraints: tuple[DiscreteBatchConstraint, ...] = field(
+        default=(),
+        converter=to_tuple,
+        validator=deep_iterable(member_validator=instance_of(DiscreteBatchConstraint)),
+    )
+    """Constraints operating on the recommendation batch level."""
+
+    def __attrs_post_init__(self) -> None:
+        """Migrate deprecated ``constraints`` argument to ``batch_constraints``."""
+        # >>>>>>>>>> Deprecation
+        if self._constraints is not None:
+            batch: tuple[DiscreteBatchConstraint, ...] = tuple(
+                c for c in self._constraints if isinstance(c, DiscreteBatchConstraint)
+            )
+            if batch:
+                self.batch_constraints = self.batch_constraints + batch
+        # <<<<<<<<<< Deprecation
 
     @override
     def __str__(self) -> str:
@@ -147,9 +172,9 @@ class SubspaceDiscrete(SerialMixin):
 
         # Convert the lists to dataFrames to be able to use pretty_printing
         param_list = [param.summary() for param in self.parameters]
-        constraints_list = [constr.summary() for constr in self.constraints]
+        batch_constraints_list = [constr.summary() for constr in self.batch_constraints]
         param_df = pd.DataFrame(param_list)
-        constraints_df = pd.DataFrame(constraints_list)
+        batch_constraints_df = pd.DataFrame(batch_constraints_list)
 
         fields = [
             to_string(
@@ -157,7 +182,7 @@ class SubspaceDiscrete(SerialMixin):
                 pretty_print_df(param_df, max_colwidth=None),
             ),
             to_string("Experimental Representation", pretty_print_df(self.exp_rep)),
-            to_string("Constraints", pretty_print_df(constraints_df)),
+            to_string("Batch Constraints", pretty_print_df(batch_constraints_df)),
             to_string("Computational Representation", pretty_print_df(self.comp_rep)),
         ]
         return to_string(self.__class__.__name__, *fields)
@@ -187,10 +212,10 @@ class SubspaceDiscrete(SerialMixin):
                 "This is not allowed, as it can lead to hard-to-detect bugs."
             )
 
-    @constraints.validator
-    def _validate_constraints(self, _, __) -> None:
-        """Validate constraints."""
-        validate_constraints(self.constraints, self.parameters)
+    @batch_constraints.validator
+    def _validate_batch_constraints(self, _, __) -> None:  # noqa: DOC101, DOC103
+        """Validate batch constraints."""
+        validate_constraints(self.batch_constraints, self.parameters)
 
     def to_searchspace(self) -> SearchSpace:
         """Turn the subspace into a search space with no continuous part."""
@@ -234,11 +259,21 @@ class SubspaceDiscrete(SerialMixin):
             )
             validate_constraints(constraints, parameters)
 
-        df = build_constrained_product(parameters, constraints)
+        filtering_constraints = [c for c in constraints if c.eval_during_creation]
+        batch_constraints = [c for c in constraints if c.eval_during_modeling]
+        assert len(filtering_constraints) + len(batch_constraints) == len(
+            constraints
+        ), (
+            "The constraints could not be fully partitioned into filtering and batch "
+            "constraints. The current logic assumes that each constraint belongs "
+            "exactly to one type."
+        )
+
+        df = build_constrained_product(parameters, filtering_constraints)
 
         return SubspaceDiscrete(
             parameters=parameters,
-            constraints=constraints,
+            batch_constraints=batch_constraints,
             exp_rep=df,
             empty_encoding=empty_encoding,  # type: ignore[arg-type]
         )
@@ -248,6 +283,7 @@ class SubspaceDiscrete(SerialMixin):
         cls,
         df: pd.DataFrame,
         parameters: Sequence[DiscreteParameter] | None = None,
+        batch_constraints: Collection[DiscreteBatchConstraint] = (),
         empty_encoding: bool | None = None,
     ) -> SubspaceDiscrete:
         """Create a discrete subspace with a specified set of configurations.
@@ -265,6 +301,8 @@ class SubspaceDiscrete(SerialMixin):
                 fallback. For both types, default values are used for their optional
                 arguments. For more details, see
                 :func:`baybe.parameters.utils.get_parameters_from_dataframe`.
+            batch_constraints: Optional batch constraints to be applied at
+                recommendation time.
             empty_encoding: Ignore! For backwards compatibility only.
 
         Returns:
@@ -301,7 +339,12 @@ class SubspaceDiscrete(SerialMixin):
         # Ensure dtype consistency
         df = normalize_input_dtypes(df, parameters)
 
-        return cls(parameters=parameters, exp_rep=df, empty_encoding=empty_encoding)  # type: ignore[arg-type]
+        return cls(
+            parameters=parameters,
+            exp_rep=df,
+            batch_constraints=batch_constraints or (),
+            empty_encoding=empty_encoding,  # type: ignore[arg-type]
+        )
 
     @classmethod
     def from_simplex(
@@ -508,15 +551,25 @@ class SubspaceDiscrete(SerialMixin):
         if boundary_only:
             drop_invalid(exp_rep, max_sum, boundary_only=True)
 
-        # Merge product parameters and apply constraints incrementally
+        filtering_constraints = [c for c in constraints if c.eval_during_creation]
+        batch_constraints_list = [c for c in constraints if c.eval_during_modeling]
+        assert len(filtering_constraints) + len(batch_constraints_list) == len(
+            constraints
+        ), (
+            "The constraints could not be fully partitioned into filtering and batch "
+            "constraints. The current logic assumes that each constraint belongs "
+            "exactly to one type."
+        )
+
+        # Merge product parameters and apply filtering constraints incrementally
         exp_rep = build_constrained_product(
-            product_parameters, constraints, initial_df=exp_rep
+            product_parameters, filtering_constraints, initial_df=exp_rep
         )
 
         return cls(
             parameters=[*simplex_parameters, *product_parameters],
             exp_rep=exp_rep,
-            constraints=constraints,
+            batch_constraints=batch_constraints_list,
         )
 
     @property
@@ -538,8 +591,8 @@ class SubspaceDiscrete(SerialMixin):
 
     @property
     def is_constrained(self) -> bool:
-        """Boolean indicating if the subspace has any constraints."""
-        return len(self.constraints) > 0
+        """Boolean indicating if the subspace has any batch constraints."""
+        return len(self.batch_constraints) > 0
 
     @property
     def parameter_names(self) -> tuple[str, ...]:
@@ -620,9 +673,7 @@ class SubspaceDiscrete(SerialMixin):
         self,
     ) -> tuple[DiscreteBatchConstraint, ...]:
         """The batch constraints of the subspace."""
-        return tuple(
-            c for c in self.constraints if isinstance(c, DiscreteBatchConstraint)
-        )
+        return self.batch_constraints
 
     @property
     def n_subsets(self) -> int:
@@ -631,11 +682,11 @@ class SubspaceDiscrete(SerialMixin):
         Returns 0 if no subset-generating constraints exist, indicating that
         no decomposition is needed.
         """
-        if not self.constraints_batch:
+        if not self.batch_constraints:
             return 0
         return prod(
             len(self.get_parameters_by_name([c.parameters[0]])[0].active_values)
-            for c in self.constraints_batch
+            for c in self.batch_constraints
         )
 
     def subset_masks(
@@ -671,10 +722,12 @@ class SubspaceDiscrete(SerialMixin):
             raise ValueError(f"Invalid {mode=}. Must be one of {allowed}.")
 
         per_constraint: list[list[npt.NDArray[np.bool_]]]
-        if not (constraints := self.constraints_batch):
+        if not self.batch_constraints:
             per_constraint = [[np.ones(len(candidates_exp), dtype=bool)]]
         else:
-            per_constraint = [c.subset_masks(candidates_exp) for c in constraints]
+            per_constraint = [
+                c.subset_masks(candidates_exp) for c in self.batch_constraints
+            ]
 
         total = prod(len(masks) for masks in per_constraint)
 
@@ -778,11 +831,13 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
         parameters = converter.structure(specs["parameters"], list[DiscreteParameter])
         validate_parameters(parameters, allow_empty=True)
 
-        constraints = specs.get("constraints", [])
-        if constraints:
-            constraints = converter.structure(
-                specs["constraints"], list[DiscreteConstraint]
-            )
+        # Support both the current `constraints` key (deprecated) and
+        # the new `batch_constraints` key for forward/backward compatibility
+        constraints_raw = specs.get("constraints", []) or specs.get(
+            "batch_constraints", []
+        )
+        if constraints_raw:
+            constraints = converter.structure(constraints_raw, list[DiscreteConstraint])
             validate_constraints(constraints, parameters)
 
     # Validate simplex inputs without constructing it
@@ -806,11 +861,13 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
 
         validate_parameters(simplex_parameters + product_parameters)
 
-        constraints = specs.get("constraints", [])
-        if constraints:
-            constraints = converter.structure(
-                specs["constraints"], list[DiscreteConstraint]
-            )
+        # Support both the current `constraints` key (deprecated) and
+        # the new `batch_constraints` key for forward/backward compatibility
+        constraints_raw = specs.get("constraints", []) or specs.get(
+            "batch_constraints", []
+        )
+        if constraints_raw:
+            constraints = converter.structure(constraints_raw, list[DiscreteConstraint])
             validate_constraints(constraints, simplex_parameters + product_parameters)
 
     # For all other types, validate by construction
@@ -818,8 +875,39 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
         converter.structure(specs, SubspaceDiscrete)
 
 
-# Register deserialization hook
-converter.register_structure_hook(SubspaceDiscrete, select_constructor_hook)
+# >>>>>>>>>> Deprecation
+def _structure_subspace_discrete(specs: dict, cls: type) -> SubspaceDiscrete:
+    """Structure hook supporting legacy ``constraints`` key migration."""
+    specs = specs.copy()
+    if "constraints" in specs and specs["constraints"] is not None:
+        warnings.warn(
+            _CONSTRAINTS_DEPRECATION_MSG,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        legacy_constraints = converter.structure(
+            specs.pop("constraints"), list[DiscreteConstraint]
+        )
+        batch_from_legacy = [
+            c for c in legacy_constraints if isinstance(c, DiscreteBatchConstraint)
+        ]
+        if batch_from_legacy:
+            existing = specs.get("batch_constraints", [])
+            existing_structured = converter.structure(
+                existing, list[DiscreteBatchConstraint]
+            )
+            specs["batch_constraints"] = [
+                c.to_dict() for c in existing_structured + batch_from_legacy
+            ]
+    else:
+        specs.pop("constraints", None)
+    return select_constructor_hook(specs, cls)
+
+
+# Uncomment when removing the deprecation:
+# converter.register_structure_hook(SubspaceDiscrete, select_constructor_hook)
+converter.register_structure_hook(SubspaceDiscrete, _structure_subspace_discrete)
+# <<<<<<<<<< Deprecation
 
 # Collect leftover original slotted classes processed by `attrs.define`
 gc.collect()

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 import random
 import warnings
-from collections.abc import Collection, Iterator, Sequence
+from collections.abc import Callable, Collection, Iterator, Sequence
 from functools import cached_property
 from itertools import islice
 from math import prod
@@ -15,7 +15,7 @@ import cattrs
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from attrs import define, field
+from attrs import define, field, fields
 from attrs.validators import deep_iterable, instance_of
 from cattrs import IterableValidationError
 from typing_extensions import override
@@ -49,21 +49,13 @@ if TYPE_CHECKING:
     from baybe.searchspace.core import SearchSpace
 
 
-_CONSTRAINTS_DEPRECATION_MSG = (
-    "Providing 'constraints' to 'SubspaceDiscrete' is no longer supported. "
-    "Use 'batch_constraints' for any 'DiscreteBatchConstraint' instances. "
-    "Filtering constraints can simply be dropped. For now, we took care of "
-    "these steps, but please familiarize yourself with the new API and update "
-    "your code accordingly."
-)
-
-
-def _deprecate_argument(error: bool, msg: str | None = None):
+def _deprecate_argument(error: bool, msg: str | Callable[[], str] | None = None):
     """Helper for deprecating legacy arguments."""  # noqa: D401
 
     def validator(self, attribute, value):
         if value is not None:
-            warning_msg = msg or (
+            # Generate message lazily if callable, otherwise use provided string
+            warning_msg = (msg() if callable(msg) else msg) or (
                 f"Providing '{attribute.alias}' to '{self.__class__.__name__}' is no "
                 f"longer supported. To proceed, simply drop the argument."
             )
@@ -138,7 +130,10 @@ class SubspaceDiscrete(SerialMixin):
     ] = field(
         alias="constraints",
         default=None,
-        validator=_deprecate_argument(error=False, msg=_CONSTRAINTS_DEPRECATION_MSG),
+        validator=_deprecate_argument(
+            error=False,
+            msg=lambda: _make_constraints_deprecation_msg(),  # noqa: PLW0108
+        ),
     )
     "Ignore! For backwards compatibility only."
 
@@ -874,12 +869,30 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
 
 
 # >>>>>>>>>> Deprecation
+def _make_constraints_deprecation_msg() -> str:
+    """Generate the constraints deprecation message with programmatic names."""
+    # Get field aliases programmatically
+    constraints_alias = fields(SubspaceDiscrete)._constraints.alias
+    batch_constraints_alias = fields(SubspaceDiscrete).batch_constraints.alias
+
+    return (
+        f"Providing '{constraints_alias}' to '{SubspaceDiscrete.__name__}' is no "
+        f"longer supported. Please update your code as follows:\n"
+        f"  • Use '{batch_constraints_alias}' for '{DiscreteBatchConstraint.__name__}' "
+        f"objects. Any batch constraints you have provided have been extracted "
+        f"automatically for you. This automatic extraction is temporary and will be "
+        f"removed in a future version.\n"
+        f"  • Filtering constraints can simply be dropped. Instead, make sure you "
+        f"construct the experimental representation to satisfy them."
+    )
+
+
 def _structure_subspace_discrete(specs: dict, cls: type) -> SubspaceDiscrete:
     """Structure hook supporting legacy ``constraints`` key migration."""
     specs = specs.copy()
     if "constraints" in specs and specs["constraints"] is not None:
         warnings.warn(
-            _CONSTRAINTS_DEPRECATION_MSG,
+            _make_constraints_deprecation_msg(),
             DeprecationWarning,
             stacklevel=2,
         )

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -667,12 +667,20 @@ class SubspaceDiscrete(SerialMixin):
             comp_rep_shape=(n_rows, n_cols_comp),
         )
 
+    # >>>>>>>>>> Deprecation
     @property
-    def constraints_batch(
-        self,
-    ) -> tuple[DiscreteBatchConstraint, ...]:
-        """The batch constraints of the subspace."""
+    def constraints_batch(self) -> tuple[DiscreteBatchConstraint, ...]:
+        """Deprecated! Use :attr:`batch_constraints` instead."""
+        replacement = fields(type(self)).batch_constraints.name
+        warnings.warn(
+            f"Accessing 'constraints_batch' is deprecated and will be disabled in a "
+            f"future version. Use '{replacement}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.batch_constraints
+
+    # <<<<<<<<<< Deprecation
 
     @property
     def n_subsets(self) -> int:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -18,7 +18,7 @@ import pandas as pd
 from attrs import define, field, fields
 from attrs.validators import deep_iterable, instance_of
 from cattrs import IterableValidationError
-from typing_extensions import override
+from typing_extensions import Self, override
 
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
 from baybe.constraints.base import DiscreteConstraint
@@ -222,12 +222,12 @@ class SubspaceDiscrete(SerialMixin):
         return SearchSpace(discrete=self)
 
     @classmethod
-    def empty(cls) -> SubspaceDiscrete:
+    def empty(cls) -> Self:
         """Create an empty discrete subspace."""
-        return SubspaceDiscrete(parameters=[], exp_rep=pd.DataFrame())
+        return cls(parameters=[], exp_rep=pd.DataFrame())
 
     @classmethod
-    def from_parameter(cls, parameter: DiscreteParameter) -> SubspaceDiscrete:
+    def from_parameter(cls, parameter: DiscreteParameter) -> Self:
         """Create a subspace from a single parameter.
 
         Args:
@@ -244,7 +244,7 @@ class SubspaceDiscrete(SerialMixin):
         parameters: Sequence[DiscreteParameter],
         constraints: Sequence[DiscreteConstraint] | None = None,
         empty_encoding: bool | None = None,
-    ) -> SubspaceDiscrete:
+    ) -> Self:
         """See :class:`baybe.searchspace.core.SearchSpace`."""
         validate_parameters(parameters, allow_empty=True)
 
@@ -269,7 +269,7 @@ class SubspaceDiscrete(SerialMixin):
 
         df = build_constrained_product(parameters, filtering_constraints)
 
-        return SubspaceDiscrete(
+        return cls(
             parameters=parameters,
             batch_constraints=batch_constraints,
             exp_rep=df,
@@ -283,7 +283,7 @@ class SubspaceDiscrete(SerialMixin):
         parameters: Sequence[DiscreteParameter] | None = None,
         batch_constraints: Collection[DiscreteBatchConstraint] = (),
         empty_encoding: bool | None = None,
-    ) -> SubspaceDiscrete:
+    ) -> Self:
         """Create a discrete subspace with a specified set of configurations.
 
         Args:
@@ -355,7 +355,7 @@ class SubspaceDiscrete(SerialMixin):
         max_nonzero: int | None = None,
         boundary_only: bool = False,
         tolerance: float = 1e-6,
-    ) -> SubspaceDiscrete:
+    ) -> Self:
         """Efficiently create discrete simplex subspaces.
 
         The same result can be achieved using

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -156,6 +156,20 @@ class SubspaceDiscrete(SerialMixin):
             batch: tuple[DiscreteBatchConstraint, ...] = tuple(
                 c for c in self._constraints if isinstance(c, DiscreteBatchConstraint)
             )
+
+            if n_non_batch := len(self._constraints) - len(batch):
+                warnings.warn(
+                    f"You provided {n_non_batch} filtering constraint(s) via "
+                    f"'constraints' but filtering constraints are (and always have "
+                    f"been) ignored when entered via '__init__'. The latter assumes "
+                    f"that all filtering constraints have already been applied to the "
+                    f"given experimental candidate representation. To avoid this "
+                    f"warning, either drop the filtering constraints or use one of the "
+                    f"alternative constructors.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
             if batch:
                 self.batch_constraints = self.batch_constraints + batch
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -163,6 +163,9 @@ class SubspaceDiscrete(SerialMixin):
             )
             if batch:
                 self.batch_constraints = self.batch_constraints + batch
+
+                # attrs validators have already run at this point, so re-validate.
+                validate_constraints(self.batch_constraints, self.parameters)
         # <<<<<<<<<< Deprecation
 
     @override

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -590,11 +590,6 @@ class SubspaceDiscrete(SerialMixin):
         return len(self.parameters) == 0
 
     @property
-    def is_constrained(self) -> bool:
-        """Boolean indicating if the subspace has any batch constraints."""
-        return len(self.batch_constraints) > 0
-
-    @property
     def parameter_names(self) -> tuple[str, ...]:
         """Return tuple of parameter names."""
         return tuple(p.name for p in self.parameters)

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -430,6 +430,12 @@ class SubspaceDiscrete(SerialMixin):
                 f"parameters: {overlap}."
             )
 
+        # Validate constraints
+        if constraints:
+            validate_constraints(
+                constraints, [*simplex_parameters, *product_parameters]
+            )
+
         # Handle degenerate simplex cases
         if len(simplex_parameters) < 2:
             warnings.warn(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -342,7 +342,7 @@ class SubspaceDiscrete(SerialMixin):
         return cls(
             parameters=parameters,
             exp_rep=df,
-            batch_constraints=batch_constraints or (),
+            batch_constraints=batch_constraints,
             empty_encoding=empty_encoding,  # type: ignore[arg-type]
         )
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -884,3 +884,19 @@ def test_deprecated_constraints_argument_from_product():
     assert_frame_equal(ss_with_batch.exp_rep, ss_none.exp_rep)
     assert len(ss_both.exp_rep) == 2
     assert len(ss_none.exp_rep) == 4
+
+
+def test_deprecated_constraints_batch_property():
+    """Accessing ``constraints_batch`` emits a deprecation warning and delegates correctly."""  # noqa: E501
+    p = NumericalDiscreteParameter("p", [0, 1, 2])
+    batch_c = DiscreteBatchConstraint(["p"])
+    subspace = SubspaceDiscrete(
+        parameters=[p],
+        exp_rep=pd.DataFrame({"p": [0, 1, 2]}),
+        batch_constraints=(batch_c,),
+    )
+
+    with pytest.warns(DeprecationWarning, match="constraints_batch"):
+        result = subspace.constraints_batch
+
+    assert result == subspace.batch_constraints == (batch_c,)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -11,19 +11,24 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-from pandas.testing import assert_series_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 from pytest import param
 
 from baybe._optional.info import CHEM_INSTALLED, POLARS_INSTALLED
 from baybe.constraints import (
     ContinuousLinearConstraint,
 )
+from baybe.constraints.conditions import SubSelectionCondition
 from baybe.constraints.continuous import ContinuousCardinalityConstraint
+from baybe.constraints.discrete import (
+    DiscreteBatchConstraint,
+    DiscreteExcludeConstraint,
+)
 from baybe.exceptions import DeprecationError
 from baybe.kernels.basic import MaternKernel
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.single import SingleTargetObjective
-from baybe.parameters.categorical import TaskParameter
+from baybe.parameters.categorical import CategoricalParameter, TaskParameter
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.numerical import (
     NumericalContinuousParameter,
@@ -788,9 +793,7 @@ def test_deprecated_subspace_discrete_arguments(arg, error):
         else pytest.warns(DeprecationWarning, match=f"Providing '{arg}'")
     )
     with context:
-        SubspaceDiscrete(
-            parameters=[], constraints=[], exp_rep=pd.DataFrame(), **{arg: 0}
-        )
+        SubspaceDiscrete(parameters=[], exp_rep=pd.DataFrame(), **{arg: 0})
 
 
 def test_deprecated_empty_encoding_from_product():
@@ -824,3 +827,60 @@ def test_deprecated_discrete_subspace_deserialization():
 
     actual = SubspaceDiscrete.from_dict(legacy_dict)
     assert actual == expected
+
+
+def test_deprecated_constraints_deserialization():
+    """Deserialization of legacy ``constraints`` key migrates batch constraints."""
+    p = NumericalDiscreteParameter("p", [0, 1, 2])
+    batch_c = DiscreteBatchConstraint(["p"])
+    expected = SubspaceDiscrete.from_product(parameters=[p], constraints=[batch_c])
+
+    # Simulate a legacy dict with `constraints` instead of `batch_constraints`
+    legacy_dict = expected.to_dict()
+    legacy_dict["constraints"] = [batch_c.to_dict()]
+    del legacy_dict["batch_constraints"]
+
+    with pytest.warns(DeprecationWarning, match="Providing 'constraints'"):
+        actual = SubspaceDiscrete.from_dict(legacy_dict)
+
+    assert actual == expected
+
+
+def test_deprecated_constraints_argument():
+    """Passing `constraints` to `SubspaceDiscrete` raises a deprecation warning."""
+    p = NumericalDiscreteParameter("p", [0, 1, 2])
+    batch_c = DiscreteBatchConstraint(["p"])
+    with pytest.warns(DeprecationWarning, match="Providing 'constraints'"):
+        subspace = SubspaceDiscrete(
+            parameters=[p],
+            exp_rep=pd.DataFrame({"p": [0, 1, 2]}),
+            constraints=[batch_c],
+        )
+    # The batch constraint must be migrated to `batch_constraints`
+    assert subspace.batch_constraints == (batch_c,)
+
+
+def test_deprecated_constraints_argument_from_product():
+    """Passing mixed constraints to ``from_product`` routes batch constraints correctly."""  # noqa: E501
+    p = CategoricalParameter("p", ["a", "b"])
+    q = CategoricalParameter("q", ["x", "y"])
+    batch_c = DiscreteBatchConstraint(["p"])
+    no_dup_c = DiscreteExcludeConstraint(["p"], [SubSelectionCondition(["a"])])
+
+    ss_both = SubspaceDiscrete.from_product(
+        parameters=[p, q], constraints=[batch_c, no_dup_c]
+    )
+    ss_none = SubspaceDiscrete.from_product(parameters=[p, q], constraints=[])
+    ss_with_batch = SubspaceDiscrete.from_product(
+        parameters=[p, q], constraints=[batch_c]
+    )
+    ss_without_batch = SubspaceDiscrete.from_product(
+        parameters=[p, q], constraints=[no_dup_c]
+    )
+
+    assert ss_both.batch_constraints == ss_with_batch.batch_constraints == (batch_c,)
+    assert ss_without_batch.batch_constraints == ss_none.batch_constraints == ()
+    assert_frame_equal(ss_both.exp_rep, ss_without_batch.exp_rep)
+    assert_frame_equal(ss_with_batch.exp_rep, ss_none.exp_rep)
+    assert len(ss_both.exp_rep) == 2
+    assert len(ss_none.exp_rep) == 4


### PR DESCRIPTION
Finally fixes #794, enabled by the previous PRs merged to #837.

The `constraints` attribute on `SubspaceDiscrete` conflated two fundamentally different roles:
- *filtering constraints* (applied once during construction to prune the candidate grid) and
- *batch constraints* (applied at recommendation time to enforce structure across the recommended batch)

Storing both under a single field was misleading – filtering constraints are only relevant during construction, and even then only for certain construction routes: when building via `from_dataframe`, the candidate grid is already fully specified by the caller, so filtering constraints were meaningless from the very beginning and had no effect whatsoever. Retaining them on the object after construction served no purpose and gave a false impression that they remained active throughout the object's lifetime. As a further consequence, `from_dataframe` never accepted any constraint objects at all – since filtering constraints are not needed there, and batch constraints were introduced later, users had no way to attach batch constraints when constructing a subspace from a dataframe.

This PR makes the distinction explicit and removes the dead storage:

- **Adds** `SubspaceDiscrete.batch_constraints`: a dedicated field for `DiscreteBatchConstraint` instances that are evaluated during recommendation. `from_dataframe` now accepts a `batch_constraints` argument – fixing the previously missing ability to attach batch constraints when constructing from a dataframe. Filtering constraints passed to `from_product`/`from_simplex` are applied during construction as before and then discarded – there is nothing left for them to do.
- **Deprecates** `SubspaceDiscrete.constraints`: passing it emits a `DeprecationWarning`; any `DiscreteBatchConstraint` instances are automatically migrated to `batch_constraints` to ease the transition.
- **Removes** `is_constrained` properties from `SubspaceDiscrete`, `SubspaceContinuous`, and `SearchSpace`: these were thin Boolean wrappers that obscured which kind of constraint was being checked and, in the discrete case, were backed by the now-meaningless stored filtering constraints.