### PR TITLE
Use Python 3.11 instead of 3.10 in the doc builiding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: --verbose --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,21 @@ jobs:
           pip install tox-uv
           tox -e lint-${{ matrix.py-version.tox }}
 
+  lychee:
+    name: "Link Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+
   build-docs:
     name: "Build Docs"
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint, lychee]
     permissions:
       contents: read
       pages: write     # Required to deploy to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --verbose --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: -vv --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Build Docs
         run: |
           pip install tox-uv
-          tox -e docs-py310 -- -r
+          tox -e docs-py311 -- -r
           
   typecheck:
     needs: [lint]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,11 @@ jobs:
           ref: ${{ github.ref }}
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Install tox
         run: pip install tox-uv
       - name: Build Docs
-        run: tox -e docs-py310 -- -r
+        run: tox -e docs-py311 -- -r
       - name: Configure sphinx bot for pushing and fetch branches
         run: |
             git config --local user.email "sphinx-upload[bot]@users.noreply.github.com"

--- a/.github/workflows/regular.yml
+++ b/.github/workflows/regular.yml
@@ -40,11 +40,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with: {python-version: "3.10"}
+        with: {python-version: "3.11"}
       - name: Build Docs
         run: |
           pip install tox-uv
-          tox -e docs-py310 -- -r
+          tox -e docs-py311 -- -r
 
   lint:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mean_factory`, `likelihood_factory`, `fit_criterion_factory`) now default to
   `None`, meaning "auto-select based on context at fit time". Accessing a field
   before fitting may return `None` instead of a concrete factory.
+<<<<<<< HEAD
 - Discrete filtering constraints now uniformly define what is **kept** in the search
   space; set `exclude=True` to invert and keep the complement instead
 - Renamed `exclusion_constraints` example to `selection_constraints`
 - Use Python 3.11 for building the documentation
+=======
+>>>>>>> 918867a44 (Remove CHANGELOG entry)
 
 ### Deprecations
 - `DiscreteExcludeConstraint` in favor of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discrete filtering constraints now uniformly define what is **kept** in the search
   space; set `exclude=True` to invert and keep the complement instead
 - Renamed `exclusion_constraints` example to `selection_constraints`
+- Use Python 3.11 for building the documentation
 
 ### Deprecations
 - `DiscreteExcludeConstraint` in favor of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-import os
-import shutil
-
 from gpytorch.kernels import Kernel as GPyTorchKernel
 from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
 from gpytorch.means import Mean as GPyTorchMean
@@ -48,64 +45,12 @@ autodoc_type_aliases = {
 
 # >>>>>>>>>> NOTE END <<<<<<<<<<
 
-# -- Path setup --------------------------------------------------------------
-
-__location__ = os.path.dirname(__file__)
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# Seems to be not necessary at the moment
-# sys.path.insert(0, os.path.join(__location__, "../examples"))
-
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "BayBE"
 copyright = "2022-2025 Merck KGaA, Darmstadt, Germany and/or its affiliates. All rights reserved."  # noqa
 author = "Merck KGaA, Darmstadt, Germany"
-
-
-# -- Run sphinx-apidoc -------------------------------------------------------
-# This hack is necessary since RTD does not issue `sphinx-apidoc` before running
-# `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/readthedocs/readthedocs.org/issues/1139
-# DON'T FORGET: Check the box "Install your project inside a virtualenv using
-# setup.py install" in the RTD Advanced Settings.
-# Additionally it helps us to avoid running apidoc manually
-
-try:  # for Sphinx >= 1.7
-    from sphinx.ext import apidoc
-except ImportError:
-    from sphinx import apidoc
-
-output_dir = os.path.join(__location__, "sdk")
-baybe_module_dir = os.path.join(__location__, "../baybe")
-try:
-    shutil.rmtree(output_dir)
-except FileNotFoundError:
-    pass
-
-try:
-    args = [
-        "--implicit-namespaces",
-        "-M",
-        "-T",
-        "-e",
-        "-f",
-        "-o",
-        output_dir,
-    ]
-
-    apidoc.main(
-        [
-            *args,
-            baybe_module_dir,
-            baybe_module_dir + "/__init__.py",
-        ]
-    )
-except Exception as e:
-    print(f"Running `sphinx-apidoc` failed!\n{e}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ autodoc_type_aliases = {
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "BayBE"
-copyright = "2022-2025 Merck KGaA, Darmstadt, Germany and/or its affiliates. All rights reserved."  # noqa
+copyright = "2022-2026 Merck KGaA, Darmstadt, Germany and/or its affiliates. All rights reserved."  # noqa
 author = "Merck KGaA, Darmstadt, Germany"
 
 

--- a/docs/scripts/build_documentation.py
+++ b/docs/scripts/build_documentation.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import pathlib
+import shutil
 from subprocess import check_call, run
 
 from build_examples import build_examples
@@ -48,6 +49,32 @@ LINKCHECK = not args.no_linkcheck
 FULL_REBUILD = args.full_rebuild
 INCLUDE_WARNINGS = args.include_warnings
 FORCE = args.force
+
+
+def _run_apidoc() -> None:
+    """Generate API reference RST stubs via sphinx-apidoc."""
+    from sphinx.ext import apidoc
+
+    output_dir = pathlib.Path("docs/sdk")
+    module_dir = pathlib.Path("baybe")
+
+    # Remove previously generated stubs to ensure a clean state
+    if output_dir.is_dir():
+        shutil.rmtree(output_dir)
+
+    apidoc.main(
+        [
+            "--implicit-namespaces",
+            "-M",
+            "-T",
+            "-e",
+            "-f",
+            "-o",
+            str(output_dir),
+            str(module_dir),
+            str(module_dir / "__init__.py"),
+        ]
+    )
 
 
 def build_documentation(
@@ -100,6 +127,9 @@ def build_documentation(
 
     if perform_linkcheck:
         check_links()
+
+    # Generate the API reference stubs via sphinx-apidoc
+    _run_apidoc()
 
     # Directory where the documentation is build.
     build_dir = pathlib.Path("docs/build")

--- a/docs/scripts/build_examples.py
+++ b/docs/scripts/build_examples.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import textwrap
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from subprocess import DEVNULL, STDOUT, check_call
 
@@ -11,7 +12,92 @@ from tqdm import tqdm
 # TODO full rebuild option
 
 
-def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
+def _convert_example(file: Path, sub_directory: Path) -> None:
+    """Convert a single example file into its documentation markdown page.
+
+    Args:
+        file: The example ``.py`` file to convert.
+        sub_directory: The example folder the file belongs to (used to locate figures).
+    """
+    file_name = file.stem
+
+    # Convert the file to a jupyter notebook
+    check_call(["jupytext", "--to", "notebook", file], stdout=DEVNULL, stderr=STDOUT)
+
+    notebook_path = file.with_suffix(".ipynb")
+
+    # Execute the notebook, then convert it to markdown
+    env = os.environ | {"PYTHONPATH": os.getcwd()}
+    convert_execute = [
+        "jupyter",
+        "nbconvert",
+        "--to",
+        "notebook",
+        "--inplace",
+        "--execute",
+        notebook_path,
+    ]
+    check_call(convert_execute, stdout=DEVNULL, stderr=STDOUT, env=env)
+    to_markdown = ["jupyter", "nbconvert", "--to", "markdown", notebook_path]
+    check_call(to_markdown, stdout=DEVNULL, stderr=STDOUT, env=env)
+
+    # Wrap long lines, except those containing a link (detected via "](")
+    markdown_path = file.with_suffix(".md")
+    with open(markdown_path, encoding="UTF-8") as markdown_file:
+        content = markdown_file.read()
+        wrapped_lines = []
+        ignored_substrings = (
+            "![svg]",
+            "![png]",
+            "<Figure size",
+            "it/s",
+            "s/it",
+        )
+        for line in content.splitlines():
+            # Skip formatter control lines
+            if "fmt: off" in line or "fmt: on" in line:
+                continue
+            if any(substring in line for substring in ignored_substrings):
+                continue
+            if (
+                len(line) > 88
+                and "](" not in line
+                and not line.lstrip().startswith("#")
+            ):
+                wrapped = textwrap.wrap(line, width=88)
+                wrapped_lines.extend(wrapped)
+            else:
+                wrapped_lines.append(line)
+
+    lines = [line + "\n" for line in wrapped_lines]
+    # Append light/dark figures if both exist, else a single figure if present
+    light_figure = Path(sub_directory / (file_name + "_light.svg"))
+    dark_figure = Path(sub_directory / (file_name + "_dark.svg"))
+    figure = Path(sub_directory / (file_name + ".svg"))
+    if light_figure.is_file() and dark_figure.is_file():
+        lines.append(f"```{{image}} {file_name}_light.svg\n")
+        lines.append(":align: center\n")
+        lines.append(":class: only-light\n")
+        lines.append("```\n")
+        lines.append(f"```{{image}} {file_name}_dark.svg\n")
+        lines.append(":align: center\n")
+        lines.append(":class: only-dark\n")
+        lines.append("```\n")
+    elif figure.is_file():
+        lines.append(f"```{{image}} {file_name}.svg\n")
+        lines.append(":align: center\n")
+        lines.append("```\n")
+
+    with open(markdown_path, "w", encoding="UTF-8") as markdown_file:
+        markdown_file.writelines(lines)
+
+
+def build_examples(
+    destination_directory: Path,
+    dummy: bool,
+    remove_dir: bool,
+    max_workers: int | None = None,
+):
     """Create the documentation version of the examples files.
 
     Note that this deletes the destination directory if it already exists.
@@ -20,6 +106,8 @@ def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
         destination_directory: The destination directory.
         dummy: Only build a dummy version of the files.
         remove_dir: Remove the examples directory if it already exists.
+        max_workers: Number of examples to convert concurrently. Defaults to the number
+            of available CPUs. Lower it if the build runs out of memory.
 
     Raises:
         OSError: If the directory already exists but should not be removed.
@@ -43,12 +131,9 @@ def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
     # examples
     ex_file = """# Examples\n\n```{toctree}\n:maxdepth: 2\n\n"""
 
-    # List all directories in the examples folder
     ex_directories = [d for d in destination_directory.iterdir() if d.is_dir()]
 
-    # This list contains the order of the examples as we want to have them in the end.
-    # The examples that should be the first ones are already included here and skipped
-    # later on. All others are just included.
+    # Desired example order; entries listed here come first, all others are appended
     ex_order = [
         "Basics<Basics/Basics>\n",
         "Searchspaces<Searchspaces/Searchspaces>\n",
@@ -59,147 +144,50 @@ def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
         "Custom Surrogates<Custom_Surrogates/Custom_Surrogates>\n",
     ]
 
-    # Iterate over the directories.
-    for sub_directory in (pbar := tqdm(ex_directories)):
-        # Get the name of the current folder
-        # Format it by replacing underscores and capitalizing the words
+    # Files to convert, collected across all folders so conversion can be batched
+    files_to_convert: list[tuple[Path, Path]] = []
+
+    # First pass (sequential): build the toctree files and collect the conversion work
+    for sub_directory in ex_directories:
+        # Folder name, formatted for display (underscores to spaces, capitalized)
         folder_name = sub_directory.stem
         formatted = " ".join(word.capitalize() for word in folder_name.split("_"))
 
-        # Create the link to the folder to the top level toctree.
+        # Add the folder to the top level toctree if not already present
         ex_file_entry = formatted + f"<{folder_name}/{folder_name}>\n"
-        # Add it to the list of examples if it is not already contained
         if ex_file_entry not in ex_order:
             ex_order.append(ex_file_entry)
 
-        # We need to create a file for the inclusion of the folder.
-        # We thus get the content of the corresponding header file.
+        # Start the folder's toctree from its header file
         header_folder_name = sub_directory / f"{folder_name}_Header.md"
         header = header_folder_name.read_text()
 
         subdir_toctree = header + "\n```{toctree}\n:maxdepth: 1\n\n"
 
-        # Set description of progressbar
-        pbar.set_description("Overall progress")
-
-        # list all .py files in the subdirectory that need to be converted
         py_files = list(sub_directory.glob("**/*.py"))
 
-        # Iterate through the individual example files
-        for file in (inner_pbar := tqdm(py_files, leave=False)):
-            # Include the name of the file to the toctree
-            # Format it by replacing underscores and capitalizing the words
+        for file in py_files:
+            # Add the file to the folder's toctree, with a formatted display name
             file_name = file.stem
 
             formatted = " ".join(word.capitalize() for word in file_name.split("_"))
-            # Remove duplicate "constraints" for the files in the constraints folder.
+            # Drop duplicate "Constraints" in the constraints folders
             if "Constraints" in folder_name and "Constraints" in formatted:
                 formatted = formatted.replace("Constraints", "")
 
-            # Also format the Prodsum name to Product/Sum
+            # Format "Prodsum" as "Product/Sum"
             if "Prodsum" in formatted:
                 formatted = formatted.replace("Prodsum", "Product/Sum")
             subdir_toctree += formatted + f"<{file_name}>\n"
 
-            # If we ignore the examples, we do not want to actually execute or convert
-            # anything. Still, due to existing links, it is necessary to construct a
-            # dummy file and then continue.
+            # In dummy mode, write a placeholder so links still resolve
             if dummy:
                 markdown_path = file.with_suffix(".md")
-                # Rewrite the file
                 with open(markdown_path, "w", encoding="UTF-8") as markdown_file:
                     markdown_file.writelines("# DUMMY FILE")
                 continue
 
-            # Set description for progress bar
-            inner_pbar.set_description(f"Progressing {folder_name}")
-
-            # Create the Markdown file:
-
-            # 1. Convert the file to jupyter notebook
-            check_call(
-                ["jupytext", "--to", "notebook", file], stdout=DEVNULL, stderr=STDOUT
-            )
-
-            notebook_path = file.with_suffix(".ipynb")
-
-            # 2. Execute the notebook and convert to markdown.
-            # This is only done if we decide not to ignore the examples.
-            # The creation of the files themselves and converting them to markdown still
-            # happens since we need the files to check for link integrity.
-            convert_execute = [
-                "jupyter",
-                "nbconvert",
-                "--to",
-                "notebook",
-                "--inplace",
-                notebook_path,
-            ]
-            convert_execute.append("--execute")
-            to_markdown = ["jupyter", "nbconvert", "--to", "markdown", notebook_path]
-            env = os.environ | {"PYTHONPATH": os.getcwd()}
-            check_call(convert_execute, stdout=DEVNULL, stderr=STDOUT, env=env)
-            check_call(to_markdown, stdout=DEVNULL, stderr=STDOUT, env=env)
-
-            # CLEANUP
-            markdown_path = file.with_suffix(".md")
-            # We wrap lines which are too long as long as they do not contain a link.
-            # To discover whether a line contains a link, we check if the string "]("
-            # is contained.
-            with open(markdown_path, encoding="UTF-8") as markdown_file:
-                content = markdown_file.read()
-                wrapped_lines = []
-                ignored_substrings = (
-                    "![svg]",
-                    "![png]",
-                    "<Figure size",
-                    "it/s",
-                    "s/it",
-                )
-                for line in content.splitlines():
-                    # Skip formatter control lines so they don't appear in docs
-                    if "fmt: off" in line or "fmt: on" in line:
-                        continue
-                    if any(substring in line for substring in ignored_substrings):
-                        continue
-                    if (
-                        len(line) > 88
-                        and "](" not in line
-                        and not line.lstrip().startswith("#")
-                    ):
-                        wrapped = textwrap.wrap(line, width=88)
-                        wrapped_lines.extend(wrapped)
-                    else:
-                        wrapped_lines.append(line)
-
-            # Add a manual new line to each of the lines
-            lines = [line + "\n" for line in wrapped_lines]
-            # Delete lines we do not want to have in our documentation
-            # lines = [line for line in lines if "![svg]" not in line]
-            # We check whether pre-built light and dark plots exist. If so, we append
-            # corresponding lines to our markdown file for including them.
-            # If not, we check if a single plot version exists and append it
-            # regardless of light/dark mode.
-            light_figure = Path(sub_directory / (file_name + "_light.svg"))
-            dark_figure = Path(sub_directory / (file_name + "_dark.svg"))
-            figure = Path(sub_directory / (file_name + ".svg"))
-            if light_figure.is_file() and dark_figure.is_file():
-                lines.append(f"```{{image}} {file_name}_light.svg\n")
-                lines.append(":align: center\n")
-                lines.append(":class: only-light\n")
-                lines.append("```\n")
-                lines.append(f"```{{image}} {file_name}_dark.svg\n")
-                lines.append(":align: center\n")
-                lines.append(":class: only-dark\n")
-                lines.append("```\n")
-            elif figure.is_file():
-                lines.append(f"```{{image}} {file_name}.svg\n")
-                lines.append(":align: center\n")
-                lines.append("```\n")
-
-            # Rewrite the file
-            with open(markdown_path, "w", encoding="UTF-8") as markdown_file:
-                markdown_file.writelines(lines)
+            files_to_convert.append((file, sub_directory))
 
         # Write last line of toctree file for this directory and write the file
         subdir_toctree += "```"
@@ -207,6 +195,23 @@ def build_examples(destination_directory: Path, dummy: bool, remove_dir: bool):
             sub_directory / f"{sub_directory.name}.md", "w", encoding="UTF-8"
         ) as f:
             f.write(subdir_toctree)
+
+    # Second pass: convert the independent example files concurrently
+    if files_to_convert:
+        if max_workers is None:
+            max_workers = os.cpu_count() or 1
+        workers = max(1, min(max_workers, len(files_to_convert)))
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(_convert_example, file, sub_directory): file
+                for file, sub_directory in files_to_convert
+            }
+            # `result()` re-raises so a failed example aborts the build
+            for future in tqdm(
+                as_completed(futures), total=len(futures), desc="Converting examples"
+            ):
+                future.result()
 
     # Append the ordered list of examples to the file for the top level folder
     ex_file += "".join(ex_order)

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -1,16 +1,18 @@
-"""Utility for checking the links of the documentation."""
+"""Utility for checking the cross-references of the documentation."""
 
 from subprocess import check_call
 
 
 def check_links() -> None:
-    """Check whether the links of the documentation are valid."""
-    link_call = [
-        "sphinx-build",
-        "-b",
-        "linkcheck",
-        "docs",
-        "docs/build",
-    ]
-
-    check_call(link_call)
+    """Check that documentation cross-references resolve (external links: lychee)."""
+    check_call(
+        [
+            "sphinx-build",
+            "-b",
+            "dummy",
+            "docs",
+            "docs/build",
+            "-n",
+            "-W",
+        ]
+    )

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,7 @@
+# External link check. Keep `exclude` in sync with `linkcheck_ignore` in docs/conf.py.
+scheme = ["https", "http"]
+exclude = [
+    "https://github\\.com/b-shields/edbo/blob.*",
+    "https://doi\\.org/10\\.26434/chemrxiv\\.10001986/v2",
+    "https://doi\\.org/10\\.1039/D5DD00050E",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ commands =
     python --version
     pip-audit {env:EXCLUDES:}
 
-[testenv:docs-py310]
+[testenv:docs-py311]
 description = Build documentation, passing posargs to control what should be built
 skip_install = True
 setenv =


### PR DESCRIPTION
This PR bumps the python version used in the doc building jobs to 3.11.

This is necessary due to the way that our guarded forward references are handled. Since doc building and link checking are separateed now, the actual doc building does not have access to already "compiled" files. As a consequence, it cannot check and verify that the references can actually resolve. We thus need to ignore errors coming from those references. However, the corresponding option is only available in a newer version of sphinx-apidoc-typehints which is not available on python 3.10 and hence requires us to update to python 3.11.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>