### PR TITLE
Add links to papers for the datasets

### DIFF
--- a/benchmarks/domains/aryl_halides/__init__.py
+++ b/benchmarks/domains/aryl_halides/__init__.py
@@ -1,1 +1,4 @@
-"""Aryl halides transfer learning benchmarks."""
+"""Aryl halides transfer learning benchmarks.
+
+Source of dataset: https://www.science.org/doi/10.1126/science.aar5169
+"""

--- a/benchmarks/domains/direct_arylation/__init__.py
+++ b/benchmarks/domains/direct_arylation/__init__.py
@@ -1,1 +1,4 @@
-"""The direct arylation benchmark configuration."""
+"""The direct arylation benchmark configuration.
+
+Source of dataset: https://www.nature.com/articles/s41586-021-03213-y
+"""


### PR DESCRIPTION
Links to the datasets used in the benchmarks were missing. Have been added to the corresponding `__init__` files.