### PR TITLE
Use `lychee` for docbuilding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,21 @@ jobs:
           pip install tox-uv
           tox -e lint-${{ matrix.py-version.tox }}
 
+  lychee:
+    name: "Link Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+
   build-docs:
     name: "Build Docs"
     runs-on: ubuntu-latest
-    needs: [lint]
+    needs: [lint, lychee]
     permissions:
       contents: read
       pages: write     # Required to deploy to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: -vv --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           persist-credentials: false
       - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: -vv --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CHANGELOG.md
+          args: -vv --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md
 
   build-docs:
     name: "Build Docs"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lychee:
+    name: "Link Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: -vv --root-dir ${{ github.workspace }} --config lychee.toml baybe docs examples README.md CONTRIBUTING.md CONTRIBUTORS.md CHANGELOG.md
+
   build:
+    needs: [lychee]
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to push docs to the gh-pages branch

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,13 +181,6 @@ nitpick_ignore_regex = [
     ("py:.*", "baybe.targets._deprecated.*"),
 ]
 
-# Ignore the following links when checking links for viability
-linkcheck_ignore = [
-    r"https://github.com/b-shields/edbo/blob*",
-    r"https://doi.org/10.26434/chemrxiv.10001986/v2",
-    r"https://doi.org/10.1039/D5DD00050E",
-]
-
 
 # Ignore the warnings that are given by autosectionlabel
 suppress_warnings = ["autosectionlabel.*"]

--- a/docs/scripts/build_documentation.py
+++ b/docs/scripts/build_documentation.py
@@ -7,7 +7,7 @@ import shutil
 from subprocess import check_call, run
 
 from build_examples import build_examples
-from check_links import check_links
+from check_crossrefs import check_crossrefs
 from utils import adjust_pictures
 
 parser = argparse.ArgumentParser()
@@ -19,8 +19,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "-l",
-    "--no_linkcheck",
-    help="Do not check the links.",
+    "--no-crossref-check",
+    help="Do not check cross-references.",
     action="store_true",
 )
 parser.add_argument(
@@ -45,7 +45,7 @@ parser.add_argument(
 # Parse input arguments
 args = parser.parse_args()
 RUN_EXAMPLES = args.run_examples
-LINKCHECK = not args.no_linkcheck
+CROSSREF_CHECK = not args.no_crossref_check
 FULL_REBUILD = args.full_rebuild
 INCLUDE_WARNINGS = args.include_warnings
 FORCE = args.force
@@ -79,7 +79,7 @@ def _run_apidoc() -> None:
 
 def build_documentation(
     run_examples: bool = False,
-    verify_links: bool = False,
+    verify_crossrefs: bool = False,
     full_rebuild: bool = False,
     force: bool = False,
 ) -> None:
@@ -87,8 +87,8 @@ def build_documentation(
 
     A full build of the documentation consists of converting the examples into jupyter
     notebooks, executing them, transforming them into markdown files, as well as
-    checking all links and performing the actual ``sphinx-build``. Such a full build can
-    be triggered using the ``full_rebuild`` flag.
+    checking cross-references and performing the actual ``sphinx-build``. Such a full
+    build can be triggered using the ``full_rebuild`` flag.
     If this flag is not set, this function tries to re-use as much of potentially
     existing structures like already built examples as possible. This behavior can be
     changed by using the other flags.
@@ -97,18 +97,18 @@ def build_documentation(
         run_examples: Fully recalculate the examples. If this is ``False`` and no
             folder containing an already built set of examples is found, dummy files
             replicating the structure of the examples are created.
-        verify_links: Check both internal and external links.
+        verify_crossrefs: Check that documentation cross-references resolve.
         full_rebuild: Perform a full rebuild of the documentation, including a
-            recalculation of the examples and checking the links. Note that this option
-            ignores the choices for ``run_examples`` and ``check_links`` if set to
-            ``True.
+            recalculation of the examples and checking cross-references. Note that this
+            option ignores the choices for ``run_examples`` and
+            ``verify_crossrefs`` if set to ``True``.
         force: Force-build the steps, ignoring any errors or warnings.
     """
     examples_directory = pathlib.Path("docs/examples")
     examples_exist = examples_directory.is_dir()
 
     rerun_examples = run_examples or full_rebuild
-    perform_linkcheck = verify_links or full_rebuild
+    perform_crossref_check = verify_crossrefs or full_rebuild
 
     if rerun_examples:
         build_examples(
@@ -125,8 +125,8 @@ def build_documentation(
             remove_dir=examples_exist,
         )
 
-    if perform_linkcheck:
-        check_links()
+    if perform_crossref_check:
+        check_crossrefs()
 
     # Generate the API reference stubs via sphinx-apidoc
     _run_apidoc()
@@ -158,11 +158,11 @@ if __name__ == "__main__":
     if not INCLUDE_WARNINGS:
         os.environ["PYTHONWARNINGS"] = "ignore"
 
-    print(f"{LINKCHECK=}")
+    print(f"{CROSSREF_CHECK=}")
 
     build_documentation(
         run_examples=RUN_EXAMPLES,
-        verify_links=LINKCHECK,
+        verify_crossrefs=CROSSREF_CHECK,
         full_rebuild=FULL_REBUILD,
         force=FORCE,
     )

--- a/docs/scripts/check_crossrefs.py
+++ b/docs/scripts/check_crossrefs.py
@@ -3,7 +3,7 @@
 from subprocess import check_call
 
 
-def check_links() -> None:
+def check_crossrefs() -> None:
     """Check that documentation cross-references resolve (external links: lychee)."""
     check_call(
         [

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -1,16 +1,18 @@
-"""Utility for checking the links of the documentation."""
+"""Utility for checking the cross-references of the documentation."""
 
 from subprocess import check_call
 
 
 def check_links() -> None:
-    """Check whether the links of the documentation are valid."""
-    link_call = [
-        "sphinx-build",
-        "-b",
-        "linkcheck",
-        "docs",
-        "docs/build",
-    ]
-
-    check_call(link_call)
+    """Check that documentation cross-references resolve (external links: lychee)."""
+    check_call(
+        [
+            "sphinx-build",
+            "-b",
+            "dummy",
+            "docs",
+            "docs/build",
+            "-n",
+            "-W",
+        ]
+    )

--- a/docs/scripts/check_links.py
+++ b/docs/scripts/check_links.py
@@ -12,7 +12,5 @@ def check_links() -> None:
             "dummy",
             "docs",
             "docs/build",
-            "-n",
-            "-W",
         ]
     )

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,7 @@
+# External link check. Keep `exclude` in sync with `linkcheck_ignore` in docs/conf.py.
+scheme = ["https", "http"]
+exclude = [
+    "https://github\\.com/b-shields/edbo/blob.*",
+    "https://doi\\.org/10\\.26434/chemrxiv\\.10001986/v2",
+    "https://doi\\.org/10\\.1039/D5DD00050E",
+]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,5 @@
 scheme = ["https", "http"]
 exclude = [
-    "https://github\\.com/b-shields/edbo/blob.*",
     "https://doi\\.org/10\\.26434/chemrxiv\\.10001986/v2",
     "https://doi\\.org/10\\.1039/D5DD00050E",
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,3 @@
-# External link check. Keep `exclude` in sync with `linkcheck_ignore` in docs/conf.py.
 scheme = ["https", "http"]
 exclude = [
     "https://github\\.com/b-shields/edbo/blob.*",


### PR DESCRIPTION
This PR separates the linkcheck job from the actual doc building. It does so by creating a new dedicated job for it in the CI and re-organizing the code.

# External link checking
  - Replace Sphinx's `linkcheck` builder with lychee for external URL validation
  - Add a standalone lychee CI job that scans `baybe/`, `docs/`, `examples/`, and top-level markdown files
  - Configure exclusions in `lychee.toml` (migrated from `linkcheck_ignore` in `docs/conf.py`)
  - Remove the now-unused `linkcheck_ignore` from `docs/conf.py`

# Cross-reference checking
  - Switch the Sphinx build in check_links.py from linkcheck to dummy builder, which validates internal cross-references (:class:, :func:, :meth:, intersphinx) without rendering HTML
  - The dummy builder runs without -n/-W flags because it cannot fully resolve intersphinx references (e.g. ArrayLike), which would cause false positives; the html build with -n -W checks those

# Naming cleanup
  - Rename things related to `check_links` to `change_crossrefs`

# CI changes
  - Add lychee job to ci.yml, gating build-docs on both lint and lychee

# Misc
- The CI job shows all links that have been checked or excluded. Excluded links are the internal ones (as those are handled by `sphinx`). At the end of that job there is also a short summary (see screenshots)
- We would also be able use `lychee` for internal links but since the `sphinx html` build already does this, there is no further speed-up that we can gain here.
- Up-to-date version of the fork is available at https://avhopp.github.io/baybe_dev/latest/ (built after my latest commits answering to the first review of @Scienfitz )
- 
<img width="949" height="337" alt="image" src="https://github.com/user-attachments/assets/6170a96f-ed58-4ea2-8ba5-910e3916c28a" />
<img width="188" height="216" alt="image" src="https://github.com/user-attachments/assets/9941e0df-dbed-4776-a55a-11c78ddd9f09" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>