### PR TITLE
Wire CandidatesProtocol into SubspaceDiscrete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,8 @@ For a full list of available tox environments and developer commands, see
 - CHANGELOG.md updated in every PR (CI enforced). Specific entries, complete
   sentences. Commit named "Update CHANGELOG" as last commit.
 - Use imperative in commit header, e.g. "Add", "Fix", "Rework", "Handle", "Adjust", etc.
+- Keep the commit header short (max ~72 characters). Move additional details to the
+  commit body.
 - Keep commit body short and informative. Do not add commit body if it has no
   additional info compared to the header.
 - Pre-commit must pass. Clean history: squash add/revert pairs, no debug prints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DiscreteParameter.is_finite` property
 - `SubspaceDiscrete.batch_constraints` field for storing batch-level constraints
 - `SubspaceDiscrete.from_dataframe` now accepts `batch_constraints`
+- `validate_parameter_input` now accepts an `allow_empty` flag to permit zero-row input
 
 ### Changed
 - Internal `Campaign` state model simplified: recommended and excluded experiments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `narwhals` as a hard dependency
 - `CandidatesProtocol` as an interface for candidates generation
-- `TableCandidates` and `ProductCandidates` classes implementing `CandidatesProtocol`
+- `EmptyCandidates`, `TableCandidates` and `ProductCandidates` classes implementing
+  `CandidatesProtocol`
 - `DiscreteParameter.is_finite` property
 - `SubspaceDiscrete.batch_constraints` field for storing batch-level constraints
 - `SubspaceDiscrete.from_dataframe` now accepts `batch_constraints`
 - `validate_parameter_input` now accepts an `allow_empty` flag to permit zero-row input
 
 ### Changed
+- `SubspaceDiscrete` has been refactored from the ground up: it now holds a `candidates`
+  attribute of type `CandidatesProtocol` instead of raw `parameters` and `exp_rep`
+  attributes, and `parameters` is now a read-only property delegating to it. The
+  associated constructor calls and all related legacy attributes have been deprecated. 
 - Internal `Campaign` state model simplified: recommended and excluded experiments
   are now stored as dataframes instead of being tracked as metadata flags
 - `SubspaceContinuous` now offers a simpler interface for passing constraints,
@@ -53,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecations
 - `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
+- `SubspaceDiscrete(parameters, exp_rep)` constructor call style
+  (use `SubspaceDiscrete.from_dataframe(parameters, exp_rep)` or
+  `SubspaceDiscrete(candidates=TableCandidates(parameters, exp_rep))` instead)
 - `SubspaceDiscrete` ignores any `empty_encoding` when provided
 - `SubspaceDiscrete` no longer accepts a `comp_rep` argument
 - `SubspaceDiscrete.constraints` attribute (use `batch_constraints` to provide and

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -31,6 +31,7 @@ from baybe.recommenders.meta.base import MetaRecommender
 from baybe.recommenders.meta.sequential import TwoPhaseMetaRecommender
 from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
+from baybe.searchspace.candidates import TableCandidates
 from baybe.searchspace.core import (
     SearchSpace,
     SearchSpaceType,
@@ -578,10 +579,16 @@ class Campaign(SerialMixin):
                     .eq("both")
                     .to_numpy()
                 )
+            # TODO: Replace index-based selection and explicit TableCandidates
+            #   instantiation with .filter() method to avoid materialization
             searchspace = evolve(
                 self.searchspace,
                 discrete=evolve(
-                    self.searchspace.discrete, exp_rep=candidates.loc[~mask_todrop]
+                    self.searchspace.discrete,
+                    candidates=TableCandidates(
+                        self.searchspace.discrete.parameters,
+                        candidates.loc[~mask_todrop],
+                    ),
                 ),
             )
         else:

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -11,6 +11,7 @@ import pandas as pd
 from attrs import evolve
 
 from baybe.searchspace import SubspaceDiscrete
+from baybe.searchspace.candidates import TableCandidates
 from baybe.utils.dataframe import to_tensor
 
 if TYPE_CHECKING:
@@ -57,7 +58,13 @@ def recommend_discrete_with_subsets(
         mask: np.ndarray,
     ) -> Callable[[], tuple[pd.DataFrame, Tensor]]:
         def optimize() -> tuple[pd.DataFrame, Tensor]:
-            subset_subspace = evolve(subspace_discrete, exp_rep=candidates.loc[mask])
+            # TODO: Replace with .filter() method to avoid materialization
+            subset_subspace = evolve(
+                subspace_discrete,
+                candidates=TableCandidates(
+                    subspace_discrete.parameters, candidates.loc[mask]
+                ),
+            )
 
             rec = recommend_discrete_without_subsets(
                 recommender, subset_subspace, batch_size

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -18,6 +18,7 @@ from baybe.exceptions import (
     MinimumCardinalityViolatedWarning,
 )
 from baybe.searchspace import SearchSpace
+from baybe.searchspace.candidates import TableCandidates
 from baybe.utils.basic import flatten
 from baybe.utils.dataframe import to_tensor
 from baybe.utils.sampling_algorithms import sample_numerical_df
@@ -200,9 +201,12 @@ def recommend_hybrid_with_subsets(
         def optimize() -> tuple[pd.DataFrame, Tensor]:
             import torch
 
+            # TODO: Replace with .filter() method to avoid materialization
             mod_disc = evolve(
                 searchspace.discrete,
-                exp_rep=candidates.loc[d_mask],
+                candidates=TableCandidates(
+                    searchspace.discrete.parameters, candidates.loc[d_mask]
+                ),
             )
             mod_cont = (
                 subspace_c._enforce_cardinality_constraints(c_inactive_params)

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -132,7 +132,10 @@ class TableCandidates(CandidatesProtocol):
     def _validate_dataframe(self, _: Attribute, value: nw.LazyFrame) -> None:  # noqa: DOC101, DOC103
         # TODO: Remove collect().to_pandas() once validation on lazy frames is supported
         validate_parameter_input(
-            value.collect().to_pandas(), self.parameters, allow_extra=False
+            value.collect().to_pandas(),
+            self.parameters,
+            allow_extra=False,
+            allow_empty=True,
         )
 
     @override

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -40,6 +40,28 @@ class CandidatesProtocol(Protocol):
 
 
 @define(frozen=True)
+class EmptyCandidates(CandidatesProtocol):
+    """Sentinel class representing an empty candidate set with no parameters."""
+
+    @override
+    @property
+    def parameters(self) -> tuple[DiscreteParameter, ...]:
+        return ()
+
+    @override
+    @property
+    def is_finite(self) -> bool:
+        return True
+
+    @override
+    def to_lazy(self) -> nw.LazyFrame:
+        # TODO: Replace hard-coded pandas type with `Settings`-based approach
+        import pandas as pd
+
+        return to_lazy(pd.DataFrame())
+
+
+@define(frozen=True)
 class ProductCandidates(CandidatesProtocol):
     """Class for managing candidates from (filtered) Cartesian product spaces."""
 

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -5,7 +5,7 @@ from typing import Protocol, runtime_checkable
 
 import narwhals.stable.v2 as nw
 from attr.validators import deep_iterable, instance_of, min_len
-from attrs import Attribute, define, field
+from attrs import Attribute, cmp_using, define, field
 from typing_extensions import override
 
 from baybe.constraints import DISCRETE_CONSTRAINTS_FILTERING_ORDER, validate_constraints
@@ -16,7 +16,7 @@ from baybe.parameters.utils import sort_parameters
 from baybe.searchspace.utils import build_constrained_product
 from baybe.searchspace.validation import validate_parameters
 from baybe.utils.basic import to_tuple
-from baybe.utils.dataframe import to_lazy
+from baybe.utils.dataframe import _df_equals, to_lazy
 from baybe.utils.validation import validate_parameter_input
 
 
@@ -126,17 +126,16 @@ class TableCandidates(CandidatesProtocol):
     )
     """See :attr:`CandidatesProtocol.parameters`."""
 
-    # TODO: Decide if this should be a LazyFrame or a DataFrame.
-    #   The former might enable performance benefits but comes with challenges, e.g.
-    #   eq-comparison, which is currently disabled
-    dataframe: nw.LazyFrame = field(converter=to_lazy, eq=False)
+    dataframe: nw.DataFrame = field(
+        converter=lambda x: nw.from_native(x, eager_only=True),
+        eq=cmp_using(eq=_df_equals),
+    )
     """The dataframe containing the candidates."""
 
     @dataframe.validator
-    def _validate_dataframe(self, _: Attribute, value: nw.LazyFrame) -> None:  # noqa: DOC101, DOC103
-        # TODO: Remove collect().to_pandas() once validation on lazy frames is supported
+    def _validate_dataframe(self, _: Attribute, value: nw.DataFrame) -> None:  # noqa: DOC101, DOC103
         validate_parameter_input(
-            value.collect().to_pandas(),
+            value.to_pandas(),
             self.parameters,
             allow_extra=False,
             allow_empty=True,
@@ -149,7 +148,7 @@ class TableCandidates(CandidatesProtocol):
 
     @override
     def to_lazy(self) -> nw.LazyFrame:
-        return self.dataframe
+        return self.dataframe.lazy()
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -16,7 +16,7 @@ from baybe.parameters.utils import sort_parameters
 from baybe.searchspace.utils import build_constrained_product
 from baybe.searchspace.validation import validate_parameters
 from baybe.utils.basic import to_tuple
-from baybe.utils.dataframe import _df_equals, to_lazy
+from baybe.utils.dataframe import _df_equals
 from baybe.utils.validation import validate_parameter_input
 
 
@@ -59,7 +59,7 @@ class EmptyCandidates(CandidatesProtocol):
         # TODO: Replace hard-coded pandas type with `Settings`-based approach
         import pandas as pd
 
-        return to_lazy(pd.DataFrame())
+        return nw.from_native(pd.DataFrame()).lazy()
 
 
 @define(frozen=True)
@@ -109,7 +109,7 @@ class ProductCandidates(CandidatesProtocol):
 
         # TODO: Remove to lazy once build_constrained_product returns a nw.LazyFrame
         assert not isinstance(candidates_df, nw.LazyFrame)
-        return to_lazy(candidates_df)
+        return nw.from_native(candidates_df).lazy()
 
 
 @define(frozen=True)

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -1,7 +1,7 @@
 """Candidates module for managing lazy candidate generation."""
 
 import gc
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import narwhals.stable.v2 as nw
 from attr.validators import deep_iterable, instance_of, min_len
@@ -20,6 +20,7 @@ from baybe.utils.dataframe import to_lazy
 from baybe.utils.validation import validate_parameter_input
 
 
+@runtime_checkable
 class CandidatesProtocol(Protocol):
     """Type protocol specifying the interface candidate generators need to implement."""
 

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -125,7 +125,10 @@ class TableCandidates(CandidatesProtocol):
     )
     """See :attr:`CandidatesProtocol.parameters`."""
 
-    dataframe: nw.LazyFrame = field(converter=to_lazy)
+    # TODO: Decide if this should be a LazyFrame or a DataFrame.
+    #   The former might enable performance benefits but comes with challenges, e.g.
+    #   eq-comparison, which is currently disabled
+    dataframe: nw.LazyFrame = field(converter=to_lazy, eq=False)
     """The dataframe containing the candidates."""
 
     @dataframe.validator

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -19,6 +19,7 @@ from baybe.constraints.base import Constraint
 from baybe.exceptions import InfeasibilityError
 from baybe.parameters import TaskParameter
 from baybe.parameters.base import ContinuousParameter, DiscreteParameter, Parameter
+from baybe.searchspace.candidates import TableCandidates
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
     MemorySize,
@@ -535,11 +536,11 @@ class SearchSpace(SerialMixin):
         disc_params = [p for p in remaining if isinstance(p, DiscreteParameter)]
         cont_params = [p for p in remaining if isinstance(p, ContinuousParameter)]
 
-        # Explicit comp_rep needed because transform() drops columns for empty inputs.
         discrete = (
             SubspaceDiscrete(
-                parameters=disc_params,
-                exp_rep=pd.DataFrame(columns=[p.name for p in disc_params]),
+                candidates=TableCandidates(
+                    disc_params, pd.DataFrame(columns=[p.name for p in disc_params])
+                )
             )
             if disc_params
             else SubspaceDiscrete.empty()

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -29,13 +29,18 @@ from baybe.parameters import (
     NumericalDiscreteParameter,
 )
 from baybe.parameters.base import DiscreteParameter
-from baybe.parameters.utils import get_parameters_from_dataframe, sort_parameters
+from baybe.parameters.utils import get_parameters_from_dataframe
+from baybe.searchspace.candidates import (
+    CandidatesProtocol,
+    EmptyCandidates,
+    ProductCandidates,
+    TableCandidates,
+)
 from baybe.searchspace.utils import build_constrained_product, select_via_flat_index
 from baybe.searchspace.validation import validate_parameters
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.settings import active_settings
 from baybe.utils.basic import to_tuple
-from baybe.utils.boolean import eq_dataframe
 from baybe.utils.conversion import to_string
 from baybe.utils.dataframe import (
     get_transform_objects,
@@ -107,19 +112,8 @@ class SubspaceDiscrete(SerialMixin):
     and provides access to candidate sets and different parameter views.
     """
 
-    parameters: tuple[DiscreteParameter, ...] = field(
-        converter=sort_parameters,
-        validator=[
-            deep_iterable(member_validator=instance_of(DiscreteParameter)),
-            lambda _, __, x: validate_parameters(x, allow_empty=True),
-        ],
-    )
-    """The parameters spanning the subspace."""
-
-    _exp_rep: pd.DataFrame = field(
-        alias="exp_rep", validator=instance_of(pd.DataFrame), eq=eq_dataframe
-    )
-    """The experimental representation of the subspace."""
+    candidates: CandidatesProtocol = field()
+    """The subspace candidate generator."""
 
     _empty_encoding: Annotated[bool, cattrs.override(omit_if_default=True)] = field(
         alias="empty_encoding",
@@ -142,7 +136,7 @@ class SubspaceDiscrete(SerialMixin):
     )
     "Ignore! For backwards compatibility only."
 
-    _comp_rep: Annotated[pd.DataFrame, cattrs.override(omit_if_default=True)] = field(
+    _comp_rep: Annotated[Any, cattrs.override(omit_if_default=True)] = field(
         alias="comp_rep",
         default=None,
         eq=False,
@@ -205,30 +199,10 @@ class SubspaceDiscrete(SerialMixin):
         ]
         return to_string(self.__class__.__name__, *fields)
 
-    @_exp_rep.validator
-    def _validate_exp_rep(  # noqa: DOC101, DOC103
-        self, _: Any, exp_rep: pd.DataFrame
-    ) -> None:
-        """Validate the experimental representation.
-
-        Raises:
-            ValueError: If the provided dataframe columns do not match the parameter
-                names of the subspace.
-            ValueError: If the index of the provided dataframe contains duplicates.
-        """
-        if set(exp_rep.columns) != {p.name for p in self.parameters}:
-            raise ValueError(
-                "The columns of the experimental representation must match the "
-                "parameter names of the subspace."
-            )
-        # TODO: We should ideally also also validate that there are no duplicate rows,
-        #    but in the current eager implementation this is a costly operation.
-        #    To be revisited once the lazy implementation is in place.
-        if exp_rep.index.has_duplicates:
-            raise ValueError(
-                "The index of this search space contains duplicates. "
-                "This is not allowed, as it can lead to hard-to-detect bugs."
-            )
+    @property
+    def parameters(self) -> tuple[DiscreteParameter, ...]:
+        """The parameters spanning the subspace."""
+        return self.candidates.parameters
 
     @batch_constraints.validator
     def _validate_batch_constraints(self, _, __) -> None:  # noqa: DOC101, DOC103
@@ -244,7 +218,7 @@ class SubspaceDiscrete(SerialMixin):
     @classmethod
     def empty(cls) -> Self:
         """Create an empty discrete subspace."""
-        return cls(parameters=[], exp_rep=pd.DataFrame())
+        return cls(candidates=EmptyCandidates())
 
     @classmethod
     def from_parameter(cls, parameter: DiscreteParameter) -> Self:
@@ -287,12 +261,13 @@ class SubspaceDiscrete(SerialMixin):
             "exactly to one type."
         )
 
-        df = build_constrained_product(parameters, filtering_constraints)
-
         return cls(
-            parameters=parameters,
+            candidates=(
+                EmptyCandidates()
+                if not parameters
+                else ProductCandidates(parameters, filtering_constraints)
+            ),
             batch_constraints=batch_constraints,
-            exp_rep=df,
             empty_encoding=empty_encoding,  # type: ignore[arg-type]
         )
 
@@ -349,7 +324,7 @@ class SubspaceDiscrete(SerialMixin):
         if df.shape[1] == 0:
             return cls.empty()
 
-        # Get the full list of both explicitly and implicitly defined parameter
+        # Get the full list of both explicitly and implicitly defined parameters
         parameters = get_parameters_from_dataframe(
             df, discrete_parameter_factory, parameters
         )
@@ -358,8 +333,7 @@ class SubspaceDiscrete(SerialMixin):
         df = normalize_input_dtypes(df, parameters)
 
         return cls(
-            parameters=parameters,
-            exp_rep=df,
+            candidates=TableCandidates(parameters, df),
             batch_constraints=batch_constraints,
             empty_encoding=empty_encoding,  # type: ignore[arg-type]
         )
@@ -590,9 +564,11 @@ class SubspaceDiscrete(SerialMixin):
             product_parameters, filtering_constraints, initial_df=exp_rep
         )
 
+        all_parameters = [*simplex_parameters, *product_parameters]
         return cls(
-            parameters=[*simplex_parameters, *product_parameters],
-            exp_rep=exp_rep,
+            # TODO: Investigate how off-the-shelf query optimization performs against
+            #   our custom TableCandidates construction
+            candidates=TableCandidates(all_parameters, exp_rep),
             batch_constraints=batch_constraints_list,
         )
 
@@ -629,7 +605,7 @@ class SubspaceDiscrete(SerialMixin):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._exp_rep
+        return self.get_candidates()
 
     @property
     def comp_rep(self) -> pd.DataFrame:
@@ -643,7 +619,7 @@ class SubspaceDiscrete(SerialMixin):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.transform(self._exp_rep)
+        return self.transform(self.get_candidates())
 
     # <<<<<<<<<< Deprecation
 
@@ -832,7 +808,7 @@ class SubspaceDiscrete(SerialMixin):
 
     def get_candidates(self) -> pd.DataFrame:
         """Return all candidate parameter configurations."""
-        return self._exp_rep
+        return self.candidates.to_lazy().collect().to_pandas()
 
     def transform(
         self,

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -916,8 +916,30 @@ def _make_constraints_deprecation_msg() -> str:
 
 
 def _structure_subspace_discrete(specs: dict, cls: type) -> SubspaceDiscrete:
-    """Structure hook supporting legacy ``constraints`` key migration."""
+    """Structure hook supporting legacy key migration."""
     specs = specs.copy()
+
+    # Migrate legacy ``parameters`` + ``exp_rep`` format to ``candidates``
+    if "exp_rep" in specs:
+        name = fields(SubspaceDiscrete).candidates.alias
+        warnings.warn(
+            f"Deserializing a '{SubspaceDiscrete.__name__}' from the legacy "
+            f"'parameters' + 'exp_rep' format is deprecated and support will be "
+            f"removed in a future version. Please re-serialize your objects to use "
+            f"the new '{name}' format.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        parameters = converter.structure(
+            specs.pop("parameters"), list[DiscreteParameter]
+        )
+        exp_rep_df = converter.structure(specs.pop("exp_rep"), pd.DataFrame)
+        specs["candidates"] = converter.unstructure(
+            TableCandidates(parameters, exp_rep_df),
+            unstructure_as=CandidatesProtocol,
+        )
+
+    # Migrate legacy ``constraints`` key to ``batch_constraints``
     if "constraints" in specs and specs["constraints"] is not None:
         warnings.warn(
             _make_constraints_deprecation_msg(),

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -94,7 +94,7 @@ class SubspaceDiscrete(SerialMixin):
     """
 
     candidates: CandidatesProtocol = field(validator=instance_of(CandidatesProtocol))
-    """The subspace candidate generator."""
+    """The discrete candidates set spanning the subspace."""
 
     batch_constraints: tuple[DiscreteBatchConstraint, ...] = field(
         default=(),

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -112,7 +112,7 @@ class SubspaceDiscrete(SerialMixin):
     and provides access to candidate sets and different parameter views.
     """
 
-    candidates: CandidatesProtocol = field()
+    candidates: CandidatesProtocol = field(validator=instance_of(CandidatesProtocol))
     """The subspace candidate generator."""
 
     _empty_encoding: Annotated[bool, cattrs.override(omit_if_default=True)] = field(

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -121,16 +121,20 @@ class SubspaceDiscrete(SerialMixin):
     )
     """The experimental representation of the subspace."""
 
-    _empty_encoding: Annotated[bool, cattrs.override(omit=True)] = field(
-        alias="empty_encoding", default=None, validator=_deprecate_argument(error=False)
+    _empty_encoding: Annotated[bool, cattrs.override(omit_if_default=True)] = field(
+        alias="empty_encoding",
+        default=None,
+        eq=False,
+        validator=_deprecate_argument(error=False),
     )
     "Ignore! For backwards compatibility only."
 
     _constraints: Annotated[
-        tuple[DiscreteConstraint, ...], cattrs.override(omit=True)
+        tuple[DiscreteConstraint, ...], cattrs.override(omit_if_default=True)
     ] = field(
         alias="constraints",
         default=None,
+        eq=False,
         validator=_deprecate_argument(
             error=False,
             msg=lambda: _make_constraints_deprecation_msg(),  # noqa: PLW0108
@@ -138,8 +142,11 @@ class SubspaceDiscrete(SerialMixin):
     )
     "Ignore! For backwards compatibility only."
 
-    _comp_rep: Annotated[pd.DataFrame, cattrs.override(omit=True)] = field(
-        alias="comp_rep", default=None, validator=_deprecate_argument(error=True)
+    _comp_rep: Annotated[pd.DataFrame, cattrs.override(omit_if_default=True)] = field(
+        alias="comp_rep",
+        default=None,
+        eq=False,
+        validator=_deprecate_argument(error=True),
     )
     "Ignore! For backwards compatibility only."
 

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -120,6 +120,7 @@ class SubspaceDiscrete(SerialMixin):
         if (
             candidates is not UNSPECIFIED
             and not isinstance(candidates, CandidatesProtocol)
+            and isinstance(candidates, Collection)
             and all(isinstance(p, DiscreteParameter) for p in candidates)
         ):
             parameters = candidates

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import gc
 import random
 import warnings
-from collections.abc import Callable, Collection, Iterator, Sequence
+from collections.abc import Collection, Iterator, Sequence
 from itertools import islice
 from math import prod
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-import cattrs
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -40,7 +39,7 @@ from baybe.searchspace.utils import build_constrained_product, select_via_flat_i
 from baybe.searchspace.validation import validate_parameters
 from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.settings import active_settings
-from baybe.utils.basic import to_tuple
+from baybe.utils.basic import UNSPECIFIED, UnspecifiedType, to_tuple
 from baybe.utils.conversion import to_string
 from baybe.utils.dataframe import (
     get_transform_objects,
@@ -51,24 +50,6 @@ from baybe.utils.memory import bytes_to_human_readable
 
 if TYPE_CHECKING:
     from baybe.searchspace.core import SearchSpace
-
-
-def _deprecate_argument(error: bool, msg: str | Callable[[], str] | None = None):
-    """Helper for deprecating legacy arguments."""  # noqa: D401
-
-    def validator(self, attribute, value):
-        if value is not None:
-            # Generate message lazily if callable, otherwise use provided string
-            warning_msg = (msg() if callable(msg) else msg) or (
-                f"Providing '{attribute.alias}' to '{self.__class__.__name__}' is no "
-                f"longer supported. To proceed, simply drop the argument."
-            )
-            if error:
-                raise DeprecationError(warning_msg)
-            else:
-                warnings.warn(warning_msg, DeprecationWarning, stacklevel=3)
-
-    return validator
 
 
 @define(kw_only=True)
@@ -115,35 +96,6 @@ class SubspaceDiscrete(SerialMixin):
     candidates: CandidatesProtocol = field(validator=instance_of(CandidatesProtocol))
     """The subspace candidate generator."""
 
-    _empty_encoding: Annotated[bool, cattrs.override(omit_if_default=True)] = field(
-        alias="empty_encoding",
-        default=None,
-        eq=False,
-        validator=_deprecate_argument(error=False),
-    )
-    "Ignore! For backwards compatibility only."
-
-    _constraints: Annotated[
-        tuple[DiscreteConstraint, ...], cattrs.override(omit_if_default=True)
-    ] = field(
-        alias="constraints",
-        default=None,
-        eq=False,
-        validator=_deprecate_argument(
-            error=False,
-            msg=lambda: _make_constraints_deprecation_msg(),  # noqa: PLW0108
-        ),
-    )
-    "Ignore! For backwards compatibility only."
-
-    _comp_rep: Annotated[Any, cattrs.override(omit_if_default=True)] = field(
-        alias="comp_rep",
-        default=None,
-        eq=False,
-        validator=_deprecate_argument(error=True),
-    )
-    "Ignore! For backwards compatibility only."
-
     batch_constraints: tuple[DiscreteBatchConstraint, ...] = field(
         default=(),
         converter=to_tuple,
@@ -151,33 +103,81 @@ class SubspaceDiscrete(SerialMixin):
     )
     """Constraints operating on the recommendation batch level."""
 
-    def __attrs_post_init__(self) -> None:
-        """Migrate deprecated ``constraints`` argument to ``batch_constraints``."""
-        # >>>>>>>>>> Deprecation
-        if self._constraints is not None:
-            batch: tuple[DiscreteBatchConstraint, ...] = tuple(
-                c for c in self._constraints if isinstance(c, DiscreteBatchConstraint)
+    # >>>>>>>>>> Deprecation
+    def __init__(
+        self,
+        candidates: CandidatesProtocol = UNSPECIFIED,  # type: ignore[assignment]
+        batch_constraints: Collection[DiscreteBatchConstraint] = (),
+        *,
+        parameters: Sequence[DiscreteParameter] | UnspecifiedType = UNSPECIFIED,
+        exp_rep: pd.DataFrame | UnspecifiedType = UNSPECIFIED,
+        empty_encoding: bool | UnspecifiedType = UNSPECIFIED,
+        constraints: Sequence[DiscreteConstraint] | UnspecifiedType = UNSPECIFIED,
+        comp_rep: Any | UnspecifiedType = UNSPECIFIED,
+    ) -> None:
+        # Detect legacy positional calls: SubspaceDiscrete([p, ...], df) where
+        # the parameters list and exp_rep DataFrame were passed as positional args.
+        if (
+            candidates is not UNSPECIFIED
+            and not isinstance(candidates, CandidatesProtocol)
+            and all(isinstance(p, DiscreteParameter) for p in candidates)
+        ):
+            parameters = candidates
+            candidates = UNSPECIFIED
+            if isinstance(batch_constraints, pd.DataFrame):
+                exp_rep = batch_constraints
+                batch_constraints = ()
+
+        # --- parameters + exp_rep ---
+        if parameters is not UNSPECIFIED and exp_rep is not UNSPECIFIED:
+            name = fields(self.__class__).candidates.alias
+            warnings.warn(
+                f"Providing 'parameters' and 'exp_rep' to '{self.__class__.__name__}' "
+                f"has been deprecated and support will be dropped in a future version. "
+                f"Please use the new '{name}' interface instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            candidates = TableCandidates(
+                parameters, normalize_input_dtypes(exp_rep, parameters)
             )
 
-            if n_non_batch := len(self._constraints) - len(batch):
+        # --- empty_encoding ---
+        if empty_encoding is not UNSPECIFIED:
+            _deprecate_argument("empty_encoding", error=False, stacklevel=3)
+
+        # --- comp_rep ---
+        if comp_rep is not UNSPECIFIED:
+            _deprecate_argument("comp_rep", error=True, stacklevel=3)
+
+        # --- constraints ---
+        if constraints is not UNSPECIFIED:
+            warnings.warn(
+                _make_constraints_deprecation_msg(),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            batch_from_legacy: list[DiscreteBatchConstraint] = [
+                c for c in constraints if isinstance(c, DiscreteBatchConstraint)
+            ]
+            if n_non_batch := len(constraints) - len(batch_from_legacy):
                 warnings.warn(
                     f"You provided {n_non_batch} filtering constraint(s) via "
                     f"'constraints' but filtering constraints are (and always have "
                     f"been) ignored when entered via '__init__'. The latter assumes "
                     f"that all filtering constraints have already been applied to the "
                     f"given experimental candidate representation. To avoid this "
-                    f"warning, either drop the filtering constraints or use one of the "
-                    f"alternative constructors.",
+                    f"warning, either drop the filtering constraints or use one of "
+                    f"the alternative constructors.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
+            if batch_from_legacy:
+                batch_constraints = tuple(batch_constraints) + tuple(batch_from_legacy)
 
-            if batch:
-                self.batch_constraints = self.batch_constraints + batch
+        self.__attrs_init__(candidates=candidates, batch_constraints=batch_constraints)  # type: ignore[attr-defined]
 
-                # attrs validators have already run at this point, so re-validate.
-                validate_constraints(self.batch_constraints, self.parameters)
-        # <<<<<<<<<< Deprecation
+    # <<<<<<<<<< Deprecation
 
     @override
     def __str__(self) -> str:
@@ -261,6 +261,7 @@ class SubspaceDiscrete(SerialMixin):
             "exactly to one type."
         )
 
+        extra = {"empty_encoding": empty_encoding} if empty_encoding is not None else {}
         return cls(
             candidates=(
                 EmptyCandidates()
@@ -268,7 +269,7 @@ class SubspaceDiscrete(SerialMixin):
                 else ProductCandidates(parameters, filtering_constraints)
             ),
             batch_constraints=batch_constraints,
-            empty_encoding=empty_encoding,  # type: ignore[arg-type]
+            **extra,
         )
 
     @classmethod
@@ -332,10 +333,11 @@ class SubspaceDiscrete(SerialMixin):
         # Ensure dtype consistency
         df = normalize_input_dtypes(df, parameters)
 
+        extra = {"empty_encoding": empty_encoding} if empty_encoding is not None else {}
         return cls(
             candidates=TableCandidates(parameters, df),
             batch_constraints=batch_constraints,
-            empty_encoding=empty_encoding,  # type: ignore[arg-type]
+            **extra,
         )
 
     @classmethod
@@ -897,15 +899,23 @@ def validate_simplex_subspace_from_config(specs: dict, _) -> None:
 
 
 # >>>>>>>>>> Deprecation
-def _make_constraints_deprecation_msg() -> str:
-    """Generate the constraints deprecation message with programmatic names."""
-    # Get field aliases programmatically
-    constraints_alias = fields(SubspaceDiscrete)._constraints.alias
-    batch_constraints_alias = fields(SubspaceDiscrete).batch_constraints.alias
+def _deprecate_argument(arg: str, *, error: bool, stacklevel: int) -> None:
+    """Raise a ``DeprecationError`` or emit a ``DeprecationWarning`` for a dropped argument."""  # noqa: E501
+    msg = (
+        f"Providing '{arg}' to '{SubspaceDiscrete.__name__}' is no longer "
+        f"supported. To proceed, simply drop the argument."
+    )
+    if error:
+        raise DeprecationError(msg)
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
 
+
+def _make_constraints_deprecation_msg() -> str:
+    """Generate the constraints deprecation message."""
+    batch_constraints_alias = fields(SubspaceDiscrete).batch_constraints.alias
     return (
-        f"Providing '{constraints_alias}' to '{SubspaceDiscrete.__name__}' is no "
-        f"longer supported. Please update your code as follows:\n"
+        f"Providing 'constraints' to '{SubspaceDiscrete.__name__}' is no longer "
+        f"supported. Please update your code as follows:\n"
         f"  • Use '{batch_constraints_alias}' for '{DiscreteBatchConstraint.__name__}' "
         f"objects. Any batch constraints you have provided have been extracted "
         f"automatically for you. This automatic extraction is temporary and will be "
@@ -938,6 +948,15 @@ def _structure_subspace_discrete(specs: dict, cls: type) -> SubspaceDiscrete:
             TableCandidates(parameters, exp_rep_df),
             unstructure_as=CandidatesProtocol,
         )
+
+    # Drop legacy ``empty_encoding`` key
+    if "empty_encoding" in specs:
+        _deprecate_argument("empty_encoding", error=False, stacklevel=2)
+        specs.pop("empty_encoding")
+
+    # Reject legacy ``comp_rep`` key
+    if "comp_rep" in specs:
+        _deprecate_argument("comp_rep", error=True, stacklevel=2)
 
     # Migrate legacy ``constraints`` key to ``batch_constraints``
     if "constraints" in specs and specs["constraints"] is not None:

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -129,6 +129,15 @@ class SubspaceDiscrete(SerialMixin):
                 exp_rep = batch_constraints
                 batch_constraints = ()
 
+        # Legacy input format requires both ``parameters`` and ``exp_rep`` together
+        if (parameters is UNSPECIFIED) != (exp_rep is UNSPECIFIED):
+            raise ValueError(
+                f"When using legacy constructor arguments for "
+                f"'{self.__class__.__name__}', provide both 'parameters' and 'exp_rep' "
+                f"together. Otherwise, use the '{fields(type(self)).candidates.alias}' "
+                f"argument."
+            )
+
         # --- parameters + exp_rep ---
         if parameters is not UNSPECIFIED and exp_rep is not UNSPECIFIED:
             name = fields(self.__class__).candidates.alias

--- a/baybe/serialization/core.py
+++ b/baybe/serialization/core.py
@@ -127,7 +127,11 @@ def make_base_structure_hook(base: type[_T]):
     def structure_base(val: dict[str, Any] | str, cls: type[_T]) -> _T:
         # Extract the type information from the given input and find
         # the corresponding class in the hierarchy
-        type_ = val if isinstance(val, str) else val.pop(_TYPE_FIELD)
+        if isinstance(val, str):
+            type_ = val
+        else:
+            val = val.copy()
+            type_ = val.pop(_TYPE_FIELD)
         subclass = find_subclass(base, type_)
 
         # Preserve generic type parameters from the abstract base class:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -11,6 +11,7 @@ import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 from narwhals.stable.v2.typing import IntoDataFrame
+from narwhals.testing import assert_frame_equal
 from typing_extensions import assert_never
 
 from baybe.exceptions import InputDataTypeWarning, SearchSpaceMatchWarning
@@ -798,3 +799,13 @@ def normalize_input_dtypes(
 def to_lazy(df: IntoDataFrame, /) -> nw.LazyFrame:
     """Convert any dataframe to a :class:`~narwhals.LazyFrame`."""
     return nw.from_native(df).lazy()
+
+
+def _df_equals(df1: nw.DataFrame, df2: nw.DataFrame, /) -> bool:
+    """Check if two dataframes are equal."""
+    # https://github.com/narwhals-dev/narwhals/issues/3715
+    try:
+        assert_frame_equal(df1, df2)
+        return True
+    except AssertionError:
+        return False

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
-from narwhals.stable.v2.typing import IntoDataFrame
 from narwhals.testing import assert_frame_equal
 from typing_extensions import assert_never
 
@@ -794,11 +793,6 @@ def normalize_input_dtypes(
     for col in cols_to_convert:
         df[col] = df[col].astype(active_settings.DTypeFloatNumpy)
     return df
-
-
-def to_lazy(df: IntoDataFrame, /) -> nw.LazyFrame:
-    """Convert any dataframe to a :class:`~narwhals.LazyFrame`."""
-    return nw.from_native(df).lazy()
 
 
 def _df_equals(df1: nw.DataFrame, df2: nw.DataFrame, /) -> bool:

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -151,6 +151,7 @@ def validate_parameter_input(
     numerical_measurements_must_be_within_tolerance: bool = False,
     *,
     allow_extra: bool = True,
+    allow_empty: bool = False,
 ) -> None:
     """Validate input dataframe columns corresponding to parameters.
 
@@ -162,16 +163,18 @@ def validate_parameter_input(
             parameter-specific tolerance.
         allow_extra: If ``False``, the dataframe is not allowed to contain columns that
             do not correspond to any parameter.
+        allow_empty: If ``True``, an empty dataframe with the correct columns is
+            accepted. If ``False``, an empty dataframe always raises.
 
     Raises:
-        ValueError: If the data is empty.
+        ValueError: If the data is empty and ``allow_empty`` is ``False``.
         ValueError: If the data misses columns for a parameter.
         ValueError: If the data contains columns that do not correspond to any parameter
             and the corresponding check is enabled.
         ValueError: If a parameter contains NaN.
         TypeError: If a parameter contains non-numeric values.
     """
-    if data.empty:
+    if data.empty and not allow_empty:
         raise ValueError("The provided input dataframe cannot be empty.")
 
     if missing := {p.name for p in parameters} - set(data.columns):
@@ -185,6 +188,9 @@ def validate_parameter_input(
             f"The input dataframe contains columns that do not correspond to any "
             f"parameter: {extra}"
         )
+
+    if data.empty:
+        return
 
     for p in parameters:
         if data[p.name].isna().any():

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -152,6 +152,7 @@ def validate_parameter_input(
     *,
     allow_extra: bool = True,
     allow_empty: bool = False,
+    allow_duplicates: bool = False,
 ) -> None:
     """Validate input dataframe columns corresponding to parameters.
 
@@ -165,12 +166,17 @@ def validate_parameter_input(
             do not correspond to any parameter.
         allow_empty: If ``True``, an empty dataframe with the correct columns is
             accepted. If ``False``, an empty dataframe always raises.
+        allow_duplicates: If ``False``, the dataframe is not allowed to contain
+            duplicate parameter configurations (i.e., rows where the corresponding
+            parameter values coincide).
 
     Raises:
         ValueError: If the data is empty and ``allow_empty`` is ``False``.
         ValueError: If the data misses columns for a parameter.
         ValueError: If the data contains columns that do not correspond to any parameter
             and the corresponding check is enabled.
+        ValueError: If the data contains duplicate parameter configurations and the
+            corresponding check is enabled.
         ValueError: If a parameter contains NaN.
         TypeError: If a parameter contains non-numeric values.
     """
@@ -224,6 +230,14 @@ def validate_parameter_input(
                     f"to 'False' to disable this behavior."
                 )
 
+    if (
+        not allow_duplicates
+        and data.duplicated(subset=[p.name for p in parameters]).any()
+    ):
+        raise ValueError(
+            "The input dataframe must not contain duplicate parameter configurations."
+        )
+
 
 def validate_object_names(objects: Iterable[Parameter | Target], /) -> None:
     """Validate that the provided objects have unique names.
@@ -270,7 +284,10 @@ def preprocess_dataframe(
         return df
 
     validate_parameter_input(
-        df, searchspace.parameters, numerical_measurements_must_be_within_tolerance
+        df,
+        searchspace.parameters,
+        numerical_measurements_must_be_within_tolerance,
+        allow_duplicates=True,
     )
     if objective is not None:
         targets = objective.targets

--- a/tests/serialization/test_searchspace_serialization.py
+++ b/tests/serialization/test_searchspace_serialization.py
@@ -3,6 +3,7 @@
 import json
 from collections.abc import Sequence
 
+import pandas as pd
 import pytest
 
 from baybe.parameters.base import Parameter
@@ -29,11 +30,13 @@ def test_roundtrip(parameters: Sequence[Parameter]) -> None:
     assert_roundtrip_consistency(searchspace)
 
 
-def test_from_dataframe_deserialization(searchspace):
-    """Deserialization from dataframe yields back the original object."""
-    unstructured = searchspace.discrete.to_dict()
-    df_string = json.dumps(unstructured["exp_rep"])
-    parameters_string = json.dumps(unstructured["parameters"])
+def test_from_dataframe_deserialization():
+    """Deserialization via ``from_dataframe`` constructor yields the original object."""
+    p = NumericalDiscreteParameter("p", [0.0, 1.0])
+    df = pd.DataFrame({"p": [0.0, 1.0]})
+    expected = SearchSpace.from_dataframe(df, parameters=[p])
+    df_string = json.dumps(converter.unstructure(df))
+    parameters_string = json.dumps([converter.unstructure(p, unstructure_as=Parameter)])
     config = """
     {
         "constructor": "from_dataframe",
@@ -44,7 +47,7 @@ def test_from_dataframe_deserialization(searchspace):
         "__fillin__parameters__", parameters_string
     )
     deserialized = SearchSpace.from_json(config)
-    assert searchspace == deserialized, (searchspace, deserialized)
+    assert expected == deserialized, (expected, deserialized)
 
 
 def test_from_simplex_deserialization():

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -78,6 +78,15 @@ def test_table_candidates_empty_rows():
     assert len(candidates_df) == 0
 
 
+def test_table_candidates_duplicate_rows():
+    """TableCandidates raises an error when the dataframe contains duplicate rows."""
+    parameters = [p_disc, p_cat]
+    data = create_fake_input(parameters, [], n_rows=1)
+    duplicate_data = pd.concat([data, data.iloc[[0]]], ignore_index=True)
+    with pytest.raises(ValueError, match="duplicate parameter configurations"):
+        TableCandidates(parameters, duplicate_data)
+
+
 @pytest.mark.parametrize(
     ("parameters", "dataframe", "error"),
     [

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -68,6 +68,18 @@ def test_table_candidates_generation(dataframe_factory):
     assert_frame_equal(candidates_df.to_pandas(), data)
 
 
+def test_table_candidates_empty_rows():
+    """TableCandidates accepts a zero-row dataframe with correct columns."""
+    parameters = [p_disc, p_cat]
+    empty_df = pd.DataFrame(columns=[p.name for p in parameters])
+    candidates = TableCandidates(parameters, empty_df)
+    candidates_df = candidates.to_lazy().collect()
+
+    assert candidates.is_finite
+    assert set(candidates_df.columns) == {p.name for p in parameters}
+    assert len(candidates_df) == 0
+
+
 @pytest.mark.parametrize(
     ("parameters", "dataframe", "error"),
     [
@@ -87,6 +99,18 @@ def test_table_candidates_generation(dataframe_factory):
             pd.DataFrame({"disc": [1], "extra": [2]}),
             ValueError("not correspond"),
             id="extra_cols",
+        ),
+        pytest.param(
+            [p_disc],
+            pd.DataFrame(),
+            ValueError("missing columns"),
+            id="empty_rows_missing_cols",
+        ),
+        pytest.param(
+            [p_disc],
+            pd.DataFrame(columns=["disc", "extra"]),
+            ValueError("not correspond"),
+            id="empty_rows_extra_cols",
         ),
     ],
 )

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -47,9 +47,7 @@ def test_empty_candidates():
     [
         pytest.param(lambda pd_df: pd_df, id="pandas_eager"),
         pytest.param(pl.DataFrame, id="polars_eager"),
-        pytest.param(pl.LazyFrame, id="polars_lazy"),
         pytest.param(lambda x: nw.from_native(x, eager_only=True), id="narwhals_eager"),
-        pytest.param(lambda x: nw.from_native(x).lazy(), id="narwhals_lazy"),
     ],
 )
 def test_table_candidates_generation(dataframe_factory):
@@ -87,7 +85,17 @@ def test_table_candidates_empty_rows():
         pytest.param(None, edf, TypeError("not iterable"), id="none_param"),
         pytest.param([p_cont], edf, TypeError("be <class"), id="param_type"),
         pytest.param(p_disc, edf, TypeError("not iterable"), id="no_param_seq"),
-        pytest.param([p_disc], 123, TypeError("dataframe type"), id="df_type"),
+        pytest.param([p_disc], 123, TypeError("Unsupported dataframe"), id="df_type"),
+        pytest.param([p_disc], pl.LazyFrame(), TypeError("eager_only"), id="pl_lazy"),
+        pytest.param(
+            [p_disc],
+            nw.from_native(pl.LazyFrame()),
+            TypeError("eager_only"),
+            id="nw_lazy",
+            marks=pytest.mark.xfail(
+                reason="https://github.com/narwhals-dev/narwhals/pull/3677", strict=True
+            ),
+        ),
         pytest.param(
             [p_disc],
             pd.DataFrame({"x": [1]}),

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -14,7 +14,11 @@ from baybe.parameters import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
 )
-from baybe.searchspace.candidates import ProductCandidates, TableCandidates
+from baybe.searchspace.candidates import (
+    EmptyCandidates,
+    ProductCandidates,
+    TableCandidates,
+)
 from baybe.utils.dataframe import create_fake_input
 
 p_disc = NumericalDiscreteParameter("disc", (1, 2))
@@ -24,6 +28,18 @@ p_cont = NumericalContinuousParameter("cont", (3, 8))
 c_sum = DiscreteSumConstraint(["disc", "disc2"], ThresholdCondition(2, "<="))
 c_sub = DiscreteExcludeConstraint(["disc"], [SubSelectionCondition([1])])
 edf = pd.DataFrame()
+
+
+def test_empty_candidates():
+    """EmptyCandidates has no parameters, is finite, and yields an empty lazy frame."""
+    candidates = EmptyCandidates()
+    candidates_ldf = candidates.to_lazy()
+    candidates_df = candidates_ldf.collect()
+
+    assert candidates.parameters == ()
+    assert candidates.is_finite
+    assert isinstance(candidates_ldf, nw.LazyFrame)
+    assert candidates_df.shape == (0, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -812,8 +812,8 @@ def test_deprecated_parameters_exp_rep_conversion():
 @pytest.mark.parametrize(
     "use_kw_exp_rep",
     [
+        pytest.param(True, id="parameters_positional"),
         pytest.param(False, id="both_positional"),
-        pytest.param(True, id="pos_params_kw_exp_rep"),
     ],
 )
 def test_deprecated_parameters_exp_rep_positional(use_kw_exp_rep):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -59,6 +59,7 @@ from baybe.targets._deprecated import (
 from baybe.targets.base import Target
 from baybe.targets.binary import BinaryTarget
 from baybe.transformations.basic import AffineTransformation
+from baybe.utils.basic import UNSPECIFIED
 from baybe.utils.dataframe import create_fake_input
 from baybe.utils.random import set_random_seed, temporary_seed
 
@@ -807,6 +808,19 @@ def test_deprecated_parameters_exp_rep_conversion():
     with pytest.warns(DeprecationWarning, match="parameters.*exp_rep"):
         actual = SubspaceDiscrete(parameters=[p], exp_rep=df)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("parameters", "exp_rep"),
+    [
+        pytest.param([NumericalDiscreteParameter("p", [0, 1])], UNSPECIFIED),
+        pytest.param(UNSPECIFIED, pd.DataFrame({"p": [0, 1]})),
+    ],
+)
+def test_partial_subspace_legacy_input(parameters, exp_rep):
+    """Providing only one of ``parameters`` and ``exp_rep`` raises a clear error."""
+    with pytest.raises(ValueError, match="provide both 'parameters' and 'exp_rep'"):
+        SubspaceDiscrete(parameters=parameters, exp_rep=exp_rep)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -7,6 +7,7 @@ from itertools import pairwise
 from pathlib import Path
 from unittest.mock import patch
 
+import cattrs
 import numpy as np
 import pandas as pd
 import pytest
@@ -825,8 +826,10 @@ def test_deprecated_discrete_subspace_deserialization():
         actual = SubspaceDiscrete.from_dict(base_dict | {"empty_encoding": False})
     assert actual == expected
 
-    with pytest.raises(DeprecationError, match="comp_rep"):
-        SubspaceDiscrete.from_dict(base_dict | {"comp_rep": {}})
+    with pytest.raises(cattrs.ClassValidationError) as exc_info:
+        SubspaceDiscrete.from_dict(base_dict | {"comp_rep": base_dict["exp_rep"]})
+    (ex,) = exc_info.value.exceptions
+    assert isinstance(ex, DeprecationError) and "comp_rep" in str(ex)
 
 
 def test_deprecated_constraints_deserialization():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -7,7 +7,6 @@ from itertools import pairwise
 from pathlib import Path
 from unittest.mock import patch
 
-import cattrs
 import numpy as np
 import pandas as pd
 import pytest
@@ -800,6 +799,36 @@ def test_deprecated_subspace_discrete_arguments(arg, error):
         SubspaceDiscrete(candidates=EmptyCandidates(), **{arg: 0})
 
 
+def test_deprecated_parameters_exp_rep_conversion():
+    """Passing ``parameters`` and ``exp_rep`` warns and yields the correct object."""
+    p = NumericalDiscreteParameter("p", [0, 1])
+    df = pd.DataFrame({"p": [0, 1]})
+    expected = SubspaceDiscrete.from_dataframe(parameters=[p], df=df)
+    with pytest.warns(DeprecationWarning, match="parameters.*exp_rep"):
+        actual = SubspaceDiscrete(parameters=[p], exp_rep=df)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "use_kw_exp_rep",
+    [
+        pytest.param(False, id="both_positional"),
+        pytest.param(True, id="pos_params_kw_exp_rep"),
+    ],
+)
+def test_deprecated_parameters_exp_rep_positional(use_kw_exp_rep):
+    """Passing ``parameters`` and ``exp_rep`` positionally (or mixed) warns."""
+    p = NumericalDiscreteParameter("p", [0, 1])
+    df = pd.DataFrame({"p": [0, 1]})
+    expected = SubspaceDiscrete.from_dataframe(parameters=[p], df=df)
+    with pytest.warns(DeprecationWarning, match="parameters.*exp_rep"):
+        if use_kw_exp_rep:
+            actual = SubspaceDiscrete([p], exp_rep=df)  # type: ignore[call-arg]
+        else:
+            actual = SubspaceDiscrete([p], df)  # type: ignore[call-arg]
+    assert actual == expected
+
+
 def test_deprecated_empty_encoding_from_product():
     """Passing `empty_encoding` to `SubspaceDiscrete.from_product` raises a warning."""  # noqa
     with pytest.warns(DeprecationWarning, match="Providing 'empty_encoding'"):
@@ -829,10 +858,8 @@ def test_deprecated_discrete_subspace_deserialization():
         actual = SubspaceDiscrete.from_dict(base_dict | {"empty_encoding": False})
     assert actual == expected
 
-    with pytest.raises(cattrs.ClassValidationError) as exc_info:
+    with pytest.raises(DeprecationError, match="comp_rep"):
         SubspaceDiscrete.from_dict(base_dict | {"comp_rep": {}})
-    (ex,) = exc_info.value.exceptions
-    assert isinstance(ex, DeprecationError) and "comp_rep" in str(ex)
 
 
 def test_deprecated_exp_rep_deserialization():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -29,6 +29,7 @@ from baybe.exceptions import DeprecationError
 from baybe.kernels.basic import MaternKernel
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.single import SingleTargetObjective
+from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.categorical import CategoricalParameter, TaskParameter
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.numerical import (
@@ -45,6 +46,7 @@ from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpace
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.searchspace.validation import get_transform_parameters
+from baybe.serialization.core import converter
 from baybe.settings import Settings
 from baybe.surrogates.gaussian_process.core import GaussianProcessSurrogate
 from baybe.targets import NumericalTarget
@@ -831,6 +833,23 @@ def test_deprecated_discrete_subspace_deserialization():
         SubspaceDiscrete.from_dict(base_dict | {"comp_rep": {}})
     (ex,) = exc_info.value.exceptions
     assert isinstance(ex, DeprecationError) and "comp_rep" in str(ex)
+
+
+def test_deprecated_exp_rep_deserialization():
+    """Deserialization from the legacy ``parameters`` + ``exp_rep`` format warns."""
+    p = NumericalDiscreteParameter("p", [0, 1])
+    df = pd.DataFrame({"p": [0, 1]})
+    expected = SubspaceDiscrete.from_dataframe(parameters=[p], df=df)
+    # Build a legacy dict as produced by the old SubspaceDiscrete serialization
+    legacy_dict = {
+        "type": "SubspaceDiscrete",
+        "parameters": [converter.unstructure(p, unstructure_as=DiscreteParameter)],
+        "exp_rep": converter.unstructure(expected.get_candidates()),
+        "batch_constraints": [],
+    }
+    with pytest.warns(DeprecationWarning, match="exp_rep"):
+        actual = SubspaceDiscrete.from_dict(legacy_dict)
+    assert actual == expected
 
 
 def test_deprecated_constraints_deserialization():

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -40,6 +40,7 @@ from baybe.recommenders.pure.bayesian import (
     BotorchRecommender,
 )
 from baybe.recommenders.pure.nonpredictive.sampling import RandomRecommender
+from baybe.searchspace.candidates import EmptyCandidates, TableCandidates
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpace
 from baybe.searchspace.discrete import SubspaceDiscrete
@@ -794,7 +795,7 @@ def test_deprecated_subspace_discrete_arguments(arg, error):
         else pytest.warns(DeprecationWarning, match=f"Providing '{arg}'")
     )
     with context:
-        SubspaceDiscrete(parameters=[], exp_rep=pd.DataFrame(), **{arg: 0})
+        SubspaceDiscrete(candidates=EmptyCandidates(), **{arg: 0})
 
 
 def test_deprecated_empty_encoding_from_product():
@@ -827,7 +828,7 @@ def test_deprecated_discrete_subspace_deserialization():
     assert actual == expected
 
     with pytest.raises(cattrs.ClassValidationError) as exc_info:
-        SubspaceDiscrete.from_dict(base_dict | {"comp_rep": base_dict["exp_rep"]})
+        SubspaceDiscrete.from_dict(base_dict | {"comp_rep": {}})
     (ex,) = exc_info.value.exceptions
     assert isinstance(ex, DeprecationError) and "comp_rep" in str(ex)
 
@@ -855,8 +856,7 @@ def test_deprecated_constraints_argument():
     batch_c = DiscreteBatchConstraint(["p"])
     with pytest.warns(DeprecationWarning, match="Providing 'constraints'"):
         subspace = SubspaceDiscrete(
-            parameters=[p],
-            exp_rep=pd.DataFrame({"p": [0, 1, 2]}),
+            candidates=TableCandidates([p], pd.DataFrame({"p": [0, 1, 2]})),
             constraints=[batch_c],
         )
     # The batch constraint must be migrated to `batch_constraints`
@@ -898,8 +898,7 @@ def test_deprecated_constraints_batch_property():
     p = NumericalDiscreteParameter("p", [0, 1, 2])
     batch_c = DiscreteBatchConstraint(["p"])
     subspace = SubspaceDiscrete(
-        parameters=[p],
-        exp_rep=pd.DataFrame({"p": [0, 1, 2]}),
+        candidates=TableCandidates([p], pd.DataFrame({"p": [0, 1, 2]})),
         batch_constraints=(batch_c,),
     )
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -816,17 +816,17 @@ def test_deprecated_empty_encoding_from_dataframe():
 
 
 def test_deprecated_discrete_subspace_deserialization():
-    """Deserialization from legacy JSON with `empty_encoding`/`comp_rep` works."""
+    """Deserialization from legacy JSON with deprecated keys raises the right signal."""
     p = NumericalDiscreteParameter("p", [0, 1])
     expected = SubspaceDiscrete.from_product(parameters=[p])
+    base_dict = expected.to_dict()
 
-    # Build a legacy dict containing the deprecated fields
-    legacy_dict = expected.to_dict()
-    legacy_dict["empty_encoding"] = False
-    legacy_dict["comp_rep"] = legacy_dict["exp_rep"]
-
-    actual = SubspaceDiscrete.from_dict(legacy_dict)
+    with pytest.warns(DeprecationWarning, match="empty_encoding"):
+        actual = SubspaceDiscrete.from_dict(base_dict | {"empty_encoding": False})
     assert actual == expected
+
+    with pytest.raises(DeprecationError, match="comp_rep"):
+        SubspaceDiscrete.from_dict(base_dict | {"comp_rep": {}})
 
 
 def test_deprecated_constraints_deserialization():


### PR DESCRIPTION
Fixes #794, #795 and #796.

The PR finally integrates the new `CandidatesProtocol` interface into `SubspaceDiscrete`, replacing the `parameters`/`exp_rep` architecture. 

Calls using the legacy arguments are still supported using a deprecation mechanism. Because supporting positional-only calls requires some custom `__init__` logic, the PR also absorbs the previous deprecation logic into the same method, resulting in a single place where legacy arguments are handled, and allowing us to drop all legacy attribute definitions.