### PR TITLE
Separate `linkcheck` job from doc building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Build Docs
         run: |
           pip install tox-uv
-          tox -e docs-py310 -- -r
+          tox -e docs-py311 -- -r
           
   typecheck:
     needs: [lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
   build-docs:
     name: "Build Docs"
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [linkcheck]
     permissions:
       contents: read
       pages: write     # Required to deploy to GitHub Pages
@@ -96,7 +96,6 @@ jobs:
     name: "Link Check"
     runs-on: ubuntu-latest
     needs: [lint]
-    continue-on-error: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,22 @@ jobs:
         run: |
           pip install tox-uv
           tox -e docs-py311 -- -r
+
+  linkcheck:
+    name: "Link Check"
+    runs-on: ubuntu-latest
+    needs: [lint]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with: {python-version: "3.11"}
+      - name: Check external links
+        run: |
+          pip install tox-uv
+          tox -e linkcheck
           
   typecheck:
     needs: [lint]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,11 @@ jobs:
           ref: ${{ github.ref }}
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Install tox
         run: pip install tox-uv
       - name: Build Docs
-        run: tox -e docs-py310 -- -r
+        run: tox -e docs-py311 -- -r
       - name: Configure sphinx bot for pushing and fetch branches
         run: |
             git config --local user.email "sphinx-upload[bot]@users.noreply.github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,8 @@ jobs:
         with: {python-version: "3.11"}
       - name: Install tox
         run: pip install tox-uv
+      - name: Check external links
+        run: tox -e linkcheck
       - name: Build Docs
         run: tox -e docs-py311 -- -r
       - name: Configure sphinx bot for pushing and fetch branches

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -40,11 +40,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Build Docs
         run: |
           pip install tox-uv
-          tox -e docs-py310 -- -r
+          tox -e docs-py311 -- -r
 
   lint:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BayesianRecommender`
 - `Parameter.is_equivalent` method for structural parameter comparison
 - `posterior_mean_function` method to `GaussianProcessSurrogate`
+- Dedicated job for checking internal links in the documentation
 
 ### Changed
 - `BOTORCH` GP preset now includes `BetaPrior(2.5, 1.5)` for the task covariance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mean_factory`, `likelihood_factory`, `fit_criterion_factory`) now default to
   `None`, meaning "auto-select based on context at fit time". Accessing a field
   before fitting may return `None` instead of a concrete factory.
+- Use Python 3.11 for building the documentation
 
 ## [0.15.0] - 2026-06-11
 ### Breaking Changes

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -52,7 +52,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
     ) -> RecommenderProtocol:
         """Follow the meta recommender chain to the selected non-meta recommender.
 
-        Recursively calls :meth:`MetaRecommender.select_recommender` until a
+        Recursively calls
+        :meth:`~baybe.recommenders.meta.base.MetaRecommender.select_recommender` until a
         non-meta recommender is encountered, which is then returned.
         Effectively, this extracts the recommender responsible for generating
         the recommendations for the specified context.

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -306,7 +306,7 @@ class GaussianProcessSurrogate(Surrogate):
         * **Eagerly:** By calling the method and passing the returned module to a GP.
         * **Lazily:** By passing the bound method itself, without eagerly calling it.
             This works because the method signature complies with
-            :class:`~.components.mean.MeanFactoryProtocol`, i.e., the new GP will use it
+            :obj:`~.components.mean.MeanFactoryProtocol`, i.e., the new GP will use it
             as a factory and call it automatically at fit time.
 
         If the mean-providing GP has not been fitted at call time, its prior mean module

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -43,10 +43,11 @@ class Transformation(SerialMixin, ABC):
         In accordance with the mathematical definition of a function's `codomain
         <https://en.wikipedia.org/wiki/Codomain>`_, we define the codomain of a given
         :class:`~baybe.utils.interval.Interval` under a certain (assumed continuous)
-        :class:`~Transformation` to be an :class:`~baybe.utils.interval.Interval`
-        guaranteed to contain all possible outcomes when the :class:`~Transformation` is
-        applied to all points in the input :class:`~baybe.utils.interval.Interval`. In
-        cases where the image cannot exactly be computed, it is often still possible to
+        :class:`~baybe.transformations.base.Transformation` to be an
+        :class:`~baybe.utils.interval.Interval` guaranteed to contain all possible
+        outcomes when the :class:`~baybe.transformations.base.Transformation` is applied
+        to all points in the input :class:`~baybe.utils.interval.Interval`. In cases
+        where the image cannot exactly be computed, it is often still possible to
         compute a codomain. The codomain always contains the image, but might be larger.
         """
 
@@ -56,10 +57,10 @@ class Transformation(SerialMixin, ABC):
         In accordance with the mathematical definition of a function's `image
         <https://en.wikipedia.org/wiki/Image_(mathematics)>`_, we define the image of a
         given :class:`~baybe.utils.interval.Interval` under a certain (assumed
-        continuous) :class:`~Transformation` to be the smallest
-        :class:`~baybe.utils.interval.Interval` containing all possible outcomes when
-        the :class:`~Transformation` is applied to all points in the input
-        :class:`~baybe.utils.interval.Interval`.
+        continuous) :class:`~baybe.transformations.base.Transformation` to be the
+        smallest :class:`~baybe.utils.interval.Interval` containing all possible
+        outcomes when the :class:`~baybe.transformations.base.Transformation` is applied
+        to all points in the input :class:`~baybe.utils.interval.Interval`.
         """
         # By default, it is assumed that the exact image of an interval cannot be
         # computed but only the codomain is available (see :meth:`get_codomain`).

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,17 @@
+---
+orphan: true
+---
+
+<!-- This page exists solely to trigger the recursive autosummary stub generation for
+the API reference. The generated `_autosummary/baybe` tree is linked from the "API
+Reference" entry of the main toctree in `index.md`. Keeping the directive off the
+landing page prevents the module summary table from being rendered there. -->
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   baybe
+```

--- a/docs/components/transformations.md
+++ b/docs/components/transformations.md
@@ -399,7 +399,7 @@ t = CustomTransformation(torch.sin)
 ```
 
 ````{admonition} Automatic Wrapping
-:note:
+:class: note
 
 When embedding custom transformations into another context, wrapping the `torch`
 callable into a {class}`~baybe.transformations.basic.CustomTransformation` happens

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-import os
-import shutil
-
 from gpytorch.kernels import Kernel as GPyTorchKernel
 from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
 from gpytorch.means import Mean as GPyTorchMean
@@ -48,64 +45,12 @@ autodoc_type_aliases = {
 
 # >>>>>>>>>> NOTE END <<<<<<<<<<
 
-# -- Path setup --------------------------------------------------------------
-
-__location__ = os.path.dirname(__file__)
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# Seems to be not necessary at the moment
-# sys.path.insert(0, os.path.join(__location__, "../examples"))
-
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "BayBE"
 copyright = "2022-2025 Merck KGaA, Darmstadt, Germany and/or its affiliates. All rights reserved."  # noqa
 author = "Merck KGaA, Darmstadt, Germany"
-
-
-# -- Run sphinx-apidoc -------------------------------------------------------
-# This hack is necessary since RTD does not issue `sphinx-apidoc` before running
-# `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/readthedocs/readthedocs.org/issues/1139
-# DON'T FORGET: Check the box "Install your project inside a virtualenv using
-# setup.py install" in the RTD Advanced Settings.
-# Additionally it helps us to avoid running apidoc manually
-
-try:  # for Sphinx >= 1.7
-    from sphinx.ext import apidoc
-except ImportError:
-    from sphinx import apidoc
-
-output_dir = os.path.join(__location__, "sdk")
-baybe_module_dir = os.path.join(__location__, "../baybe")
-try:
-    shutil.rmtree(output_dir)
-except FileNotFoundError:
-    pass
-
-try:
-    args = [
-        "--implicit-namespaces",
-        "-M",
-        "-T",
-        "-e",
-        "-f",
-        "-o",
-        output_dir,
-    ]
-
-    apidoc.main(
-        [
-            *args,
-            baybe_module_dir,
-            baybe_module_dir + "/__init__.py",
-        ]
-    )
-except Exception as e:
-    print(f"Running `sphinx-apidoc` failed!\n{e}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,25 +151,59 @@ source_suffix = [".rst", ".md"]
 # Here, we define regex expressions for errors produced by nitpick that we want to
 # ignore.
 nitpick_ignore_regex = [
-    # Ignore errors that are from inherited classes we cannot control
+    ##### External package references #####
+    # Qualified references to external packages whose internal module paths cannot be
+    # resolved via intersphinx (e.g. pandas.core.frame.DataFrame vs pandas.DataFrame).
+    (
+        r"py:.*",
+        r"(pandas|numpy|torch|botorch|gpytorch|scipy|sklearn|pathlib|polars|attr|joblib|matplotlib|skfp|rdkit|shap|xyzpy|typing)[\._].*",
+    ),  # noqa: E501
+    ##### Inherited torch.nn.Module docstring references #####
+    # Unqualified names from inherited external docstrings (torch, botorch, sklearn)
+    # that cannot be resolved outside their original documentation context.
+    (r"py:class", r"^(Tensor|Module|Parameter|Dropout|BatchNorm)$"),
+    (r"py:class", r"^(Posterior|MetadataRequest|Ignored)$"),
+    (r"py:attr", r"^(persistent|grad_input|grad_output|requires_grad)$"),
+    (r"py:attr", r"^(device|dtype|dst_type|non_blocking)$"),
+    (r"py:func", r"^(register_module_forward_hook|register_module_forward_pre_hook)$"),
+    (r"py:func", r"^(register_module_full_backward_hook)$"),
+    (r"py:func", r"^(register_module_full_backward_pre_hook|load_state_dict)$"),
+    (r"py:meth", r"^nn\.Module\.load_state_dict$"),
+    ##### Inherited sklearn/scipy docstring artifacts #####
+    # sklearn docstrings use informal type descriptions that Sphinx parses as refs.
+    (r"py:class", r"^(optional|shape|shape=|n_samples|n_features|n_query)$"),
+    (r"py:class", r"^(n_features_new|n_outputs|n_indexed|n_clusters)$"),
+    (r"py:class", r"^(array-like|ndarray|ndarray array|string)$"),
+    (r"py:class", r"^(estimator instance|sparse matrix\})$"),
+    (r"py:class", r"^(\{array-like|default=.*|\{\"default\")$"),
+    (r"py:class", r"^(dtype=np\.int64|if metric == 'precomputed')$"),
+    ##### Type aliases in TYPE_CHECKING blocks #####
+    # These exist only at type-checking time and cannot be resolved by Sphinx.
+    (r"py:class", r"^(GPComponent|TensorCallable|ConvertibleToFloat)$"),
+    (r"py:class", r"^(GPyTorchKernel|GPyTorchLikelihood|GPyTorchMean|GPyTorchModel)$"),
+    (r"py:class", r"^(pd\.DataFrame|pl\.Expr)$"),
+    (r"py:class", r"^(TypeAliasForwardRef|P)$"),
+    (r"py:class", r"^\"(pandas|polars)\"\}?$"),
+    ##### BayBE-specific suppressions #####
+    # Inherited classes we cannot control
     (r"py:.*", r".*DTypeFloatONNX.*"),
-    # Ignore the functions that we manually delete from in child classes
+    # Serialization functions manually deleted from child classes
     (r"py:.*", r".*from_dict.*"),
     (r"py:.*", r".*from_json.*"),
     (r"py:.*", r".*to_dict.*"),
     (r"py:.*", r".*to_json.*"),
     (r"py:.*", r".*_T.*"),
-    # Ignore files for which no __init__ is available at all
+    # Classes for which no __init__ is available at all
     (r"py:.*", "baybe.constraints.conditions.Condition.__init__"),
     (r"py:.*", "baybe.serialization.mixin.SerialMixin.__init__"),
     (r"DeprecationWarning:", ""),
-    # Ignore the generics/aliases
+    # Generics/aliases
     (r"py:class", "baybe.utils.basic._C"),
     (r"py:class", "baybe.utils.basic._T"),
     (r"py:class", "baybe.utils.basic._U"),
     (r"py:class", "baybe.surrogates.composite._SurrogateGetter"),
     (r"ref:obj", "baybe.surrogates.base.ModelContext"),
-    # Ignore custom class properties
+    # Custom class properties
     (r"py:obj", "baybe.settings._AdoptedRandomSeed.*"),
     (r"py:obj", "baybe.acquisition.acqfs.*.supports_batching"),
     (r"py:obj", "baybe.acquisition.acqfs.*.supports_pending_experiments"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,6 @@ myst_heading_anchors = 4
 templates_path = ["templates"]
 # Tell sphinx which files should be excluded
 exclude_patterns = ["sdk", "AGENTS.md", "CLAUDE.md", "**/AGENTS.md", "**/CLAUDE.md"]
-autodoc_exclude_modules = ["baybe.utils.clustering_algorithms.third_party.kmedoids"]
 
 # Enable markdown
 # Note that we do not need additional configuration here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,8 +151,6 @@ source_suffix = [".rst", ".md"]
 # Here, we define regex expressions for errors produced by nitpick that we want to
 # ignore.
 nitpick_ignore_regex = [
-    # Ignore everything that does not include baybe
-    (r"py:.*", r"^(?!.*baybe).*"),
     # Ignore errors that are from inherited classes we cannot control
     (r"py:.*", r".*DTypeFloatONNX.*"),
     # Ignore the functions that we manually delete from in child classes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,8 +240,15 @@ linkcheck_ignore = [
 ]
 
 
-# Ignore the warnings that are given by autosectionlabel
-suppress_warnings = ["autosectionlabel.*"]
+# Ignore certain warning categories
+suppress_warnings = [
+    "autosectionlabel.*",
+    # Forward reference and guarded import warnings from sphinx-autodoc-typehints.
+    # These are unavoidable since heavy deps (torch, botorch, gpytorch) are lazy-loaded
+    # and only available in TYPE_CHECKING blocks at runtime.
+    "sphinx_autodoc_typehints.forward_reference",
+    "sphinx_autodoc_typehints.guarded_import",
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,6 +183,10 @@ linkcheck_ignore = [
     r"https://doi.org/10.1039/D5DD00050E",
 ]
 
+# Bound the time spent on any single external link so that a slow or unresponsive
+# host cannot stall the linkcheck job.
+linkcheck_timeout = 30
+
 
 # Ignore certain warning categories
 suppress_warnings = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,11 +181,18 @@ linkcheck_ignore = [
     r"https://github.com/b-shields/edbo/blob*",
     r"https://doi.org/10.26434/chemrxiv.10001986/v2",
     r"https://doi.org/10.1039/D5DD00050E",
+    # Wikipedia aggressively rate-limits automated requests (HTTP 403), which would
+    # cause false failures now that linkcheck gates the documentation build.
+    r"https://en\.wikipedia\.org/.*",
 ]
 
 # Bound the time spent on any single external link so that a slow or unresponsive
 # host cannot stall the linkcheck job.
 linkcheck_timeout = 30
+
+# Retry transient failures before declaring a link broken, since linkcheck now gates
+# the documentation build.
+linkcheck_retries = 3
 
 
 # Ignore certain warning categories

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,6 @@ FAQ <faq>
    :toctree: _autosummary
    :template: custom-module-template.rst
    :recursive:
-   :hidden:
 
    baybe
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,15 +23,6 @@ FAQ <faq>
 :relative-docs: docs/
 ```
 
-```{eval-rst}
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-   :recursive:
-
-   baybe
-```
-
 ```{toctree}
 :maxdepth: 2
 :titlesonly:

--- a/docs/scripts/build_documentation.py
+++ b/docs/scripts/build_documentation.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import pathlib
+import shutil
 from subprocess import check_call, run
 
 from build_examples import build_examples
@@ -48,6 +49,32 @@ LINKCHECK = not args.no_linkcheck
 FULL_REBUILD = args.full_rebuild
 INCLUDE_WARNINGS = args.include_warnings
 FORCE = args.force
+
+
+def _run_apidoc() -> None:
+    """Generate API reference RST stubs via sphinx-apidoc."""
+    from sphinx.ext import apidoc
+
+    output_dir = pathlib.Path("docs/sdk")
+    module_dir = pathlib.Path("baybe")
+
+    # Remove previously generated stubs to ensure a clean state
+    if output_dir.is_dir():
+        shutil.rmtree(output_dir)
+
+    apidoc.main(
+        [
+            "--implicit-namespaces",
+            "-M",
+            "-T",
+            "-e",
+            "-f",
+            "-o",
+            str(output_dir),
+            str(module_dir),
+            str(module_dir / "__init__.py"),
+        ]
+    )
 
 
 def build_documentation(
@@ -100,6 +127,9 @@ def build_documentation(
 
     if perform_linkcheck:
         check_links()
+
+    # Generate the API reference stubs via sphinx-apidoc
+    _run_apidoc()
 
     # Directory where the documentation is build.
     build_dir = pathlib.Path("docs/build")

--- a/docs/scripts/build_documentation.py
+++ b/docs/scripts/build_documentation.py
@@ -127,6 +127,8 @@ def build_documentation(
         build_dir,
         "-n",  # Being nitpicky
         "-W",  # Fail when encountering an error or a warning
+        "-j",  # Build in parallel
+        "auto",
     ]
 
     if force:

--- a/docs/scripts/build_documentation.py
+++ b/docs/scripts/build_documentation.py
@@ -7,7 +7,6 @@ import shutil
 from subprocess import check_call, run
 
 from build_examples import build_examples
-from check_links import check_links
 from utils import adjust_pictures
 
 parser = argparse.ArgumentParser()
@@ -18,15 +17,9 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument(
-    "-l",
-    "--no_linkcheck",
-    help="Do not check the links.",
-    action="store_true",
-)
-parser.add_argument(
     "-r",
     "--full-rebuild",
-    help="Perform a full rebuild, independent of `-e` and `-l` flags.",
+    help="Perform a full rebuild, independent of `-e` flag.",
     action="store_true",
 )
 parser.add_argument(
@@ -45,7 +38,6 @@ parser.add_argument(
 # Parse input arguments
 args = parser.parse_args()
 RUN_EXAMPLES = args.run_examples
-LINKCHECK = not args.no_linkcheck
 FULL_REBUILD = args.full_rebuild
 INCLUDE_WARNINGS = args.include_warnings
 FORCE = args.force
@@ -79,16 +71,15 @@ def _run_apidoc() -> None:
 
 def build_documentation(
     run_examples: bool = False,
-    verify_links: bool = False,
     full_rebuild: bool = False,
     force: bool = False,
 ) -> None:
     """Build the documentation.
 
     A full build of the documentation consists of converting the examples into jupyter
-    notebooks, executing them, transforming them into markdown files, as well as
-    checking all links and performing the actual ``sphinx-build``. Such a full build can
-    be triggered using the ``full_rebuild`` flag.
+    notebooks, executing them, transforming them into markdown files, and performing
+    the actual ``sphinx-build``. Such a full build can be triggered using the
+    ``full_rebuild`` flag.
     If this flag is not set, this function tries to re-use as much of potentially
     existing structures like already built examples as possible. This behavior can be
     changed by using the other flags.
@@ -97,18 +88,14 @@ def build_documentation(
         run_examples: Fully recalculate the examples. If this is ``False`` and no
             folder containing an already built set of examples is found, dummy files
             replicating the structure of the examples are created.
-        verify_links: Check both internal and external links.
         full_rebuild: Perform a full rebuild of the documentation, including a
-            recalculation of the examples and checking the links. Note that this option
-            ignores the choices for ``run_examples`` and ``check_links`` if set to
-            ``True.
+            recalculation of the examples.
         force: Force-build the steps, ignoring any errors or warnings.
     """
     examples_directory = pathlib.Path("docs/examples")
     examples_exist = examples_directory.is_dir()
 
     rerun_examples = run_examples or full_rebuild
-    perform_linkcheck = verify_links or full_rebuild
 
     if rerun_examples:
         build_examples(
@@ -124,9 +111,6 @@ def build_documentation(
             dummy=True,
             remove_dir=examples_exist,
         )
-
-    if perform_linkcheck:
-        check_links()
 
     # Generate the API reference stubs via sphinx-apidoc
     _run_apidoc()
@@ -158,11 +142,8 @@ if __name__ == "__main__":
     if not INCLUDE_WARNINGS:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
-    print(f"{LINKCHECK=}")
-
     build_documentation(
         run_examples=RUN_EXAMPLES,
-        verify_links=LINKCHECK,
         full_rebuild=FULL_REBUILD,
         force=FORCE,
     )

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -1,10 +1,10 @@
-"""Utility for checking the links of the documentation."""
+"""Utility for checking the external links of the documentation."""
 
 from subprocess import check_call
 
 
 def check_links() -> None:
-    """Check whether the links of the documentation are valid."""
+    """Check whether the external links of the documentation are valid."""
     link_call = [
         "sphinx-build",
         "-b",
@@ -14,3 +14,7 @@ def check_links() -> None:
     ]
 
     check_call(link_call)
+
+
+if __name__ == "__main__":
+    check_links()

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -11,6 +11,8 @@ def check_links() -> None:
         "linkcheck",
         "docs",
         "docs/build",
+        "-j",  # Build in parallel
+        "auto",
     ]
 
     check_call(link_call)

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy", "baybe.utils.clustering_algorithms.third_party.kmedoids") %}
+{% if not item in ("kmedoids",) %}
    {{ item }}
 {%- endif %}
 {%- endfor %}

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy") %}
+{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy", "baybe.utils.clustering_algorithms.third_party.kmedoids") %}
    {{ item }}
 {%- endif %}
 {%- endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands =
     python --version
     pip-audit {env:EXCLUDES:}
 
-[testenv:docs-py310]
+[testenv:docs-py311]
 description = Build documentation, passing posargs to control what should be built
 skip_install = True
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -102,10 +102,19 @@ commands =
     uv run --locked --extra docs docs/scripts/build_documentation.py {posargs}
 
 [testenv:docs-quickbuild]
-description = Force-build documentation, ignoring links and examples
+description = Force-build documentation, ignoring  examples
 skip_install = True
 setenv =
     SMOKE_TEST = true
 commands = 
     python --version
-    uv run --locked --extra docs docs/scripts/build_documentation.py -f -l
+    uv run --locked --extra docs docs/scripts/build_documentation.py -f
+
+[testenv:linkcheck]
+description = Check external links in the documentation
+skip_install = True
+setenv =
+    SMOKE_TEST = true
+commands =
+    python --version
+    uv run --locked --extra docs docs/scripts/check_links.py

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ commands =
     uv run --locked --extra docs docs/scripts/build_documentation.py {posargs}
 
 [testenv:docs-quickbuild]
-description = Force-build documentation, ignoring  examples
+description = Force-build documentation, ignoring examples
 skip_install = True
 setenv =
     SMOKE_TEST = true


### PR DESCRIPTION
This PR separates the `linkcheck` job from the actual doc building. It does so by creating a new dedicated job for it in the CI and re-organizing the code.

Note that this job only checks *external* links. Internal links are handled by the 2nd PR of this stack.

**IMPORTANT** Our doc building so far relied on the doc building being run twice in the same environment for checking the forward references guarded by the TYPE_CHECKING guards. Since we now run `linkcheck` and doc building in different jobs, this does no longer work, and we get warnings which are being treated as errors. This is fixed in the later PRs of the stack, but has the implication that the doc building on *this* branch is broken, and that this PR should not be merged without the other PRs of this stack also being merged.




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>