### PR TITLE
Narwhalify recommendation layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer requiring users to manually group constraints according to their type
 - Parameter and constraint validation has been streamlined, using `validate_parameters`
   and `validate_constraints` as the only remaining public entry points
-- Dataframe indices are no longer used as information carriers anywhere, and candidates
-  from discrete subspaces are no longer assumed to be in any particular order. In
-  particular, recommendation dataframes no longer reflect discrete subspace positions
-  via their index, and `_recommend_discrete` and kin now return a `pd.DataFrame`
-  subselection of the candidates instead of a `pd.Index`.
+- For pandas users: series/dataframe indices are no longer used as information carriers
+  anywhere and, accordingly, they are not guaranteed to be preserved during
+  method/function calls. In particular, recommendation dataframes no longer reflect
+  discrete subspace locations via their index. Similarly, `_recommend_discrete` and kin
+  now return a dataframe-based subselection instead of a `pd.Index`.
 - `SubspaceDiscrete.from_product` and `SubspaceDiscrete.from_simplex` now split
   their `constraints` argument into filtering constraints (applied during construction)
   and batch constraints (stored in `batch_constraints`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parameter and constraint validation has been streamlined, using `validate_parameters`
   and `validate_constraints` as the only remaining public entry points
 - For pandas users: series/dataframe indices are no longer used as information carriers
-  anywhere and, accordingly, they are not guaranteed to be preserved during
-  method/function calls. In particular, recommendation dataframes no longer reflect
-  discrete subspace locations via their index. Similarly, `_recommend_discrete` and kin
-  now return a dataframe-based subselection instead of a `pd.Index`.
+  anywhere. In particular, recommendation dataframes no longer reflect discrete subspace
+  locations via their index. Similarly, `_recommend_discrete` and kin now return a
+  dataframe-based subselection instead of a `pd.Index`.
 - `SubspaceDiscrete.from_product` and `SubspaceDiscrete.from_simplex` now split
   their `constraints` argument into filtering constraints (applied during construction)
   and batch constraints (stored in `batch_constraints`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer requiring users to manually group constraints according to their type
 - Parameter and constraint validation has been streamlined, using `validate_parameters`
   and `validate_constraints` as the only remaining public entry points
-- `_recommend_discrete` and kin now return a `pd.DataFrame` subselection of the
-  candidates instead of a `pd.Index`
+- Dataframe indices are no longer used as information carriers anywhere, and candidates
+  from discrete subspaces are no longer assumed to be in any particular order. In
+  particular, recommendation dataframes no longer reflect discrete subspace positions
+  via their index, and `_recommend_discrete` and kin now return a `pd.DataFrame`
+  subselection of the candidates instead of a `pd.Index`.
 - `SubspaceDiscrete.from_product` and `SubspaceDiscrete.from_simplex` now split
   their `constraints` argument into filtering constraints (applied during construction)
   and batch constraints (stored in `batch_constraints`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Breaking Changes
+- For pandas users: series/dataframe indices are no longer used as information carriers
+  anywhere. In particular, recommendation dataframes no longer reflect discrete subspace
+  locations via their index. Similarly, `_recommend_discrete` and kin now return a
+  dataframe-based subselection instead of a `pd.Index`.
 - All optional arguments of `SubspaceDiscrete.from_simplex` after `simplex_parameters` 
   are now keyword-only
 - `Campaign.measurements` no longer contains `FitNr` or `BatchNr` metadata columns
@@ -49,10 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer requiring users to manually group constraints according to their type
 - Parameter and constraint validation has been streamlined, using `validate_parameters`
   and `validate_constraints` as the only remaining public entry points
-- For pandas users: series/dataframe indices are no longer used as information carriers
-  anywhere. In particular, recommendation dataframes no longer reflect discrete subspace
-  locations via their index. Similarly, `_recommend_discrete` and kin now return a
-  dataframe-based subselection instead of a `pd.Index`.
 - `SubspaceDiscrete.from_product` and `SubspaceDiscrete.from_simplex` now split
   their `constraints` argument into filtering constraints (applied during construction)
   and batch constraints (stored in `batch_constraints`)

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -10,6 +10,7 @@ from functools import reduce
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import cattrs
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import Attribute, define, evolve, field, fields, setters
 from attrs.converters import optional
@@ -649,6 +650,8 @@ class Campaign(SerialMixin):
             raise NotEnoughPointsLeftError(
                 f"{str(ex)} Consider setting {message}."
             ) from ex
+
+        rec = nw.from_native(rec, eager_only=True).to_pandas()
 
         if (
             active_settings.cache_campaign_recommendations

--- a/baybe/constraints/utils.py
+++ b/baybe/constraints/utils.py
@@ -1,14 +1,15 @@
 """Constraint utilities."""
 
+import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
+from narwhals.stable.v2.typing import IntoDataFrame
 
 from baybe.parameters.utils import is_inactive
 from baybe.searchspace import SubspaceContinuous
 
 
 def is_cardinality_fulfilled(
-    df: pd.DataFrame,
+    df: IntoDataFrame,
     subspace_continuous: SubspaceContinuous,
     *,
     check_minimum: bool = True,
@@ -25,6 +26,7 @@ def is_cardinality_fulfilled(
     Returns:
         ``True`` if all cardinality constraints are fulfilled, ``False`` otherwise.
     """
+    df = nw.from_native(df, eager_only=True).to_pandas()
     for c in subspace_continuous.constraints_cardinality:
         # Get the activity thresholds for all parameters
         cols = df[c.parameters]

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -252,25 +252,16 @@ class Objective(ABC, SerialMixin):
 
         import torch
 
-        ns = nw.get_native_namespace(nw_df)
         with torch.no_grad():
             transformed = self._full_transformation(
                 to_tensor(nw_df.select([t.name for t in targets]))
-            )
-
-        # TODO[narwhalify]: drop index handling once pandas index is removed globally
-        if ns is pd:
-            return pd.DataFrame(  # type: ignore[return-value]
-                transformed.numpy(),
-                columns=self.output_names,
-                index=nw_df.to_pandas().index,
             )
 
         return nw.from_numpy(
             # For 1-D transforms, we explicitly reshape to 2-D to please nw.from_numpy
             transformed.numpy().reshape(-1, len(self.output_names)),
             schema=self.output_names,
-            backend=ns,
+            backend=nw.get_native_namespace(nw_df),
         ).to_native()
 
     def identify_non_dominated_configurations(

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -15,7 +15,7 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.targets.base import Target
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import is_all_instance
-from baybe.utils.dataframe import get_transform_objects, to_tensor
+from baybe.utils.dataframe import _copy_index, get_transform_objects, to_tensor
 from baybe.utils.dataframe import (
     handle_missing_values as df_handle_missing_values,
 )
@@ -257,12 +257,14 @@ class Objective(ABC, SerialMixin):
                 to_tensor(nw_df.select([t.name for t in targets]))
             )
 
-        return nw.from_numpy(
+        out = nw.from_numpy(
             # For 1-D transforms, we explicitly reshape to 2-D to please nw.from_numpy
             transformed.numpy().reshape(-1, len(self.output_names)),
             schema=self.output_names,
             backend=nw.get_native_namespace(nw_df),
-        ).to_native()
+        )
+
+        return _copy_index(out, nw_df).to_native()
 
     def identify_non_dominated_configurations(
         self, configurations: pd.DataFrame, /

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -207,20 +207,13 @@ class DiscreteParameter(Parameter, ABC):
             )
 
         table = self._encoding_table(series.unique())
-        result = (
+        return (
             series.rename(_JOIN_KEY)
             .to_frame()
             .join(table, on=_JOIN_KEY, how="left")
             .drop(_JOIN_KEY)
+            .to_native()
         )
-
-        # TODO[narwhalify]: drop once pandas index handling is removed globally
-        if nw.get_native_namespace(series) is pd:
-            native = result.to_native()
-            native.index = series.to_list() if all_values else series.to_pandas().index
-            return native
-
-        return result.to_native()
 
     @abstractmethod
     def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -206,14 +206,16 @@ class DiscreteParameter(Parameter, ABC):
                 backend=active_settings.default_dataframe_backend,
             )
 
+        from baybe.utils.dataframe import _copy_index
+
         table = self._encoding_table(series.unique())
-        return (
+        out = (
             series.rename(_JOIN_KEY)
             .to_frame()
             .join(table, on=_JOIN_KEY, how="left")
             .drop(_JOIN_KEY)
-            .to_native()
         )
+        return out.to_native() if all_values else _copy_index(out, series).to_native()
 
     @abstractmethod
     def _encoding_table(self, values: nw.Series, /) -> nw.DataFrame:

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -49,7 +49,7 @@ class CategoricalParameter(_EncodedDiscreteParameter):
     encoding: CategoricalEncoding = field(
         default=CategoricalEncoding.OHE, converter=CategoricalEncoding, kw_only=True
     )
-    # See base class.
+    """The encoding used the generate the parameters computational representation."""
 
     @override
     @property
@@ -108,7 +108,7 @@ class TaskParameter(CategoricalParameter):
     """Parameter class for task parameters."""
 
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
-    # See base class.
+    """The encoding used the generate the parameters computational representation."""
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -55,7 +55,7 @@ class SubstanceParameter(_EncodedDiscreteParameter):
     encoding: SubstanceEncoding = field(
         default=SubstanceEncoding.MORDRED, converter=SubstanceEncoding, kw_only=True
     )
-    # See base class.
+    """The encoding used the generate the parameters computational representation."""
 
     decorrelate: bool | float = field(
         default=True, validator=validate_decorrelation, kw_only=True

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-import pandas as pd
-
 from baybe.objectives.base import Objective
 from baybe.searchspace import SearchSpace
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 @runtime_checkable
@@ -26,9 +24,9 @@ class RecommenderProtocol(Protocol):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         """Recommend a batch of points from the given search space.
 
         Args:

--- a/baybe/recommenders/base.py
+++ b/baybe/recommenders/base.py
@@ -1,11 +1,16 @@
 """Base protocol for all recommenders."""
 
-from typing import Protocol, runtime_checkable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import pandas as pd
 
 from baybe.objectives.base import Objective
 from baybe.searchspace import SearchSpace
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 
 @runtime_checkable
@@ -21,8 +26,8 @@ class RecommenderProtocol(Protocol):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         """Recommend a batch of points from the given search space.
 

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -1,8 +1,10 @@
 """Base classes for all meta recommenders."""
 
+from __future__ import annotations
+
 import gc
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 from attrs import define
@@ -16,6 +18,9 @@ from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace
 from baybe.serialization import SerialMixin
 from baybe.utils.validation import validate_object_names
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 
 @define
@@ -33,8 +38,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> RecommenderProtocol:
         """Select a recommender for the given experimentation context.
 
@@ -47,8 +52,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> RecommenderProtocol:
         """Follow the meta recommender chain to the selected non-meta recommender.
 
@@ -95,8 +100,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         """See :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
         if objective is not None:

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -6,7 +6,6 @@ import gc
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -20,7 +19,7 @@ from baybe.serialization import SerialMixin
 from baybe.utils.validation import validate_object_names
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 @define
@@ -38,8 +37,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
         """Select a recommender for the given experimentation context.
 
@@ -52,8 +51,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
         """Follow the meta recommender chain to the selected non-meta recommender.
 
@@ -100,9 +99,9 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         """See :meth:`baybe.recommenders.base.RecommenderProtocol.recommend`."""
         if objective is not None:
             validate_object_names(searchspace.parameters + objective.targets)

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -11,7 +11,6 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import cattrs
-import pandas as pd
 from attrs import Factory, define, field, fields
 from attrs.validators import deep_iterable, ge, in_, instance_of
 from typing_extensions import override
@@ -31,7 +30,7 @@ from baybe.serialization import (
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 _T = TypeVar("_T")
 
@@ -82,8 +81,8 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
         n_data = len(measurements) if measurements is not None else 0
         if (n_data >= self.switch_after) or (
@@ -136,8 +135,8 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
         # If the training dataset size has decreased, something went wrong
         if (
@@ -165,9 +164,9 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         recommendation = super().recommend(
             batch_size, searchspace, objective, measurements, pending_experiments
         )

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -3,10 +3,12 @@
 #  this file will resolve type errors
 # mypy: disable-error-code="arg-type"
 
+from __future__ import annotations
+
 import gc
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator
-from typing import Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import cattrs
 import pandas as pd
@@ -27,6 +29,9 @@ from baybe.serialization import (
     converter,
 )
 from baybe.utils.conversion import to_string
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 _T = TypeVar("_T")
 
@@ -77,8 +82,8 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> RecommenderProtocol:
         n_data = len(measurements) if measurements is not None else 0
         if (n_data >= self.switch_after) or (
@@ -131,8 +136,8 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         batch_size: int | None = None,
         searchspace: SearchSpace | None = None,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> RecommenderProtocol:
         # If the training dataset size has decreased, something went wrong
         if (
@@ -160,8 +165,8 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         recommendation = super().recommend(
             batch_size, searchspace, objective, measurements, pending_experiments

--- a/baybe/recommenders/meta/sequential.py
+++ b/baybe/recommenders/meta/sequential.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 import cattrs
+import narwhals.stable.v2 as nw
 from attrs import Factory, define, field, fields
 from attrs.validators import deep_iterable, ge, in_, instance_of
 from typing_extensions import override
@@ -84,7 +85,11 @@ class TwoPhaseMetaRecommender(MetaRecommender):
         measurements: IntoDataFrameT | None = None,
         pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
-        n_data = len(measurements) if measurements is not None else 0
+        n_data = (
+            len(nw.from_native(measurements, eager_only=True))
+            if measurements is not None
+            else 0
+        )
         if (n_data >= self.switch_after) or (
             self._has_switched and self.remain_switched
         ):
@@ -139,9 +144,12 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         pending_experiments: IntoDataFrameT | None = None,
     ) -> RecommenderProtocol:
         # If the training dataset size has decreased, something went wrong
-        if (
-            n_data := len(measurements) if measurements is not None else 0
-        ) < self._n_last_measurements:
+        n_data = (
+            len(nw.from_native(measurements, eager_only=True))
+            if measurements is not None
+            else 0
+        )
+        if n_data < self._n_last_measurements:
             raise RuntimeError(
                 f"The training dataset size decreased from {self._n_last_measurements} "
                 f"to {n_data} since the last function call, which indicates that "
@@ -173,7 +181,11 @@ class BaseSequentialMetaRecommender(MetaRecommender):
         self._was_used = True
 
         # Remember the training dataset size for the next call
-        self._n_last_measurements = len(measurements) if measurements is not None else 0
+        self._n_last_measurements = (
+            len(nw.from_native(measurements, eager_only=True))
+            if measurements is not None
+            else 0
+        )
 
         return recommendation
 

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -1,8 +1,11 @@
 """Naive recommender for hybrid spaces."""
 
-import gc
-from typing import ClassVar
+from __future__ import annotations
 
+import gc
+from typing import TYPE_CHECKING, ClassVar
+
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import define, field
 from typing_extensions import override
@@ -13,7 +16,11 @@ from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
-from baybe.utils.dataframe import to_tensor
+from baybe.settings import active_settings
+from baybe.utils.dataframe import _df_with_backend, to_tensor
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 @define
@@ -53,10 +60,17 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         from baybe.acquisition.partial import PartialAcquisitionFunction
+
+        reference = measurements if measurements is not None else pending_experiments
+        backend = (
+            nw.get_native_namespace(reference)
+            if reference is not None
+            else active_settings.default_dataframe_backend
+        )
 
         disc_is_bayesian = isinstance(self.disc_recommender, BayesianRecommender)
         if not disc_is_bayesian and not isinstance(
@@ -92,11 +106,23 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         cont_part = searchspace.continuous.sample_uniform(1)
         cont_part_tensor = to_tensor(cont_part).unsqueeze(-2)
 
+        # Convert to pandas for BoTorch internals (acqf setup requires pd.DataFrame)
+        measurements_pd = (
+            nw.from_native(measurements, eager_only=True).to_pandas()
+            if measurements is not None
+            else None
+        )
+        pending_experiments_pd = (
+            nw.from_native(pending_experiments, eager_only=True).to_pandas()
+            if pending_experiments is not None
+            else None
+        )
+
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
             self.disc_recommender._setup_botorch_acqf(
-                searchspace, objective, measurements, pending_experiments
+                searchspace, objective, measurements_pd, pending_experiments_pd
             )
 
             # Construct the partial acquisition function that attaches cont_part
@@ -122,7 +148,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
 
         # Setup a fresh acquisition function for the continuous recommender
         self.cont_recommender._setup_botorch_acqf(
-            searchspace, objective, measurements, pending_experiments
+            searchspace, objective, measurements_pd, pending_experiments_pd
         )
 
         # Construct the continuous space as a standalone space
@@ -143,7 +169,9 @@ class NaiveHybridSpaceRecommender(PureRecommender):
             [disc_rec.reset_index(drop=True), rec_cont.reset_index(drop=True)],
             axis=1,
         )
-        return rec_exp
+        return _df_with_backend(
+            nw.from_native(rec_exp, eager_only=True), backend
+        ).to_native()
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -139,8 +139,10 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         )
 
         # Glue the solutions together and return them
-        rec_cont.index = disc_rec.index
-        rec_exp = pd.concat([disc_rec, rec_cont], axis=1)
+        rec_exp = pd.concat(
+            [disc_rec.reset_index(drop=True), rec_cont.reset_index(drop=True)],
+            axis=1,
+        )
         return rec_exp
 
 

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -6,7 +6,6 @@ import gc
 from typing import TYPE_CHECKING, ClassVar
 
 import narwhals.stable.v2 as nw
-import pandas as pd
 from attrs import define, field
 from typing_extensions import override
 
@@ -165,13 +164,14 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         )
 
         # Glue the solutions together and return them
-        rec_exp = pd.concat(
-            [disc_rec.reset_index(drop=True), rec_cont.reset_index(drop=True)],
-            axis=1,
+        rec_exp = nw.concat(
+            [
+                _df_with_backend(nw.from_native(disc_rec, eager_only=True), backend),
+                _df_with_backend(nw.from_native(rec_cont, eager_only=True), backend),
+            ],
+            how="horizontal",
         )
-        return _df_with_backend(
-            nw.from_native(rec_exp, eager_only=True), backend
-        ).to_native()
+        return rec_exp.to_native()
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -15,8 +15,7 @@ from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
-from baybe.settings import active_settings
-from baybe.utils.dataframe import _df_with_backend, to_tensor
+from baybe.utils.dataframe import _df_with_backend, _infer_backend, to_tensor
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrameT
@@ -64,12 +63,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
     ) -> IntoDataFrameT:
         from baybe.acquisition.partial import PartialAcquisitionFunction
 
-        reference = measurements if measurements is not None else pending_experiments
-        backend = (
-            nw.get_native_namespace(reference)
-            if reference is not None
-            else active_settings.default_dataframe_backend
-        )
+        backend = _infer_backend(measurements, pending_experiments)
 
         disc_is_bayesian = isinstance(self.disc_recommender, BayesianRecommender)
         if not disc_is_bayesian and not isinstance(

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -15,7 +15,8 @@ from baybe.recommenders.pure.bayesian.base import BayesianRecommender
 from baybe.recommenders.pure.bayesian.botorch import BotorchRecommender
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType
-from baybe.utils.dataframe import _df_with_backend, _infer_backend, to_tensor
+from baybe.settings import Settings
+from baybe.utils.dataframe import _infer_backend, to_tensor
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrameT
@@ -128,44 +129,44 @@ class NaiveHybridSpaceRecommender(PureRecommender):
 
             self.disc_recommender._botorch_acqf = disc_acqf_part
 
-        # Call the private function of the discrete recommender and get the candidates
-        disc_rec = self.disc_recommender._recommend_discrete(
-            subspace_discrete=searchspace.discrete,
-            batch_size=batch_size,
-        )
+        with Settings(default_dataframe_backend=backend):
+            # Call the private function of the discrete recommender
+            disc_rec = self.disc_recommender._recommend_discrete(
+                subspace_discrete=searchspace.discrete,
+                batch_size=batch_size,
+            )
 
-        # Get one random discrete point that will be attached when evaluating the
-        # acquisition function in the discrete space.
-        disc_part = searchspace.discrete.transform(disc_rec).sample(1)
-        disc_part_tensor = to_tensor(disc_part).unsqueeze(-2)
+            # Get one random discrete point that will be attached when evaluating the
+            # acquisition function in the discrete space.
+            disc_part = searchspace.discrete.transform(disc_rec).sample(1)
+            disc_part_tensor = to_tensor(disc_part).unsqueeze(-2)
 
-        # Setup a fresh acquisition function for the continuous recommender
-        self.cont_recommender._setup_botorch_acqf(
-            searchspace, objective, measurements_pd, pending_experiments_pd
-        )
+            # Setup a fresh acquisition function for the continuous recommender
+            self.cont_recommender._setup_botorch_acqf(
+                searchspace, objective, measurements_pd, pending_experiments_pd
+            )
 
-        # Construct the continuous space as a standalone space
-        cont_acqf_part = PartialAcquisitionFunction(
-            botorch_acqf=self.cont_recommender._botorch_acqf,
-            pinned_part=disc_part_tensor,
-            pin_discrete=True,
-        )
-        self.cont_recommender._botorch_acqf = cont_acqf_part
+            # Construct the continuous space as a standalone space
+            cont_acqf_part = PartialAcquisitionFunction(
+                botorch_acqf=self.cont_recommender._botorch_acqf,
+                pinned_part=disc_part_tensor,
+                pin_discrete=True,
+            )
+            self.cont_recommender._botorch_acqf = cont_acqf_part
 
-        # Call the private function of the continuous recommender
-        rec_cont = self.cont_recommender._recommend_continuous(
-            searchspace.continuous, batch_size
-        )
+            # Call the private function of the continuous recommender
+            rec_cont = self.cont_recommender._recommend_continuous(
+                searchspace.continuous, batch_size
+            )
 
         # Glue the solutions together and return them
-        rec_exp = nw.concat(
+        return nw.concat(
             [
-                _df_with_backend(nw.from_native(disc_rec, eager_only=True), backend),
-                _df_with_backend(nw.from_native(rec_cont, eager_only=True), backend),
+                nw.from_native(disc_rec, eager_only=True),
+                nw.from_native(rec_cont, eager_only=True),
             ],
             how="horizontal",
-        )
-        return rec_exp.to_native()
+        ).to_native()
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -1,11 +1,14 @@
 """Base classes for all pure recommenders."""
 
+from __future__ import annotations
+
 import gc
 from abc import ABC
 from collections.abc import Callable
-from typing import Any, ClassVar, NoReturn
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn
 
 import cattrs
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import define, field
 from cattrs.gen import make_dict_unstructure_fn
@@ -25,6 +28,9 @@ from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.serialization.core import add_type, converter
 from baybe.utils.boolean import is_abstract
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 _DEPRECATION_ERROR_MESSAGE = (
     "The attribute '{}' is no longer available for recommenders. "
@@ -107,15 +113,15 @@ class PureRecommender(ABC, RecommenderProtocol):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         if objective is not None:
             validate_object_names(searchspace.parameters + objective.targets)
 
         if measurements is not None:
             measurements = preprocess_dataframe(
-                measurements,
+                nw.from_native(measurements, eager_only=True).to_pandas(),
                 searchspace,
                 objective,
                 numerical_measurements_must_be_within_tolerance=False,
@@ -123,7 +129,7 @@ class PureRecommender(ABC, RecommenderProtocol):
 
         if pending_experiments is not None:
             pending_experiments = preprocess_dataframe(
-                pending_experiments,
+                nw.from_native(pending_experiments, eager_only=True).to_pandas(),
                 searchspace,
                 numerical_measurements_must_be_within_tolerance=False,
             )

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import gc
 from abc import ABC
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, NoReturn
+from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, cast
 
 import cattrs
-import narwhals.stable.v2 as nw
 from attrs import define, field
 from cattrs.gen import make_dict_unstructure_fn
 from typing_extensions import override
@@ -25,8 +24,9 @@ from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpaceType
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.serialization.core import add_type, converter
+from baybe.settings import Settings
 from baybe.utils.boolean import is_abstract
-from baybe.utils.dataframe import _df_with_backend, _infer_backend
+from baybe.utils.dataframe import _infer_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
@@ -136,16 +136,13 @@ class PureRecommender(ABC, RecommenderProtocol):
                 numerical_measurements_must_be_within_tolerance=False,
             )
 
-        if searchspace.type is SearchSpaceType.CONTINUOUS:
-            rec = self._recommend_continuous(
-                subspace_continuous=searchspace.continuous, batch_size=batch_size
-            )
-        else:
-            rec = self._recommend_with_discrete_parts(searchspace, batch_size)
+        with Settings(default_dataframe_backend=backend):
+            if searchspace.type is SearchSpaceType.CONTINUOUS:
+                rec = self._recommend_continuous(searchspace.continuous, batch_size)
+            else:
+                rec = self._recommend_with_discrete_parts(searchspace, batch_size)
 
-        return _df_with_backend(
-            nw.from_native(rec, eager_only=True), backend
-        ).to_native()
+        return cast(IntoDataFrameT, rec)
 
     def _recommend_discrete(
         self,

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, NoReturn
 
 import cattrs
 import narwhals.stable.v2 as nw
-import pandas as pd
 from attrs import define, field
 from cattrs.gen import make_dict_unstructure_fn
 from typing_extensions import override
@@ -32,7 +31,7 @@ from baybe.utils.dataframe import _df_with_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrameT
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
 
 _DEPRECATION_ERROR_MESSAGE = (
     "The attribute '{}' is no longer available for recommenders. "
@@ -158,7 +157,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         self,
         subspace_discrete: SubspaceDiscrete,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a discrete search space.
 
         Args:
@@ -194,7 +193,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         self,
         subspace_continuous: SubspaceContinuous,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a continuous search space.
 
         Args:
@@ -229,7 +228,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         self,
         searchspace: SearchSpace,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a hybrid search space.
 
         If the recommender does not implement additional functions for discrete and
@@ -256,7 +255,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         self,
         searchspace: SearchSpace,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Obtain recommendations in search spaces with a discrete part.
 
         Convenience helper which sequentially performs the following tasks: get discrete

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import gc
 from abc import ABC
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, NoReturn, cast
+from typing import Any, ClassVar, NoReturn, cast
 
 import cattrs
 from attrs import define, field
 from cattrs.gen import make_dict_unstructure_fn
+from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
 from typing_extensions import override
 
 from baybe.exceptions import (
@@ -28,9 +29,6 @@ from baybe.settings import Settings
 from baybe.utils.boolean import is_abstract
 from baybe.utils.dataframe import _infer_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
-
-if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
 
 _DEPRECATION_ERROR_MESSAGE = (
     "The attribute '{}' is no longer available for recommenders. "

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -25,9 +25,8 @@ from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpaceType
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.serialization.core import add_type, converter
-from baybe.settings import active_settings
 from baybe.utils.boolean import is_abstract
-from baybe.utils.dataframe import _df_with_backend
+from baybe.utils.dataframe import _df_with_backend, _infer_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
@@ -120,12 +119,7 @@ class PureRecommender(ABC, RecommenderProtocol):
         if objective is not None:
             validate_object_names(searchspace.parameters + objective.targets)
 
-        reference = measurements if measurements is not None else pending_experiments
-        backend = (
-            nw.get_native_namespace(reference)
-            if reference is not None
-            else active_settings.default_dataframe_backend
-        )
+        backend = _infer_backend(measurements, pending_experiments)
 
         if measurements is not None:
             measurements = preprocess_dataframe(

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -26,11 +26,13 @@ from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.core import SearchSpaceType
 from baybe.searchspace.discrete import SubspaceDiscrete
 from baybe.serialization.core import add_type, converter
+from baybe.settings import active_settings
 from baybe.utils.boolean import is_abstract
+from baybe.utils.dataframe import _df_with_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 _DEPRECATION_ERROR_MESSAGE = (
     "The attribute '{}' is no longer available for recommenders. "
@@ -113,15 +115,22 @@ class PureRecommender(ABC, RecommenderProtocol):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         if objective is not None:
             validate_object_names(searchspace.parameters + objective.targets)
 
+        reference = measurements if measurements is not None else pending_experiments
+        backend = (
+            nw.get_native_namespace(reference)
+            if reference is not None
+            else active_settings.default_dataframe_backend
+        )
+
         if measurements is not None:
             measurements = preprocess_dataframe(
-                nw.from_native(measurements, eager_only=True).to_pandas(),
+                measurements,
                 searchspace,
                 objective,
                 numerical_measurements_must_be_within_tolerance=False,
@@ -129,17 +138,21 @@ class PureRecommender(ABC, RecommenderProtocol):
 
         if pending_experiments is not None:
             pending_experiments = preprocess_dataframe(
-                nw.from_native(pending_experiments, eager_only=True).to_pandas(),
+                pending_experiments,
                 searchspace,
                 numerical_measurements_must_be_within_tolerance=False,
             )
 
         if searchspace.type is SearchSpaceType.CONTINUOUS:
-            return self._recommend_continuous(
+            rec = self._recommend_continuous(
                 subspace_continuous=searchspace.continuous, batch_size=batch_size
             )
         else:
-            return self._recommend_with_discrete_parts(searchspace, batch_size)
+            rec = self._recommend_with_discrete_parts(searchspace, batch_size)
+
+        return _df_with_backend(
+            nw.from_native(rec, eager_only=True), backend
+        ).to_native()
 
     def _recommend_discrete(
         self,

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -150,6 +150,18 @@ class PureRecommender(ABC, RecommenderProtocol):
             f"but backend '{expected}' was expected."
         )
 
+        # For pandas-backed results, assert that the dataframe has a default index
+        if actual is nw.Implementation.PANDAS:
+            import pandas as pd
+
+            assert isinstance(rec, pd.DataFrame) and rec.index.equals(
+                pd.RangeIndex(len(rec))
+            ), (
+                f"The generated recommendations dataframe has a non-default pandas "
+                f"index. Ensure '{self.__class__.__name__}' calls "
+                f"'{nw.maybe_reset_index.__name__}' before returning."
+            )
+
         return cast(IntoDataFrameT, rec)
 
     def _recommend_discrete(

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Any, ClassVar, NoReturn, cast
 
 import cattrs
+import narwhals.stable.v2 as nw
 from attrs import define, field
 from cattrs.gen import make_dict_unstructure_fn
 from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
@@ -139,6 +140,15 @@ class PureRecommender(ABC, RecommenderProtocol):
                 rec = self._recommend_continuous(searchspace.continuous, batch_size)
             else:
                 rec = self._recommend_with_discrete_parts(searchspace, batch_size)
+
+        # Assert that the expected backend is used, which cannot be guaranteed using
+        # static type checking but is implicitly controlled by the runtime settings
+        actual = nw.Implementation.from_backend(nw.get_native_namespace(rec))
+        expected = nw.Implementation.from_backend(backend)
+        assert actual == expected, (
+            f"The generated recommendations dataframe uses backend '{actual}' "
+            f"but backend '{expected}' was expected."
+        )
 
         return cast(IntoDataFrameT, rec)
 

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -31,7 +31,7 @@ from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 def _autoreplicate(surrogate: SurrogateProtocol, /) -> SurrogateProtocol:
@@ -134,9 +134,9 @@ class BayesianRecommender(PureRecommender, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         if objective is None:
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' require "
@@ -145,9 +145,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
         validate_object_names(searchspace.parameters + objective.targets)
 
-        if measurements is not None:
-            measurements = nw.from_native(measurements, eager_only=True).to_pandas()
-        if (measurements is None) or measurements.empty:
+        if (measurements is None) or len(measurements) == 0:
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
                 f"empty training data."
@@ -159,16 +157,22 @@ class BayesianRecommender(PureRecommender, ABC):
             objective,
             numerical_measurements_must_be_within_tolerance=False,
         )
+        measurements_pd = nw.from_native(measurements, eager_only=True).to_pandas()
 
         if pending_experiments is not None:
             pending_experiments = preprocess_dataframe(
-                nw.from_native(pending_experiments, eager_only=True).to_pandas(),
+                pending_experiments,
                 searchspace,
                 numerical_measurements_must_be_within_tolerance=False,
             )
+        pending_experiments_pd = (
+            nw.from_native(pending_experiments, eager_only=True).to_pandas()
+            if pending_experiments is not None
+            else None
+        )
 
         self._setup_botorch_acqf(
-            searchspace, objective, measurements, pending_experiments
+            searchspace, objective, measurements_pd, pending_experiments_pd
         )
 
         try:

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -6,6 +6,7 @@ import gc
 from abc import ABC
 from typing import TYPE_CHECKING
 
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import define, field
 from attrs.converters import optional
@@ -30,6 +31,7 @@ from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 
 def _autoreplicate(surrogate: SurrogateProtocol, /) -> SurrogateProtocol:
@@ -132,8 +134,8 @@ class BayesianRecommender(PureRecommender, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         if objective is None:
             raise NotImplementedError(
@@ -143,6 +145,8 @@ class BayesianRecommender(PureRecommender, ABC):
 
         validate_object_names(searchspace.parameters + objective.targets)
 
+        if measurements is not None:
+            measurements = nw.from_native(measurements, eager_only=True).to_pandas()
         if (measurements is None) or measurements.empty:
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
@@ -158,7 +162,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
         if pending_experiments is not None:
             pending_experiments = preprocess_dataframe(
-                pending_experiments,
+                nw.from_native(pending_experiments, eager_only=True).to_pandas(),
                 searchspace,
                 numerical_measurements_must_be_within_tolerance=False,
             )

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -10,6 +10,7 @@ import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import define, field
 from attrs.converters import optional
+from narwhals.stable.v2.typing import IntoDataFrameT
 from typing_extensions import override
 
 from baybe.acquisition import qLogEI, qLogNEHVI
@@ -31,7 +32,6 @@ from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
-    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 def _autoreplicate(surrogate: SurrogateProtocol, /) -> SurrogateProtocol:

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -145,7 +145,9 @@ class BayesianRecommender(PureRecommender, ABC):
 
         validate_object_names(searchspace.parameters + objective.targets)
 
-        if (measurements is None) or len(measurements) == 0:
+        if (measurements is None) or nw.from_native(
+            measurements, eager_only=True
+        ).is_empty:
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
                 f"empty training data."

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -147,7 +147,7 @@ class BayesianRecommender(PureRecommender, ABC):
 
         if (measurements is None) or nw.from_native(
             measurements, eager_only=True
-        ).is_empty:
+        ).is_empty():
             raise NotImplementedError(
                 f"Recommenders of type '{BayesianRecommender.__name__}' do not support "
                 f"empty training data."

--- a/baybe/recommenders/pure/bayesian/botorch/continuous.py
+++ b/baybe/recommenders/pure/bayesian/botorch/continuous.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Callable, Collection, Iterable
 from typing import TYPE_CHECKING
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 from attrs import fields
 
 from baybe.constraints.utils import is_cardinality_fulfilled
@@ -16,6 +16,7 @@ from baybe.exceptions import (
 )
 from baybe.parameters.numerical import _FixedNumericalContinuousParameter
 from baybe.searchspace import SubspaceContinuous
+from baybe.settings import active_settings
 from baybe.utils.basic import flatten
 from baybe.utils.dataframe import to_tensor
 
@@ -113,7 +114,11 @@ def recommend_continuous_with_cardinality_constraints(
 
     # Check if any minimum cardinality constraints are violated
     if not is_cardinality_fulfilled(
-        pd.DataFrame(points, columns=subspace_continuous.parameter_names),
+        nw.DataFrame.from_numpy(
+            points.numpy(),
+            subspace_continuous.parameter_names,
+            backend=active_settings.default_dataframe_backend,
+        ),
         subspace_continuous,
         check_maximum=False,
     ):

--- a/baybe/recommenders/pure/bayesian/botorch/core.py
+++ b/baybe/recommenders/pure/bayesian/botorch/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gc
 import warnings
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 import narwhals.stable.v2 as nw
 import numpy as np
@@ -43,6 +43,8 @@ from baybe.utils.sampling_algorithms import DiscreteSamplingMethod
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame
     from torch import Tensor
+
+_T = TypeVar("_T")
 
 
 @define(kw_only=True)
@@ -240,8 +242,8 @@ class BotorchRecommender(BayesianRecommender):
 
     def _optimize_over_subsets(
         self,
-        subset_callables: Iterable[Callable[[], tuple[Any, Tensor]]],
-    ) -> tuple[Any, Tensor]:
+        subset_callables: Iterable[Callable[[], tuple[_T, Tensor]]],
+    ) -> tuple[_T, Tensor]:
         """Optimize across subsets and return the result with the best acqf value.
 
         Each callable performs optimization for one subset configuration and returns
@@ -262,7 +264,7 @@ class BotorchRecommender(BayesianRecommender):
         """
         from botorch.exceptions.errors import InfeasibilityError as BoInfeasibilityError
 
-        results_all: list = []
+        results_all: list[_T] = []
         acqf_values_all: list[Tensor] = []
 
         for optimize_fn in subset_callables:

--- a/baybe/recommenders/pure/bayesian/botorch/core.py
+++ b/baybe/recommenders/pure/bayesian/botorch/core.py
@@ -7,8 +7,8 @@ import warnings
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
 from attrs import define, field
 from attrs.converters import optional as optional_c
 from attrs.validators import ge, gt, instance_of
@@ -36,6 +36,7 @@ from baybe.searchspace import (
     SubspaceContinuous,
     SubspaceDiscrete,
 )
+from baybe.settings import active_settings
 from baybe.utils.conversion import to_string
 from baybe.utils.sampling_algorithms import DiscreteSamplingMethod
 
@@ -209,7 +210,11 @@ class BotorchRecommender(BayesianRecommender):
 
         points, _ = recommend_continuous_torch(self, subspace_continuous, batch_size)
 
-        return pd.DataFrame(points, columns=subspace_continuous.parameter_names)
+        return nw.from_numpy(
+            points.numpy(),
+            schema=subspace_continuous.parameter_names,
+            backend=active_settings.default_dataframe_backend,
+        ).to_native()
 
     @override
     def _recommend_hybrid(

--- a/baybe/recommenders/pure/bayesian/botorch/core.py
+++ b/baybe/recommenders/pure/bayesian/botorch/core.py
@@ -40,6 +40,7 @@ from baybe.utils.conversion import to_string
 from baybe.utils.sampling_algorithms import DiscreteSamplingMethod
 
 if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
     from torch import Tensor
 
 
@@ -157,7 +158,7 @@ class BotorchRecommender(BayesianRecommender):
         self,
         subspace_discrete: SubspaceDiscrete,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a discrete search space.
 
         Dispatches to the appropriate optimization routine depending on whether
@@ -181,7 +182,7 @@ class BotorchRecommender(BayesianRecommender):
         self,
         subspace_continuous: SubspaceContinuous,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a continuous search space.
 
         Args:
@@ -215,7 +216,7 @@ class BotorchRecommender(BayesianRecommender):
         self,
         searchspace: SearchSpace,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         """Generate recommendations from a hybrid search space.
 
         Dispatches to the appropriate optimization routine depending on whether

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -123,25 +123,17 @@ def recommend_discrete_without_subsets(
 
     from botorch.optim import optimize_acqf_discrete
 
-    # Determine the next set of points to be tested
     candidates = subspace_discrete.get_candidates()
     candidates_comp = subspace_discrete.transform(candidates)
-    points, _ = optimize_acqf_discrete(
-        recommender._botorch_acqf, batch_size, to_tensor(candidates_comp)
+    choices = to_tensor(candidates_comp)
+
+    points, _ = optimize_acqf_discrete(recommender._botorch_acqf, batch_size, choices)
+
+    # Recover the positional index of each selected point in the candidate set.
+    # Operating directly on the BoTorch output avoids introducing any further
+    # imprecision beyond what the optimizer itself produces.
+    row_idxs = (
+        (choices.unsqueeze(0) == points.unsqueeze(1)).all(dim=-1).int().argmax(dim=1)
     )
 
-    # Retrieve the rows from the subspace corresponding to the selected points
-    # IMPROVE: The merging procedure is conceptually similar to what
-    #   `SearchSpace._match_measurement_with_searchspace_indices` does, though using
-    #   a simpler matching logic. When refactoring the SearchSpace class to
-    #   handle continuous parameters, a corresponding utility could be extracted.
-    idxs = pd.Index(
-        pd.merge(
-            pd.DataFrame(points, columns=candidates_comp.columns),
-            candidates_comp.reset_index(),
-            on=list(candidates_comp),
-            how="left",
-        )["index"]
-    )
-
-    return candidates.loc[idxs]
+    return candidates.iloc[row_idxs.numpy()].reset_index(drop=True)

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
 from attrs import evolve
 
 from baybe.searchspace import SubspaceDiscrete
@@ -15,6 +14,7 @@ from baybe.searchspace.candidates import TableCandidates
 from baybe.utils.dataframe import to_tensor
 
 if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
     from torch import Tensor
 
     from baybe.recommenders.pure.bayesian.botorch.core import BotorchRecommender
@@ -24,7 +24,7 @@ def recommend_discrete_with_subsets(
     recommender: BotorchRecommender,
     subspace_discrete: SubspaceDiscrete,
     batch_size: int,
-) -> pd.DataFrame:
+) -> IntoDataFrame:
     """Recommend from a discrete space with subset-generating constraints.
 
     Splits the candidate set into subsets according to subset-generating constraints,
@@ -56,8 +56,8 @@ def recommend_discrete_with_subsets(
 
     def make_callable(
         mask: np.ndarray,
-    ) -> Callable[[], tuple[pd.DataFrame, Tensor]]:
-        def optimize() -> tuple[pd.DataFrame, Tensor]:
+    ) -> Callable[[], tuple[IntoDataFrame, Tensor]]:
+        def optimize() -> tuple[IntoDataFrame, Tensor]:
             # TODO: Replace with .filter() method to avoid materialization
             subset_subspace = evolve(
                 subspace_discrete,
@@ -86,7 +86,7 @@ def recommend_discrete_without_subsets(
     recommender: BotorchRecommender,
     subspace_discrete: SubspaceDiscrete,
     batch_size: int,
-) -> pd.DataFrame:
+) -> IntoDataFrame:
     """Generate recommendations from a discrete search space.
 
     Args:

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -137,11 +137,11 @@ def recommend_discrete_without_subsets(
     # Recover the positional index of each selected point in the candidate set.
     # Operating directly on the BoTorch output avoids introducing any further
     # imprecision beyond what the optimizer itself produces.
-    row_idxs = (
-        (choices.unsqueeze(0) == points.unsqueeze(1)).all(dim=-1).int().argmax(dim=1)
-    )
+    from baybe.utils.torch import index_in_tensor
+
+    row_idxs = index_in_tensor(points, choices)
 
     return _df_with_backend(
-        nw.from_native(candidates, eager_only=True)[row_idxs.tolist()],
+        nw.from_native(candidates, eager_only=True)[row_idxs],
         active_settings.default_dataframe_backend,
     ).to_native()

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import numpy.typing as npt
 from attrs import evolve
 
 from baybe.searchspace import SubspaceDiscrete
 from baybe.searchspace.candidates import TableCandidates
-from baybe.utils.dataframe import to_tensor
+from baybe.settings import active_settings
+from baybe.utils.dataframe import _df_with_backend, to_tensor
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame
@@ -62,7 +64,10 @@ def recommend_discrete_with_subsets(
             subset_subspace = evolve(
                 subspace_discrete,
                 candidates=TableCandidates(
-                    subspace_discrete.parameters, candidates.loc[mask]
+                    subspace_discrete.parameters,
+                    nw.from_native(candidates, eager_only=True)
+                    .filter(mask.tolist())
+                    .to_native(),
                 ),
             )
 
@@ -136,4 +141,7 @@ def recommend_discrete_without_subsets(
         (choices.unsqueeze(0) == points.unsqueeze(1)).all(dim=-1).int().argmax(dim=1)
     )
 
-    return candidates.iloc[row_idxs.numpy()].reset_index(drop=True)
+    return _df_with_backend(
+        nw.from_native(candidates, eager_only=True)[row_idxs.tolist()],
+        active_settings.default_dataframe_backend,
+    ).to_native()

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -141,7 +141,9 @@ def recommend_discrete_without_subsets(
 
     row_idxs = index_in_tensor(points, choices)
 
-    return _df_with_backend(
-        nw.from_native(candidates, eager_only=True)[row_idxs],
-        active_settings.default_dataframe_backend,
+    return nw.maybe_reset_index(
+        _df_with_backend(
+            nw.from_native(candidates, eager_only=True)[row_idxs],
+            active_settings.default_dataframe_backend,
+        )
     ).to_native()

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -7,8 +7,8 @@ import warnings
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
+import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
 from attrs import evolve
 
 from baybe.constraints.utils import is_cardinality_fulfilled
@@ -19,8 +19,9 @@ from baybe.exceptions import (
 )
 from baybe.searchspace import SearchSpace
 from baybe.searchspace.candidates import TableCandidates
+from baybe.settings import active_settings
 from baybe.utils.basic import flatten
-from baybe.utils.dataframe import to_tensor
+from baybe.utils.dataframe import _df_with_backend, to_tensor
 from baybe.utils.sampling_algorithms import sample_numerical_df
 
 if TYPE_CHECKING:
@@ -82,24 +83,28 @@ def recommend_hybrid_without_subsets(
     from botorch.optim import optimize_acqf_mixed
 
     # Transform discrete candidates
-    candidates = searchspace.discrete.get_candidates()
-    candidates_comp = searchspace.discrete.transform(candidates)
+    candidates = nw.from_native(searchspace.discrete.get_candidates(), eager_only=True)
+    candidates_comp = nw.from_native(searchspace.discrete.transform(candidates))
 
     # Calculate the number of samples from the given percentage
     n_candidates = math.ceil(recommender.sampling_percentage * len(candidates_comp))
 
     # Potential sampling of discrete candidates
     if recommender.hybrid_sampler is not None:
-        candidates_comp = sample_numerical_df(
-            candidates_comp, n_candidates, method=recommender.hybrid_sampler
+        candidates_comp = nw.from_native(
+            sample_numerical_df(
+                candidates_comp.to_pandas(),
+                n_candidates,
+                method=recommender.hybrid_sampler,
+            ),
         )
 
     # Prepare all considered discrete configurations in the
     # List[Dict[int, float]] format expected by BoTorch.
     n_comp_columns = len(candidates_comp.columns)
-    fixed_features_df = candidates_comp.copy()
-    fixed_features_df.columns = list(range(n_comp_columns))
-    fixed_features_list = fixed_features_df.to_dict("records")
+    fixed_features_list = [
+        dict(enumerate(row)) for row in candidates_comp.to_numpy().tolist()
+    ]
 
     # Actual call of the BoTorch optimization routine
     # NOTE: The explicit `or None` conversion is added as an additional safety net
@@ -112,7 +117,7 @@ def recommend_hybrid_without_subsets(
         q=batch_size,
         num_restarts=recommender.n_restarts,
         raw_samples=recommender.n_raw_samples,
-        fixed_features_list=fixed_features_list,  # type: ignore[arg-type]
+        fixed_features_list=fixed_features_list,
         equality_constraints=flatten(
             c.to_botorch(
                 searchspace.continuous.parameters,
@@ -147,19 +152,15 @@ def recommend_hybrid_without_subsets(
 
     # Combine the discrete part in experimental representation with the
     # optimized continuous part from the BoTorch output
-    rec_disc_exp = candidates.iloc[row_idxs.numpy()].reset_index(drop=True)
-    rec_exp = pd.concat(
-        [
-            rec_disc_exp,
-            pd.DataFrame(
-                points[:, n_comp_columns:].numpy(),
-                columns=searchspace.continuous.parameter_names,
-            ),
-        ],
-        axis=1,
+    rec_cont = nw.from_numpy(
+        points[:, n_comp_columns:].numpy(),
+        schema=searchspace.continuous.parameter_names,
+        backend=active_settings.default_dataframe_backend,
     )
-
-    return rec_exp
+    rec_disc_exp = _df_with_backend(
+        candidates[row_idxs.tolist()], active_settings.default_dataframe_backend
+    )
+    return nw.concat([rec_disc_exp, rec_cont], how="horizontal").to_native()
 
 
 def recommend_hybrid_with_subsets(
@@ -188,7 +189,7 @@ def recommend_hybrid_with_subsets(
     # NOTE: No min_discrete_candidates filtering in hybrid spaces because
     # optimize_acqf_mixed can produce multiple recommendations from a single
     # discrete candidate by varying continuous parameters.
-    candidates = searchspace.discrete.get_candidates()
+    candidates = nw.from_native(searchspace.discrete.get_candidates(), eager_only=True)
     combined_masks: Iterable[tuple[np.ndarray, frozenset[str]]]
     if searchspace.n_subsets <= recommender.max_n_subsets:
         combined_masks = searchspace.subsets()
@@ -206,7 +207,8 @@ def recommend_hybrid_with_subsets(
             mod_disc = evolve(
                 searchspace.discrete,
                 candidates=TableCandidates(
-                    searchspace.discrete.parameters, candidates.loc[d_mask]
+                    searchspace.discrete.parameters,
+                    candidates.filter(d_mask.tolist()).to_native(),
                 ),
             )
             mod_cont = (
@@ -234,7 +236,9 @@ def recommend_hybrid_with_subsets(
 
     # Post-check minimum cardinality on continuous columns
     if subspace_c.constraints_cardinality and not is_cardinality_fulfilled(
-        best_rec[list(subspace_c.parameter_names)],
+        nw.from_native(best_rec, eager_only=True)
+        .select(subspace_c.parameter_names)
+        .to_pandas(),
         subspace_c,
         check_maximum=False,
     ):

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -238,7 +238,7 @@ def recommend_hybrid_with_subsets(
     if subspace_c.constraints_cardinality and not is_cardinality_fulfilled(
         nw.from_native(best_rec, eager_only=True)
         .select(subspace_c.parameter_names)
-        .to_pandas(),
+        .to_native(),
         subspace_c,
         check_maximum=False,
     ):

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -24,6 +24,7 @@ from baybe.utils.dataframe import to_tensor
 from baybe.utils.sampling_algorithms import sample_numerical_df
 
 if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
     from torch import Tensor
 
     from baybe.recommenders.pure.bayesian.botorch.core import BotorchRecommender
@@ -33,7 +34,7 @@ def recommend_hybrid_without_subsets(
     recommender: BotorchRecommender,
     searchspace: SearchSpace,
     batch_size: int,
-) -> pd.DataFrame:
+) -> IntoDataFrame:
     """Recommend points using the ``optimize_acqf_mixed`` function of BoTorch.
 
     This functions samples points from the discrete subspace, performs optimization
@@ -165,7 +166,7 @@ def recommend_hybrid_with_subsets(
     recommender: BotorchRecommender,
     searchspace: SearchSpace,
     batch_size: int,
-) -> pd.DataFrame:
+) -> IntoDataFrame:
     """Recommend from a hybrid space with subset constraints.
 
     Uses ``SearchSpace.subsets()`` to enumerate the Cartesian
@@ -197,8 +198,8 @@ def recommend_hybrid_with_subsets(
     def make_callable(
         d_mask: np.ndarray,
         c_inactive_params: frozenset[str],
-    ) -> Callable[[], tuple[pd.DataFrame, Tensor]]:
-        def optimize() -> tuple[pd.DataFrame, Tensor]:
+    ) -> Callable[[], tuple[IntoDataFrame, Tensor]]:
+        def optimize() -> tuple[IntoDataFrame, Tensor]:
             import torch
 
             # TODO: Replace with .filter() method to avoid materialization
@@ -223,9 +224,7 @@ def recommend_hybrid_with_subsets(
 
             comp = mod_searchspace.transform(rec)
             with torch.no_grad():
-                acqf_value = recommender._botorch_acqf(
-                    to_tensor(comp.values).unsqueeze(0)
-                )
+                acqf_value = recommender._botorch_acqf(to_tensor(comp).unsqueeze(0))
             return rec, acqf_value
 
         return optimize

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -85,9 +85,7 @@ def recommend_hybrid_without_subsets(
     candidates_comp = searchspace.discrete.transform(candidates)
 
     # Calculate the number of samples from the given percentage
-    n_candidates = math.ceil(
-        recommender.sampling_percentage * len(candidates_comp.index)
-    )
+    n_candidates = math.ceil(recommender.sampling_percentage * len(candidates_comp))
 
     # Potential sampling of discrete candidates
     if recommender.hybrid_sampler is not None:
@@ -97,9 +95,10 @@ def recommend_hybrid_without_subsets(
 
     # Prepare all considered discrete configurations in the
     # List[Dict[int, float]] format expected by BoTorch.
-    num_comp_columns = len(candidates_comp.columns)
-    candidates_comp.columns = list(range(num_comp_columns))
-    fixed_features_list = candidates_comp.to_dict("records")
+    n_comp_columns = len(candidates_comp.columns)
+    fixed_features_df = candidates_comp.copy()
+    fixed_features_df.columns = list(range(n_comp_columns))
+    fixed_features_list = fixed_features_df.to_dict("records")
 
     # Actual call of the BoTorch optimization routine
     # NOTE: The explicit `or None` conversion is added as an additional safety net
@@ -116,7 +115,7 @@ def recommend_hybrid_without_subsets(
         equality_constraints=flatten(
             c.to_botorch(
                 searchspace.continuous.parameters,
-                idx_offset=len(candidates_comp.columns),
+                idx_offset=n_comp_columns,
                 batch_size=batch_size if c.is_interpoint else None,
             )
             for c in searchspace.continuous.constraints_lin_eq
@@ -125,7 +124,7 @@ def recommend_hybrid_without_subsets(
         inequality_constraints=flatten(
             c.to_botorch(
                 searchspace.continuous.parameters,
-                idx_offset=num_comp_columns,
+                idx_offset=n_comp_columns,
                 batch_size=batch_size if c.is_interpoint else None,
             )
             for c in searchspace.continuous.constraints_lin_ineq
@@ -133,25 +132,27 @@ def recommend_hybrid_without_subsets(
         or None,
     )
 
-    # Align candidates with search space index. Done via including the search space
-    # index during the merge, which is used later for back-translation into the
-    # experimental representation
-    merged = pd.merge(
-        pd.DataFrame(points),
-        candidates_comp.reset_index(),
-        on=list(candidates_comp.columns),
-        how="left",
-    ).set_index("index")
+    # Recover the positional index of the discrete part of each recommended point.
+    # Operating directly on the BoTorch output avoids introducing any further
+    # imprecision beyond what the optimizer itself produces.
+    disc_choices = to_tensor(candidates_comp)
+    disc_points = points[:, :n_comp_columns]
+    row_idxs = (
+        (disc_choices.unsqueeze(0) == disc_points.unsqueeze(1))
+        .all(dim=-1)
+        .int()
+        .argmax(dim=1)
+    )
 
-    # Get experimental representation of discrete part
-    rec_disc_exp = candidates.loc[merged.index]
-
-    # Combine discrete and continuous parts
+    # Combine the discrete part in experimental representation with the
+    # optimized continuous part from the BoTorch output
+    rec_disc_exp = candidates.iloc[row_idxs.numpy()].reset_index(drop=True)
     rec_exp = pd.concat(
         [
             rec_disc_exp,
-            merged.iloc[:, num_comp_columns:].set_axis(
-                searchspace.continuous.parameter_names, axis=1
+            pd.DataFrame(
+                points[:, n_comp_columns:].numpy(),
+                columns=searchspace.continuous.parameter_names,
             ),
         ],
         axis=1,

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -93,7 +93,7 @@ def recommend_hybrid_without_subsets(
     if recommender.hybrid_sampler is not None:
         candidates_comp = nw.from_native(
             sample_numerical_df(
-                candidates_comp.to_pandas(),
+                candidates_comp.to_native(),
                 n_candidates,
                 method=recommender.hybrid_sampler,
             ),

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 import narwhals.stable.v2 as nw
 import numpy as np
-from attrs import evolve, fields
+import pandas as pd
+from attrs import evolve
 
 from baybe.constraints.utils import is_cardinality_fulfilled
 from baybe.exceptions import (
@@ -21,6 +23,7 @@ from baybe.searchspace.candidates import TableCandidates
 from baybe.settings import active_settings
 from baybe.utils.basic import flatten
 from baybe.utils.dataframe import _df_with_backend, to_tensor
+from baybe.utils.sampling_algorithms import sample_numerical_df
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame
@@ -53,13 +56,17 @@ def recommend_hybrid_without_subsets(
         batch_size: The size of the calculated batch.
 
     Raises:
-        NotImplementedError: If ``hybrid_sampler`` is set on the recommender.
         IncompatibleAcquisitionFunctionError: If a non-Monte Carlo acquisition
             function is used with a batch size > 1.
 
     Returns:
         The recommended points.
     """
+    # TODO: Narhwalification is currently blocked by the fact that the alignment of
+    #   experimental and computational representations in the subsampled path
+    #   (i.e. when `sample_numerical_df` is used) is inherently index-based and
+    #   requires a narwhals-compatible subsampling mechanism first.
+
     assert recommender._objective is not None
 
     # Interpoint constraints cannot be used with optimize_acqf_mixed, see
@@ -82,26 +89,25 @@ def recommend_hybrid_without_subsets(
     from botorch.optim import optimize_acqf_mixed
 
     # Transform discrete candidates
-    candidates = nw.from_native(searchspace.discrete.get_candidates(), eager_only=True)
-    candidates_comp = nw.from_native(searchspace.discrete.transform(candidates))
+    candidates = searchspace.discrete.get_candidates()
+    candidates_comp = searchspace.discrete.transform(candidates)
 
+    # Calculate the number of samples from the given percentage
+    n_candidates = math.ceil(
+        recommender.sampling_percentage * len(candidates_comp.index)
+    )
+
+    # Potential sampling of discrete candidates
     if recommender.hybrid_sampler is not None:
-        # Subsampling must keep `candidates` and `candidates_comp` row-aligned, which
-        # requires a narwhals-compatible refactor of the sampling procedure. This is
-        # deferred until the optimizer refactoring is complete.
-        from baybe.recommenders.pure.bayesian.botorch.core import BotorchRecommender
-
-        raise NotImplementedError(
-            f"Using '{fields(BotorchRecommender).hybrid_sampler.alias}' is "
-            f"temporarily not supported."
+        candidates_comp = sample_numerical_df(
+            candidates_comp, n_candidates, method=recommender.hybrid_sampler
         )
 
     # Prepare all considered discrete configurations in the
     # List[Dict[int, float]] format expected by BoTorch.
-    n_comp_columns = len(candidates_comp.columns)
-    fixed_features_list = [
-        dict(enumerate(row)) for row in candidates_comp.to_numpy().tolist()
-    ]
+    num_comp_columns = len(candidates_comp.columns)
+    candidates_comp.columns = list(range(num_comp_columns))
+    fixed_features_list = candidates_comp.to_dict("records")
 
     # Actual call of the BoTorch optimization routine
     # NOTE: The explicit `or None` conversion is added as an additional safety net
@@ -114,11 +120,11 @@ def recommend_hybrid_without_subsets(
         q=batch_size,
         num_restarts=recommender.n_restarts,
         raw_samples=recommender.n_raw_samples,
-        fixed_features_list=fixed_features_list,
+        fixed_features_list=fixed_features_list,  # type: ignore[arg-type]
         equality_constraints=flatten(
             c.to_botorch(
                 searchspace.continuous.parameters,
-                idx_offset=n_comp_columns,
+                idx_offset=len(candidates_comp.columns),
                 batch_size=batch_size if c.is_interpoint else None,
             )
             for c in searchspace.continuous.constraints_lin_eq
@@ -127,7 +133,7 @@ def recommend_hybrid_without_subsets(
         inequality_constraints=flatten(
             c.to_botorch(
                 searchspace.continuous.parameters,
-                idx_offset=n_comp_columns,
+                idx_offset=num_comp_columns,
                 batch_size=batch_size if c.is_interpoint else None,
             )
             for c in searchspace.continuous.constraints_lin_ineq
@@ -135,28 +141,34 @@ def recommend_hybrid_without_subsets(
         or None,
     )
 
-    # Recover the positional index of the discrete part of each recommended point.
-    # Operating directly on the BoTorch output avoids introducing any further
-    # imprecision beyond what the optimizer itself produces.
-    from baybe.utils.torch import index_in_tensor
+    # Align candidates with search space index. Done via including the search space
+    # index during the merge, which is used later for back-translation into the
+    # experimental representation
+    merged = pd.merge(
+        pd.DataFrame(points),
+        candidates_comp.reset_index(),
+        on=list(candidates_comp.columns),
+        how="left",
+    ).set_index("index")
 
-    disc_choices = to_tensor(candidates_comp)
-    disc_points = points[:, :n_comp_columns]
-    row_idxs = index_in_tensor(disc_points, disc_choices)
+    # Get experimental representation of discrete part
+    rec_disc_exp = candidates.loc[merged.index]
 
-    # Combine the discrete part in experimental representation with the
-    # optimized continuous part from the BoTorch output
-    rec_cont = nw.from_numpy(
-        points[:, n_comp_columns:].numpy(),
-        schema=searchspace.continuous.parameter_names,
-        backend=active_settings.default_dataframe_backend,
+    # Combine discrete and continuous parts
+    rec_exp = pd.concat(
+        [
+            rec_disc_exp,
+            merged.iloc[:, num_comp_columns:].set_axis(
+                searchspace.continuous.parameter_names, axis=1
+            ),
+        ],
+        axis=1,
     )
-    rec_disc_exp = nw.maybe_reset_index(
-        _df_with_backend(
-            candidates[row_idxs], active_settings.default_dataframe_backend
-        )
-    )
-    return nw.concat([rec_disc_exp, rec_cont], how="horizontal").to_native()
+
+    return _df_with_backend(
+        nw.from_native(rec_exp.reset_index(drop=True)),
+        active_settings.default_dataframe_backend,
+    ).to_native()
 
 
 def recommend_hybrid_with_subsets(

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -151,8 +151,10 @@ def recommend_hybrid_without_subsets(
         schema=searchspace.continuous.parameter_names,
         backend=active_settings.default_dataframe_backend,
     )
-    rec_disc_exp = _df_with_backend(
-        candidates[row_idxs], active_settings.default_dataframe_backend
+    rec_disc_exp = nw.maybe_reset_index(
+        _df_with_backend(
+            candidates[row_idxs], active_settings.default_dataframe_backend
+        )
     )
     return nw.concat([rec_disc_exp, rec_cont], how="horizontal").to_native()
 

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import math
 import warnings
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 import narwhals.stable.v2 as nw
 import numpy as np
-from attrs import evolve
+from attrs import evolve, fields
 
 from baybe.constraints.utils import is_cardinality_fulfilled
 from baybe.exceptions import (
@@ -22,7 +21,6 @@ from baybe.searchspace.candidates import TableCandidates
 from baybe.settings import active_settings
 from baybe.utils.basic import flatten
 from baybe.utils.dataframe import _df_with_backend, to_tensor
-from baybe.utils.sampling_algorithms import sample_numerical_df
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame
@@ -55,6 +53,7 @@ def recommend_hybrid_without_subsets(
         batch_size: The size of the calculated batch.
 
     Raises:
+        NotImplementedError: If ``hybrid_sampler`` is set on the recommender.
         IncompatibleAcquisitionFunctionError: If a non-Monte Carlo acquisition
             function is used with a batch size > 1.
 
@@ -86,17 +85,15 @@ def recommend_hybrid_without_subsets(
     candidates = nw.from_native(searchspace.discrete.get_candidates(), eager_only=True)
     candidates_comp = nw.from_native(searchspace.discrete.transform(candidates))
 
-    # Calculate the number of samples from the given percentage
-    n_candidates = math.ceil(recommender.sampling_percentage * len(candidates_comp))
-
-    # Potential sampling of discrete candidates
     if recommender.hybrid_sampler is not None:
-        candidates_comp = nw.from_native(
-            sample_numerical_df(
-                candidates_comp.to_native(),
-                n_candidates,
-                method=recommender.hybrid_sampler,
-            ),
+        # Subsampling must keep `candidates` and `candidates_comp` row-aligned, which
+        # requires a narwhals-compatible refactor of the sampling procedure. This is
+        # deferred until the optimizer refactoring is complete.
+        from baybe.recommenders.pure.bayesian.botorch.core import BotorchRecommender
+
+        raise NotImplementedError(
+            f"Using '{fields(BotorchRecommender).hybrid_sampler.alias}' is "
+            f"temporarily not supported."
         )
 
     # Prepare all considered discrete configurations in the

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -197,7 +197,7 @@ def recommend_hybrid_with_subsets(
         def optimize() -> tuple[IntoDataFrame, Tensor]:
             import torch
 
-            # TODO: Replace with .filter() method to avoid materialization
+            # TODO: Replace with SubspaceDiscrete.filter method to avoid materialization
             mod_disc = evolve(
                 searchspace.discrete,
                 candidates=TableCandidates(

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -138,14 +138,11 @@ def recommend_hybrid_without_subsets(
     # Recover the positional index of the discrete part of each recommended point.
     # Operating directly on the BoTorch output avoids introducing any further
     # imprecision beyond what the optimizer itself produces.
+    from baybe.utils.torch import index_in_tensor
+
     disc_choices = to_tensor(candidates_comp)
     disc_points = points[:, :n_comp_columns]
-    row_idxs = (
-        (disc_choices.unsqueeze(0) == disc_points.unsqueeze(1))
-        .all(dim=-1)
-        .int()
-        .argmax(dim=1)
-    )
+    row_idxs = index_in_tensor(disc_points, disc_choices)
 
     # Combine the discrete part in experimental representation with the
     # optimized continuous part from the BoTorch output
@@ -155,7 +152,7 @@ def recommend_hybrid_without_subsets(
         backend=active_settings.default_dataframe_backend,
     )
     rec_disc_exp = _df_with_backend(
-        candidates[row_idxs.tolist()], active_settings.default_dataframe_backend
+        candidates[row_idxs], active_settings.default_dataframe_backend
     )
     return nw.concat([rec_disc_exp, rec_cont], how="horizontal").to_native()
 

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -17,8 +17,7 @@ from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace.core import SearchSpace
 
 if TYPE_CHECKING:
-    import pandas as pd
-    from narwhals.stable.v2.typing import IntoDataFrame
+    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 @define
@@ -31,9 +30,9 @@ class NonPredictiveRecommender(PureRecommender, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: IntoDataFrame | None = None,
-        pending_experiments: IntoDataFrame | None = None,
-    ) -> pd.DataFrame:
+        measurements: IntoDataFrameT | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoDataFrameT:
         if pending_experiments is not None:
             raise IncompatibleArgumentError(
                 f"Pending experiments were passed to '{self.__class__.__name__}"

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 import gc
 import warnings
 from abc import ABC
-from typing import TYPE_CHECKING
 
 import narwhals.stable.v2 as nw
 from attrs import define
+from narwhals.stable.v2.typing import IntoDataFrameT
 from typing_extensions import override
 
 from baybe.exceptions import IncompatibleArgumentError, UnusedObjectWarning
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace.core import SearchSpace
-
-if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrameT
 
 
 @define

--- a/baybe/recommenders/pure/nonpredictive/base.py
+++ b/baybe/recommenders/pure/nonpredictive/base.py
@@ -1,10 +1,13 @@
 """Base class for all nonpredictive recommenders."""
 
+from __future__ import annotations
+
 import gc
 import warnings
 from abc import ABC
+from typing import TYPE_CHECKING
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 from attrs import define
 from typing_extensions import override
 
@@ -12,6 +15,10 @@ from baybe.exceptions import IncompatibleArgumentError, UnusedObjectWarning
 from baybe.objectives.base import Objective
 from baybe.recommenders.pure.base import PureRecommender
 from baybe.searchspace.core import SearchSpace
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 
 @define
@@ -24,8 +31,8 @@ class NonPredictiveRecommender(PureRecommender, ABC):
         batch_size: int,
         searchspace: SearchSpace,
         objective: Objective | None = None,
-        measurements: pd.DataFrame | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> pd.DataFrame:
         if pending_experiments is not None:
             raise IncompatibleArgumentError(
@@ -35,7 +42,9 @@ class NonPredictiveRecommender(PureRecommender, ABC):
                 f"experiments from the candidate set, adjust the search space "
                 f"accordingly."
             )
-        if (measurements is not None) and not measurements.empty:
+        if (measurements is not None) and len(
+            nw.from_native(measurements, eager_only=True)
+        ) > 0:
             warnings.warn(
                 f"'{self.recommend.__name__}' was called with a non-empty "
                 f"set of measurements but '{self.__class__.__name__}' does not "

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -129,7 +129,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
             selection = self._make_selection_default(model, candidates_scaled)
 
         # Select rows by positional indices and return the corresponding subset
-        return candidates.iloc[selection]
+        return candidates.iloc[selection].reset_index(drop=True)
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
-import pandas as pd
 from attrs import define, field
 from typing_extensions import override
 
@@ -16,6 +15,8 @@ from baybe.searchspace import SearchSpaceType, SubspaceDiscrete
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
+    import pandas as pd
+    from narwhals.stable.v2.typing import IntoDataFrame
     from sklearn.base import ClusterMixin
 
 
@@ -102,7 +103,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         self,
         subspace_discrete: SubspaceDiscrete,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         # Fit scaler on entire search space
         from sklearn.preprocessing import StandardScaler
 

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -71,7 +71,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         """
         assigned_clusters = model.predict(candidates_scaled)
         selection = [
-            np.random.choice(np.argwhere(cluster == assigned_clusters).flatten())
+            np.random.choice(np.argwhere(cluster == assigned_clusters).flatten()).item()
             for cluster in np.unique(assigned_clusters)
         ]
         return selection

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -131,7 +131,9 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
             selection = self._make_selection_default(model, candidates_scaled)
 
         # Select rows by positional indices and return the corresponding subset
-        return nw.from_native(candidates, eager_only=True)[selection].to_native()
+        return nw.maybe_reset_index(
+            nw.from_native(candidates, eager_only=True)[selection]
+        ).to_native()
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -13,7 +13,9 @@ from typing_extensions import override
 
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpaceType, SubspaceDiscrete
+from baybe.settings import active_settings
 from baybe.utils.conversion import to_string
+from baybe.utils.dataframe import _df_with_backend
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -132,7 +134,10 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
 
         # Select rows by positional indices and return the corresponding subset
         return nw.maybe_reset_index(
-            nw.from_native(candidates, eager_only=True)[selection]
+            _df_with_backend(
+                nw.from_native(candidates, eager_only=True)[selection],
+                active_settings.default_dataframe_backend,
+            )
         ).to_native()
 
     @override

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -6,6 +6,7 @@ import gc
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
+import narwhals.stable.v2 as nw
 import numpy as np
 from attrs import define, field
 from typing_extensions import override
@@ -130,7 +131,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
             selection = self._make_selection_default(model, candidates_scaled)
 
         # Select rows by positional indices and return the corresponding subset
-        return candidates.iloc[selection].reset_index(drop=True)
+        return nw.from_native(candidates, eager_only=True)[selection].to_native()
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -65,8 +65,10 @@ class RandomRecommender(NonPredictiveRecommender):
         if not is_hybrid:
             return disc_random
 
-        cont_random.index = disc_random.index
-        return pd.concat([disc_random, cont_random], axis=1)
+        return pd.concat(
+            [disc_random.reset_index(drop=True), cont_random.reset_index(drop=True)],
+            axis=1,
+        )
 
     @override
     def __str__(self) -> str:
@@ -174,7 +176,7 @@ class FPSRecommender(NonPredictiveRecommender):
                 initialization=self.initialization.value,
                 random_tie_break=self.random_tie_break,
             )
-        return candidates.iloc[ilocs]
+        return candidates.iloc[ilocs].reset_index(drop=True)
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -1,7 +1,9 @@
 """Recommenders based on sampling."""
 
+from __future__ import annotations
+
 from enum import Enum
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
 import pandas as pd
@@ -13,6 +15,9 @@ from baybe.exceptions import InfeasibilityError
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType, SubspaceDiscrete
 from baybe.settings import Settings, active_settings
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
 from baybe.utils.conversion import to_string
 from baybe.utils.sampling_algorithms import farthest_point_sampling
 
@@ -32,7 +37,7 @@ class RandomRecommender(NonPredictiveRecommender):
         self,
         searchspace: SearchSpace,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         is_hybrid = searchspace.type is SearchSpaceType.HYBRID
 
         # Sample continuous part if applicable
@@ -149,7 +154,7 @@ class FPSRecommender(NonPredictiveRecommender):
         self,
         subspace_discrete: SubspaceDiscrete,
         batch_size: int,
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrame:
         # Fit scaler on entire search space
         from sklearn.preprocessing import StandardScaler
 

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar
 
+import narwhals.stable.v2 as nw
 import numpy as np
-import pandas as pd
 from attrs import define, field, fields
 from attrs.validators import instance_of
 from typing_extensions import override
@@ -15,6 +15,7 @@ from baybe.exceptions import InfeasibilityError
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SearchSpaceType, SubspaceDiscrete
 from baybe.settings import Settings, active_settings
+from baybe.utils.dataframe import _df_with_backend
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame
@@ -38,15 +39,24 @@ class RandomRecommender(NonPredictiveRecommender):
         searchspace: SearchSpace,
         batch_size: int,
     ) -> IntoDataFrame:
+        backend = active_settings.default_dataframe_backend
         is_hybrid = searchspace.type is SearchSpaceType.HYBRID
 
         # Sample continuous part if applicable
         if is_hybrid or searchspace.type is SearchSpaceType.CONTINUOUS:
-            cont_random = searchspace.continuous.sample_uniform(batch_size=batch_size)
+            cont_random = _df_with_backend(
+                nw.from_native(
+                    searchspace.continuous.sample_uniform(batch_size=batch_size),
+                    eager_only=True,
+                ),
+                backend,
+            )
             if searchspace.type is SearchSpaceType.CONTINUOUS:
-                return cont_random
+                return cont_random.to_native()
 
-        candidates_exp = searchspace.discrete.get_candidates()
+        candidates_exp = nw.from_native(
+            searchspace.discrete.get_candidates(), eager_only=True
+        )
 
         # Restrict to a random subset if subset-generating constraints are present
         if searchspace.discrete.n_subsets > 0:
@@ -60,20 +70,20 @@ class RandomRecommender(NonPredictiveRecommender):
                     "subset-generating constraints. All subsets have fewer "
                     f"candidates than the requested {batch_size=}."
                 )
-            candidates_exp = candidates_exp.loc[masks[0]]
+            candidates_exp = candidates_exp.filter(masks[0].tolist())
 
-        disc_random = candidates_exp.sample(
-            n=batch_size,
-            replace=is_hybrid or len(candidates_exp) < batch_size,
+        disc_random = _df_with_backend(
+            candidates_exp.sample(
+                n=batch_size,
+                with_replacement=is_hybrid or len(candidates_exp) < batch_size,
+            ),
+            backend,
         )
 
         if not is_hybrid:
-            return disc_random
+            return disc_random.to_native()
 
-        return pd.concat(
-            [disc_random.reset_index(drop=True), cont_random.reset_index(drop=True)],
-            axis=1,
-        )
+        return nw.concat([disc_random, cont_random], how="horizontal").to_native()
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -180,18 +180,21 @@ class FPSRecommender(NonPredictiveRecommender):
         if active_settings.use_fpsample:
             from baybe._optional.fpsample import fps_sampling
 
-            ilocs = fps_sampling(
+            idcs = fps_sampling(
                 candidates_scaled,
                 n_samples=batch_size,
             )
         else:
-            ilocs = farthest_point_sampling(
+            idcs = farthest_point_sampling(
                 candidates_scaled,
                 batch_size,
                 initialization=self.initialization.value,
                 random_tie_break=self.random_tie_break,
             )
-        return candidates.iloc[ilocs].reset_index(drop=True)
+        return _df_with_backend(
+            nw.from_native(candidates, eager_only=True)[idcs],
+            active_settings.default_dataframe_backend,
+        ).to_native()
 
     @override
     def __str__(self) -> str:

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -72,12 +72,14 @@ class RandomRecommender(NonPredictiveRecommender):
                 )
             candidates_exp = candidates_exp.filter(masks[0].tolist())
 
-        disc_random = _df_with_backend(
-            candidates_exp.sample(
-                n=batch_size,
-                with_replacement=is_hybrid or len(candidates_exp) < batch_size,
-            ),
-            backend,
+        disc_random = nw.maybe_reset_index(
+            _df_with_backend(
+                candidates_exp.sample(
+                    n=batch_size,
+                    with_replacement=is_hybrid or len(candidates_exp) < batch_size,
+                ),
+                backend,
+            )
         )
 
         if not is_hybrid:
@@ -191,9 +193,11 @@ class FPSRecommender(NonPredictiveRecommender):
                 initialization=self.initialization.value,
                 random_tie_break=self.random_tie_break,
             )
-        return _df_with_backend(
-            nw.from_native(candidates, eager_only=True)[idcs],
-            active_settings.default_dataframe_backend,
+        return nw.maybe_reset_index(
+            _df_with_backend(
+                nw.from_native(candidates, eager_only=True)[idcs],
+                active_settings.default_dataframe_backend,
+            )
         ).to_native()
 
     @override

--- a/baybe/settings.py
+++ b/baybe/settings.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 import narwhals.stable.v2 as nw
 import numpy as np
 from attrs import Attribute, Converter, Factory, define, field, fields
+from attrs.converters import optional as optional_c
 from attrs.setters import validate
 from attrs.validators import in_, instance_of
 from attrs.validators import optional as optional_v
@@ -221,6 +222,7 @@ class Settings(_SlottedContextDecorator):
     _default_dataframe_backend: nw.Implementation | None = field(
         alias="default_dataframe_backend",
         default=None,
+        converter=optional_c(nw.Implementation.from_backend),  # type: ignore[misc]
         validator=optional_v(in_(typing.get_args(EagerAllowed))),
     )
     """Controls which backend is used when constructing dataframes from scratch. Set to ``None`` to apply automatic selection."""  # noqa: E501

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -751,20 +751,11 @@ class NumericalTarget(Target, SerialMixin):
         from baybe.utils.dataframe import to_tensor
 
         nw_series = nw.from_native(series, series_only=True)
-        ns = nw.get_native_namespace(nw_series)
-        result = nw.new_series(
+        return nw.new_series(
             name=nw_series.name,
             values=self.transformation(to_tensor(series)).numpy(),
-            backend=ns,
-        )
-
-        # TODO[narwhalify]: drop once pandas index handling is removed globally
-        if ns is pd:
-            native = result.to_native()
-            native.index = nw_series.to_pandas().index
-            return native
-
-        return result.to_native()
+            backend=nw.get_native_namespace(nw_series),
+        ).to_native()
 
     @override
     def summary(self):

--- a/baybe/targets/numerical.py
+++ b/baybe/targets/numerical.py
@@ -46,6 +46,7 @@ from baybe.transformations import (
     convert_transformation,
 )
 from baybe.utils.boolean import UncertainBool
+from baybe.utils.dataframe import _copy_index, to_tensor
 from baybe.utils.interval import ConvertibleToInterval, Interval
 from baybe.utils.metadata import (
     ConvertibleToMeasurableMetadata,
@@ -748,14 +749,13 @@ class NumericalTarget(Target, SerialMixin):
         assert series is not None
         # <<<<<<<<<< Deprecation
 
-        from baybe.utils.dataframe import to_tensor
-
         nw_series = nw.from_native(series, series_only=True)
-        return nw.new_series(
+        out = nw.new_series(
             name=nw_series.name,
             values=self.transformation(to_tensor(series)).numpy(),
             backend=nw.get_native_namespace(nw_series),
-        ).to_native()
+        )
+        return _copy_index(out, nw_series).to_native()
 
     @override
     def summary(self):

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -25,6 +25,7 @@ from baybe.settings import active_settings
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+    from narwhals.typing import IntoBackend
     from torch import Tensor
 
     from baybe.targets.base import Target
@@ -799,9 +800,7 @@ def normalize_input_dtypes(
     return df
 
 
-def _df_with_backend(
-    obj: _SeriesOrFrameT, backend: nw.Implementation, /
-) -> _SeriesOrFrameT:
+def _df_with_backend(obj: _SeriesOrFrameT, backend: IntoBackend, /) -> _SeriesOrFrameT:
     """Convert a narwhals Series/DataFrame to a different native backend.
 
     Args:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -819,6 +819,30 @@ def _infer_backend(*frames: IntoFrame | None) -> IntoBackend:
     return active_settings.default_dataframe_backend
 
 
+def _copy_index(
+    output: _SeriesOrFrameT, source: nw.DataFrame | nw.Series, /
+) -> _SeriesOrFrameT:
+    """Copy the pandas index from one series/dataframe to another.
+
+    For non-pandas backends this is a no-op, since they have no index concept.
+
+    Args:
+        output: The narwhals Series or DataFrame to copy the index onto.
+        source: The narwhals Series or DataFrame whose index is to be copied.
+
+    Returns:
+        The output with the index copied from the source.
+    """
+    # TODO: Replace once built-in solution is available
+    # https://github.com/narwhals-dev/narwhals/issues/3693
+    # https://github.com/narwhals-dev/narwhals/issues/3864
+    if (index := nw.maybe_get_index(source)) is not None:
+        return nw.maybe_set_index(
+            output, index=nw.from_native(pd.Series(index), series_only=True)
+        )
+    return output
+
+
 def _df_with_backend(obj: _SeriesOrFrameT, backend: IntoBackend, /) -> _SeriesOrFrameT:
     """Convert a narwhals Series/DataFrame to a different native backend.
 

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
         int | float | np.ndarray | nw.Series | nw.DataFrame | IntoSeries | IntoDataFrame
     )
 
+_SeriesOrFrameT = TypeVar("_SeriesOrFrameT", nw.Series, nw.DataFrame)
+
 
 @overload
 def to_tensor(x: _IntoTensor, /) -> Tensor: ...
@@ -795,6 +797,27 @@ def normalize_input_dtypes(
     for col in cols_to_convert:
         df[col] = df[col].astype(active_settings.DTypeFloatNumpy)
     return df
+
+
+def _df_with_backend(
+    obj: _SeriesOrFrameT, backend: nw.Implementation, /
+) -> _SeriesOrFrameT:
+    """Convert a narwhals Series/DataFrame to a different native backend.
+
+    Args:
+        obj: The narwhals Series/DataFrame to convert.
+        backend: The target backend to convert to.
+
+    Returns:
+        The input object converted to the specified backend.
+    """
+    # TODO: Replace once built-in solution is available
+    # https://github.com/narwhals-dev/narwhals/issues/3812
+
+    if isinstance(obj, nw.Series):
+        name = obj.name
+        return nw.from_dict(obj.to_frame().to_dict(), backend=backend)[name]  # type: ignore[return-value]
+    return nw.from_dict(obj.to_dict(), backend=backend)  # type: ignore[return-value]
 
 
 def _df_equals(df1: nw.DataFrame, df2: nw.DataFrame, /) -> bool:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -24,7 +24,7 @@ from baybe.parameters.base import Parameter
 from baybe.settings import active_settings
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame, IntoSeries
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoFrame, IntoSeries
     from narwhals.typing import IntoBackend
     from torch import Tensor
 
@@ -798,6 +798,25 @@ def normalize_input_dtypes(
     for col in cols_to_convert:
         df[col] = df[col].astype(active_settings.DTypeFloatNumpy)
     return df
+
+
+def _infer_backend(*frames: IntoFrame | None) -> IntoBackend:
+    """Infer the dataframe backend from the first non-``None`` frame.
+
+    Falls back to :attr:`~baybe.settings.Settings.default_dataframe_backend` if all
+    provided frames are ``None``.
+
+    Args:
+        *frames: The frames to inspect. Accepts both eager and lazy frames.
+            Any of them may be ``None``.
+
+    Returns:
+        The inferred backend.
+    """
+    for frame in frames:
+        if frame is not None:
+            return nw.get_native_namespace(frame)
+    return active_settings.default_dataframe_backend
 
 
 def _df_with_backend(obj: _SeriesOrFrameT, backend: IntoBackend, /) -> _SeriesOrFrameT:

--- a/baybe/utils/dataframe.py
+++ b/baybe/utils/dataframe.py
@@ -856,6 +856,11 @@ def _df_with_backend(obj: _SeriesOrFrameT, backend: IntoBackend, /) -> _SeriesOr
     # TODO: Replace once built-in solution is available
     # https://github.com/narwhals-dev/narwhals/issues/3812
 
+    incoming = nw.Implementation.from_backend(nw.get_native_namespace(obj))
+    target = nw.Implementation.from_backend(backend)
+    if incoming == target:
+        return obj
+
     if isinstance(obj, nw.Series):
         name = obj.name
         return nw.from_dict(obj.to_frame().to_dict(), backend=backend)[name]  # type: ignore[return-value]

--- a/baybe/utils/sampling_algorithms.py
+++ b/baybe/utils/sampling_algorithms.py
@@ -6,8 +6,10 @@ from collections.abc import Collection
 from enum import Enum
 from typing import Literal
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
+from narwhals.stable.v2.typing import IntoDataFrame
 
 from baybe.utils.basic import is_all_instance
 
@@ -183,7 +185,7 @@ class DiscreteSamplingMethod(Enum):
 
 
 def sample_numerical_df(
-    df: pd.DataFrame,
+    df: IntoDataFrame,
     n_points: int,
     *,
     method: DiscreteSamplingMethod = DiscreteSamplingMethod.Random,
@@ -206,6 +208,8 @@ def sample_numerical_df(
         TypeError: If the provided dataframe has non-numerical content.
         ValueError: When an invalid sampling method was provided.
     """
+    df = nw.from_native(df, eager_only=True).to_pandas()
+
     if any(df[col].dtype.kind not in "iufb" for col in df.columns):
         raise TypeError(
             f"'{sample_numerical_df.__name__}' only supports purely numerical "

--- a/baybe/utils/sampling_algorithms.py
+++ b/baybe/utils/sampling_algorithms.py
@@ -6,10 +6,8 @@ from collections.abc import Collection
 from enum import Enum
 from typing import Literal
 
-import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
-from narwhals.stable.v2.typing import IntoDataFrame
 
 from baybe.utils.basic import is_all_instance
 
@@ -185,7 +183,7 @@ class DiscreteSamplingMethod(Enum):
 
 
 def sample_numerical_df(
-    df: IntoDataFrame,
+    df: pd.DataFrame,
     n_points: int,
     *,
     method: DiscreteSamplingMethod = DiscreteSamplingMethod.Random,
@@ -208,8 +206,6 @@ def sample_numerical_df(
         TypeError: If the provided dataframe has non-numerical content.
         ValueError: When an invalid sampling method was provided.
     """
-    df = nw.from_native(df, eager_only=True).to_pandas()
-
     if any(df[col].dtype.kind not in "iufb" for col in df.columns):
         raise TypeError(
             f"'{sample_numerical_df.__name__}' only supports purely numerical "

--- a/baybe/utils/sampling_algorithms.py
+++ b/baybe/utils/sampling_algorithms.py
@@ -136,7 +136,7 @@ def farthest_point_sampling(
             map(int, np.unravel_index(idx_1d, dist_matrix.shape))
         )
         if n_samples == 1:
-            return [sort_idx[selected_point_indices[0]]]
+            return [int(sort_idx[selected_point_indices[0]])]
     elif isinstance(initialization, Collection) and is_all_instance(
         initialization, int
     ):

--- a/baybe/utils/torch.py
+++ b/baybe/utils/torch.py
@@ -10,3 +10,24 @@ torch_to_numpy_dtype_mapping: dict[torch.dtype, np.dtype[Any]] = {
     torch.float64: np.dtype("float64"),
 }
 """Mapping from Torch to NumPy dtypes."""
+
+
+def index_in_tensor(needle: torch.Tensor, haystack: torch.Tensor) -> list[int]:
+    """Find the position of each row of one tensor within another tensor.
+
+    Args:
+        needle: A ``(n, d)`` tensor whose rows are to be located.
+        haystack: A ``(m, d)`` tensor to search in.
+
+    Raises:
+        ValueError: If any row of ``needle`` has no exact match in ``haystack``.
+
+    Returns:
+        The row indices into ``haystack`` for each row of ``needle``.
+    """
+    match_mask = (haystack.unsqueeze(0) == needle.unsqueeze(1)).all(dim=-1)
+    if not match_mask.any(dim=1).all():
+        raise ValueError(
+            "Could not find all rows of the search tensor in the target tensor."
+        )
+    return match_mask.int().argmax(dim=1).tolist()

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -13,7 +13,7 @@ from attrs import Attribute
 
 from baybe.exceptions import IncompleteMeasurementsError
 from baybe.settings import active_settings
-from baybe.utils.dataframe import normalize_input_dtypes
+from baybe.utils.dataframe import _df_with_backend, normalize_input_dtypes
 
 if TYPE_CHECKING:
     from narwhals.stable.v2.typing import IntoDataFrameT
@@ -304,8 +304,6 @@ def preprocess_dataframe(
     else:
         targets = ()
     result_pd = normalize_input_dtypes(df_pd, [*searchspace.parameters, *targets])
-    result_nw = nw.from_native(result_pd, eager_only=True)
-    return nw.from_dict(
-        {col: result_nw[col] for col in result_nw.columns},
-        backend=nw.get_native_namespace(df),
+    return _df_with_backend(
+        nw.from_native(result_pd, eager_only=True), df_nw.implementation
     ).to_native()

--- a/baybe/utils/validation.py
+++ b/baybe/utils/validation.py
@@ -6,6 +6,7 @@ import math
 from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 from attrs import Attribute
@@ -15,6 +16,8 @@ from baybe.settings import active_settings
 from baybe.utils.dataframe import normalize_input_dtypes
 
 if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrameT
+
     from baybe.objectives.base import Objective
     from baybe.parameters.base import Parameter
     from baybe.searchspace.core import SearchSpace
@@ -260,12 +263,12 @@ def validate_object_names(objects: Iterable[Parameter | Target], /) -> None:
 
 
 def preprocess_dataframe(
-    df: pd.DataFrame,
+    df: IntoDataFrameT,
     /,
     searchspace: SearchSpace,
     objective: Objective | None = None,
     numerical_measurements_must_be_within_tolerance: bool = True,
-) -> pd.DataFrame:
+) -> IntoDataFrameT:
     """Preprocess an experimental dataframe by validating and normalizing its contents.
 
     Checks that the dataframe contains all required columns for the given
@@ -282,19 +285,27 @@ def preprocess_dataframe(
     Returns:
         The preprocessed dataframe.
     """
+    df_nw = nw.from_native(df, eager_only=True)
+    df_pd = df_nw.to_pandas()
+
     if not active_settings.preprocess_dataframes:
         return df
 
     validate_parameter_input(
-        df,
+        df_pd,
         searchspace.parameters,
         numerical_measurements_must_be_within_tolerance,
         allow_duplicates=True,
     )
     if objective is not None:
         targets = objective.targets
-        validate_target_input(df, targets)
-        validate_objective_input(df, objective)
+        validate_target_input(df_pd, targets)
+        validate_objective_input(df_pd, objective)
     else:
         targets = ()
-    return normalize_input_dtypes(df, [*searchspace.parameters, *targets])
+    result_pd = normalize_input_dtypes(df_pd, [*searchspace.parameters, *targets])
+    result_nw = nw.from_native(result_pd, eager_only=True)
+    return nw.from_dict(
+        {col: result_nw[col] for col in result_nw.columns},
+        backend=nw.get_native_namespace(df),
+    ).to_native()

--- a/examples/Custom_Hooks/campaign_stopping.py
+++ b/examples/Custom_Hooks/campaign_stopping.py
@@ -18,6 +18,7 @@ import warnings
 
 import pandas as pd
 import seaborn as sns
+from narwhals.stable.v2.typing import IntoDataFrameT
 
 from baybe import Campaign, active_settings
 from baybe.acquisition import ProbabilityOfImprovement
@@ -129,7 +130,7 @@ def stop_on_PI(
     self: BotorchRecommender,
     searchspace: SearchSpace,
     objective: Objective | None = None,
-    measurements: pd.DataFrame | None = None,
+    measurements: IntoDataFrameT | None = None,
 ) -> None:
     """Raise an exception if the PI-based stopping criterion is fulfilled."""
     if searchspace.type != SearchSpaceType.DISCRETE:

--- a/examples/Custom_Hooks/probability_of_improvement.py
+++ b/examples/Custom_Hooks/probability_of_improvement.py
@@ -21,6 +21,7 @@ import pandas as pd
 from botorch.test_functions.synthetic import Hartmann
 from matplotlib.collections import PolyCollection
 from mpl_toolkits.mplot3d import Axes3D
+from narwhals.stable.v2.typing import IntoDataFrameT
 from scipy.stats import gaussian_kde
 
 from baybe import active_settings
@@ -70,7 +71,7 @@ def extract_pi(
     self: BotorchRecommender,
     searchspace: SearchSpace,
     objective: Objective | None = None,
-    measurements: pd.DataFrame | None = None,
+    measurements: IntoDataFrameT | None = None,
 ) -> None:
     """Calculate and store the probability of improvement."""
     if searchspace.type is not SearchSpaceType.DISCRETE:

--- a/examples/Mixtures/traditional.py
+++ b/examples/Mixtures/traditional.py
@@ -24,10 +24,13 @@
 import numpy as np
 import pandas as pd
 
+from baybe import active_settings
 from baybe.constraints import ContinuousLinearConstraint
 from baybe.parameters import NumericalContinuousParameter
 from baybe.recommenders import RandomRecommender
 from baybe.searchspace import SearchSpace
+
+active_settings.default_dataframe_backend = "pandas"
 
 ### Parameter Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "exceptiongroup",
     "gpytorch>=1.9.1,<2",
     "joblib>1.4.0,<2",
-    "narwhals>=2,<3",
+    "narwhals>=2.25.0,<3",  # https://github.com/narwhals-dev/narwhals/pull/3866
     "numpy>=1.24.1,<3",
     "pandas>=2.1.0,<4",
     "scikit-learn>=1.1.1,<2",

--- a/pytest.ini
+++ b/pytest.ini
@@ -40,6 +40,8 @@ filterwarnings =
     ignore:.*friedman_mse.*:FutureWarning:sklearn.tree._classes
     ; https://github.com/scipy/scipy/pull/25541
     ignore:.*NumPy array is not writable.*:UserWarning:botorch.generation.gen
+    ; https://github.com/joblib/joblib/issues/1772
+    ignore:Setting the shape on a NumPy array has been deprecated.*:DeprecationWarning:joblib.numpy_pickle
 
     ; Numerics/optimization
     ; ---------------------

--- a/streamlit/initial_recommender.py
+++ b/streamlit/initial_recommender.py
@@ -6,9 +6,12 @@ import plotly.graph_objects as go
 import streamlit as st
 from sklearn.datasets import make_blobs
 
+from baybe import active_settings
 from baybe.recommenders.pure.nonpredictive.base import NonPredictiveRecommender
 from baybe.searchspace import SearchSpace, SubspaceDiscrete
 from baybe.utils.basic import get_subclasses
+
+active_settings.default_dataframe_backend = "pandas"
 
 
 def uniform_distribution(n_points: int) -> np.ndarray:
@@ -113,8 +116,13 @@ def main():
     recommender = selection_recommenders[recommender_name]()
     selection = recommender.recommend(searchspace=searchspace, batch_size=n_selected)
 
+    # Recover the original row positions in `points` for each selected point.
+    selection_indices = selection.merge(points.reset_index(), on=["x", "y"])[
+        "index"
+    ].values
+
     # show the result
-    fig = plot_point_selection(points.values, selection.index.values, recommender_name)
+    fig = plot_point_selection(points.values, selection_indices, recommender_name)
     st.plotly_chart(fig)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -985,8 +985,7 @@ def select_recommender(
 ) -> PureRecommender:
     """Select a recommender for a given training dataset size."""
     searchspace = Mock(spec=SearchSpace)
-    df = Mock()
-    df.__len__ = Mock(return_value=training_size)
+    df = pd.DataFrame(index=range(training_size))
     return meta_recommender.select_recommender(
         batch_size=1, searchspace=searchspace, measurements=df
     )

--- a/tests/constraints/test_cardinality_constraint_continuous.py
+++ b/tests/constraints/test_cardinality_constraint_continuous.py
@@ -5,9 +5,11 @@ from collections.abc import Sequence
 from itertools import combinations_with_replacement
 from warnings import WarningMessage
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import pandas as pd
 import pytest
+from narwhals.stable.v2.typing import IntoDataFrame
 
 from baybe.constraints.continuous import (
     ContinuousCardinalityConstraint,
@@ -24,7 +26,7 @@ from baybe.targets import NumericalTarget
 
 
 def _validate_cardinality_constrained_batch(
-    batch: pd.DataFrame,
+    batch: IntoDataFrame,
     subspace_continuous: SubspaceContinuous,
     batch_size: int,
     captured_warnings: Sequence[WarningMessage],
@@ -54,7 +56,7 @@ def _validate_cardinality_constrained_batch(
     assert is_min_cardinality_fulfilled != bool(cardinality_warnings)
 
     # Assert that we obtain as many samples as requested
-    assert batch.shape[0] == batch_size
+    assert len(batch) == batch_size
 
     # Sanity check: If all recommendations in the batch are identical, something is
     # fishy – unless the cardinality is 0, in which case the entire batch must contain
@@ -68,10 +70,10 @@ def _validate_cardinality_constrained_batch(
     max_cardinalities = [
         c.max_cardinality for c in subspace_continuous.constraints_cardinality
     ]
-    if len(unique_row := batch.drop_duplicates()) == 1:
-        assert (unique_row.iloc[0] == 0.0).all() and all(
-            max_cardinality == 0 for max_cardinality in max_cardinalities
-        )
+    if len(unique_row := nw.from_native(batch).unique()) == 1:
+        assert unique_row.select(
+            nw.all_horizontal(nw.all() == 0.0, ignore_nulls=True).all()
+        ).item() and all(max_cardinality == 0 for max_cardinality in max_cardinalities)
 
 
 # Combinations of cardinalities to be tested

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1027,7 +1027,7 @@ else:
 )
 def test_deprecated_comp_df(param):
     """Accessing ``comp_df`` on any discrete parameter emits a deprecation warning."""
+    expected = nw.from_native(param.transform(), eager_only=True).to_pandas()
     with pytest.warns(DeprecationWarning, match="comp_df"):
         result = param.comp_df
-    expected = nw.from_native(param.transform(), eager_only=True).to_pandas()
     assert_frame_equal(result, expected)

--- a/tests/test_pandas_index.py
+++ b/tests/test_pandas_index.py
@@ -1,0 +1,142 @@
+"""Tests verifying that transformation methods preserve the pandas index."""
+
+import functools
+
+import pandas as pd
+import pytest
+
+from baybe._optional.info import CHEM_INSTALLED
+from baybe.objectives import (
+    DesirabilityObjective,
+    ParetoObjective,
+    SingleTargetObjective,
+)
+from baybe.objectives.base import Objective
+from baybe.parameters.base import DiscreteParameter
+from baybe.parameters.categorical import CategoricalParameter, TaskParameter
+from baybe.parameters.custom import CustomDiscreteParameter
+from baybe.parameters.numerical import (
+    NumericalContinuousParameter,
+    NumericalDiscreteParameter,
+)
+from baybe.searchspace import SearchSpace
+from baybe.targets._deprecated import LegacyTarget
+from baybe.targets.base import Target
+from baybe.targets.binary import BinaryTarget
+from baybe.targets.numerical import NumericalTarget
+from baybe.utils.basic import get_subclasses
+
+_INDEX = [10, 20, 30]
+_DATA = pd.DataFrame(
+    {
+        "num": [1.0, 2.0, 3.0],
+        "cat": ["a", "b", "c"],
+        "task": ["A", "B", "C"],
+        "mol": ["Water", "THF", "DMF"],
+        "mol_custom": ["mol1", "mol2", "mol3"],
+        "t1": [1.0, 2.0, 3.0],
+        "t2": [4.0, 5.0, 6.0],
+        "binary": ["yes", "no", "yes"],
+        "conti": [0.1, 0.5, 0.9],
+    },
+    index=_INDEX,
+)
+
+_custom_parameter_data = pd.DataFrame(
+    {"D1": [1.1, 1.4, 1.7], "D2": [11, 23, 55]},
+    index=["mol1", "mol2", "mol3"],
+)
+_substance_data = {"Water": "O", "THF": "C1CCOC1", "DMF": "CN(C)C=O"}
+_desirability_targets = [
+    NumericalTarget.normalized_ramp("t1", cutoffs=(0, 10)),
+    NumericalTarget.normalized_ramp("t2", cutoffs=(0, 10)),
+]
+
+
+_targets: list[Target] = [
+    NumericalTarget("num"),
+    BinaryTarget("binary", success_value="yes", failure_value="no"),
+]
+
+_objectives: list[Objective] = [
+    SingleTargetObjective(NumericalTarget("t1")),
+    DesirabilityObjective(_desirability_targets),
+    ParetoObjective((NumericalTarget("t1"), NumericalTarget("t2", minimize=True))),
+]
+
+_parameters: list[DiscreteParameter] = [
+    NumericalDiscreteParameter("num", values=[1.0, 2.0, 3.0]),
+    CategoricalParameter("cat", values=["a", "b", "c"]),
+    TaskParameter("task", values=["A", "B", "C"]),
+    CustomDiscreteParameter("mol_custom", data=_custom_parameter_data),
+]
+if CHEM_INSTALLED:
+    from baybe.parameters.substance import SubstanceParameter
+
+    _parameters.append(SubstanceParameter("mol", data=_substance_data))
+
+_searchspaces: list[tuple[str, SearchSpace]] = [
+    (
+        "SubspaceDiscrete-numerical",
+        SearchSpace.from_product(
+            [NumericalDiscreteParameter("num", values=[1.0, 2.0, 3.0])]
+        ),
+    ),
+    (
+        "SubspaceDiscrete-categorical",
+        SearchSpace.from_product([CategoricalParameter("cat", values=["a", "b", "c"])]),
+    ),
+    (
+        "SubspaceContinuous",
+        SearchSpace.from_product(
+            [NumericalContinuousParameter("conti", bounds=(0, 1))]
+        ),
+    ),
+    (
+        "SearchSpace-hybrid",
+        SearchSpace.from_product(
+            [
+                NumericalDiscreteParameter("num", values=[1.0, 2.0, 3.0]),
+                NumericalContinuousParameter("conti", bounds=(0, 1)),
+            ]
+        ),
+    ),
+]
+
+
+assert set(get_subclasses(Target)) - {LegacyTarget} == {t.__class__ for t in _targets}
+assert set(get_subclasses(Objective)) == {o.__class__ for o in _objectives}
+assert set(get_subclasses(DiscreteParameter)) == {p.__class__ for p in _parameters}
+
+
+@pytest.mark.parametrize(
+    "callable,data",
+    [
+        *(
+            pytest.param(t.transform, _DATA[t.name], id=t.__class__.__name__)
+            for t in _targets
+        ),
+        *(
+            pytest.param(
+                functools.partial(o.transform, allow_extra=True),
+                _DATA,
+                id=o.__class__.__name__,
+            )
+            for o in _objectives
+        ),
+        *(
+            pytest.param(p.transform, _DATA[p.name], id=p.__class__.__name__)
+            for p in _parameters
+        ),
+        *(
+            pytest.param(
+                functools.partial(ss.transform, allow_extra=True), _DATA, id=id_
+            )
+            for id_, ss in _searchspaces
+        ),
+    ],
+)
+def test_transform_preserves_pandas_index(callable, data):
+    """Transformation callables preserve a non-default pandas index."""
+    result = callable(data)
+    assert list(pd.DataFrame(result).index) == _INDEX

--- a/tests/test_pandas_index.py
+++ b/tests/test_pandas_index.py
@@ -1,6 +1,7 @@
 """Tests verifying that transformation methods preserve the pandas index."""
 
 import functools
+import os
 
 import pandas as pd
 import pytest
@@ -19,12 +20,18 @@ from baybe.parameters.numerical import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
 )
+from baybe.parameters.substance import SubstanceParameter
 from baybe.searchspace import SearchSpace
 from baybe.targets._deprecated import LegacyTarget
 from baybe.targets.base import Target
 from baybe.targets.binary import BinaryTarget
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import get_subclasses
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("BAYBE_TEST_ENV") != "FULLTEST",
+    reason="Only possible in FULLTEST environment.",
+)
 
 _INDEX = [10, 20, 30]
 _DATA = pd.DataFrame(
@@ -71,9 +78,8 @@ _parameters: list[DiscreteParameter] = [
     CustomDiscreteParameter("mol_custom", data=_custom_parameter_data),
 ]
 if CHEM_INSTALLED:
-    from baybe.parameters.substance import SubstanceParameter
-
     _parameters.append(SubstanceParameter("mol", data=_substance_data))
+
 
 _searchspaces: list[tuple[str, SearchSpace]] = [
     (
@@ -104,9 +110,11 @@ _searchspaces: list[tuple[str, SearchSpace]] = [
 ]
 
 
-assert set(get_subclasses(Target)) - {LegacyTarget} == {t.__class__ for t in _targets}
-assert set(get_subclasses(Objective)) == {o.__class__ for o in _objectives}
-assert set(get_subclasses(DiscreteParameter)) == {p.__class__ for p in _parameters}
+def test_coverage():
+    """All concrete subclasses providing transformation methods are covered."""
+    assert set(get_subclasses(Target)) - {LegacyTarget} == {type(t) for t in _targets}
+    assert set(get_subclasses(Objective)) == {type(o) for o in _objectives}
+    assert set(get_subclasses(DiscreteParameter)) == {type(p) for p in _parameters}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -155,13 +155,6 @@ def test_numerical_target_transform_affine(series_constructor):
     assert list(result) == pytest.approx([3.0, 5.0, 7.0])
 
 
-def test_numerical_target_transform_index_preserved():
-    """NumericalTarget.transform preserves a non-default pandas index."""
-    t = NumericalTarget("t")
-    series = pd.Series([1.0, 2.0, 3.0], name="t", index=[10, 20, 30])
-    assert list(t.transform(series).index) == [10, 20, 30]
-
-
 # ── BinaryTarget.transform ────────────────────────────────────────────────────
 
 

--- a/tests/utils/test_sampling_algorithms.py
+++ b/tests/utils/test_sampling_algorithms.py
@@ -259,7 +259,10 @@ def test_fps_recommender_utility_call(use_fpsample):
             return_value=[2, 0],
         )
 
-    with context as mock_, Settings(use_fpsample=use_fpsample):
+    with (
+        context as mock_,
+        Settings(use_fpsample=use_fpsample, default_dataframe_backend="pandas"),
+    ):
         result = FPSRecommender().recommend(batch_size=2, searchspace=ss)
 
     mock_.assert_called_once()

--- a/tests/utils/test_sampling_algorithms.py
+++ b/tests/utils/test_sampling_algorithms.py
@@ -13,6 +13,7 @@ from pytest import param
 from sklearn.metrics import pairwise_distances
 
 from baybe._optional.info import FPSAMPLE_INSTALLED
+from baybe.parameters.numerical import NumericalDiscreteParameter
 from baybe.recommenders.pure.nonpredictive.sampling import (
     FPSInitialization,
     FPSRecommender,
@@ -246,21 +247,24 @@ def test_fps_recommender_utility_initialization_indices(searchspace):
         False,
     ],
 )
-def test_fps_recommender_utility_call(searchspace, use_fpsample):
+def test_fps_recommender_utility_call(use_fpsample):
     """FPSRecommender calls expected underlying utility."""
+    ss = NumericalDiscreteParameter("p", [1.0, 2.0, 3.0, 4.0]).to_searchspace()
+
     if use_fpsample:
-        context = patch("baybe._optional.fpsample.fps_sampling", return_value=[0, 1, 2])
+        context = patch("baybe._optional.fpsample.fps_sampling", return_value=[2, 0])
     else:
         context = patch(
             "baybe.recommenders.pure.nonpredictive.sampling.farthest_point_sampling",
-            return_value=[0, 1, 2],
+            return_value=[2, 0],
         )
 
     with context as mock_, Settings(use_fpsample=use_fpsample):
-        result = FPSRecommender().recommend(batch_size=3, searchspace=searchspace)
+        result = FPSRecommender().recommend(batch_size=2, searchspace=ss)
 
     mock_.assert_called_once()
-    assert result.index.tolist() == [0, 1, 2]
+    expected = ss.discrete.get_candidates().iloc[[2, 0]].reset_index(drop=True)
+    assert result.equals(expected)
 
 
 @pytest.mark.skipif(

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-12T12:57:26.466234Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -433,7 +433,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.7.3,!=3.9.1" },
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.19.1" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0.0" },
-    { name = "narwhals", specifier = ">=2,<3" },
+    { name = "narwhals", specifier = ">=2.25.0,<3" },
     { name = "ngboost", marker = "extra == 'extras'", specifier = ">=0.3.12,<1" },
     { name = "numpy", specifier = ">=1.24.1,<3" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.16.0" },
@@ -3089,11 +3089,11 @@ wheels = [
 
 [[package]]
 name = "narwhals"
-version = "2.20.0"
+version = "2.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/f3/257adc69a71011b4c8cda321b00f02c5bf1980ae38ffd05a58d9632d4de8/narwhals-2.20.0.tar.gz", hash = "sha256:c10994975fa7dc5a68c2cffcddbd5908fc8ebb2d463c5bab085309c0ee1f551e", size = 627848, upload-time = "2026-04-20T12:11:45.427Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl", hash = "sha256:16e750ea5507d4ba6e8d03455b5f93a535e0405976561baea235bca5dc9f475d", size = 449373, upload-time = "2026-04-20T12:11:43.596Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Narwhalifies the recommendation layer, focusing on the core logic. That is, some methods/functions are narwhalified only at their API boundary, keeping an internal conversion to `pd.DataFrame`. These internals can be narhwhalified at any later point in time in the form of isolated PRs.