### PR TITLE
Narwhalify `DiscreteParameter.transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argument passing between methods
 - The `encoding` attribute has been removed from `DiscreteParameter` base class and
   now only exists on concrete subclasses that actually use it
-- `DiscreteParameter.transform` narhwalified: now accepts `narwhals`-compatible series,
+- `DiscreteParameter.transform` narwhalified: now accepts `narwhals`-compatible series,
   arbitrary iterables, or `None`, and returns a `nw.LazyFrame` instead of a
   `pd.DataFrame`
 - Passing a series to `DiscreteParameter.transform` whose name does not match the
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deserialization with constructor selection now correctly respects converter settings
 - Missing validators and converters were added to several parameter fields
 - `validate_parameter_input` no longer uses row-by-row iteration, fixing a significant
-  performance problem for large candidate sets 
+  performance problem for large candidate sets
 
 ### Deprecations
 - `DiscreteParameter.comp_df` property (use `transform()` instead)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubspaceDiscrete.batch_constraints` field for storing batch-level constraints
 - `SubspaceDiscrete.from_dataframe` now accepts `batch_constraints`
 - `validate_parameter_input` now accepts an `allow_empty` flag to permit zero-row input
+- `DiscreteParameter.transform` narwhalified: now accepts `narwhals`-compatible series,
+  arbitrary iterables, or `None`
 
 ### Changed
 - `SubspaceDiscrete` has been refactored from the ground up: it now holds a `candidates`
@@ -55,9 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argument passing between methods
 - The `encoding` attribute has been removed from `DiscreteParameter` base class and
   now only exists on concrete subclasses that actually use it
-- `DiscreteParameter.transform` narwhalified: now accepts `narwhals`-compatible series,
-  arbitrary iterables, or `None`, and returns a `nw.LazyFrame` instead of a
-  `pd.DataFrame`
 - Passing a series to `DiscreteParameter.transform` whose name does not match the
   parameter name now raises a `ValueError`
 - `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SearchSpace.sample_subsets`
 - `SubspaceDiscrete.get_candidates` now returns only the experimental representation
   instead of a tuple of experimental and computational representations
+- Optional/secondary fields of discrete parameter classes are now keyword-only
 
 ### Added
 - `coefficients` attribute for `DiscreteSumConstraint`, enabling weighted sums. Follows
@@ -52,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and batch constraints (stored in `batch_constraints`)
 - Internal search space and recommender logic simplified by reducing indirection and
   argument passing between methods
+- The `encoding` attribute has been removed from `DiscreteParameter` base class and
+  now only exists on concrete subclasses that actually use it
+- `DiscreteParameter.transform` narhwalified: now accepts `narwhals`-compatible series,
+  arbitrary iterables, or `None`, and returns a `nw.LazyFrame` instead of a
+  `pd.DataFrame`
+- Passing a series to `DiscreteParameter.transform` whose name does not match the
+  parameter name now raises a `ValueError`
 - `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance
   kernel in multi-task scenarios, matching BoTorch's `MultiTaskGP` defaults introduced
   in version `0.18.0`
@@ -63,11 +71,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped polars to `>=0.20.8`
 - Bumped cattrs to `>=26.1.0`
 
-
 ### Fixed
 - Deserialization with constructor selection now correctly respects converter settings
+- Missing validators and converters were added to several parameter fields
+- `validate_parameter_input` no longer uses row-by-row iteration, fixing a significant
+  performance problem for large candidate sets 
 
 ### Deprecations
+- `DiscreteParameter.comp_df` property (use `transform()` instead)
+- `CustomEncoding` enum class
 - `Campaign.n_fits_done` and `Campaign.n_batches_done` attributes
 - `SubspaceDiscrete(parameters, exp_rep)` constructor call style
   (use `SubspaceDiscrete.from_dataframe(parameters, exp_rep)` or

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import gc
+import warnings
 from abc import ABC, abstractmethod
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pandas as pd
@@ -130,16 +130,16 @@ class DiscreteParameter(Parameter, ABC):
         """The values that are considered for recommendation."""
         return self.values
 
-    @cached_property
-    @abstractmethod
-    def comp_df(self) -> pd.DataFrame:
-        # TODO: Should be renamed to `comp_rep`
-        """Return the computational representation of the parameter."""
-
-    @override
     @property
-    def comp_rep_columns(self) -> tuple[str, ...]:
-        return tuple(self.comp_df.columns)
+    def comp_df(self) -> pd.DataFrame:
+        """Deprecated! Use :meth:`transform` instead."""
+        warnings.warn(
+            f"'{self.__class__.__name__}.comp_df' is deprecated and will be removed "
+            f"in a future version. Use '.{self.transform.__name__}()' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.transform()
 
     def to_subspace(self) -> SubspaceDiscrete:
         """Create a one-dimensional search space from the parameter."""
@@ -151,17 +151,18 @@ class DiscreteParameter(Parameter, ABC):
     def is_in_range(self, item: Any) -> bool:
         return item in self.values
 
-    def transform(self, series: pd.Series, /) -> pd.DataFrame:
+    @abstractmethod
+    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
         """Transform parameter values to computational representation.
 
         Args:
             series: The parameter values in experimental representation to be
-                transformed.
+                transformed. If ``None``, the full computational representation
+                for all parameter values is returned.
 
         Returns:
             A dataframe containing the transformed values.
         """
-        return series.to_frame()
 
     @override
     def summary(self) -> dict:
@@ -204,6 +205,27 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
 
         return self._active_values
 
+    @override
+    @property
+    def comp_rep_columns(self) -> tuple[str, ...]:
+        # TODO: Refactor this workaround once the parameter logic has been decoupled
+        #  from comp_df materialization.
+        if not hasattr(self, "_comp_df"):
+            raise NotImplementedError()
+
+        return tuple(self._comp_df.columns)
+
+    @override
+    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+        # TODO: Refactor this workaround once the parameter logic has been decoupled
+        #  from comp_df materialization.
+        if not hasattr(self, "_comp_df"):
+            raise NotImplementedError()
+
+        if series is None:
+            return self._comp_df
+        return self._comp_df.loc[series.to_numpy()].set_index(series.index)  # type: ignore[attr-defined]
+
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103
         self, _: Any, content: tuple[str | bool, ...]
@@ -232,16 +254,6 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
                 f"All active values must be valid parameter choices from: "
                 f"{self.values}, provided: {content}"
             )
-
-    @override
-    def transform(self, series: pd.Series, /) -> pd.DataFrame:
-        return pd.merge(
-            left=series.rename("Labels").to_frame(),
-            left_on="Labels",
-            right=self.comp_df,
-            right_index=True,
-            how="left",
-        ).drop(columns="Labels")
 
     @override
     def summary(self) -> dict:

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -25,7 +25,7 @@ from baybe.utils.metadata import MeasurableMetadata, to_metadata
 if TYPE_CHECKING:
     from typing import Any
 
-    from narwhals.typing import IntoFrame
+    from narwhals.typing import IntoDataFrame
 
     from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 
 # TODO: Reactive slots in all classes once cached_property is supported:
 #   https://github.com/python-attrs/attrs/issues/164
+
+# Sentinel column name used internally during joins to avoid name conflicts
+_JOIN_KEY = "__join_key__"
 
 
 @define(frozen=True, slots=False)
@@ -146,7 +149,9 @@ class DiscreteParameter(Parameter, ABC):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self._transform().collect().to_pandas()
+        return pd.DataFrame(
+            nw.from_native(self.transform(), eager_only=True).to_pandas()
+        )
 
     def to_subspace(self) -> SubspaceDiscrete:
         """Create a one-dimensional search space from the parameter."""
@@ -160,7 +165,7 @@ class DiscreteParameter(Parameter, ABC):
 
     def transform(
         self, series: nw.IntoSeries | Iterable[Any] | None = None, /
-    ) -> IntoFrame:
+    ) -> IntoDataFrame:
         """Transform parameter values to computational representation.
 
         Args:
@@ -169,28 +174,59 @@ class DiscreteParameter(Parameter, ABC):
                 for all parameter values is returned.
 
         Returns:
-            A native frame containing the transformed values, in the same backend as the
-            input series.
+            A native eager frame containing the transformed values, in the same
+            backend as the input series.
 
         Raises:
             ValueError: If the series name does not match the parameter name.
         """
-        if series is not None:
-            if is_into_series(series):
-                series = nw.from_native(series, series_only=True)
-                if series.name != self.name:
-                    raise ValueError(
-                        f"The provided series name '{series.name}' does not match "
-                        f"parameter name '{self.name}'."
-                    )
-            else:
-                # TODO[narwhalify]: use settings-based backend selection
-                series = nw.new_series(name=self.name, values=series, backend=pd)
-        return self._transform(series).to_native()
+        if series is None:
+            # TODO[narwhalify]: use settings-based backend selection
+            # TODO[narwhalify]: drop pandas index
+            series = nw.from_native(
+                pd.Series(list(self.values), index=list(self.values), name=self.name),
+                series_only=True,
+            )
+        elif is_into_series(series):
+            series = nw.from_native(series, series_only=True)
+            if series.name != self.name:
+                raise ValueError(
+                    f"The provided series name '{series.name}' does not match "
+                    f"parameter name '{self.name}'."
+                )
+        else:
+            # TODO[narwhalify]: use settings-based backend selection
+            series = nw.new_series(name=self.name, values=series, backend=pd)
+
+        table = self._encoding_table(series.unique())
+        result = (
+            series.rename(_JOIN_KEY)
+            .to_frame()
+            .join(table, on=_JOIN_KEY, how="left")
+            .drop(_JOIN_KEY)
+        )
+
+        # TODO[narwhalify]: drop once pandas index handling is removed globally
+        if nw.get_native_namespace(series) is pd:
+            native = result.to_native()
+            native.index = series.to_pandas().index
+            return native
+
+        return result.to_native()
 
     @abstractmethod
-    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
-        """See :meth:`transform`."""
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
+        """Create the encoding table for the given unique parameter values.
+
+        The returned dataframe must use :data:`_JOIN_KEY` as the key column (holding the
+        experimental values) plus one column per entry in :attr:`comp_rep_columns`.
+
+        Args:
+            values: The unique experimental values to encode.
+
+        Returns:
+            A dataframe mapping parameter values to their encoded representation.
+        """
 
     @override
     def summary(self) -> dict:
@@ -244,22 +280,19 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
         return tuple(self._comp_df.columns)
 
     @override
-    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
         # TODO: Refactor this workaround once the parameter logic has been decoupled
         #  from comp_df materialization.
         if not hasattr(self, "_comp_df"):
             raise NotImplementedError()
 
-        if series is None:
-            return nw.from_native(self._comp_df).lazy()
-
-        # We use pandas because _comp_df is a pandas-native workaround.
-        # We use reindex instead of loc because the input series may contain Booleans,
-        # which would result in wrong indexing.
-        pd_series = series.to_pandas()
-        return nw.from_native(
-            self._comp_df.reindex(pd_series.to_numpy()).set_index(pd_series.index)
-        ).lazy()
+        # _comp_df is always pandas-backed; filter and convert to the input backend
+        return (
+            nw.from_native(self._comp_df.reset_index(names=_JOIN_KEY), eager_only=True)
+            .filter(nw.col(_JOIN_KEY).is_in(values))
+            .lazy()
+            .collect(backend=nw.get_native_namespace(values))
+        )
 
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -6,7 +6,7 @@ import gc
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, overload
 
 import narwhals.stable.v2 as nw
 import pandas as pd
@@ -25,6 +25,7 @@ from baybe.utils.metadata import MeasurableMetadata, to_metadata
 if TYPE_CHECKING:
     from typing import Any
 
+    import polars as pl
     from narwhals.typing import IntoDataFrame
 
     from baybe.parameters.enum import _ParameterKind
@@ -162,6 +163,15 @@ class DiscreteParameter(Parameter, ABC):
     @override
     def is_in_range(self, item: Any) -> bool:
         return item in self.values
+
+    @overload
+    def transform(self, series: None = None, /) -> IntoDataFrame: ...
+    @overload
+    def transform(self, series: pd.Series[Any], /) -> pd.DataFrame: ...
+    @overload
+    def transform(self, series: pl.Series, /) -> pl.DataFrame: ...
+    @overload
+    def transform(self, series: Iterable[Any], /) -> IntoDataFrame: ...  # type: ignore[overload-cannot-match]
 
     def transform(
         self, series: nw.IntoSeries | Iterable[Any] | None = None, /

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -7,6 +7,7 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attr.converters import optional as optional_c
 from attrs import Converter, define, field
@@ -139,7 +140,7 @@ class DiscreteParameter(Parameter, ABC):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.transform()
+        return self.transform().collect().to_pandas()
 
     def to_subspace(self) -> SubspaceDiscrete:
         """Create a one-dimensional search space from the parameter."""
@@ -152,7 +153,7 @@ class DiscreteParameter(Parameter, ABC):
         return item in self.values
 
     @abstractmethod
-    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         """Transform parameter values to computational representation.
 
         Args:
@@ -161,7 +162,7 @@ class DiscreteParameter(Parameter, ABC):
                 for all parameter values is returned.
 
         Returns:
-            A dataframe containing the transformed values.
+            A lazy frame containing the transformed values.
         """
 
     @override
@@ -216,17 +217,22 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
         return tuple(self._comp_df.columns)
 
     @override
-    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         # TODO: Refactor this workaround once the parameter logic has been decoupled
         #  from comp_df materialization.
         if not hasattr(self, "_comp_df"):
             raise NotImplementedError()
 
         if series is None:
-            return self._comp_df
-        # NOTE: reindex is used instead of loc because the input series may contain
-        #   Booleans, which would result in wrong indexing
-        return self._comp_df.reindex(series.to_numpy()).set_index(series.index)
+            return nw.from_native(self._comp_df).lazy()
+
+        # We use pandas because _comp_df is a pandas-native workaround.
+        # We use reindex instead of loc because the input series may contain Booleans,
+        # which would result in wrong indexing.
+        pd_series = series.to_pandas()
+        return nw.from_native(
+            self._comp_df.reindex(pd_series.to_numpy()).set_index(pd_series.index)
+        ).lazy()
 
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -13,7 +13,7 @@ import pandas as pd
 from attr.converters import optional as optional_c
 from attrs import Converter, define, field
 from attrs.validators import instance_of, min_len
-from narwhals.dependencies import is_into_series
+from narwhals.stable.v2.dependencies import is_into_series
 from typing_extensions import override
 
 from baybe.serialization import (
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     import polars as pl
-    from narwhals.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import gc
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import narwhals.stable.v2 as nw
@@ -12,6 +13,7 @@ import pandas as pd
 from attr.converters import optional as optional_c
 from attrs import Converter, define, field
 from attrs.validators import instance_of, min_len
+from narwhals.dependencies import is_into_series
 from typing_extensions import override
 
 from baybe.serialization import (
@@ -152,7 +154,9 @@ class DiscreteParameter(Parameter, ABC):
     def is_in_range(self, item: Any) -> bool:
         return item in self.values
 
-    def transform(self, series: nw.IntoSeries | None = None, /) -> nw.LazyFrame:
+    def transform(
+        self, series: nw.IntoSeries | Iterable[Any] | None = None, /
+    ) -> nw.LazyFrame:
         """Transform parameter values to computational representation.
 
         Args:
@@ -167,12 +171,16 @@ class DiscreteParameter(Parameter, ABC):
             ValueError: If the series name does not match the parameter name.
         """
         if series is not None:
-            series = nw.from_native(series, series_only=True)
-            if series.name != self.name:
-                raise ValueError(
-                    f"The provided series name '{series.name}' does not match "
-                    f"parameter name '{self.name}'."
-                )
+            if is_into_series(series):
+                series = nw.from_native(series, series_only=True)
+                if series.name != self.name:
+                    raise ValueError(
+                        f"The provided series name '{series.name}' does not match "
+                        f"parameter name '{self.name}'."
+                    )
+            else:
+                # TODO[narwhalify]: use settings-based backend selection
+                series = nw.new_series(name=self.name, values=series, backend=pd)
         return self._transform(series)
 
     @abstractmethod

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -19,6 +19,7 @@ from typing_extensions import override
 from baybe.serialization import (
     SerialMixin,
 )
+from baybe.settings import active_settings
 from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
@@ -190,14 +191,8 @@ class DiscreteParameter(Parameter, ABC):
         Raises:
             ValueError: If the series name does not match the parameter name.
         """
-        if series is None:
-            # TODO[narwhalify]: use settings-based backend selection
-            # TODO[narwhalify]: drop pandas index
-            series = nw.from_native(
-                pd.Series(list(self.values), index=list(self.values), name=self.name),
-                series_only=True,
-            )
-        elif is_into_series(series):
+        all_values = series is None
+        if is_into_series(series):
             series = nw.from_native(series, series_only=True)
             if series.name != self.name:
                 raise ValueError(
@@ -205,8 +200,12 @@ class DiscreteParameter(Parameter, ABC):
                     f"parameter name '{self.name}'."
                 )
         else:
-            # TODO[narwhalify]: use settings-based backend selection
-            series = nw.new_series(name=self.name, values=series, backend=pd)
+            # TODO[typing]: https://github.com/narwhals-dev/narwhals/issues/3808
+            series = nw.new_series(
+                name=self.name,
+                values=self.values if all_values else series,
+                backend=active_settings.default_dataframe_backend,  # type: ignore[arg-type]
+            )
 
         table = self._encoding_table(series.unique())
         result = (
@@ -219,7 +218,7 @@ class DiscreteParameter(Parameter, ABC):
         # TODO[narwhalify]: drop once pandas index handling is removed globally
         if nw.get_native_namespace(series) is pd:
             native = result.to_native()
-            native.index = series.to_pandas().index
+            native.index = series.to_list() if all_values else series.to_pandas().index
             return native
 
         return result.to_native()

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -152,7 +152,7 @@ class DiscreteParameter(Parameter, ABC):
     def is_in_range(self, item: Any) -> bool:
         return item in self.values
 
-    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+    def transform(self, series: nw.IntoSeries | None = None, /) -> nw.LazyFrame:
         """Transform parameter values to computational representation.
 
         Args:
@@ -166,11 +166,13 @@ class DiscreteParameter(Parameter, ABC):
         Raises:
             ValueError: If the series name does not match the parameter name.
         """
-        if series is not None and series.name != self.name:
-            raise ValueError(
-                f"The provided series name '{series.name}' does not match "
-                f"parameter name '{self.name}'."
-            )
+        if series is not None:
+            series = nw.from_native(series, series_only=True)
+            if series.name != self.name:
+                raise ValueError(
+                    f"The provided series name '{series.name}' does not match "
+                    f"parameter name '{self.name}'."
+                )
         return self._transform(series)
 
     @abstractmethod

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -8,15 +8,15 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pandas as pd
-from attrs import define, field
-from attrs.converters import optional as optional_c
+from attr.converters import optional as optional_c
+from attrs import Converter, define, field
 from attrs.validators import instance_of, min_len
 from typing_extensions import override
 
 from baybe.serialization import (
     SerialMixin,
 )
-from baybe.utils.basic import to_tuple
+from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
@@ -186,7 +186,11 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
     # object variables
     _active_values: tuple[str | bool, ...] | None = field(
         default=None,
-        converter=optional_c(to_tuple),
+        converter=optional_c(
+            Converter(  # type: ignore[misc, call-overload]
+                nonstring_to_tuple, takes_self=True, takes_field=True
+            )
+        ),
         kw_only=True,
         alias="active_values",
     )

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -6,7 +6,7 @@ import gc
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import narwhals.stable.v2 as nw
 import pandas as pd
@@ -23,6 +23,10 @@ from baybe.utils.conversion import nonstring_to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
+    from typing import Any
+
+    from narwhals.typing import IntoFrame
+
     from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
     from baybe.searchspace.core import SearchSpace
@@ -142,7 +146,7 @@ class DiscreteParameter(Parameter, ABC):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.transform().collect().to_pandas()
+        return self._transform().collect().to_pandas()
 
     def to_subspace(self) -> SubspaceDiscrete:
         """Create a one-dimensional search space from the parameter."""
@@ -156,7 +160,7 @@ class DiscreteParameter(Parameter, ABC):
 
     def transform(
         self, series: nw.IntoSeries | Iterable[Any] | None = None, /
-    ) -> nw.LazyFrame:
+    ) -> IntoFrame:
         """Transform parameter values to computational representation.
 
         Args:
@@ -165,7 +169,8 @@ class DiscreteParameter(Parameter, ABC):
                 for all parameter values is returned.
 
         Returns:
-            A lazy frame containing the transformed values.
+            A native frame containing the transformed values, in the same backend as the
+            input series.
 
         Raises:
             ValueError: If the series name does not match the parameter name.
@@ -181,7 +186,7 @@ class DiscreteParameter(Parameter, ABC):
             else:
                 # TODO[narwhalify]: use settings-based backend selection
                 series = nw.new_series(name=self.name, values=series, backend=pd)
-        return self._transform(series)
+        return self._transform(series).to_native()
 
     @abstractmethod
     def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -173,8 +173,8 @@ class DiscreteParameter(Parameter, ABC):
 
 
 @define(frozen=True, slots=False)
-class _DiscreteLabelLikeParameter(DiscreteParameter, ABC):
-    """Abstract class for discrete label-like parameters.
+class _EncodedDiscreteParameter(DiscreteParameter, ABC):
+    """Abstract class for encoded discrete parameters.
 
     In general, these are parameters with non-numerical experimental representations.
     """

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -152,7 +152,6 @@ class DiscreteParameter(Parameter, ABC):
     def is_in_range(self, item: Any) -> bool:
         return item in self.values
 
-    @abstractmethod
     def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         """Transform parameter values to computational representation.
 
@@ -163,7 +162,20 @@ class DiscreteParameter(Parameter, ABC):
 
         Returns:
             A lazy frame containing the transformed values.
+
+        Raises:
+            ValueError: If the series name does not match the parameter name.
         """
+        if series is not None and series.name != self.name:
+            raise ValueError(
+                f"The provided series name '{series.name}' does not match "
+                f"parameter name '{self.name}'."
+            )
+        return self._transform(series)
+
+    @abstractmethod
+    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+        """See :meth:`transform`."""
 
     @override
     def summary(self) -> dict:
@@ -217,7 +229,7 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
         return tuple(self._comp_df.columns)
 
     @override
-    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         # TODO: Refactor this workaround once the parameter logic has been decoupled
         #  from comp_df materialization.
         if not hasattr(self, "_comp_df"):

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -224,7 +224,9 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
 
         if series is None:
             return self._comp_df
-        return self._comp_df.loc[series.to_numpy()].set_index(series.index)  # type: ignore[attr-defined]
+        # NOTE: reindex is used instead of loc because the input series may contain
+        #   Booleans, which would result in wrong indexing
+        return self._comp_df.reindex(series.to_numpy()).set_index(series.index)
 
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -269,31 +269,6 @@ class _EncodedDiscreteParameter(DiscreteParameter, ABC):
 
         return self._active_values
 
-    @override
-    @property
-    def comp_rep_columns(self) -> tuple[str, ...]:
-        # TODO: Refactor this workaround once the parameter logic has been decoupled
-        #  from comp_df materialization.
-        if not hasattr(self, "_comp_df"):
-            raise NotImplementedError()
-
-        return tuple(self._comp_df.columns)
-
-    @override
-    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
-        # TODO: Refactor this workaround once the parameter logic has been decoupled
-        #  from comp_df materialization.
-        if not hasattr(self, "_comp_df"):
-            raise NotImplementedError()
-
-        # _comp_df is always pandas-backed; filter and convert to the input backend
-        return (
-            nw.from_native(self._comp_df.reset_index(names=_JOIN_KEY), eager_only=True)
-            .filter(nw.col(_JOIN_KEY).is_in(values))
-            .lazy()
-            .collect(backend=nw.get_native_namespace(values))
-        )
-
     @_active_values.validator
     def _validate_active_values(  # noqa: DOC101, DOC103
         self, _: Any, content: tuple[str | bool, ...]

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -13,7 +13,6 @@ from attrs.converters import optional as optional_c
 from attrs.validators import instance_of, min_len
 from typing_extensions import override
 
-from baybe.parameters.enum import ParameterEncoding
 from baybe.serialization import (
     SerialMixin,
 )
@@ -115,10 +114,6 @@ class Parameter(ABC, SerialMixin):
 class DiscreteParameter(Parameter, ABC):
     """Abstract class for discrete parameters."""
 
-    # class variables
-    encoding: ParameterEncoding | None = field(init=False, default=None)
-    """An optional encoding for the parameter."""
-
     @property
     @abstractmethod
     def values(self) -> tuple:
@@ -164,32 +159,17 @@ class DiscreteParameter(Parameter, ABC):
                 transformed.
 
         Returns:
-            A series containing the transformed values. The series name matches
-            that of the input.
+            A dataframe containing the transformed values.
         """
-        if self.encoding:
-            # replace each label with the corresponding encoding
-            transformed = pd.merge(
-                left=series.rename("Labels").to_frame(),
-                left_on="Labels",
-                right=self.comp_df,
-                right_index=True,
-                how="left",
-            ).drop(columns="Labels")
-        else:
-            transformed = series.to_frame()
-
-        return transformed
+        return series.to_frame()
 
     @override
     def summary(self) -> dict:
-        param_dict = dict(
+        return dict(
             Name=self.name,
             Type=self.__class__.__name__,
             nValues=len(self.values),
-            Encoding=self.encoding,
         )
-        return param_dict
 
 
 @define(frozen=True, slots=False)
@@ -248,6 +228,16 @@ class _DiscreteLabelLikeParameter(DiscreteParameter, ABC):
                 f"All active values must be valid parameter choices from: "
                 f"{self.values}, provided: {content}"
             )
+
+    @override
+    def transform(self, series: pd.Series, /) -> pd.DataFrame:
+        return pd.merge(
+            left=series.rename("Labels").to_frame(),
+            left_on="Labels",
+            right=self.comp_df,
+            right_index=True,
+            how="left",
+        ).drop(columns="Labels")
 
     @override
     def summary(self) -> dict:

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -61,6 +61,10 @@ class CategoricalParameter(_DiscreteLabelLikeParameter):
         return self._values
 
     @override
+    def summary(self) -> dict:
+        return {**super().summary(), "Encoding": self.encoding}
+
+    @override
     @cached_property
     def comp_df(self) -> pd.DataFrame:
         if self.encoding is CategoricalEncoding.OHE:

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -78,7 +78,7 @@ class CategoricalParameter(_EncodedDiscreteParameter):
         assert_never(self.encoding)
 
     @override
-    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         # TODO[narwhalify]: use settings-based backend selection
         if series is None:
             series = nw.from_native(

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -9,7 +9,7 @@ from attrs import Converter, define, field
 from attrs.validators import deep_iterable, instance_of, min_len
 from typing_extensions import override
 
-from baybe.parameters.base import _DiscreteLabelLikeParameter
+from baybe.parameters.base import _EncodedDiscreteParameter
 from baybe.parameters.enum import CategoricalEncoding
 from baybe.parameters.validation import validate_unique_values
 from baybe.settings import active_settings
@@ -32,7 +32,7 @@ def _validate_label_min_len(self, attr, value) -> None:
 
 
 @define(frozen=True, slots=False)
-class CategoricalParameter(_DiscreteLabelLikeParameter):
+class CategoricalParameter(_EncodedDiscreteParameter):
     """Parameter class for categorical parameters."""
 
     # object variables

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -99,7 +99,7 @@ class CategoricalParameter(_EncodedDiscreteParameter):
             result = nw.from_numpy(data, schema=list(self.comp_rep_columns), backend=ns)
 
             # Special handling for pandas backend to preserve index
-            # TODO[narwhalify]: needs to be dropped once we ingore indices in general
+            # TODO[narwhalify]: needs to be dropped once we ignore indices in general
             if ns is pd:
                 native = result.to_native()
                 native.index = series.to_pandas().index

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -3,16 +3,13 @@
 import gc
 
 import narwhals.stable.v2 as nw
-import numpy as np
-import pandas as pd
 from attrs import Converter, define, field
 from attrs.validators import deep_iterable, instance_of, min_len
 from typing_extensions import assert_never, override
 
-from baybe.parameters.base import _EncodedDiscreteParameter
+from baybe.parameters.base import _JOIN_KEY, _EncodedDiscreteParameter
 from baybe.parameters.enum import CategoricalEncoding
 from baybe.parameters.validation import validate_unique_values
-from baybe.settings import active_settings
 from baybe.utils.conversion import nonstring_to_tuple
 
 
@@ -78,42 +75,29 @@ class CategoricalParameter(_EncodedDiscreteParameter):
         assert_never(self.encoding)
 
     @override
-    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
-        # TODO[narwhalify]: use settings-based backend selection
-        if series is None:
-            series = nw.from_native(
-                pd.Series(self.values, index=self.values, name=self.name),
-                series_only=True,
-            )
-
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
         if self.encoding is CategoricalEncoding.OHE:
-            # Create OHE representation
-            vals = series.to_numpy()
-            ns = nw.get_native_namespace(series)
-            positions = {v: i for i, v in enumerate(self.values)}
-            data = np.zeros(
-                (len(vals), len(self.values)), dtype=active_settings.DTypeFloatNumpy
+            # TODO[narwhalify]: avoid hard-coded float type
+            return (
+                values.rename(_JOIN_KEY)
+                .to_frame()
+                .with_columns(
+                    (nw.col(_JOIN_KEY) == v).cast(nw.Float64).alias(ohe_col)
+                    for v, ohe_col in zip(self.values, self.comp_rep_columns)
+                )
             )
-            for row, val in enumerate(vals):
-                data[row, positions[val]] = 1.0
-            result = nw.from_numpy(data, schema=list(self.comp_rep_columns), backend=ns)
-
-            # Special handling for pandas backend to preserve index
-            # TODO[narwhalify]: needs to be dropped once we ignore indices in general
-            if ns is pd:
-                native = result.to_native()
-                native.index = series.to_pandas().index
-                result = nw.from_native(native)
-
-            return result.lazy()
 
         if self.encoding is CategoricalEncoding.INT:
             # TODO[narwhalify]: avoid hard-coded float type
             mapping = {v: float(i) for i, v in enumerate(self.values)}
             return (
-                series.replace_strict(mapping, return_dtype=nw.Float64)
+                values.rename(_JOIN_KEY)
                 .to_frame()
-                .lazy()
+                .with_columns(
+                    nw.col(_JOIN_KEY)
+                    .replace_strict(mapping, return_dtype=nw.Float64)
+                    .alias(self.name)
+                )
             )
 
         assert_never(self.encoding)

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -2,6 +2,7 @@
 
 import gc
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 from attrs import Converter, define, field
@@ -71,36 +72,48 @@ class CategoricalParameter(_EncodedDiscreteParameter):
                 f"{self.name}_{'b' if isinstance(val, bool) else ''}{val}"
                 for val in self.values
             )
-
         if self.encoding is CategoricalEncoding.INT:
             return (self.name,)
 
         assert_never(self.encoding)
 
     @override
-    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
-        vals = self.values if series is None else series.to_numpy()
-        index = pd.Index(self.values) if series is None else series.index
+    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+        # TODO[narwhalify]: use settings-based backend selection
+        if series is None:
+            series = nw.from_native(
+                pd.Series(self.values, index=self.values, name=self.name),
+                series_only=True,
+            )
 
         if self.encoding is CategoricalEncoding.OHE:
+            # Create OHE representation
+            vals = series.to_numpy()
+            ns = nw.get_native_namespace(series)
             positions = {v: i for i, v in enumerate(self.values)}
             data = np.zeros(
                 (len(vals), len(self.values)), dtype=active_settings.DTypeFloatNumpy
             )
             for row, val in enumerate(vals):
                 data[row, positions[val]] = 1.0
-            return pd.DataFrame(data, index=index, columns=list(self.comp_rep_columns))
+            result = nw.from_numpy(data, schema=list(self.comp_rep_columns), backend=ns)
+
+            # Special handling for pandas backend to preserve index
+            # TODO[narwhalify]: needs to be dropped once we ingore indices in general
+            if ns is pd:
+                native = result.to_native()
+                native.index = series.to_pandas().index
+                result = nw.from_native(native)
+
+            return result.lazy()
 
         if self.encoding is CategoricalEncoding.INT:
-            mapping = {v: i for i, v in enumerate(self.values)}
-            return pd.DataFrame(
-                {
-                    self.name: pd.array(
-                        [mapping[v] for v in vals],
-                        dtype=active_settings.DTypeFloatNumpy,
-                    )
-                },
-                index=index,
+            # TODO[narwhalify]: avoid hard-coded float type
+            mapping = {v: float(i) for i, v in enumerate(self.values)}
+            return (
+                series.replace_strict(mapping, return_dtype=nw.Float64)
+                .to_frame()
+                .lazy()
             )
 
         assert_never(self.encoding)

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -1,13 +1,12 @@
 """Categorical parameters."""
 
 import gc
-from functools import cached_property
 
 import numpy as np
 import pandas as pd
 from attrs import Converter, define, field
 from attrs.validators import deep_iterable, instance_of, min_len
-from typing_extensions import override
+from typing_extensions import assert_never, override
 
 from baybe.parameters.base import _EncodedDiscreteParameter
 from baybe.parameters.enum import CategoricalEncoding
@@ -64,26 +63,47 @@ class CategoricalParameter(_EncodedDiscreteParameter):
     def summary(self) -> dict:
         return {**super().summary(), "Encoding": self.encoding}
 
-    @cached_property
-    def _comp_df(self) -> pd.DataFrame:
+    @override
+    @property
+    def comp_rep_columns(self) -> tuple[str, ...]:
         if self.encoding is CategoricalEncoding.OHE:
-            cols = [
+            return tuple(
                 f"{self.name}_{'b' if isinstance(val, bool) else ''}{val}"
                 for val in self.values
-            ]
-            comp_df = pd.DataFrame(
-                np.eye(len(self.values), dtype=active_settings.DTypeFloatNumpy),
-                columns=cols,
             )
-        elif self.encoding is CategoricalEncoding.INT:
-            comp_df = pd.DataFrame(
-                range(len(self.values)),
-                dtype=active_settings.DTypeFloatNumpy,
-                columns=[self.name],
-            )
-        comp_df.index = pd.Index(self.values)
 
-        return comp_df
+        if self.encoding is CategoricalEncoding.INT:
+            return (self.name,)
+
+        assert_never(self.encoding)
+
+    @override
+    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+        vals = self.values if series is None else series.to_numpy()
+        index = pd.Index(self.values) if series is None else series.index
+
+        if self.encoding is CategoricalEncoding.OHE:
+            positions = {v: i for i, v in enumerate(self.values)}
+            data = np.zeros(
+                (len(vals), len(self.values)), dtype=active_settings.DTypeFloatNumpy
+            )
+            for row, val in enumerate(vals):
+                data[row, positions[val]] = 1.0
+            return pd.DataFrame(data, index=index, columns=list(self.comp_rep_columns))
+
+        if self.encoding is CategoricalEncoding.INT:
+            mapping = {v: i for i, v in enumerate(self.values)}
+            return pd.DataFrame(
+                {
+                    self.name: pd.array(
+                        [mapping[v] for v in vals],
+                        dtype=active_settings.DTypeFloatNumpy,
+                    )
+                },
+                index=index,
+            )
+
+        assert_never(self.encoding)
 
 
 @define(frozen=True, slots=False)

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -50,7 +50,7 @@ class CategoricalParameter(_EncodedDiscreteParameter):
     # See base class.
 
     encoding: CategoricalEncoding = field(
-        default=CategoricalEncoding.OHE, converter=CategoricalEncoding
+        default=CategoricalEncoding.OHE, converter=CategoricalEncoding, kw_only=True
     )
     # See base class.
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -64,9 +64,8 @@ class CategoricalParameter(_EncodedDiscreteParameter):
     def summary(self) -> dict:
         return {**super().summary(), "Encoding": self.encoding}
 
-    @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:
+    def _comp_df(self) -> pd.DataFrame:
         if self.encoding is CategoricalEncoding.OHE:
             cols = [
                 f"{self.name}_{'b' if isinstance(val, bool) else ''}{val}"

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -11,7 +11,6 @@ from attrs.validators import min_len
 from typing_extensions import override
 
 from baybe.parameters.base import _DiscreteLabelLikeParameter
-from baybe.parameters.enum import CustomEncoding
 from baybe.parameters.validation import validate_decorrelation
 from baybe.settings import active_settings
 from baybe.utils.boolean import eq_dataframe
@@ -37,9 +36,6 @@ class CustomDiscreteParameter(_DiscreteLabelLikeParameter):
         - ``True``: The encoding is decorrelated using a default correlation threshold.
         - float in (0, 1): The encoding is decorrelated using the specified threshold.
     """
-
-    encoding: CustomEncoding = field(init=False, default=CustomEncoding.CUSTOM)
-    # See base class.
 
     @data.validator
     def _validate_custom_data(  # noqa: DOC101, DOC103

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -4,17 +4,40 @@ import gc
 from functools import cached_property
 from typing import Any
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 from attrs import define, field
 from attrs.validators import instance_of, min_len
 from typing_extensions import override
 
-from baybe.parameters.base import _EncodedDiscreteParameter
+from baybe.parameters.base import _JOIN_KEY, _EncodedDiscreteParameter
 from baybe.parameters.validation import validate_decorrelation
 from baybe.settings import active_settings
 from baybe.utils.boolean import eq_dataframe
 from baybe.utils.dataframe import df_uncorrelated_features
+
+
+def _encoding_table_from_comp_df(
+    comp_df: pd.DataFrame, values: nw.Series, /
+) -> nw.DataFrame:
+    """Build a narwhals encoding table from a pandas-backed exhaustive encoding table.
+
+    Args:
+        comp_df: A pandas dataframe whose index holds all experimental parameter values
+            and whose columns hold the encoded representation.
+        values: The unique experimental values to include in the table.
+
+    Returns:
+        A narwhals dataframe with :data:`~baybe.parameters.base._JOIN_KEY` as the
+        key column, converted to the same backend as ``values``.
+    """
+    return (
+        nw.from_native(comp_df.reset_index(names=_JOIN_KEY), eager_only=True)
+        .filter(nw.col(_JOIN_KEY).is_in(values))
+        .lazy()
+        .collect(backend=nw.get_native_namespace(values))
+    )
 
 
 @define(frozen=True, slots=False)
@@ -117,6 +140,15 @@ class CustomDiscreteParameter(_EncodedDiscreteParameter):
                 comp_df = df_uncorrelated_features(comp_df, threshold=self.decorrelate)
 
         return comp_df
+
+    @override
+    @property
+    def comp_rep_columns(self) -> tuple[str, ...]:
+        return tuple(self._comp_df.columns)
+
+    @override
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
+        return _encoding_table_from_comp_df(self._comp_df, values)
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -10,7 +10,7 @@ from attrs import define, field
 from attrs.validators import min_len
 from typing_extensions import override
 
-from baybe.parameters.base import _DiscreteLabelLikeParameter
+from baybe.parameters.base import _EncodedDiscreteParameter
 from baybe.parameters.validation import validate_decorrelation
 from baybe.settings import active_settings
 from baybe.utils.boolean import eq_dataframe
@@ -18,7 +18,7 @@ from baybe.utils.dataframe import df_uncorrelated_features
 
 
 @define(frozen=True, slots=False)
-class CustomDiscreteParameter(_DiscreteLabelLikeParameter):
+class CustomDiscreteParameter(_EncodedDiscreteParameter):
     """Custom parameters.
 
     For these parameters, the user can read in a precomputed representation for labels,

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -29,7 +29,9 @@ class CustomDiscreteParameter(_EncodedDiscreteParameter):
     data: pd.DataFrame = field(validator=min_len(2), eq=eq_dataframe)
     """A mapping that provides the encoding for all available parameter values."""
 
-    decorrelate: bool | float = field(default=True, validator=validate_decorrelation)
+    decorrelate: bool | float = field(
+        default=True, validator=validate_decorrelation, kw_only=True
+    )
     """Specifies the used decorrelation mode for the parameter encoding.
 
         - ``False``: The encoding is used as is.

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from attrs import define, field
-from attrs.validators import min_len
+from attrs.validators import instance_of, min_len
 from typing_extensions import override
 
 from baybe.parameters.base import _EncodedDiscreteParameter
@@ -26,7 +26,9 @@ class CustomDiscreteParameter(_EncodedDiscreteParameter):
     """
 
     # object variables
-    data: pd.DataFrame = field(validator=min_len(2), eq=eq_dataframe)
+    data: pd.DataFrame = field(
+        validator=(instance_of(pd.DataFrame), min_len(2)), eq=eq_dataframe
+    )
     """A mapping that provides the encoding for all available parameter values."""
 
     decorrelate: bool | float = field(

--- a/baybe/parameters/custom.py
+++ b/baybe/parameters/custom.py
@@ -100,9 +100,8 @@ class CustomDiscreteParameter(_EncodedDiscreteParameter):
         """Returns the representing labels of the parameter."""
         return tuple(self.data.index)
 
-    @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:
+    def _comp_df(self) -> pd.DataFrame:
         # The encoding is directly provided by the user
         # We prepend the parameter name to the columns names to avoid potential
         # conflicts with other parameters

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -35,11 +35,7 @@ class _ParameterKind(Flag):
         return _ParameterKind.REGULAR
 
 
-class ParameterEncoding(Enum):
-    """Generic base class for all parameter encodings."""
-
-
-class CategoricalEncoding(ParameterEncoding):
+class CategoricalEncoding(Enum):
     """Available encodings for categorical parameters."""
 
     OHE = "OHE"
@@ -49,14 +45,14 @@ class CategoricalEncoding(ParameterEncoding):
     """Integer encoding."""
 
 
-class CustomEncoding(ParameterEncoding):
+class CustomEncoding(Enum):
     """Available encodings for custom parameters."""
 
     CUSTOM = "CUSTOM"
     """User-defined encoding."""
 
 
-class SubstanceEncoding(ParameterEncoding):
+class SubstanceEncoding(Enum):
     """Available encodings for substance parameters from
     `scikit-fingerprints <https://scikit-fingerprints.readthedocs.io/>`_ package.
     """  # noqa: D205

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from enum import Enum, Flag, auto
+import warnings
+from enum import Enum, EnumMeta, Flag, auto
 from typing import TYPE_CHECKING
+
+from typing_extensions import override
 
 if TYPE_CHECKING:
     from baybe.parameters.base import Parameter
@@ -45,11 +48,33 @@ class CategoricalEncoding(Enum):
     """Integer encoding."""
 
 
-class CustomEncoding(Enum):
-    """Available encodings for custom parameters."""
+# >>>>>>>>>> Deprecation
+class _DeprecatedCustomEncodingMeta(EnumMeta):
+    """Metaclass that emits a deprecation warning on member access."""
+
+    _msg = "'CustomEncoding' is deprecated and will be removed in a future version."
+
+    @override
+    def __getattribute__(cls, name: str) -> object:
+        obj = super().__getattribute__(name)
+        if isinstance(obj, cls):
+            warnings.warn(cls._msg, DeprecationWarning, stacklevel=2)
+        return obj
+
+    @override
+    def __call__(cls, *args, **kwargs):
+        warnings.warn(cls._msg, DeprecationWarning, stacklevel=2)
+        return super().__call__(*args, **kwargs)
+
+
+class CustomEncoding(Enum, metaclass=_DeprecatedCustomEncodingMeta):
+    """Deprecated!"""
 
     CUSTOM = "CUSTOM"
     """User-defined encoding."""
+
+
+# <<<<<<<<<< Deprecation
 
 
 class SubstanceEncoding(Enum):

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -8,7 +8,7 @@ import cattrs
 import numpy as np
 import pandas as pd
 from attrs import define, field
-from attrs.validators import min_len
+from attrs.validators import ge, min_len
 from typing_extensions import override
 
 from baybe.exceptions import NumericalUnderflowError
@@ -16,6 +16,7 @@ from baybe.parameters.base import ContinuousParameter, DiscreteParameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
 from baybe.settings import active_settings
 from baybe.utils.interval import InfiniteIntervalError, Interval
+from baybe.utils.validation import finite_float
 
 
 @define(frozen=True, slots=False)
@@ -41,7 +42,9 @@ class NumericalDiscreteParameter(DiscreteParameter):
     )
     """The values the parameter can take."""
 
-    tolerance: float = field(default=0.0, kw_only=True)
+    tolerance: float = field(
+        default=0.0, converter=float, validator=(finite_float, ge(0.0)), kw_only=True
+    )
     """The absolute tolerance used for deciding whether a value is in range. A tolerance
         larger than half the minimum distance between parameter values is not allowed
         because that could cause ambiguity when inputting data points later."""
@@ -163,7 +166,7 @@ class _FixedNumericalContinuousParameter(ContinuousParameter):
     is_numerical: ClassVar[bool] = True
     # See base class.
 
-    value: float = field(converter=float)
+    value: float = field(converter=float, validator=finite_float)
     """The fixed value of the parameter."""
 
     @property

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -4,6 +4,7 @@ import gc
 from typing import Any, ClassVar
 
 import cattrs
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 from attrs import define, field
@@ -97,10 +98,16 @@ class NumericalDiscreteParameter(DiscreteParameter):
         return (self.name,)
 
     @override
-    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+        # TODO[narwhalify]: use settings-based backend selection
         if series is None:
-            series = pd.Series(self.values, index=self.values, name=self.name)
-        return series.to_frame().astype(active_settings.DTypeFloatNumpy)
+            pd_series = pd.Series(self.values, index=self.values, name=self.name)
+            return nw.from_native(
+                pd_series.to_frame().astype(active_settings.DTypeFloatNumpy)
+            ).lazy()
+
+        # TODO[narwhalify]: avoid hard-coded float type
+        return series.cast(nw.Float64).to_frame().lazy()
 
     @override
     def is_in_range(self, item: float) -> bool:

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -41,7 +41,7 @@ class NumericalDiscreteParameter(DiscreteParameter):
     )
     """The values the parameter can take."""
 
-    tolerance: float = field(default=0.0)
+    tolerance: float = field(default=0.0, kw_only=True)
     """The absolute tolerance used for deciding whether a value is in range. A tolerance
         larger than half the minimum distance between parameter values is not allowed
         because that could cause ambiguity when inputting data points later."""

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -1,7 +1,6 @@
 """Numerical parameters."""
 
 import gc
-from functools import cached_property
 from typing import Any, ClassVar
 
 import cattrs
@@ -93,14 +92,15 @@ class NumericalDiscreteParameter(DiscreteParameter):
         return tuple(active_settings.DTypeFloatNumpy(itm) for itm in self._values)
 
     @override
-    @cached_property
-    def comp_df(self) -> pd.DataFrame:
-        comp_df = pd.DataFrame(
-            {self.name: self.values},
-            index=self.values,
-            dtype=active_settings.DTypeFloatNumpy,
-        )
-        return comp_df
+    @property
+    def comp_rep_columns(self) -> tuple[str, ...]:
+        return (self.name,)
+
+    @override
+    def transform(self, series: pd.Series | None = None, /) -> pd.DataFrame:
+        if series is None:
+            series = pd.Series(self.values, index=self.values, name=self.name)
+        return series.to_frame().astype(active_settings.DTypeFloatNumpy)
 
     @override
     def is_in_range(self, item: float) -> bool:

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -98,7 +98,7 @@ class NumericalDiscreteParameter(DiscreteParameter):
         return (self.name,)
 
     @override
-    def transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
+    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
         # TODO[narwhalify]: use settings-based backend selection
         if series is None:
             pd_series = pd.Series(self.values, index=self.values, name=self.name)

--- a/baybe/parameters/numerical.py
+++ b/baybe/parameters/numerical.py
@@ -6,13 +6,12 @@ from typing import Any, ClassVar
 import cattrs
 import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
 from attrs import define, field
 from attrs.validators import ge, min_len
 from typing_extensions import override
 
 from baybe.exceptions import NumericalUnderflowError
-from baybe.parameters.base import ContinuousParameter, DiscreteParameter
+from baybe.parameters.base import _JOIN_KEY, ContinuousParameter, DiscreteParameter
 from baybe.parameters.validation import validate_is_finite, validate_unique_values
 from baybe.settings import active_settings
 from baybe.utils.interval import InfiniteIntervalError, Interval
@@ -98,16 +97,13 @@ class NumericalDiscreteParameter(DiscreteParameter):
         return (self.name,)
 
     @override
-    def _transform(self, series: nw.Series | None = None, /) -> nw.LazyFrame:
-        # TODO[narwhalify]: use settings-based backend selection
-        if series is None:
-            pd_series = pd.Series(self.values, index=self.values, name=self.name)
-            return nw.from_native(
-                pd_series.to_frame().astype(active_settings.DTypeFloatNumpy)
-            ).lazy()
-
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
         # TODO[narwhalify]: avoid hard-coded float type
-        return series.cast(nw.Float64).to_frame().lazy()
+        return (
+            values.rename(_JOIN_KEY)
+            .to_frame()
+            .with_columns(nw.col(_JOIN_KEY).cast(nw.Float64).alias(self.name))
+        )
 
     @override
     def is_in_range(self, item: float) -> bool:

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -4,12 +4,14 @@ import gc
 from functools import cached_property
 from typing import Any
 
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_mapping, instance_of, min_len
 from typing_extensions import override
 
 from baybe.parameters.base import _EncodedDiscreteParameter
+from baybe.parameters.custom import _encoding_table_from_comp_df
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.validation import validate_decorrelation
 from baybe.utils.basic import group_duplicate_values
@@ -160,6 +162,15 @@ class SubstanceParameter(_EncodedDiscreteParameter):
         add_noise_to_perturb_degenerate_rows(comp_df)
 
         return comp_df
+
+    @override
+    @property
+    def comp_rep_columns(self) -> tuple[str, ...]:
+        return tuple(self._comp_df.columns)
+
+    @override
+    def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:
+        return _encoding_table_from_comp_df(self._comp_df, values)
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -112,6 +112,10 @@ class SubstanceParameter(_DiscreteLabelLikeParameter):
             raise ExceptionGroup("duplicate substances", exceptions)
 
     @override
+    def summary(self) -> dict:
+        return {**super().summary(), "Encoding": self.encoding}
+
+    @override
     @property
     def values(self) -> tuple:
         """Returns the labels of the given set of molecules."""

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -49,7 +49,14 @@ class SubstanceParameter(_EncodedDiscreteParameter):
     )
     """A mapping that provides the SMILES strings for all available parameter values."""
 
-    decorrelate: bool | float = field(default=True, validator=validate_decorrelation)
+    encoding: SubstanceEncoding = field(
+        default=SubstanceEncoding.MORDRED, converter=SubstanceEncoding, kw_only=True
+    )
+    # See base class.
+
+    decorrelate: bool | float = field(
+        default=True, validator=validate_decorrelation, kw_only=True
+    )
     """Specifies the used decorrelation mode for the parameter encoding.
 
         - ``False``: The encoding is used as is.
@@ -57,17 +64,14 @@ class SubstanceParameter(_EncodedDiscreteParameter):
         - float in (0, 1): The encoding is decorrelated using the specified threshold.
     """
 
-    encoding: SubstanceEncoding = field(
-        default=SubstanceEncoding.MORDRED, converter=SubstanceEncoding
-    )
-    # See base class.
-
     kwargs_fingerprint: dict[str, Any] = field(
-        factory=dict, validator=instance_of(dict)
+        factory=dict, validator=instance_of(dict), kw_only=True
     )
     """Keyword arguments passed to fingerprint generator."""
 
-    kwargs_conformer: dict[str, Any] = field(factory=dict, validator=instance_of(dict))
+    kwargs_conformer: dict[str, Any] = field(
+        factory=dict, validator=instance_of(dict), kw_only=True
+    )
     """Keyword arguments passed to conformer generator."""
 
     @data.validator

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -45,6 +45,7 @@ class SubstanceParameter(_EncodedDiscreteParameter):
         validator=deep_mapping(
             mapping_validator=min_len(2),
             key_validator=(instance_of(str), min_len(1)),
+            value_validator=instance_of(Smiles),
         ),
     )
     """A mapping that provides the SMILES strings for all available parameter values."""

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -9,7 +9,7 @@ from attrs import define, field
 from attrs.validators import deep_mapping, instance_of, min_len
 from typing_extensions import override
 
-from baybe.parameters.base import _DiscreteLabelLikeParameter
+from baybe.parameters.base import _EncodedDiscreteParameter
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.validation import validate_decorrelation
 from baybe.utils.basic import group_duplicate_values
@@ -29,7 +29,7 @@ Smiles = str
 
 
 @define(frozen=True, slots=False)
-class SubstanceParameter(_DiscreteLabelLikeParameter):
+class SubstanceParameter(_EncodedDiscreteParameter):
     """Generic substances that are treated with cheminformatics descriptors.
 
     Only a decorrelated subset of descriptors should be used as otherwise this can

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -126,9 +126,8 @@ class SubstanceParameter(_EncodedDiscreteParameter):
         """Returns the labels of the given set of molecules."""
         return tuple(self.data.keys())
 
-    @override
     @cached_property
-    def comp_df(self) -> pd.DataFrame:
+    def _comp_df(self) -> pd.DataFrame:
         from baybe.utils import chemistry
 
         vals = list(self.data.values())

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -56,7 +56,7 @@ class EmptyCandidates(CandidatesProtocol):
 
     @override
     def to_lazy(self) -> nw.LazyFrame:
-        # TODO: Replace hard-coded pandas type with `Settings`-based approach
+        # TODO[narwhalify]: use settings-based backend selection
         import pandas as pd
 
         return nw.from_native(pd.DataFrame()).lazy()

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -10,7 +10,6 @@ from itertools import islice
 from math import prod
 from typing import TYPE_CHECKING, Any, Literal
 
-import narwhals.stable.v2 as nw
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -649,9 +648,7 @@ class SubspaceDiscrete(SerialMixin):
         """The minimum and maximum values of the computational representation."""
         if not self.parameters:
             return pd.DataFrame(index=["min", "max"])
-        df = nw.concat(
-            [p.transform().collect() for p in self.parameters], how="horizontal"
-        ).to_pandas()
+        df = pd.concat([p.transform() for p in self.parameters], axis=1)
         return pd.DataFrame({"min": df.min(), "max": df.max()}).T
 
     @property
@@ -659,10 +656,7 @@ class SubspaceDiscrete(SerialMixin):
         """The bounds used for scaling the surrogate model input."""
         return (
             pd.concat(
-                [
-                    p.transform().collect().to_pandas().agg(["min", "max"])
-                    for p in self.parameters
-                ],
+                [p.transform().agg(["min", "max"]) for p in self.parameters],
                 axis=1,
             )
             if self.parameters
@@ -849,15 +843,8 @@ class SubspaceDiscrete(SerialMixin):
         )
 
         # Transform the parameters
-        dfs = []
-        for param in parameters:
-            lazy = param.transform(nw.from_native(df[param.name], series_only=True))
-            dfs.append(lazy)
-        return (
-            nw.concat([lf.collect() for lf in dfs], how="horizontal").to_pandas()
-            if dfs
-            else pd.DataFrame()
-        )
+        dfs = [param.transform(df[param.name]) for param in parameters]
+        return pd.concat(dfs, axis=1) if dfs else pd.DataFrame()
 
     def get_parameters_by_name(
         self, names: Sequence[str]

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -10,6 +10,7 @@ from itertools import islice
 from math import prod
 from typing import TYPE_CHECKING, Any, Literal
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -648,7 +649,9 @@ class SubspaceDiscrete(SerialMixin):
         """The minimum and maximum values of the computational representation."""
         if not self.parameters:
             return pd.DataFrame(index=["min", "max"])
-        df = pd.concat([p.transform() for p in self.parameters], axis=1)
+        df = nw.concat(
+            [p.transform().collect() for p in self.parameters], how="horizontal"
+        ).to_pandas()
         return pd.DataFrame({"min": df.min(), "max": df.max()}).T
 
     @property
@@ -656,7 +659,11 @@ class SubspaceDiscrete(SerialMixin):
         """The bounds used for scaling the surrogate model input."""
         return (
             pd.concat(
-                [p.transform().agg(["min", "max"]) for p in self.parameters], axis=1
+                [
+                    p.transform().collect().to_pandas().agg(["min", "max"])
+                    for p in self.parameters
+                ],
+                axis=1,
             )
             if self.parameters
             else pd.DataFrame(index=["min", "max"])
@@ -676,7 +683,7 @@ class SubspaceDiscrete(SerialMixin):
         """
         # Compute the dataframe shapes
         n_cols_exp = len(parameters)
-        n_cols_comp = sum(p.transform().shape[1] for p in parameters)
+        n_cols_comp = sum(len(p.comp_rep_columns) for p in parameters)
         n_rows = prod(len(p.active_values) for p in parameters)
 
         # Comp rep space is estimated as the size of float times the number of matrix
@@ -844,9 +851,13 @@ class SubspaceDiscrete(SerialMixin):
         # Transform the parameters
         dfs = []
         for param in parameters:
-            comp_df = param.transform(df[param.name])
-            dfs.append(comp_df)
-        return pd.concat(dfs, axis=1) if dfs else pd.DataFrame()
+            lazy = param.transform(nw.from_native(df[param.name], series_only=True))
+            dfs.append(lazy)
+        return (
+            nw.concat([lf.collect() for lf in dfs], how="horizontal").to_pandas()
+            if dfs
+            else pd.DataFrame()
+        )
 
     def get_parameters_by_name(
         self, names: Sequence[str]

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -648,14 +648,16 @@ class SubspaceDiscrete(SerialMixin):
         """The minimum and maximum values of the computational representation."""
         if not self.parameters:
             return pd.DataFrame(index=["min", "max"])
-        df = pd.concat([p.comp_df for p in self.parameters], axis=1)
+        df = pd.concat([p.transform() for p in self.parameters], axis=1)
         return pd.DataFrame({"min": df.min(), "max": df.max()}).T
 
     @property
     def scaling_bounds(self) -> pd.DataFrame:
         """The bounds used for scaling the surrogate model input."""
         return (
-            pd.concat([p.comp_df.agg(["min", "max"]) for p in self.parameters], axis=1)
+            pd.concat(
+                [p.transform().agg(["min", "max"]) for p in self.parameters], axis=1
+            )
             if self.parameters
             else pd.DataFrame(index=["min", "max"])
         )
@@ -674,7 +676,7 @@ class SubspaceDiscrete(SerialMixin):
         """
         # Compute the dataframe shapes
         n_cols_exp = len(parameters)
-        n_cols_comp = sum(p.comp_df.shape[1] for p in parameters)
+        n_cols_comp = sum(p.transform().shape[1] for p in parameters)
         n_rows = prod(len(p.active_values) for p in parameters)
 
         # Comp rep space is estimated as the size of float times the number of matrix

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -10,6 +10,7 @@ from itertools import islice
 from math import prod
 from typing import TYPE_CHECKING, Any, Literal
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -648,7 +649,13 @@ class SubspaceDiscrete(SerialMixin):
         """The minimum and maximum values of the computational representation."""
         if not self.parameters:
             return pd.DataFrame(index=["min", "max"])
-        df = pd.concat([p.transform() for p in self.parameters], axis=1)
+        df = pd.concat(
+            [
+                nw.from_native(p.transform(), eager_only=True).to_pandas()
+                for p in self.parameters
+            ],
+            axis=1,
+        )
         return pd.DataFrame({"min": df.min(), "max": df.max()}).T
 
     @property
@@ -656,7 +663,12 @@ class SubspaceDiscrete(SerialMixin):
         """The bounds used for scaling the surrogate model input."""
         return (
             pd.concat(
-                [p.transform().agg(["min", "max"]) for p in self.parameters],
+                [
+                    nw.from_native(p.transform(), eager_only=True)
+                    .to_pandas()
+                    .agg(["min", "max"])
+                    for p in self.parameters
+                ],
                 axis=1,
             )
             if self.parameters
@@ -843,7 +855,10 @@ class SubspaceDiscrete(SerialMixin):
         )
 
         # Transform the parameters
-        dfs = [param.transform(df[param.name]) for param in parameters]
+        dfs = [
+            nw.from_native(param.transform(df[param.name]), eager_only=True).to_pandas()
+            for param in parameters
+        ]
         return pd.concat(dfs, axis=1) if dfs else pd.DataFrame()
 
     def get_parameters_by_name(

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 import pandas as pd
 
 from baybe.exceptions import EmptySearchSpaceError, IncompatibilityError
-from baybe.parameters.base import Parameter, _DiscreteLabelLikeParameter
+from baybe.parameters.base import Parameter, _EncodedDiscreteParameter
 from baybe.parameters.categorical import TaskParameter
 from baybe.utils.dataframe import get_transform_objects
 
@@ -65,7 +65,7 @@ def validate_dataframe_active_values(
     exceptions: list[IncompatibilityError] = []
 
     for param in parameters:
-        if isinstance(param, _DiscreteLabelLikeParameter):
+        if isinstance(param, _EncodedDiscreteParameter):
             df_values = set(df[param.name])
             active_values = set(param.active_values)
             if invalid_values := df_values - active_values:

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -211,24 +211,26 @@ def validate_parameter_input(
             )
 
         # Check if all rows have valid inputs matching allowed parameter values
-        for ind, row in data.iterrows():
-            valid = True
-            if p.is_numerical:
-                if numerical_measurements_must_be_within_tolerance:
-                    valid &= p.is_in_range(row[p.name])
-            else:
-                valid &= p.is_in_range(row[p.name])
-            if not valid:
-                raise ValueError(
-                    f"Input data on row with the index {row.name} has invalid "
-                    f"values in parameter '{p.name}'. "
-                    f"For categorical parameters, values need to exactly match a "
-                    f"valid choice defined in your config. "
-                    f"For numerical parameters, a match is accepted only if "
-                    f"the input value is within the specified tolerance/range. Set "
-                    f"the flag 'numerical_measurements_must_be_within_tolerance' "
-                    f"to 'False' to disable this behavior."
-                )
+        if p.is_numerical:
+            valid = (
+                not numerical_measurements_must_be_within_tolerance
+                or data[p.name].map(p.is_in_range).all()
+            )
+        else:
+            from baybe.parameters.base import _EncodedDiscreteParameter
+
+            assert isinstance(p, _EncodedDiscreteParameter)
+            valid = data[p.name].isin(p.values).all()
+        if not valid:
+            raise ValueError(
+                f"The provided dataframe has invalid values for parameter '{p.name}'. "
+                f"For categorical parameters, values need to exactly match a "
+                f"valid choice defined in your config. "
+                f"For numerical parameters, a match is accepted only if "
+                f"the input value is within the specified tolerance/range. Set "
+                f"the flag 'numerical_measurements_must_be_within_tolerance' "
+                f"to 'False' to disable this behavior."
+            )
 
     if (
         not allow_duplicates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def fixture_parameters(
             name="Categorical_1_subset",
             values=("A", "B", "C"),
             encoding="OHE",
-            active_values=("A"),
+            active_values=("A",),
         ),
         CategoricalParameter(
             name="Categorical_2",

--- a/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
+++ b/tests/hypothesis_strategies/alternative_creation/test_searchspace.py
@@ -265,23 +265,26 @@ def test_discrete_space_creation_from_simplex_coefficients(
     cols = [p.name for p in params]
 
     # Ground truth via brute force
-    expected = _brute_force_weighted_simplex(
-        params, max_sum, coeffs, boundary_only=boundary_only
-    )
-    expected = expected.sort_values(cols).reset_index(drop=True)
-
-    # from_simplex
-    result_simplex = (
-        SubspaceDiscrete.from_simplex(
-            max_sum,
-            params,
-            simplex_coefficients=coefficients,
-            boundary_only=boundary_only,
+    expected = (
+        _brute_force_weighted_simplex(
+            params, max_sum, coeffs, boundary_only=boundary_only
         )
-        .exp_rep.sort_values(cols)
+        .sort_values(cols)
         .reset_index(drop=True)
     )
-    assert_frame_equal(result_simplex, expected, check_dtype=False)
+
+    # from_simplex
+    result_simplex = SubspaceDiscrete.from_simplex(
+        max_sum,
+        params,
+        simplex_coefficients=coefficients,
+        boundary_only=boundary_only,
+    ).get_candidates()
+    assert_frame_equal(
+        result_simplex.sort_values(cols).reset_index(drop=True),
+        expected,
+        check_dtype=False,
+    )
 
     # from_product with equivalent constraint
     operator = "=" if boundary_only else "<="
@@ -290,12 +293,14 @@ def test_discrete_space_creation_from_simplex_coefficients(
         condition=ThresholdCondition(threshold=max_sum, operator=operator),
         coefficients=tuple(coeffs),
     )
-    result_product = (
-        SubspaceDiscrete.from_product(params, constraints=[constraint])
-        .exp_rep.sort_values(cols)
-        .reset_index(drop=True)
+    result_product = SubspaceDiscrete.from_product(
+        params, constraints=[constraint]
+    ).get_candidates()
+    assert_frame_equal(
+        result_product.sort_values(cols).reset_index(drop=True),
+        expected,
+        check_dtype=False,
     )
-    assert_frame_equal(result_product, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -53,7 +53,7 @@ def test_empty_candidates():
 def test_table_candidates_generation(dataframe_factory):
     """TableCandidates generates the expected lazy dataframe."""
     parameters = [p_disc, p_cat]
-    data = create_fake_input(parameters, [], n_rows=4)
+    data = pd.DataFrame({"disc": [1, 2], "cat": ["a", "b"]})
     df = dataframe_factory(data)
     candidates = TableCandidates(parameters, df)
     candidates_ldf = candidates.to_lazy()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1028,4 +1028,4 @@ def test_deprecated_comp_df(param):
     """Accessing ``comp_df`` on any discrete parameter emits a deprecation warning."""
     with pytest.warns(DeprecationWarning, match="comp_df"):
         result = param.comp_df
-    assert_frame_equal(result, param.transform().collect().to_pandas())
+    assert_frame_equal(result, param.transform())

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -7,6 +7,7 @@ from itertools import pairwise
 from pathlib import Path
 from unittest.mock import patch
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 import pytest
@@ -1028,4 +1029,5 @@ def test_deprecated_comp_df(param):
     """Accessing ``comp_df`` on any discrete parameter emits a deprecation warning."""
     with pytest.warns(DeprecationWarning, match="comp_df"):
         result = param.comp_df
-    assert_frame_equal(result, param.transform())
+    expected = nw.from_native(param.transform(), eager_only=True).to_pandas()
+    assert_frame_equal(result, expected)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -30,6 +30,7 @@ from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.single import SingleTargetObjective
 from baybe.parameters.base import DiscreteParameter
 from baybe.parameters.categorical import CategoricalParameter, TaskParameter
+from baybe.parameters.custom import CustomDiscreteParameter
 from baybe.parameters.enum import SubstanceEncoding
 from baybe.parameters.numerical import (
     NumericalContinuousParameter,
@@ -993,3 +994,38 @@ def test_deprecated_custom_encoding():
 
     with pytest.warns(DeprecationWarning, match="CustomEncoding"):
         CustomEncoding("CUSTOM")
+
+
+if CHEM_INSTALLED:
+    from baybe.parameters.substance import SubstanceParameter as _SubstanceParameter
+
+    _substance_param = _SubstanceParameter("p", {"water": "O", "ethanol": "CCO"})
+else:
+    _substance_param = None
+
+
+@pytest.mark.parametrize(
+    "param",
+    [
+        NumericalDiscreteParameter("p", [1.0, 2.0, 3.0]),
+        CategoricalParameter("p", ["a", "b"]),
+        TaskParameter("p", ["a", "b"]),
+        CustomDiscreteParameter(
+            "p",
+            data=pd.DataFrame({"d1": [1.0, 2.0], "d2": [3.0, 4.0]}, index=["a", "b"]),
+            decorrelate=False,
+        ),
+        pytest.param(
+            _substance_param,
+            marks=pytest.mark.skipif(
+                not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+            ),
+        ),
+    ],
+    ids=type,
+)
+def test_deprecated_comp_df(param):
+    """Accessing ``comp_df`` on any discrete parameter emits a deprecation warning."""
+    with pytest.warns(DeprecationWarning, match="comp_df"):
+        result = param.comp_df
+    assert_frame_equal(result, param.transform())

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -982,3 +982,14 @@ def test_deprecated_comp_rep_property():
     with pytest.warns(DeprecationWarning, match="Accessing 'comp_rep'"):
         result = subspace.comp_rep
     assert_frame_equal(result, subspace.transform(subspace.get_candidates()))
+
+
+def test_deprecated_custom_encoding():
+    """Accessing ``CustomEncoding.CUSTOM`` emits a deprecation warning."""
+    from baybe.parameters.enum import CustomEncoding
+
+    with pytest.warns(DeprecationWarning, match="CustomEncoding"):
+        _ = CustomEncoding.CUSTOM
+
+    with pytest.warns(DeprecationWarning, match="CustomEncoding"):
+        CustomEncoding("CUSTOM")

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -731,7 +731,7 @@ def test_legacy_excluded_metadata_deserialization():
 def test_deprecated_constraints_arguments(positional):
     """Using the deprecated subspace constraint arguments raises a warning."""
     p = NumericalContinuousParameter("p", (0, 1))
-    c = ContinuousLinearConstraint(["p"], "=", [0], 0)
+    c = ContinuousLinearConstraint(["p"], "=", [1], 0)
     c_lin_eq = ContinuousLinearConstraint(["p"], "=", [1], 0)
     c_lin_ineq = ContinuousLinearConstraint(["p"], ">=", [1], 0)
     c_nonlin = ContinuousCardinalityConstraint(["p"], 1)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1028,4 +1028,4 @@ def test_deprecated_comp_df(param):
     """Accessing ``comp_df`` on any discrete parameter emits a deprecation warning."""
     with pytest.warns(DeprecationWarning, match="comp_df"):
         result = param.comp_df
-    assert_frame_equal(result, param.transform())
+    assert_frame_equal(result, param.transform().collect().to_pandas())

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
+from narwhals.dependencies import is_into_series
 from narwhals.testing import assert_frame_equal
 
 from baybe._optional.info import CHEM_INSTALLED
@@ -31,6 +32,10 @@ def _nw_series(name, values):
     return nw.new_series(name=name, values=values, backend=pl)
 
 
+def _list(name, values):
+    return list(values)
+
+
 @pytest.mark.parametrize(
     ("index_select", "series_factory"),
     [
@@ -38,6 +43,7 @@ def _nw_series(name, values):
         pytest.param([-1, 0], _pd_series, id="partial_input-pd"),
         pytest.param([-1, 0], _pl_series, id="partial_input-pl"),
         pytest.param([-1, 0], _nw_series, id="partial_input-nw"),
+        pytest.param([-1, 0], _list, id="partial_input-list"),
     ],
 )
 @pytest.mark.parametrize(
@@ -137,18 +143,17 @@ def test_transform(param, expected, index_select, series_factory):
         positions = expected.index.get_indexer(labels).tolist()
 
         series = series_factory(param.name, labels)
-        expected_backend = nw.get_native_namespace(series)
         result = param.transform(series)
+        result_backend = nw.get_native_namespace(result)
 
-        with pytest.raises(ValueError, match="does not match parameter name"):
-            param.transform(series_factory("wrong name", labels))
+        if is_into_series(series):
+            assert result_backend is nw.get_native_namespace(series)
+            with pytest.raises(ValueError, match="does not match parameter name"):
+                param.transform(series_factory("wrong name", labels))
 
-        assert nw.get_native_namespace(result) is expected_backend
         assert_frame_equal(
             result.collect(),
-            nw.from_native(expected)[positions]
-            .lazy()
-            .collect(backend=expected_backend),
+            nw.from_native(expected)[positions].lazy().collect(backend=result_backend),
         )
 
     assert isinstance(result, nw.LazyFrame)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,102 @@
+"""Tests for parameters."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from baybe._optional.info import CHEM_INSTALLED
+from baybe.parameters.categorical import CategoricalParameter
+from baybe.parameters.custom import CustomDiscreteParameter
+from baybe.parameters.numerical import NumericalDiscreteParameter
+from baybe.settings import active_settings
+
+if CHEM_INSTALLED:
+    from baybe.parameters.substance import SubstanceParameter
+
+
+def test_comp_df_numerical():
+    """NumericalDiscreteParameter comp_df is the identity mapping of its values."""
+    p = NumericalDiscreteParameter(name="x", values=[1.0, 2.0, 3.0])
+    expected = pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0]},
+        index=pd.Index([1.0, 2.0, 3.0]),
+        dtype=active_settings.DTypeFloatNumpy,
+    )
+    assert_frame_equal(p.comp_df, expected)
+
+
+def test_comp_df_categorical_ohe():
+    """CategoricalParameter OHE comp_df is an identity matrix, one column per value."""
+    p = CategoricalParameter(
+        name="color", values=["red", "green", "blue"], active_values=["red"]
+    )
+    # Values get sorted: blue, green, red
+    expected = pd.DataFrame(
+        np.eye(3, dtype=active_settings.DTypeFloatNumpy),
+        columns=["color_blue", "color_green", "color_red"],
+        index=pd.Index(["blue", "green", "red"]),
+    )
+    assert_frame_equal(p.comp_df, expected)
+
+
+def test_comp_df_categorical_int():
+    """CategoricalParameter INT comp_df assigns consecutive integers to sorted values."""  # noqa: E501
+    p = CategoricalParameter(
+        name="size", values=["S", "M", "L"], encoding="INT", active_values=["S"]
+    )
+    # Values get sorted: L, M, S
+    expected = pd.DataFrame(
+        {"size": [0.0, 1.0, 2.0]},
+        index=pd.Index(["L", "M", "S"]),
+        dtype=active_settings.DTypeFloatNumpy,
+    )
+    assert_frame_equal(p.comp_df, expected)
+
+
+def test_comp_df_categorical_ohe_bool():
+    """CategoricalParameter OHE with Boolean values uses 'b' prefix in column names."""
+    p = CategoricalParameter(name="flag", values=[True, False], active_values=[True])
+    # Values get sorted by (type_str, value): False before True
+    expected = pd.DataFrame(
+        np.eye(2, dtype=active_settings.DTypeFloatNumpy),
+        columns=["flag_bFalse", "flag_bTrue"],
+        index=pd.Index([False, True]),
+    )
+    assert_frame_equal(p.comp_df, expected)
+
+
+def test_comp_df_custom():
+    """CustomDiscreteParameter comp_df prefixes columns and preserves values."""
+    p = CustomDiscreteParameter(
+        name="mol",
+        data=pd.DataFrame(
+            {"d1": [1.0, 2.0, 3.0], "d2": [4.0, 5.0, 6.0]},
+            index=["A", "B", "C"],
+        ),
+        decorrelate=False,
+        active_values=["A"],
+    )
+    expected = pd.DataFrame(
+        {"mol_d1": [1.0, 2.0, 3.0], "mol_d2": [4.0, 5.0, 6.0]},
+        index=pd.Index(["A", "B", "C"]),
+        dtype=active_settings.DTypeFloatNumpy,
+    )
+    assert_frame_equal(p.comp_df, expected)
+
+
+@pytest.mark.skipif(
+    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+)
+def test_comp_df_substance():
+    """SubstanceParameter comp_df has one row per substance, indexed by label."""
+    data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
+    p = SubstanceParameter(
+        name="solvent", data=data, decorrelate=False, active_values=["water"]
+    )
+
+    comp = p.comp_df
+    assert list(comp.index) == list(p.values)
+    assert all(col.startswith("solvent_") for col in comp.columns)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -87,6 +87,17 @@ def test_comp_df_custom():
     assert_frame_equal(p.comp_df, expected)
 
 
+def test_comp_df_custom_decorrelation():
+    """CustomDiscreteParameter drops correlated columns when decorrelate=True."""
+    data = pd.DataFrame(
+        # d2 = 2*d1 (perfectly correlated with d1), d3 independent
+        {"d1": [1.0, 2.0, 3.0], "d2": [2.0, 4.0, 6.0], "d3": [1.0, 4.0, 2.0]},
+        index=["A", "B", "C"],
+    )
+    p = CustomDiscreteParameter(name="mol", data=data, decorrelate=True)
+    assert tuple(p.comp_df.columns) == ("mol_d1", "mol_d3")
+
+
 @pytest.mark.skipif(
     not CHEM_INSTALLED, reason="Optional chem dependency not installed."
 )
@@ -100,3 +111,14 @@ def test_comp_df_substance():
     comp = p.comp_df
     assert list(comp.index) == list(p.values)
     assert all(col.startswith("solvent_") for col in comp.columns)
+
+
+@pytest.mark.skipif(
+    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+)
+def test_comp_df_substance_decorrelation():
+    """SubstanceParameter drops correlated columns when decorrelate=True."""
+    data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
+    p_raw = SubstanceParameter(name="solvent", data=data, decorrelate=False)
+    p_decorr = SubstanceParameter(name="solvent", data=data, decorrelate=True)
+    assert len(p_decorr.comp_df.columns) < len(p_raw.comp_df.columns)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -146,7 +146,8 @@ def test_transform(param, expected, index_select, series_factory):
     """Parameter encodings return the correct rows, index and backend."""
     if expected is None:
         assert isinstance(param, SubstanceParameter)
-        expected = param.transform()
+        expected = nw.from_native(param.transform(), eager_only=True).to_pandas()
+        expected.index = pd.Index(param.values)
         assert all(col.startswith(f"{param.name}_") for col in expected.columns)
 
     if index_select is None:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -19,13 +19,25 @@ if CHEM_INSTALLED:
     from baybe.parameters.substance import SubstanceParameter
 
 
+def _pd_series(name, values):
+    return pd.Series(values, name=name)
+
+
+def _pl_series(name, values):
+    return pl.Series(name=name, values=values)
+
+
+def _nw_series(name, values):
+    return nw.new_series(name=name, values=values, backend=pl)
+
+
 @pytest.mark.parametrize(
-    ("index_select", "backend"),
+    ("index_select", "series_factory"),
     [
         pytest.param(None, None, id="no_input"),
-        pytest.param([-1, 0], pd, id="partial_input-pandas"),
-        pytest.param([-1, 0], pl, id="partial_input-polars"),
-        pytest.param(slice(None), pd, id="full_input"),
+        pytest.param([-1, 0], _pd_series, id="partial_input-pd"),
+        pytest.param([-1, 0], _pl_series, id="partial_input-pl"),
+        pytest.param([-1, 0], _nw_series, id="partial_input-nw"),
     ],
 )
 @pytest.mark.parametrize(
@@ -110,7 +122,7 @@ if CHEM_INSTALLED:
         ),
     ],
 )
-def test_transform(param, expected, index_select, backend):
+def test_transform(param, expected, index_select, series_factory):
     """Parameter encodings return the correct rows, index and backend."""
     if expected is None:
         assert isinstance(param, SubstanceParameter)
@@ -124,17 +136,19 @@ def test_transform(param, expected, index_select, backend):
         labels = list(expected.index[index_select])
         positions = expected.index.get_indexer(labels).tolist()
 
-        nw_series = nw.new_series(name=param.name, values=labels, backend=backend)
-        result = param.transform(nw_series)
-        result_ns = nw.get_native_namespace(result)
+        series = series_factory(param.name, labels)
+        expected_backend = nw.get_native_namespace(series)
+        result = param.transform(series)
 
         with pytest.raises(ValueError, match="does not match parameter name"):
-            param.transform(nw_series.alias(name="wrong name"))
+            param.transform(series_factory("wrong name", labels))
 
-        assert result_ns is backend
+        assert nw.get_native_namespace(result) is expected_backend
         assert_frame_equal(
             result.collect(),
-            nw.from_native(expected)[positions].lazy().collect(backend=result_ns),
+            nw.from_native(expected)[positions]
+            .lazy()
+            .collect(backend=expected_backend),
         )
 
     assert isinstance(result, nw.LazyFrame)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -8,7 +8,7 @@ import pandas as pd
 import polars as pl
 import pytest
 from narwhals.dependencies import is_into_series
-from narwhals.testing import assert_frame_equal
+from narwhals.typing import IntoFrame
 
 from baybe._optional.info import CHEM_INSTALLED
 from baybe.parameters.categorical import CategoricalParameter
@@ -18,6 +18,20 @@ from baybe.settings import active_settings
 
 if CHEM_INSTALLED:
     from baybe.parameters.substance import SubstanceParameter
+
+
+def _to_pd(frame: IntoFrame) -> pd.DataFrame:
+    """Normalize any native frame to pandas."""
+    return nw.from_native(frame).lazy().collect(backend=pd).to_native()
+
+
+def assert_frame_equal(left: IntoFrame, right: IntoFrame, **kwargs) -> None:
+    """Cross-backend frame equality assertion via pandas normalization."""
+    pd.testing.assert_frame_equal(
+        _to_pd(left).reset_index(drop=True),
+        _to_pd(right).reset_index(drop=True),
+        **kwargs,
+    )
 
 
 def _pd_series(name, values):
@@ -132,31 +146,25 @@ def test_transform(param, expected, index_select, series_factory):
     """Parameter encodings return the correct rows, index and backend."""
     if expected is None:
         assert isinstance(param, SubstanceParameter)
-        expected = param.transform().collect().to_pandas()
+        expected = param.transform()
         assert all(col.startswith(f"{param.name}_") for col in expected.columns)
 
     if index_select is None:
         result = param.transform()
-        assert_frame_equal(result, nw.from_native(expected).lazy())
+        assert_frame_equal(result, expected)
     else:
         labels = list(expected.index[index_select])
         positions = expected.index.get_indexer(labels).tolist()
 
         series = series_factory(param.name, labels)
         result = param.transform(series)
-        result_backend = nw.get_native_namespace(result)
 
         if is_into_series(series):
-            assert result_backend is nw.get_native_namespace(series)
+            assert nw.get_native_namespace(result) is nw.get_native_namespace(series)
             with pytest.raises(ValueError, match="does not match parameter name"):
                 param.transform(series_factory("wrong name", labels))
 
-        assert_frame_equal(
-            result.collect(),
-            nw.from_native(expected)[positions].lazy().collect(backend=result_backend),
-        )
-
-    assert isinstance(result, nw.LazyFrame)
+        assert_frame_equal(result, nw.from_native(expected)[positions])
 
 
 def test_decorrelation_custom():
@@ -167,7 +175,7 @@ def test_decorrelation_custom():
         index=["A", "B", "C"],
     )
     p = CustomDiscreteParameter(name="mol", data=data, decorrelate=True)
-    assert tuple(p.transform().collect_schema().names()) == ("mol_d1", "mol_d3")
+    assert tuple(p.transform().columns) == ("mol_d1", "mol_d3")
 
 
 @pytest.mark.skipif(
@@ -178,6 +186,4 @@ def test_decorrelation_substance():
     data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
     p_raw = SubstanceParameter(name="solvent", data=data, decorrelate=False)
     p_decorr = SubstanceParameter(name="solvent", data=data, decorrelate=True)
-    assert len(p_decorr.transform().collect_schema().names()) < len(
-        p_raw.transform().collect_schema().names()
-    )
+    assert len(p_decorr.transform().columns) < len(p_raw.transform().columns)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -17,19 +17,19 @@ if CHEM_INSTALLED:
     from baybe.parameters.substance import SubstanceParameter
 
 
-def test_comp_df_numerical():
-    """NumericalDiscreteParameter comp_df is the identity mapping of its values."""
+def test_transform_numerical():
+    """NumericalDiscreteParameter encoding is the identity mapping of its values."""
     p = NumericalDiscreteParameter(name="x", values=[1.0, 2.0, 3.0])
     expected = pd.DataFrame(
         {"x": [1.0, 2.0, 3.0]},
         index=pd.Index([1.0, 2.0, 3.0]),
         dtype=active_settings.DTypeFloatNumpy,
     )
-    assert_frame_equal(p.comp_df, expected)
+    assert_frame_equal(p.transform(), expected)
 
 
-def test_comp_df_categorical_ohe():
-    """CategoricalParameter OHE comp_df is an identity matrix, one column per value."""
+def test_transform_categorical_ohe():
+    """CategoricalParameter OHE encoding is an identity matrix, one column per value."""
     p = CategoricalParameter(
         name="color", values=["red", "green", "blue"], active_values=["red"]
     )
@@ -39,11 +39,11 @@ def test_comp_df_categorical_ohe():
         columns=["color_blue", "color_green", "color_red"],
         index=pd.Index(["blue", "green", "red"]),
     )
-    assert_frame_equal(p.comp_df, expected)
+    assert_frame_equal(p.transform(), expected)
 
 
-def test_comp_df_categorical_int():
-    """CategoricalParameter INT comp_df assigns consecutive integers to sorted values."""  # noqa: E501
+def test_transform_categorical_int():
+    """CategoricalParameter INT encoding assigns consecutive integers to sorted values."""  # noqa: E501
     p = CategoricalParameter(
         name="size", values=["S", "M", "L"], encoding="INT", active_values=["S"]
     )
@@ -53,10 +53,10 @@ def test_comp_df_categorical_int():
         index=pd.Index(["L", "M", "S"]),
         dtype=active_settings.DTypeFloatNumpy,
     )
-    assert_frame_equal(p.comp_df, expected)
+    assert_frame_equal(p.transform(), expected)
 
 
-def test_comp_df_categorical_ohe_bool():
+def test_transform_categorical_ohe_bool():
     """CategoricalParameter OHE with Boolean values uses 'b' prefix in column names."""
     p = CategoricalParameter(name="flag", values=[True, False], active_values=[True])
     # Values get sorted by (type_str, value): False before True
@@ -65,11 +65,11 @@ def test_comp_df_categorical_ohe_bool():
         columns=["flag_bFalse", "flag_bTrue"],
         index=pd.Index([False, True]),
     )
-    assert_frame_equal(p.comp_df, expected)
+    assert_frame_equal(p.transform(), expected)
 
 
-def test_comp_df_custom():
-    """CustomDiscreteParameter comp_df prefixes columns and preserves values."""
+def test_transform_custom():
+    """CustomDiscreteParameter encoding prefixes columns and preserves values."""
     p = CustomDiscreteParameter(
         name="mol",
         data=pd.DataFrame(
@@ -84,31 +84,31 @@ def test_comp_df_custom():
         index=pd.Index(["A", "B", "C"]),
         dtype=active_settings.DTypeFloatNumpy,
     )
-    assert_frame_equal(p.comp_df, expected)
+    assert_frame_equal(p.transform(), expected)
 
 
-def test_comp_df_custom_decorrelation():
-    """CustomDiscreteParameter drops correlated columns when decorrelate=True."""
+def test_decorrelation_custom():
+    """CustomDiscreteParameter encoding drops correlated columns when decorrelate=True."""  # noqa: E501
     data = pd.DataFrame(
         # d2 = 2*d1 (perfectly correlated with d1), d3 independent
         {"d1": [1.0, 2.0, 3.0], "d2": [2.0, 4.0, 6.0], "d3": [1.0, 4.0, 2.0]},
         index=["A", "B", "C"],
     )
     p = CustomDiscreteParameter(name="mol", data=data, decorrelate=True)
-    assert tuple(p.comp_df.columns) == ("mol_d1", "mol_d3")
+    assert tuple(p.transform().columns) == ("mol_d1", "mol_d3")
 
 
 @pytest.mark.skipif(
     not CHEM_INSTALLED, reason="Optional chem dependency not installed."
 )
-def test_comp_df_substance():
-    """SubstanceParameter comp_df has one row per substance, indexed by label."""
+def test_transform_substance():
+    """SubstanceParameter encoding has one row per substance, indexed by label."""
     data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
     p = SubstanceParameter(
         name="solvent", data=data, decorrelate=False, active_values=["water"]
     )
 
-    comp = p.comp_df
+    comp = p.transform()
     assert list(comp.index) == list(p.values)
     assert all(col.startswith("solvent_") for col in comp.columns)
 
@@ -116,9 +116,9 @@ def test_comp_df_substance():
 @pytest.mark.skipif(
     not CHEM_INSTALLED, reason="Optional chem dependency not installed."
 )
-def test_comp_df_substance_decorrelation():
+def test_decorrelation_substance():
     """SubstanceParameter drops correlated columns when decorrelate=True."""
     data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
     p_raw = SubstanceParameter(name="solvent", data=data, decorrelate=False)
     p_decorr = SubstanceParameter(name="solvent", data=data, decorrelate=True)
-    assert len(p_decorr.comp_df.columns) < len(p_raw.comp_df.columns)
+    assert len(p_decorr.transform().columns) < len(p_raw.transform().columns)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -118,7 +118,8 @@ def test_transform(param, expected, index_select, backend):
         assert all(col.startswith(f"{param.name}_") for col in expected.columns)
 
     if index_select is None:
-        assert_frame_equal(param.transform(), nw.from_native(expected).lazy())
+        result = param.transform()
+        assert_frame_equal(result, nw.from_native(expected).lazy())
     else:
         labels = list(expected.index[index_select])
         positions = expected.index.get_indexer(labels).tolist()
@@ -127,12 +128,16 @@ def test_transform(param, expected, index_select, backend):
         result = param.transform(nw_series)
         result_ns = nw.get_native_namespace(result)
 
-        assert isinstance(result, nw.LazyFrame)
+        with pytest.raises(ValueError, match="does not match parameter name"):
+            param.transform(nw_series.alias(name="wrong name"))
+
         assert result_ns is backend
         assert_frame_equal(
             result.collect(),
             nw.from_native(expected)[positions].lazy().collect(backend=result_ns),
         )
+
+    assert isinstance(result, nw.LazyFrame)
 
 
 def test_decorrelation_custom():

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -17,74 +17,121 @@ if CHEM_INSTALLED:
     from baybe.parameters.substance import SubstanceParameter
 
 
-def test_transform_numerical():
-    """NumericalDiscreteParameter encoding is the identity mapping of its values."""
-    p = NumericalDiscreteParameter(name="x", values=[1.0, 2.0, 3.0])
-    expected = pd.DataFrame(
-        {"x": [1.0, 2.0, 3.0]},
-        index=pd.Index([1.0, 2.0, 3.0]),
-        dtype=active_settings.DTypeFloatNumpy,
-    )
-    assert_frame_equal(p.transform(), expected)
-
-
-def test_transform_categorical_ohe():
-    """CategoricalParameter OHE encoding is an identity matrix, one column per value."""
-    p = CategoricalParameter(
-        name="color", values=["red", "green", "blue"], active_values=["red"]
-    )
-    # Values get sorted: blue, green, red
-    expected = pd.DataFrame(
-        np.eye(3, dtype=active_settings.DTypeFloatNumpy),
-        columns=["color_blue", "color_green", "color_red"],
-        index=pd.Index(["blue", "green", "red"]),
-    )
-    assert_frame_equal(p.transform(), expected)
-
-
-def test_transform_categorical_int():
-    """CategoricalParameter INT encoding assigns consecutive integers to sorted values."""  # noqa: E501
-    p = CategoricalParameter(
-        name="size", values=["S", "M", "L"], encoding="INT", active_values=["S"]
-    )
-    # Values get sorted: L, M, S
-    expected = pd.DataFrame(
-        {"size": [0.0, 1.0, 2.0]},
-        index=pd.Index(["L", "M", "S"]),
-        dtype=active_settings.DTypeFloatNumpy,
-    )
-    assert_frame_equal(p.transform(), expected)
-
-
-def test_transform_categorical_ohe_bool():
-    """CategoricalParameter OHE with Boolean values uses 'b' prefix in column names."""
-    p = CategoricalParameter(name="flag", values=[True, False], active_values=[True])
-    # Values get sorted by (type_str, value): False before True
-    expected = pd.DataFrame(
-        np.eye(2, dtype=active_settings.DTypeFloatNumpy),
-        columns=["flag_bFalse", "flag_bTrue"],
-        index=pd.Index([False, True]),
-    )
-    assert_frame_equal(p.transform(), expected)
-
-
-def test_transform_custom():
-    """CustomDiscreteParameter encoding prefixes columns and preserves values."""
-    p = CustomDiscreteParameter(
-        name="mol",
-        data=pd.DataFrame(
-            {"d1": [1.0, 2.0, 3.0], "d2": [4.0, 5.0, 6.0]},
-            index=["A", "B", "C"],
+@pytest.mark.parametrize(
+    "index_select",
+    [
+        pytest.param(None, id="no_input"),
+        pytest.param(slice(None), id="full_input"),
+        pytest.param([-1, 0], id="partial_input"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("param", "expected"),
+    [
+        pytest.param(
+            NumericalDiscreteParameter(name="x", values=[1.0, 2.0, 3.0]),
+            pd.DataFrame(
+                {"x": [1.0, 2.0, 3.0]},
+                index=pd.Index([1.0, 2.0, 3.0]),
+                dtype=active_settings.DTypeFloatNumpy,
+            ),
+            id="numerical",
         ),
-        decorrelate=False,
-        active_values=["A"],
+        pytest.param(
+            # Values get sorted: blue, green, red
+            CategoricalParameter(
+                name="color", values=["red", "green", "blue"], active_values=["red"]
+            ),
+            pd.DataFrame(
+                np.eye(3, dtype=active_settings.DTypeFloatNumpy),
+                columns=["color_blue", "color_green", "color_red"],
+                index=pd.Index(["blue", "green", "red"]),
+            ),
+            id="categorical_ohe",
+        ),
+        pytest.param(
+            # Values get sorted: L, M, S
+            CategoricalParameter(
+                name="size", values=["S", "M", "L"], encoding="INT", active_values=["S"]
+            ),
+            pd.DataFrame(
+                {"size": [0.0, 1.0, 2.0]},
+                index=pd.Index(["L", "M", "S"]),
+                dtype=active_settings.DTypeFloatNumpy,
+            ),
+            id="categorical_int",
+        ),
+        pytest.param(
+            # Values get sorted by (type_str, value): False before True
+            CategoricalParameter(
+                name="flag", values=[True, False], active_values=[True]
+            ),
+            pd.DataFrame(
+                np.eye(2, dtype=active_settings.DTypeFloatNumpy),
+                columns=["flag_bFalse", "flag_bTrue"],
+                index=pd.Index([False, True]),
+            ),
+            id="categorical_ohe_bool",
+        ),
+        pytest.param(
+            CustomDiscreteParameter(
+                name="mol",
+                data=pd.DataFrame(
+                    {"d1": [1.0, 2.0, 3.0], "d2": [4.0, 5.0, 6.0]},
+                    index=["A", "B", "C"],
+                ),
+                decorrelate=False,
+                active_values=["A"],
+            ),
+            pd.DataFrame(
+                {"mol_d1": [1.0, 2.0, 3.0], "mol_d2": [4.0, 5.0, 6.0]},
+                index=pd.Index(["A", "B", "C"]),
+                dtype=active_settings.DTypeFloatNumpy,
+            ),
+            id="custom",
+        ),
+    ],
+)
+def test_transform(param, expected, index_select):
+    """Parameter encodings return the correct rows with the correct index."""
+    if index_select is None:
+        assert_frame_equal(param.transform(), expected)
+    else:
+        labels = list(expected.index[index_select])
+        series = pd.Series(labels, index=range(10, 10 + len(labels)), name=param.name)
+        assert_frame_equal(
+            param.transform(series),
+            expected.reindex(labels).set_index(series.index),
+        )
+
+
+@pytest.mark.skipif(
+    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+)
+@pytest.mark.parametrize(
+    "subset",
+    [
+        pytest.param(None, id="no_input"),
+        pytest.param(["ethanol", "water", "methanol"], id="full_input"),
+        pytest.param(["methanol", "water"], id="partial_input"),
+    ],
+)
+def test_transform_substance(subset):
+    """SubstanceParameter encoding returns the correct rows with the correct index."""
+    data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
+    p = SubstanceParameter(
+        name="solvent", data=data, decorrelate=False, active_values=["water"]
     )
-    expected = pd.DataFrame(
-        {"mol_d1": [1.0, 2.0, 3.0], "mol_d2": [4.0, 5.0, 6.0]},
-        index=pd.Index(["A", "B", "C"]),
-        dtype=active_settings.DTypeFloatNumpy,
-    )
-    assert_frame_equal(p.transform(), expected)
+    full = p.transform()
+    if subset is None:
+        assert list(full.index) == list(p.values)
+        assert all(col.startswith("solvent_") for col in full.columns)
+    else:
+        series = pd.Series(subset, index=range(10, 10 + len(subset)), name=p.name)
+        assert_frame_equal(
+            p.transform(series),
+            full.reindex(subset).set_index(series.index),
+        )
 
 
 def test_decorrelation_custom():
@@ -96,21 +143,6 @@ def test_decorrelation_custom():
     )
     p = CustomDiscreteParameter(name="mol", data=data, decorrelate=True)
     assert tuple(p.transform().columns) == ("mol_d1", "mol_d3")
-
-
-@pytest.mark.skipif(
-    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
-)
-def test_transform_substance():
-    """SubstanceParameter encoding has one row per substance, indexed by label."""
-    data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
-    p = SubstanceParameter(
-        name="solvent", data=data, decorrelate=False, active_values=["water"]
-    )
-
-    comp = p.transform()
-    assert list(comp.index) == list(p.values)
-    assert all(col.startswith("solvent_") for col in comp.columns)
 
 
 @pytest.mark.skipif(

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -93,60 +93,45 @@ if CHEM_INSTALLED:
             ),
             id="custom",
         ),
+        pytest.param(
+            SubstanceParameter(
+                name="solvent",
+                data={"water": "O", "ethanol": "CCO", "methanol": "CO"},
+                decorrelate=False,
+                active_values=["water"],
+            )
+            if CHEM_INSTALLED
+            else None,
+            None,  # expected computed at runtime from transform()
+            id="substance",
+            marks=pytest.mark.skipif(
+                not CHEM_INSTALLED, reason="Optional chem dependency not installed."
+            ),
+        ),
     ],
 )
 def test_transform(param, expected, index_select, backend):
     """Parameter encodings return the correct rows, index and backend."""
+    if expected is None:
+        assert isinstance(param, SubstanceParameter)
+        expected = param.transform().collect().to_pandas()
+        assert all(col.startswith(f"{param.name}_") for col in expected.columns)
+
     if index_select is None:
         assert_frame_equal(param.transform(), nw.from_native(expected).lazy())
     else:
         labels = list(expected.index[index_select])
+        positions = expected.index.get_indexer(labels).tolist()
 
         nw_series = nw.new_series(name=param.name, values=labels, backend=backend)
         result = param.transform(nw_series)
-        result_collected = result.collect()
-        result_ns = nw.get_native_namespace(result_collected)
-
-        assert result_ns is backend
-        positions = expected.index.get_indexer(labels).tolist()
-        assert_frame_equal(
-            result_collected,
-            nw.from_native(expected)[positions].lazy().collect(backend=result_ns),
-        )
-
-
-@pytest.mark.skipif(
-    not CHEM_INSTALLED, reason="Optional chem dependency not installed."
-)
-@pytest.mark.parametrize(
-    ("subset", "backend"),
-    [
-        pytest.param(None, None, id="no_input"),
-        pytest.param(["methanol", "water"], pd, id="partial_input-pandas"),
-        pytest.param(["methanol", "water"], pl, id="partial_input-polars"),
-        pytest.param(["ethanol", "water", "methanol"], pd, id="full_input"),
-    ],
-)
-def test_transform_substance(subset, backend):
-    """SubstanceParameter encoding returns the correct rows, index and backend."""
-    data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
-    p = SubstanceParameter(
-        name="solvent", data=data, decorrelate=False, active_values=["water"]
-    )
-    full = p.transform().collect()
-    if subset is None:
-        assert list(full.to_pandas().index) == list(p.values)
-        assert all(col.startswith("solvent_") for col in full.columns)
-    else:
-        nw_series = nw.new_series(name=p.name, values=subset, backend=backend)
-        result = p.transform(nw_series).collect()
         result_ns = nw.get_native_namespace(result)
 
+        assert isinstance(result, nw.LazyFrame)
         assert result_ns is backend
-        positions = full.to_pandas().index.get_indexer(subset).tolist()
         assert_frame_equal(
-            result,
-            full[positions].lazy().collect(backend=result_ns),
+            result.collect(),
+            nw.from_native(expected)[positions].lazy().collect(backend=result_ns),
         )
 
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
-from pandas.testing import assert_frame_equal
+from narwhals.testing import assert_frame_equal
 
 from baybe._optional.info import CHEM_INSTALLED
 from baybe.parameters.categorical import CategoricalParameter
@@ -18,11 +20,12 @@ if CHEM_INSTALLED:
 
 
 @pytest.mark.parametrize(
-    "index_select",
+    ("index_select", "backend"),
     [
-        pytest.param(None, id="no_input"),
-        pytest.param(slice(None), id="full_input"),
-        pytest.param([-1, 0], id="partial_input"),
+        pytest.param(None, None, id="no_input"),
+        pytest.param([-1, 0], pd, id="partial_input-pandas"),
+        pytest.param([-1, 0], pl, id="partial_input-polars"),
+        pytest.param(slice(None), pd, id="full_input"),
     ],
 )
 @pytest.mark.parametrize(
@@ -92,16 +95,23 @@ if CHEM_INSTALLED:
         ),
     ],
 )
-def test_transform(param, expected, index_select):
-    """Parameter encodings return the correct rows with the correct index."""
+def test_transform(param, expected, index_select, backend):
+    """Parameter encodings return the correct rows, index and backend."""
     if index_select is None:
-        assert_frame_equal(param.transform(), expected)
+        assert_frame_equal(param.transform(), nw.from_native(expected).lazy())
     else:
         labels = list(expected.index[index_select])
-        series = pd.Series(labels, index=range(10, 10 + len(labels)), name=param.name)
+
+        nw_series = nw.new_series(name=param.name, values=labels, backend=backend)
+        result = param.transform(nw_series)
+        result_collected = result.collect()
+        result_ns = nw.get_native_namespace(result_collected)
+
+        assert result_ns is backend
+        positions = expected.index.get_indexer(labels).tolist()
         assert_frame_equal(
-            param.transform(series),
-            expected.reindex(labels).set_index(series.index),
+            result_collected,
+            nw.from_native(expected)[positions].lazy().collect(backend=result_ns),
         )
 
 
@@ -109,28 +119,34 @@ def test_transform(param, expected, index_select):
     not CHEM_INSTALLED, reason="Optional chem dependency not installed."
 )
 @pytest.mark.parametrize(
-    "subset",
+    ("subset", "backend"),
     [
-        pytest.param(None, id="no_input"),
-        pytest.param(["ethanol", "water", "methanol"], id="full_input"),
-        pytest.param(["methanol", "water"], id="partial_input"),
+        pytest.param(None, None, id="no_input"),
+        pytest.param(["methanol", "water"], pd, id="partial_input-pandas"),
+        pytest.param(["methanol", "water"], pl, id="partial_input-polars"),
+        pytest.param(["ethanol", "water", "methanol"], pd, id="full_input"),
     ],
 )
-def test_transform_substance(subset):
-    """SubstanceParameter encoding returns the correct rows with the correct index."""
+def test_transform_substance(subset, backend):
+    """SubstanceParameter encoding returns the correct rows, index and backend."""
     data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
     p = SubstanceParameter(
         name="solvent", data=data, decorrelate=False, active_values=["water"]
     )
-    full = p.transform()
+    full = p.transform().collect()
     if subset is None:
-        assert list(full.index) == list(p.values)
+        assert list(full.to_pandas().index) == list(p.values)
         assert all(col.startswith("solvent_") for col in full.columns)
     else:
-        series = pd.Series(subset, index=range(10, 10 + len(subset)), name=p.name)
+        nw_series = nw.new_series(name=p.name, values=subset, backend=backend)
+        result = p.transform(nw_series).collect()
+        result_ns = nw.get_native_namespace(result)
+
+        assert result_ns is backend
+        positions = full.to_pandas().index.get_indexer(subset).tolist()
         assert_frame_equal(
-            p.transform(series),
-            full.reindex(subset).set_index(series.index),
+            result,
+            full[positions].lazy().collect(backend=result_ns),
         )
 
 
@@ -142,7 +158,7 @@ def test_decorrelation_custom():
         index=["A", "B", "C"],
     )
     p = CustomDiscreteParameter(name="mol", data=data, decorrelate=True)
-    assert tuple(p.transform().columns) == ("mol_d1", "mol_d3")
+    assert tuple(p.transform().collect_schema().names()) == ("mol_d1", "mol_d3")
 
 
 @pytest.mark.skipif(
@@ -153,4 +169,6 @@ def test_decorrelation_substance():
     data = {"water": "O", "ethanol": "CCO", "methanol": "CO"}
     p_raw = SubstanceParameter(name="solvent", data=data, decorrelate=False)
     p_decorr = SubstanceParameter(name="solvent", data=data, decorrelate=True)
-    assert len(p_decorr.transform().columns) < len(p_raw.transform().columns)
+    assert len(p_decorr.transform().collect_schema().names()) < len(
+        p_raw.transform().collect_schema().names()
+    )

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -7,8 +7,8 @@ import numpy as np
 import pandas as pd
 import polars as pl
 import pytest
-from narwhals.dependencies import is_into_series
-from narwhals.typing import IntoFrame
+from narwhals.stable.v2.dependencies import is_into_series
+from narwhals.stable.v2.typing import IntoFrame
 
 from baybe._optional.info import CHEM_INSTALLED
 from baybe.parameters.categorical import CategoricalParameter

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -46,6 +46,6 @@ def test_degenerate_comp_df():
     }
     p = SubstanceParameter(name="p", data=dict_base, encoding="RDKITFINGERPRINT")
 
-    assert not p.comp_df.duplicated().any(), (
-        "A degenerate comp_df was not correctly treated."
+    assert not p.transform().duplicated().any(), (
+        "A degenerate computational representation was not correctly treated."
     )

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -46,6 +46,6 @@ def test_degenerate_comp_df():
     }
     p = SubstanceParameter(name="p", data=dict_base, encoding="RDKITFINGERPRINT")
 
-    assert not p.transform().duplicated().any(), (
+    assert not p.transform().collect().is_duplicated().any(), (
         "A degenerate computational representation was not correctly treated."
     )

--- a/tests/test_substance_parameter.py
+++ b/tests/test_substance_parameter.py
@@ -1,5 +1,6 @@
 """Tests for the substance parameter."""
 
+import narwhals.stable.v2 as nw
 import pytest
 from pytest import param
 
@@ -46,6 +47,6 @@ def test_degenerate_comp_df():
     }
     p = SubstanceParameter(name="p", data=dict_base, encoding="RDKITFINGERPRINT")
 
-    assert not p.transform().collect().is_duplicated().any(), (
+    assert not nw.from_native(p.transform(), eager_only=True).is_duplicated().any(), (
         "A degenerate computational representation was not correctly treated."
     )


### PR DESCRIPTION
Cleans up the discrete parameter hierarchy and broadens the `transform` interface toward narwhals-native evaluation, laying the groundwork for backend-agnostic computational representations.

### Background

The long-term goal is to make `DiscreteParameter.transform` fully backend-agnostic: accept any narwhals-compatible input and return a corresponding native eager dataframe. This PR implements the interface change and migrates `NumericalDiscreteParameter` and `CategoricalParameter` fully; `SubstanceParameter` and `CustomDiscreteParameter` retain a pandas-backed `_comp_df` fallback pending a follow-up.

Several related cleanups are bundled here because they are prerequisites or natural companions: the encoding attribute was spuriously placed on the base class, `CustomEncoding` was a `CategoricalEncoding` enum value that never applied to `CustomDiscreteParameter` (whose "encoding" is the user-supplied DataFrame itself, not an enum choice), several parameter fields lacked validators/converters, and `validate_parameter_input` had an `iterrows`-based loop that caused significant slowdowns once `TableCandidates` began calling it at construction time.