### PR TITLE
Fix doc references

### DIFF
--- a/baybe/constraints/base.py
+++ b/baybe/constraints/base.py
@@ -88,8 +88,8 @@ class DiscreteFilteringConstraint(DiscreteConstraint, ABC):
     specification instead defines which entries are **removed** and the complement is
     kept.
 
-    Subclasses implement :meth:`_get_matching_rows` (and optionally
-    :meth:`_get_matching_rows_polars`) to express positive matching-rows logic. The
+    Subclasses implement ``_get_matching_rows`` (and optionally
+    ``_get_matching_rows_polars``) to express positive matching-rows logic. The
     base class derives the removal set and applies the ``exclude`` inversion.
     """
 

--- a/baybe/recommenders/meta/base.py
+++ b/baybe/recommenders/meta/base.py
@@ -52,7 +52,8 @@ class MetaRecommender(SerialMixin, RecommenderProtocol, ABC):
     ) -> RecommenderProtocol:
         """Follow the meta recommender chain to the selected non-meta recommender.
 
-        Recursively calls :meth:`MetaRecommender.select_recommender` until a
+        Recursively calls
+        :meth:`~baybe.recommenders.meta.base.MetaRecommender.select_recommender` until a
         non-meta recommender is encountered, which is then returned.
         Effectively, this extracts the recommender responsible for generating
         the recommendations for the specified context.

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -307,7 +307,7 @@ class GaussianProcessSurrogate(Surrogate):
         * **Eagerly:** By calling the method and passing the returned module to a GP.
         * **Lazily:** By passing the bound method itself, without eagerly calling it.
             This works because the method signature complies with
-            :class:`~.components.mean.MeanFactoryProtocol`, i.e., the new GP will use it
+            :obj:`~.components.mean.MeanFactoryProtocol`, i.e., the new GP will use it
             as a factory and call it automatically at fit time.
 
         If the mean-providing GP has not been fitted at call time, its prior mean module

--- a/baybe/transformations/base.py
+++ b/baybe/transformations/base.py
@@ -48,10 +48,11 @@ class Transformation(SerialMixin, ABC):
         In accordance with the mathematical definition of a function's `codomain
         <https://en.wikipedia.org/wiki/Codomain>`_, we define the codomain of a given
         :class:`~baybe.utils.interval.Interval` under a certain (assumed continuous)
-        :class:`~Transformation` to be an :class:`~baybe.utils.interval.Interval`
-        guaranteed to contain all possible outcomes when the :class:`~Transformation` is
-        applied to all points in the input :class:`~baybe.utils.interval.Interval`. In
-        cases where the image cannot exactly be computed, it is often still possible to
+        :class:`~baybe.transformations.base.Transformation` to be an
+        :class:`~baybe.utils.interval.Interval` guaranteed to contain all possible
+        outcomes when the :class:`~baybe.transformations.base.Transformation` is applied
+        to all points in the input :class:`~baybe.utils.interval.Interval`. In cases
+        where the image cannot exactly be computed, it is often still possible to
         compute a codomain. The codomain always contains the image, but might be larger.
         """
 
@@ -61,10 +62,10 @@ class Transformation(SerialMixin, ABC):
         In accordance with the mathematical definition of a function's `image
         <https://en.wikipedia.org/wiki/Image_(mathematics)>`_, we define the image of a
         given :class:`~baybe.utils.interval.Interval` under a certain (assumed
-        continuous) :class:`~Transformation` to be the smallest
-        :class:`~baybe.utils.interval.Interval` containing all possible outcomes when
-        the :class:`~Transformation` is applied to all points in the input
-        :class:`~baybe.utils.interval.Interval`.
+        continuous) :class:`~baybe.transformations.base.Transformation` to be the
+        smallest :class:`~baybe.utils.interval.Interval` containing all possible
+        outcomes when the :class:`~baybe.transformations.base.Transformation` is applied
+        to all points in the input :class:`~baybe.utils.interval.Interval`.
         """
         # By default, it is assumed that the exact image of an interval cannot be
         # computed but only the codomain is available (see :meth:`get_codomain`).

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,17 @@
+---
+orphan: true
+---
+
+<!-- This page exists solely to trigger the recursive autosummary stub generation for
+the API reference. The generated `_autosummary/baybe` tree is linked from the "API
+Reference" entry of the main toctree in `index.md`. Keeping the directive off the
+landing page prevents the module summary table from being rendered there. -->
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+
+   baybe
+```

--- a/docs/components/transformations.md
+++ b/docs/components/transformations.md
@@ -399,7 +399,7 @@ t = CustomTransformation(torch.sin)
 ```
 
 ````{admonition} Automatic Wrapping
-:note:
+:class: note
 
 When embedding custom transformations into another context, wrapping the `torch`
 callable into a {class}`~baybe.transformations.basic.CustomTransformation` happens

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,25 +151,59 @@ source_suffix = [".rst", ".md"]
 # Here, we define regex expressions for errors produced by nitpick that we want to
 # ignore.
 nitpick_ignore_regex = [
-    # Ignore errors that are from inherited classes we cannot control
+    ##### External package references #####
+    # Qualified references to external packages whose internal module paths cannot be
+    # resolved via intersphinx (e.g. pandas.core.frame.DataFrame vs pandas.DataFrame).
+    (
+        r"py:.*",
+        r"(pandas|numpy|torch|botorch|gpytorch|scipy|sklearn|pathlib|polars|attr|joblib|matplotlib|skfp|rdkit|shap|xyzpy|typing)[\._].*",
+    ),  # noqa: E501
+    ##### Inherited torch.nn.Module docstring references #####
+    # Unqualified names from inherited external docstrings (torch, botorch, sklearn)
+    # that cannot be resolved outside their original documentation context.
+    (r"py:class", r"^(Tensor|Module|Parameter|Dropout|BatchNorm)$"),
+    (r"py:class", r"^(Posterior|MetadataRequest|Ignored)$"),
+    (r"py:attr", r"^(persistent|grad_input|grad_output|requires_grad)$"),
+    (r"py:attr", r"^(device|dtype|dst_type|non_blocking)$"),
+    (r"py:func", r"^(register_module_forward_hook|register_module_forward_pre_hook)$"),
+    (r"py:func", r"^(register_module_full_backward_hook)$"),
+    (r"py:func", r"^(register_module_full_backward_pre_hook|load_state_dict)$"),
+    (r"py:meth", r"^nn\.Module\.load_state_dict$"),
+    ##### Inherited sklearn/scipy docstring artifacts #####
+    # sklearn docstrings use informal type descriptions that Sphinx parses as refs.
+    (r"py:class", r"^(optional|shape|shape=|n_samples|n_features|n_query)$"),
+    (r"py:class", r"^(n_features_new|n_outputs|n_indexed|n_clusters)$"),
+    (r"py:class", r"^(array-like|ndarray|ndarray array|string)$"),
+    (r"py:class", r"^(estimator instance|sparse matrix\})$"),
+    (r"py:class", r"^(\{array-like|default=.*|\{\"default\")$"),
+    (r"py:class", r"^(dtype=np\.int64|if metric == 'precomputed')$"),
+    ##### Type aliases in TYPE_CHECKING blocks #####
+    # These exist only at type-checking time and cannot be resolved by Sphinx.
+    (r"py:class", r"^(GPComponent|TensorCallable|ConvertibleToFloat)$"),
+    (r"py:class", r"^(GPyTorchKernel|GPyTorchLikelihood|GPyTorchMean|GPyTorchModel)$"),
+    (r"py:class", r"^(pd\.DataFrame|pl\.Expr)$"),
+    (r"py:class", r"^(TypeAliasForwardRef|P)$"),
+    (r"py:class", r"^\"(pandas|polars)\"\}?$"),
+    ##### BayBE-specific suppressions #####
+    # Inherited classes we cannot control
     (r"py:.*", r".*DTypeFloatONNX.*"),
-    # Ignore the functions that we manually delete from in child classes
+    # Serialization functions manually deleted from child classes
     (r"py:.*", r".*from_dict.*"),
     (r"py:.*", r".*from_json.*"),
     (r"py:.*", r".*to_dict.*"),
     (r"py:.*", r".*to_json.*"),
     (r"py:.*", r".*_T.*"),
-    # Ignore files for which no __init__ is available at all
+    # Classes for which no __init__ is available at all
     (r"py:.*", "baybe.constraints.conditions.Condition.__init__"),
     (r"py:.*", "baybe.serialization.mixin.SerialMixin.__init__"),
     (r"DeprecationWarning:", ""),
-    # Ignore the generics/aliases
+    # Generics/aliases
     (r"py:class", "baybe.utils.basic._C"),
     (r"py:class", "baybe.utils.basic._T"),
     (r"py:class", "baybe.utils.basic._U"),
     (r"py:class", "baybe.surrogates.composite._SurrogateGetter"),
     (r"ref:obj", "baybe.surrogates.base.ModelContext"),
-    # Ignore custom class properties
+    # Custom class properties
     (r"py:obj", "baybe.settings._AdoptedRandomSeed.*"),
     (r"py:obj", "baybe.acquisition.acqfs.*.supports_batching"),
     (r"py:obj", "baybe.acquisition.acqfs.*.supports_pending_experiments"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,6 @@ myst_heading_anchors = 4
 templates_path = ["templates"]
 # Tell sphinx which files should be excluded
 exclude_patterns = ["sdk", "AGENTS.md", "CLAUDE.md", "**/AGENTS.md", "**/CLAUDE.md"]
-autodoc_exclude_modules = ["baybe.utils.clustering_algorithms.third_party.kmedoids"]
 
 # Enable markdown
 # Note that we do not need additional configuration here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,8 +151,6 @@ source_suffix = [".rst", ".md"]
 # Here, we define regex expressions for errors produced by nitpick that we want to
 # ignore.
 nitpick_ignore_regex = [
-    # Ignore everything that does not include baybe
-    (r"py:.*", r"^(?!.*baybe).*"),
     # Ignore errors that are from inherited classes we cannot control
     (r"py:.*", r".*DTypeFloatONNX.*"),
     # Ignore the functions that we manually delete from in child classes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,8 +240,15 @@ linkcheck_ignore = [
 ]
 
 
-# Ignore the warnings that are given by autosectionlabel
-suppress_warnings = ["autosectionlabel.*"]
+# Ignore certain warning categories
+suppress_warnings = [
+    "autosectionlabel.*",
+    # Forward reference and guarded import warnings from sphinx-autodoc-typehints.
+    # These are unavoidable since heavy deps (torch, botorch, gpytorch) are lazy-loaded
+    # and only available in TYPE_CHECKING blocks at runtime.
+    "sphinx_autodoc_typehints.forward_reference",
+    "sphinx_autodoc_typehints.guarded_import",
+]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,15 +239,8 @@ linkcheck_ignore = [
 ]
 
 
-# Ignore certain warning categories
-suppress_warnings = [
-    "autosectionlabel.*",
-    # Forward reference and guarded import warnings from sphinx-autodoc-typehints.
-    # These are unavoidable since heavy deps (torch, botorch, gpytorch) are lazy-loaded
-    # and only available in TYPE_CHECKING blocks at runtime.
-    "sphinx_autodoc_typehints.forward_reference",
-    "sphinx_autodoc_typehints.guarded_import",
-]
+# Ignore the warnings that are given by autosectionlabel
+suppress_warnings = ["autosectionlabel.*"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,6 @@ FAQ <faq>
    :toctree: _autosummary
    :template: custom-module-template.rst
    :recursive:
-   :hidden:
 
    baybe
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,15 +23,6 @@ FAQ <faq>
 :relative-docs: docs/
 ```
 
-```{eval-rst}
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-   :recursive:
-
-   baybe
-```
-
 ```{toctree}
 :maxdepth: 2
 :titlesonly:

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy", "baybe.utils.clustering_algorithms.third_party.kmedoids") %}
+{% if not item in ("kmedoids",) %}
    {{ item }}
 {%- endif %}
 {%- endfor %}

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy") %}
+{% if not item in ("baybe.objectives.deprecation", "baybe.recommenders.pure.bayesian.sequential_greedy", "baybe.utils.clustering_algorithms.third_party.kmedoids") %}
    {{ item }}
 {%- endif %}
 {%- endfor %}

--- a/docs/templates/custom-module-template.rst
+++ b/docs/templates/custom-module-template.rst
@@ -61,7 +61,7 @@
    :template: custom-module-template.rst
    :recursive:
 {% for item in modules %}
-{% if not item in ("kmedoids",) %}
+{% if not item in ("baybe.utils.clustering_algorithms.third_party.kmedoids",) %}
    {{ item }}
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
This PR fixes incorrect doc references and makes some general changes to how we check our internal links.

# The issue

The core issue that is fixed here is that we previously ignored all links that do not contain or start with `baybe`. As a consequence, internal relative links were being skipped, and if those links were broken, we simply didn't know. 

# The fix
We now also check links that do not start with or contain the string `baybe`. This is done by removing the very general regex that we had on top of `conf.py`. As a consequence, we however now need to manually add a lot of additional regexes that we need to ignore now.

# The changes
Some broken internal links were found and are repaired now. 

# Important note
The additional regexes have been identified and added by AI. I did *not* manually review all of them, since "the tests are passing and I checked it manually" is sufficient imo.

# Compiled documentation:

Available at https://avhopp.github.io/baybe_dev/latest/

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>