### PR TITLE
Fix Polars Deprecation Warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in version `0.18.0`
 - The `BOTORCH` GP preset now requires BoTorch `>= 0.18.0` and raises an
   `IncompatibilityError` if an older version is installed
+- Minimum required polars version increased to `0.20.8`
 
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -214,11 +214,7 @@ class DiscreteLinkedParametersConstraint(DiscreteConstraint):
     def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
-        expr = (
-            pl.concat_list(pl.col(self.parameters))
-            .list.eval(pl.element().n_unique())
-            .explode()
-        ) != 1
+        expr = pl.concat_list(pl.col(self.parameters)).list.n_unique() != 1
 
         return expr
 

--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -179,11 +179,9 @@ class DiscreteNoLabelDuplicatesConstraint(DiscreteConstraint):
     def get_invalid_polars(self) -> pl.Expr:
         from baybe._optional.polars import polars as pl
 
-        expr = (
-            pl.concat_list(pl.col(self.parameters))
-            .list.eval(pl.element().n_unique())
-            .explode()
-        ) != len(self.parameters)
+        expr = pl.concat_list(pl.col(self.parameters)).list.n_unique() != len(
+            self.parameters
+        )
 
         return expr
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ mypy = [
 ]
 
 polars = [
-    "polars[pyarrow]>=0.19.19,<2",
+    "polars[pyarrow]>=0.20.8,<2",
 ]
 
 simulation = [

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -163,8 +163,7 @@ def test_polars_linked_parameters(parameters, constraints):
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
-        .list.eval(pl.element().n_unique())
-        .explode()
+        .list.n_unique()
         .alias("n_unique")
     )
     df = ldf.filter(pl.col("n_unique") != 1).collect()

--- a/tests/constraints/test_constraints_polars.py
+++ b/tests/constraints/test_constraints_polars.py
@@ -144,8 +144,7 @@ def test_polars_label_duplicates(parameters, constraints):
 
     ldf = ldf.with_columns(
         pl.concat_list(pl.col(["Solvent_1", "Solvent_2", "Solvent_3"]))
-        .list.eval(pl.element().n_unique())
-        .explode()
+        .list.n_unique()
         .alias("n_unique")
     )
     df = ldf.filter(pl.col("n_unique") != len(parameters)).collect()

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-22T09:27:47.33792Z"
+exclude-newer = "2026-06-26T09:11:42.462317Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -441,7 +441,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'examples'", specifier = ">=10.0.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.5.5" },
     { name = "plotly", marker = "extra == 'examples'", specifier = ">=5.10.0" },
-    { name = "polars", extras = ["pyarrow"], marker = "extra == 'polars'", specifier = ">=0.19.19,<2" },
+    { name = "polars", extras = ["pyarrow"], marker = "extra == 'polars'", specifier = ">=0.20.8,<2" },
     { name = "pre-commit", marker = "extra == 'lint'", specifier = "==4.2.0" },
     { name = "psutil", marker = "extra == 'benchmarking'", specifier = ">=7.0.0" },
     { name = "pydoclint", marker = "extra == 'lint'", specifier = "==0.5.5" },


### PR DESCRIPTION
Since likely `1.42.0` polars throws deprecation warnings for usage of `.explode()`, causing CI [failure](https://github.com/emdgroup/baybe/actions/runs/28647289944/job/84957104109?pr=850#599) for us

The corresponding polars expressions have been reworked to be simpler and avoid `explode`. A minor version bump for polars was needed due to the availability of `list.n_unique`