### PR TITLE
Ignore link to BayBE paper in `linkcheck`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,10 +200,11 @@ nitpick_ignore_regex = [
     ("py:.*", "baybe.targets._deprecated.*"),
 ]
 
-# Ignore the following links when checking inks for viability
+# Ignore the following links when checking links for viability
 linkcheck_ignore = [
     r"https://github.com/b-shields/edbo/blob*",
     r"https://doi.org/10.26434/chemrxiv.10001986/v2",
+    r"https://doi.org/10.1039/D5DD00050E",
 ]
 
 


### PR DESCRIPTION
Fixes #848 by ignoring the link to the BayBE paper.

I tried to replace the link with two alternative links that would resolve to the same website, but both of them were also causing the same error, hence I decided to simply add them to the already existing `linkcheck_ignore` list.