### PR TITLE
Add generality-oriented BO features

### DIFF
--- a/baybe/aggregation/__init__.py
+++ b/baybe/aggregation/__init__.py
@@ -1,0 +1,15 @@
+"""Aggregation functions for generality-oriented optimization."""
+
+from baybe.aggregation.aggregations import (
+    MeanAggregation,
+    MinAggregation,
+    SigmoidAggregation,
+)
+from baybe.aggregation.base import AggregationFunction
+
+__all__ = [
+    "AggregationFunction",
+    "MeanAggregation",
+    "MinAggregation",
+    "SigmoidAggregation",
+]

--- a/baybe/aggregation/aggregations.py
+++ b/baybe/aggregation/aggregations.py
@@ -1,0 +1,59 @@
+"""Aggregation functions."""
+
+from __future__ import annotations
+
+import gc
+from typing import TYPE_CHECKING
+
+from attrs import define, field
+from attrs.validators import gt
+from typing_extensions import override
+
+from baybe.aggregation.base import AggregationFunction
+from baybe.utils.validation import finite_float
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+@define(frozen=True)
+class MeanAggregation(AggregationFunction):
+    """Mean over contexts."""
+
+    @override
+    def forward(self, Y: Tensor) -> Tensor:
+        """See base class."""
+        return Y.mean(dim=-1)
+
+
+@define(frozen=True)
+class MinAggregation(AggregationFunction):
+    """Minimum over contexts (worst-case generality)."""
+
+    @override
+    def forward(self, Y: Tensor) -> Tensor:
+        """See base class."""
+        return Y.min(dim=-1).values
+
+
+@define(frozen=True)
+class SigmoidAggregation(AggregationFunction):
+    """Fraction of contexts above threshold."""
+
+    threshold: float = field(validator=[finite_float])
+    """The threshold above which contexts count as successful."""
+
+    steepness: float = field(default=50.0, validator=[finite_float, gt(0.0)])
+    """Sigmoid steepness for differentiable threshold approximation."""
+
+    @override
+    def forward(self, Y: Tensor) -> Tensor:
+        """See base class."""
+        import torch
+
+        sigmoid_values = torch.sigmoid(self.steepness * (Y - self.threshold))
+        return sigmoid_values.mean(dim=-1)
+
+
+# Collect leftover original slotted classes processed by `attrs.define`
+gc.collect()

--- a/baybe/aggregation/base.py
+++ b/baybe/aggregation/base.py
@@ -1,0 +1,34 @@
+"""Base class for aggregation functions."""
+
+from __future__ import annotations
+
+import gc
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from attrs import define
+
+from baybe.serialization.mixin import SerialMixin
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+
+@define(frozen=True)
+class AggregationFunction(ABC, SerialMixin):
+    """Abstract base class for aggregation over contexts, for generality BO."""
+
+    @abstractmethod
+    def forward(self, Y: Tensor) -> Tensor:
+        """Aggregate over the last dimension.
+
+        Args:
+            Y: Tensor of shape (..., r) where r is the number of contexts.
+
+        Returns:
+            Tensor of shape (...) with the aggregated values.
+        """
+
+
+# Collect leftover original slotted classes processed by `attrs.define`
+gc.collect()

--- a/baybe/parameters/__init__.py
+++ b/baybe/parameters/__init__.py
@@ -1,6 +1,10 @@
 """BayBE parameters."""
 
-from baybe.parameters.categorical import CategoricalParameter, TaskParameter
+from baybe.parameters.categorical import (
+    CategoricalParameter,
+    GeneralityParameter,
+    TaskParameter,
+)
 from baybe.parameters.custom import CustomDiscreteParameter
 from baybe.parameters.enum import (
     CategoricalEncoding,
@@ -19,6 +23,7 @@ __all__ = [
     "CategoricalParameter",
     "CustomDiscreteParameter",
     "CustomEncoding",
+    "GeneralityParameter",
     "MeasurableMetadata",
     "NumericalContinuousParameter",
     "NumericalDiscreteParameter",

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -9,7 +9,9 @@ from attrs import Converter, define, field
 from attrs.validators import deep_iterable, instance_of, min_len
 from typing_extensions import override
 
-from baybe.parameters.base import _DiscreteLabelLikeParameter
+from baybe.aggregation.aggregations import MeanAggregation
+from baybe.aggregation.base import AggregationFunction
+from baybe.parameters.base import DiscreteParameter, _DiscreteLabelLikeParameter
 from baybe.parameters.enum import CategoricalEncoding
 from baybe.settings import active_settings
 from baybe.utils.conversion import nonstring_to_tuple, sort_tuple
@@ -86,6 +88,34 @@ class TaskParameter(CategoricalParameter):
 
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
     # See base class.
+
+
+@define(frozen=True, slots=False)
+class GeneralityParameter(_DiscreteLabelLikeParameter):
+    """Parameter marking a discrete parameter as the context dimension."""
+
+    context: DiscreteParameter = field()
+    """Parameter for the contexts."""
+
+    aggregation: AggregationFunction = field(factory=MeanAggregation)
+    """Aggregation mode over contexts."""
+
+    @property
+    def encoding(self):
+        """The encoding of the context parameter."""
+        return self.context.encoding
+
+    @override
+    @property
+    def values(self) -> tuple:
+        """The values of the context parameter."""
+        return self.context.values
+
+    @override
+    @cached_property
+    def comp_df(self) -> pd.DataFrame:
+        """The comp_df of the context parameter."""
+        return self.context.comp_df
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/parameters/enum.py
+++ b/baybe/parameters/enum.py
@@ -25,6 +25,9 @@ class _ParameterKind(Flag):
     FIDELITY = auto()
     """Fidelity parameter for multi-fidelity modelling."""
 
+    GENERALITY = auto()
+    """Generality parameter for context-aggregated optimization."""
+
     @staticmethod
     def from_parameter(parameter: Parameter) -> _ParameterKind:
         """Determine the kind of a parameter from its type."""

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -128,6 +128,13 @@ class PureRecommender(ABC, RecommenderProtocol):
                 numerical_measurements_must_be_within_tolerance=False,
             )
 
+        if searchspace._generality_parameter is not None:
+            return self._recommend_generality(
+                searchspace=searchspace,
+                batch_size=batch_size,
+                measurements=measurements,
+            )
+
         if searchspace.type is SearchSpaceType.CONTINUOUS:
             return self._recommend_continuous(
                 subspace_continuous=searchspace.continuous, batch_size=batch_size
@@ -243,6 +250,31 @@ class PureRecommender(ABC, RecommenderProtocol):
         raise NotImplementedError(
             f"A hybrid search space was provided, but the used recommender "
             f"'{self.__class__.__name__}' does not implement hybrid recommendation."
+        )
+
+    def _recommend_generality(
+        self,
+        searchspace: SearchSpace,
+        batch_size: int,
+        measurements: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        """Generate recommendations for search spaces with a generality parameter.
+
+        Args:
+            searchspace: The search space containing the generality parameter.
+            batch_size: The size of the recommendation batch.
+            measurements: The preprocessed measurements.
+
+        Raises:
+            NotImplementedError: If the function is not implemented by the child class.
+
+        Returns:
+            A dataframe containing the recommendations as individual rows.
+        """
+        raise NotImplementedError(
+            f"A generality parameter is present in the search space, but the used "
+            f"recommender '{self.__class__.__name__}' does not implement generality "
+            f"recommendation."
         )
 
     def _recommend_with_discrete_parts(

--- a/baybe/recommenders/pure/bayesian/core.py
+++ b/baybe/recommenders/pure/bayesian/core.py
@@ -30,6 +30,7 @@ from baybe.recommenders.pure.bayesian.discrete import (
     recommend_discrete_with_subsets,
     recommend_discrete_without_subsets,
 )
+from baybe.recommenders.pure.bayesian.generality import recommend_generality
 from baybe.recommenders.pure.bayesian.hybrid import (
     recommend_hybrid_with_subsets,
     recommend_hybrid_without_subsets,
@@ -247,6 +248,16 @@ class BayesianRecommender(PureRecommender):
                 ) from ex
             else:
                 raise
+
+    @override
+    def _recommend_generality(
+        self,
+        searchspace: SearchSpace,
+        batch_size: int,
+        measurements: pd.DataFrame | None = None,
+    ) -> pd.DataFrame:
+        """Generate recommendations for search spaces with a generality parameter."""
+        return recommend_generality(self, searchspace, batch_size, measurements)
 
     @override
     def _recommend_discrete(

--- a/baybe/recommenders/pure/bayesian/generality.py
+++ b/baybe/recommenders/pure/bayesian/generality.py
@@ -1,0 +1,138 @@
+"""Generality recommendation logic for BayesianRecommender (CurryBO algorithm)."""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, NamedTuple
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+    from baybe.parameters.categorical import GeneralityParameter
+    from baybe.recommenders.pure.bayesian.core import BayesianRecommender
+    from baybe.searchspace import SearchSpace
+
+
+class _Context(NamedTuple):
+    """Context values and column mapping for the generality parameter."""
+
+    w_values_comp: Tensor
+    """All context values in comp-rep."""
+
+    x_col_indices: list[int]
+    """Indices of X columns in the full comp-rep."""
+
+    w_col_indices: list[int]
+    """Indices of W columns in the full comp-rep."""
+
+    gen_param: GeneralityParameter
+    """The generality parameter object."""
+
+
+def recommend_generality(
+    recommender: BayesianRecommender,
+    searchspace: SearchSpace,
+    batch_size: int,
+    measurements: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Two-step generality recommendation.
+
+    Step 1: Optimize acquisition function over x-space using a
+        model wrapper that aggregates predictions across all contexts.
+    Step 2: Select which context to measure via posterior uncertainty.
+
+    Args:
+        recommender: The BayesianRecommender instance.
+        searchspace: The full search space (possibly pre-filtered by campaign).
+        batch_size: Number of points to recommend.
+        measurements: The preprocessed measurements.
+
+    Returns:
+        DataFrame with batch_size rows of recommended experiments.
+    """
+    from botorch.acquisition.analytic import PosteriorStandardDeviation
+    from botorch.acquisition.objective import IdentityMCObjective
+
+    from baybe.acquisition.base import _get_botorch_acqf_class
+    from baybe.surrogates.generality import _GeneralityModel
+    from baybe.utils.basic import match_attributes
+
+    gen_param = searchspace._generality_parameter
+
+    objective = recommender._objective
+    base_model = recommender._surrogate_model.to_botorch()
+
+    x_subspace, x_col_indices, w_col_indices, w_values = (
+        searchspace._split_by_generality()
+    )
+    w_ctx = _Context(
+        w_values_comp=w_values,
+        x_col_indices=x_col_indices,
+        w_col_indices=w_col_indices,
+        gen_param=gen_param,
+    )
+
+    target_transform = objective.to_botorch()
+
+    gen_model = _GeneralityModel(
+        base_model=base_model,
+        w_values_comp=w_ctx.w_values_comp,
+        x_col_indices=w_ctx.x_col_indices,
+        w_col_indices=w_ctx.w_col_indices,
+        aggregation=gen_param.aggregation,
+        target_transform=target_transform,
+    )
+
+    acqf_obj = recommender._get_acquisition_function(objective)
+    botorch_acqf_cls = _get_botorch_acqf_class(type(acqf_obj))
+
+    acqf_kwargs: dict = dict(
+        model=gen_model,
+        objective=IdentityMCObjective(),
+    )
+
+    if not objective.is_multi_output:
+        from botorch.acquisition.analytic import PosteriorMean
+
+        _, best_f_scores = recommender.optimizer(
+            1, PosteriorMean(model=gen_model), x_subspace
+        )
+        acqf_kwargs["best_f"] = best_f_scores.item()
+
+    user_attrs, _ = match_attributes(
+        acqf_obj,
+        botorch_acqf_cls.__init__,
+        strict=False,
+        ignore=acqf_obj._non_botorch_attrs,
+    )
+    acqf_kwargs.update(user_attrs)
+
+    sig = inspect.signature(botorch_acqf_cls).parameters
+    botorch_acqf = botorch_acqf_cls(
+        **{k: v for k, v in acqf_kwargs.items() if k in sig}
+    )
+
+    x_points, _ = recommender.optimizer(batch_size, botorch_acqf, x_subspace)
+
+    w_acqf = PosteriorStandardDeviation(model=base_model)
+
+    rows: list[dict] = []
+    for i in range(batch_size):
+        x_comp = x_points[i]
+        x_exp_row = x_subspace._comp_rep_to_exp_rep(
+            dict(zip(x_subspace.comp_rep_columns, x_comp.tolist()))
+        )
+
+        w_searchspace = searchspace._fix_parameters(**x_exp_row)
+        w_point, _ = recommender.optimizer(1, w_acqf, w_searchspace)
+        w_exp_row = w_searchspace._comp_rep_to_exp_rep(
+            dict(zip(w_searchspace.comp_rep_columns, w_point[0].tolist()))
+        )
+
+        entry = dict(x_exp_row)
+        entry[gen_param.name] = w_exp_row[gen_param.name]
+        rows.append(entry)
+
+    return pd.DataFrame(rows)

--- a/baybe/searchspace/core.py
+++ b/baybe/searchspace/core.py
@@ -16,8 +16,8 @@ from typing_extensions import override
 
 from baybe.constraints import validate_constraints
 from baybe.constraints.base import Constraint
-from baybe.exceptions import InfeasibilityError
-from baybe.parameters import TaskParameter
+from baybe.exceptions import IncompatibilityError, InfeasibilityError
+from baybe.parameters import GeneralityParameter, TaskParameter
 from baybe.parameters.base import Parameter
 from baybe.searchspace.continuous import SubspaceContinuous
 from baybe.searchspace.discrete import (
@@ -33,6 +33,8 @@ from baybe.serialization import SerialMixin, converter, select_constructor_hook
 from baybe.utils.conversion import to_string
 
 if TYPE_CHECKING:
+    from torch import Tensor
+
     from baybe.parameters.selectors import ParameterSelectorProtocol
 
 
@@ -380,6 +382,68 @@ class SearchSpace(SerialMixin):
             # When there are no task parameters, we effectively have a single task
             return 1
         return len(task_param.values)
+
+    @property
+    def _generality_parameter(self) -> GeneralityParameter | None:
+        """The (single) generality parameter of the space, if it exists."""
+        params = [p for p in self.parameters if isinstance(p, GeneralityParameter)]
+
+        if not params:
+            return None
+
+        assert len(params) == 1
+        return params[0]
+
+    def _split_by_generality(
+        self,
+    ) -> tuple[SearchSpace, list[int], list[int], Tensor]:
+        """Split the search space into design subspace and generality context.
+
+        Separates the generality (context) parameter from the design parameters
+        and computes the associated comp-rep column indices and context values.
+
+        Raises:
+            IncompatibilityError: If constraints involve both design and generality
+                parameters.
+
+        Returns:
+            A tuple of (design_subspace, x_col_indices, w_col_indices, w_values)
+            where the indices refer to column positions in the full comp-rep and
+            w_values is the comp-rep encoding of all context values, shape (r, d_w).
+        """
+        import torch
+
+        gen_param = self._generality_parameter
+
+        x_params = [p for p in self.parameters if p.name != gen_param.name]
+        x_param_names = {p.name for p in x_params}
+
+        for c in self.constraints:
+            c_params = set(c.parameters)
+            if gen_param.name in c_params and bool(c_params & x_param_names):
+                raise IncompatibilityError(
+                    "Constraints involving both design parameters and the context "
+                    "parameter are not supported for generality optimization."
+                )
+
+        sample_row = self.discrete.exp_rep.head(1)
+        full_comp = self.transform(sample_row, allow_extra=True)
+        full_columns = list(full_comp.columns)
+
+        w_comp_columns = list(gen_param.comp_df.columns)
+        w_col_indices = [full_columns.index(c) for c in w_comp_columns]
+        x_col_indices = [i for i in range(len(full_columns)) if i not in w_col_indices]
+
+        w_values = torch.tensor(gen_param.comp_df.values, dtype=torch.float)
+
+        x_constraints = [
+            c for c in self.constraints if set(c.parameters) <= x_param_names
+        ]
+        design_subspace = SearchSpace.from_product(
+            parameters=x_params, constraints=x_constraints
+        )
+
+        return design_subspace, x_col_indices, w_col_indices, w_values
 
     @property
     def n_subsets(self) -> int:

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -7,7 +7,7 @@ from typing import TypeVar
 import pandas as pd
 
 from baybe.exceptions import EmptySearchSpaceError, IncompatibilityError
-from baybe.parameters import TaskParameter
+from baybe.parameters import GeneralityParameter, TaskParameter
 from baybe.parameters.base import Parameter, _DiscreteLabelLikeParameter
 from baybe.utils.dataframe import get_transform_objects
 
@@ -39,6 +39,8 @@ def validate_parameters(parameters: Collection[Parameter]) -> None:  # noqa: DOC
         EmptySearchSpaceError: If the parameter list is empty.
         NotImplementedError: If more than one
             :class:`baybe.parameters.categorical.TaskParameter` is requested.
+        IncompatibilityError: If both a TaskParameter and a GeneralityParameter
+            are present.
     """
     if not parameters:
         raise EmptySearchSpaceError("At least one parameter must be provided.")
@@ -47,6 +49,19 @@ def validate_parameters(parameters: Collection[Parameter]) -> None:  # noqa: DOC
     if len([p for p in parameters if isinstance(p, TaskParameter)]) > 1:
         raise NotImplementedError(
             "Currently, at most one task parameter can be considered."
+        )
+
+    n_generality = len([p for p in parameters if isinstance(p, GeneralityParameter)])
+    if n_generality > 1:
+        raise NotImplementedError(
+            "Currently, at most one generality parameter can be considered."
+        )
+
+    has_task = any(isinstance(p, TaskParameter) for p in parameters)
+    if has_task and n_generality > 0:
+        raise IncompatibilityError(
+            "TaskParameter and GeneralityParameter cannot be used in the same "
+            "search space."
         )
 
     # Assert: unique names

--- a/baybe/surrogates/generality.py
+++ b/baybe/surrogates/generality.py
@@ -1,0 +1,224 @@
+"""Generality model wrapper for context-aggregated Bayesian optimization."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from botorch.models.model import Model
+from botorch.posteriors import Posterior
+from torch import Tensor
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from baybe.aggregation.base import AggregationFunction
+
+
+class _GeneralityPosterior(Posterior):
+    """Posterior that aggregates base GP posterior across context values."""
+
+    def __init__(
+        self,
+        base_posterior: Posterior,
+        q: int,
+        r: int,
+        m: int,
+        aggregation: AggregationFunction,
+        target_transform: torch.nn.Module,
+        n_variance_samples: int = 64,
+    ) -> None:
+        super().__init__()
+        self._base = base_posterior
+        self._q = q
+        self._r = r
+        self._m = m
+        self._aggregation = aggregation
+        self._target_transform = target_transform
+        self._n_variance_samples = n_variance_samples
+
+    @override
+    @property
+    def device(self) -> torch.device:
+        """The device of the posterior."""
+        return self._base.device
+
+    @override
+    @property
+    def dtype(self) -> torch.dtype:
+        """The dtype of the posterior."""
+        return self._base.dtype
+
+    @property
+    def batch_shape(self) -> torch.Size:
+        """The batch shape of the posterior."""
+        return self._base.batch_shape  # type: ignore[attr-defined]
+
+    @override
+    @property
+    def base_sample_shape(self) -> torch.Size:
+        """The base sample shape."""
+        return self._base.base_sample_shape
+
+    @override
+    @property
+    def batch_range(self) -> tuple[int, int]:
+        """The t-batch range."""
+        return self._base.batch_range
+
+    @override
+    def rsample(self, sample_shape: torch.Size | None = None) -> Tensor:
+        """Draw samples and aggregate over contexts."""
+        if sample_shape is None:
+            sample_shape = torch.Size()
+        samples = self._base.rsample(sample_shape)
+        return self._aggregate(samples)
+
+    @override
+    def rsample_from_base_samples(
+        self,
+        sample_shape: torch.Size,
+        base_samples: Tensor,
+    ) -> Tensor:
+        """Draw samples from base samples and aggregate over contexts."""
+        samples = self._base.rsample_from_base_samples(sample_shape, base_samples)
+        return self._aggregate(samples)
+
+    @property
+    def mean(self) -> Tensor:
+        """Aggregated posterior mean."""
+        mean = self._base.mean  # type: ignore[attr-defined]
+        return self._aggregate_mean(mean)
+
+    @property
+    def variance(self) -> Tensor:
+        """Aggregated posterior variance via MC samples."""
+        samples = self.rsample(torch.Size([self._n_variance_samples]))
+        return samples.var(dim=0)
+
+    def _aggregate(self, samples: Tensor) -> Tensor:
+        """Aggregate samples over context dimension."""
+        samples = samples.view(*samples.shape[:-2], self._q, self._r, self._m)
+        samples = self._target_transform(samples, None)
+        samples = samples.transpose(-1, -2)  # (..., q, m, r)
+        return self._aggregation.forward(samples)  # (..., q, m)
+
+    def _aggregate_mean(self, mean: Tensor) -> Tensor:
+        """Aggregate mean tensor."""
+        mean = mean.view(*mean.shape[:-2], self._q, self._r, self._m)
+        mean = self._target_transform(mean, None)
+        mean = mean.transpose(-1, -2)  # (..., q, m, r)
+        return self._aggregation.forward(mean)  # (..., q, m)
+
+
+def _register_generality_sampler() -> None:
+    """Register a sampler for _GeneralityPosterior with BoTorch's dispatcher."""
+    from botorch.sampling.get_sampler import GetSampler
+    from botorch.sampling.normal import SobolQMCNormalSampler
+
+    @GetSampler.register(_GeneralityPosterior)
+    def _get_sampler_generality(
+        posterior: _GeneralityPosterior,
+        sample_shape: torch.Size,
+        seed: int | None = None,
+    ) -> SobolQMCNormalSampler:
+        # Delegate to base posterior's sampler, but wrap in our aggregation.
+        # Since _GeneralityPosterior.rsample() handles aggregation internally,
+        # we just need the sampler to call rsample() correctly.
+        # Use the base posterior's event shape for base_samples.
+        return SobolQMCNormalSampler(sample_shape=sample_shape, seed=seed)
+
+
+_register_generality_sampler()
+
+
+class _GeneralityModel(Model):
+    """BoTorch Model wrapper for generality-oriented optimization."""
+
+    w_values_comp: Tensor
+
+    def __init__(
+        self,
+        base_model: Model,
+        w_values_comp: Tensor,
+        x_col_indices: list[int],
+        w_col_indices: list[int],
+        aggregation: AggregationFunction,
+        target_transform: torch.nn.Module,
+    ) -> None:
+        super().__init__()
+        self.base_model = base_model
+        self.register_buffer("w_values_comp", w_values_comp)
+        self._x_col_indices = x_col_indices
+        self._w_col_indices = w_col_indices
+        self._aggregation = aggregation
+        self._target_transform = target_transform
+        self._r = w_values_comp.shape[0]
+        self._m = base_model.num_outputs
+        self._d_full = len(x_col_indices) + len(w_col_indices)
+
+    @override
+    @property
+    def num_outputs(self) -> int:
+        """Number of outputs after aggregation (one per target)."""
+        return self._m
+
+    @override
+    def posterior(  # type: ignore[override]
+        self,
+        X: Tensor,
+        output_indices: list[int] | None = None,
+        observation_noise: bool = False,
+        posterior_transform: Any = None,
+    ) -> _GeneralityPosterior:
+        """Compute the aggregated posterior.
+
+        Args:
+            X: Input tensor in x-only space.
+            output_indices: Ignored.
+            observation_noise: Ignored.
+            posterior_transform: Ignored.
+
+        Returns:
+            _GeneralityPosterior: Aggregated posterior over context values.
+        """
+        q = X.shape[-2]
+        X_full = self._expand(X)
+        base_posterior = self.base_model.posterior(X_full)
+        return _GeneralityPosterior(
+            base_posterior,
+            q,
+            self._r,
+            self._m,
+            self._aggregation,
+            self._target_transform,
+        )
+
+    def _expand(self, X: Tensor) -> Tensor:
+        """Pair each candidate with all context values for the base GP.
+
+        Args:
+            X: Tensor in x-subspace.
+
+        Returns:
+            Tensor in (x,w)-space, expanded over all contexts.
+        """
+        batch_shape = X.shape[:-2]
+        q = X.shape[-2]
+
+        x_expanded = X.unsqueeze(-2).expand(*batch_shape, q, self._r, -1)
+        w_expanded = self.w_values_comp.expand(*batch_shape, q, self._r, -1)
+
+        parts: list[Tensor] = []
+        x_idx = 0
+        w_idx = 0
+        x_set = set(self._x_col_indices)
+        for i in range(self._d_full):
+            if i in x_set:
+                parts.append(x_expanded[..., x_idx : x_idx + 1])
+                x_idx += 1
+            else:
+                parts.append(w_expanded[..., w_idx : w_idx + 1])
+                w_idx += 1
+
+        X_full = torch.cat(parts, dim=-1)  # (..., q, r, d_full)
+        return X_full.reshape(*batch_shape, q * self._r, self._d_full)

--- a/tests/test_generality.py
+++ b/tests/test_generality.py
@@ -1,0 +1,494 @@
+"""Tests for generality-oriented Bayesian optimization (CurryBO)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pandas as pd
+import pytest
+import torch
+from torch import nn
+
+from baybe.aggregation import MeanAggregation, MinAggregation, SigmoidAggregation
+from baybe.parameters import CategoricalParameter, NumericalDiscreteParameter
+from baybe.parameters.categorical import GeneralityParameter
+from baybe.searchspace import SearchSpace
+
+
+class _NoOpTransform(nn.Module):
+    """Identity transform matching BoTorch's (Y, Yvar) call signature."""
+
+    def forward(self, Y, Yvar=None):
+        return Y
+
+
+# ─── Aggregation unit tests ───────────────────────────────────────────────────
+
+
+class TestAggregation:
+    """Unit tests for aggregation functions."""
+
+    def test_mean(self):
+        """MeanAggregation averages over last dim."""
+        Y = torch.tensor([[1.0, 2.0, 3.0]])
+        assert torch.allclose(MeanAggregation().forward(Y), torch.tensor([2.0]))
+
+    def test_min(self):
+        """MinAggregation takes minimum over last dim."""
+        Y = torch.tensor([[1.0, 2.0, 3.0]])
+        assert torch.allclose(MinAggregation().forward(Y), torch.tensor([1.0]))
+
+    def test_sigmoid(self):
+        """SigmoidAggregation gives fraction above threshold (smooth)."""
+        Y = torch.tensor([[0.0, 1.0]])  # threshold=0.5 → one below, one above
+        result = SigmoidAggregation(threshold=0.5, steepness=100.0).forward(Y)
+        # With high steepness, should be close to 0.5 (1 of 2 above)
+        assert 0.4 < result.item() < 0.6
+
+    def test_single_context(self):
+        """All aggregations handle r=1 (single context value)."""
+        Y = torch.tensor([[7.0]])
+        assert MeanAggregation().forward(Y).item() == pytest.approx(7.0)
+        assert MinAggregation().forward(Y).item() == pytest.approx(7.0)
+        sig = SigmoidAggregation(threshold=5.0, steepness=100.0)
+        assert sig.forward(Y).item() > 0.9
+
+    def test_batch_shape_preserved(self):
+        """Aggregation preserves leading batch dimensions."""
+        Y = torch.randn(4, 3, 5)  # (batch=4, q=3, r=5)
+        result = MeanAggregation().forward(Y)
+        assert result.shape == (4, 3)
+
+
+# ─── SearchSpace._split_by_generality ─────────────────────────────────────────
+
+
+@pytest.fixture(name="gen_searchspace")
+def fixture_gen_searchspace():
+    """A search space with one design param and one generality param."""
+    x = NumericalDiscreteParameter("x", values=[1.0, 2.0, 3.0])
+    w = GeneralityParameter(
+        name="solvent",
+        context=CategoricalParameter("solvent", values=["A", "B", "C"]),
+    )
+    return SearchSpace.from_product(parameters=[x, w])
+
+
+class TestSplitByGenerality:
+    """Tests for _split_by_generality."""
+
+    def test_design_subspace_excludes_generality(self, gen_searchspace):
+        """Design subspace contains only non-generality parameters."""
+        design_ss, _, _, _ = gen_searchspace._split_by_generality()
+        assert "x" in design_ss.parameter_names
+        assert "solvent" not in design_ss.parameter_names
+
+    def test_w_values_shape(self, gen_searchspace):
+        """w_values has shape (n_contexts, d_w)."""
+        _, _, _, w_values = gen_searchspace._split_by_generality()
+        assert w_values.shape[0] == 3  # A, B, C
+
+    def test_indices_cover_all_columns(self, gen_searchspace):
+        """x_col_indices + w_col_indices = all column indices."""
+        _, x_idx, w_idx, _ = gen_searchspace._split_by_generality()
+        n_cols = len(gen_searchspace.comp_rep_columns)
+        assert sorted(x_idx + w_idx) == list(range(n_cols))
+
+    def test_constraint_across_design_and_context_raises(self):
+        """Constraint spanning both design and context params raises."""
+        from baybe.constraints.conditions import (
+            SubSelectionCondition,
+            ThresholdCondition,
+        )
+        from baybe.constraints.discrete import DiscreteExcludeConstraint
+        from baybe.exceptions import IncompatibilityError
+
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0, 3.0])
+        w = GeneralityParameter(
+            name="solvent",
+            context=CategoricalParameter("solvent", values=["A", "B", "C"]),
+        )
+        ss = SearchSpace.from_product(
+            parameters=[x, w],
+            constraints=[
+                DiscreteExcludeConstraint(
+                    parameters=["x", "solvent"],
+                    combiner="AND",
+                    conditions=[
+                        ThresholdCondition(threshold=2.0, operator=">"),
+                        SubSelectionCondition(selection=["A"]),
+                    ],
+                )
+            ],
+        )
+        with pytest.raises(IncompatibilityError, match="[Cc]onstraint"):
+            ss._split_by_generality()
+
+
+# ─── SearchSpace._fix_parameters ──────────────────────────────────────────────
+
+
+class TestFixParameters:
+    """Tests for _fix_parameters."""
+
+    def test_returns_new_space_with_fixed_values(self, gen_searchspace):
+        """Fixed values propagate to the new space's discrete subspace."""
+        fixed = gen_searchspace._fix_parameters(x=2.0)
+        assert fixed.discrete._fixed_values == {"x": 2.0}
+
+    def test_unknown_param_raises(self, gen_searchspace):
+        """Fixing an unknown parameter raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown"):
+            gen_searchspace._fix_parameters(bogus=1.0)
+
+    def test_original_unchanged(self, gen_searchspace):
+        """Original space is not mutated."""
+        gen_searchspace._fix_parameters(x=2.0)
+        assert gen_searchspace.discrete._fixed_values == {}
+
+
+# ─── SearchSpace._comp_rep_to_exp_rep ─────────────────────────────────────────
+
+
+class TestCompRepToExpRep:
+    """Tests for _comp_rep_to_exp_rep."""
+
+    def test_numerical_roundtrip(self):
+        """Numerical discrete parameter round-trips through comp-rep."""
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0, 3.0])
+        ss = SearchSpace.from_product(parameters=[x])
+        comp_cols = ss.comp_rep_columns
+        result = ss._comp_rep_to_exp_rep({comp_cols[0]: 2.0})
+        assert result["x"] == 2.0
+
+    def test_onehot_categorical_roundtrip(self):
+        """One-hot encoded categorical round-trips correctly."""
+        cat = CategoricalParameter("color", values=["red", "blue", "green"])
+        ss = SearchSpace.from_product(parameters=[cat])
+        # Get comp-rep for "blue"
+        comp_row = ss.discrete.comp_rep[ss.discrete.exp_rep["color"] == "blue"].iloc[0]
+        comp_dict = comp_row.to_dict()
+        result = ss._comp_rep_to_exp_rep(comp_dict)
+        assert result["color"] == "blue"
+
+
+# ─── _ReducedSearchSpace ──────────────────────────────────────────────────────
+
+
+class TestReducedSearchSpace:
+    """Tests for _ReducedSearchSpace attribute guard."""
+
+    def test_allowed_attributes_work(self):
+        """Allowed attributes are accessible."""
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0])
+        cat = CategoricalParameter("c", values=["A", "B"])
+        ss = SearchSpace.from_product(parameters=[x, cat])
+        reduced = ss._drop_parameters({"x"})
+        # These should not raise
+        _ = reduced.parameters
+        _ = reduced.parameter_names
+        _ = reduced.comp_rep_columns
+
+    def test_disallowed_attribute_raises(self):
+        """Accessing transform or other heavy methods raises AttributeError."""
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0])
+        cat = CategoricalParameter("c", values=["A", "B"])
+        ss = SearchSpace.from_product(parameters=[x, cat])
+        reduced = ss._drop_parameters({"x"})
+        with pytest.raises(AttributeError, match="does not support"):
+            reduced.transform(pd.DataFrame())
+
+
+# ─── _GeneralityModel._expand ─────────────────────────────────────────────────
+
+
+class TestGeneralityModelExpand:
+    """Tests for _GeneralityModel._expand content correctness."""
+
+    def test_expand_interleaving(self):
+        """Columns are interleaved correctly per x_col_indices/w_col_indices."""
+        from baybe.surrogates.generality import _GeneralityModel
+
+        # x has 1 col at index 0, w has 2 cols at indices 1,2
+        base_model = MagicMock()
+        base_model.num_outputs = 1
+        w_values = torch.tensor([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+
+        model = _GeneralityModel(
+            base_model=base_model,
+            w_values_comp=w_values,
+            x_col_indices=[0],
+            w_col_indices=[1, 2],
+            aggregation=MeanAggregation(),
+            target_transform=_NoOpTransform(),
+        )
+
+        X = torch.tensor([[7.0]])  # q=1, d_x=1
+        result = model._expand(X)
+
+        # Output shape: (q*r, d_full) = (3, 3)
+        assert result.shape == (3, 3)
+        # Column 0 (x) should be 7.0 for all rows
+        assert torch.allclose(result[:, 0], torch.tensor([7.0, 7.0, 7.0]))
+        # Columns 1,2 (w) should be the w_values rows
+        assert torch.allclose(result[:, 1:], w_values)
+
+    def test_expand_x_cols_not_contiguous(self):
+        """Works when x columns are non-contiguous (e.g., indices 0 and 2)."""
+        from baybe.surrogates.generality import _GeneralityModel
+
+        base_model = MagicMock()
+        base_model.num_outputs = 1
+        w_values = torch.tensor([[0.5], [0.9]])  # r=2, d_w=1
+
+        model = _GeneralityModel(
+            base_model=base_model,
+            w_values_comp=w_values,
+            x_col_indices=[0, 2],  # x at positions 0 and 2
+            w_col_indices=[1],  # w at position 1
+            aggregation=MeanAggregation(),
+            target_transform=_NoOpTransform(),
+        )
+
+        X = torch.tensor([[1.0, 3.0]])  # q=1, d_x=2
+        result = model._expand(X)
+
+        # Shape: (q*r, d_full) = (2, 3)
+        assert result.shape == (2, 3)
+        # Col 0: x[0] = 1.0
+        assert torch.allclose(result[:, 0], torch.tensor([1.0, 1.0]))
+        # Col 1: w values
+        assert torch.allclose(result[:, 1], torch.tensor([0.5, 0.9]))
+        # Col 2: x[1] = 3.0
+        assert torch.allclose(result[:, 2], torch.tensor([3.0, 3.0]))
+
+    def test_expand_batch_shape(self):
+        """Handles batch dimensions correctly."""
+        from baybe.surrogates.generality import _GeneralityModel
+
+        base_model = MagicMock()
+        base_model.num_outputs = 1
+        w_values = torch.tensor([[0.1], [0.2]])
+
+        model = _GeneralityModel(
+            base_model=base_model,
+            w_values_comp=w_values,
+            x_col_indices=[0],
+            w_col_indices=[1],
+            aggregation=MeanAggregation(),
+            target_transform=_NoOpTransform(),
+        )
+
+        X = torch.randn(5, 3, 1)  # batch=5, q=3, d_x=1
+        result = model._expand(X)
+        # (5, q*r, d_full) = (5, 6, 2)
+        assert result.shape == (5, 6, 2)
+
+
+# ─── _GeneralityPosterior._aggregate ──────────────────────────────────────────
+
+
+class TestGeneralityPosteriorAggregate:
+    """Tests for _GeneralityPosterior aggregation logic."""
+
+    def _make_posterior(self, samples, q, r, m, aggregation=None):
+        """Build a _GeneralityPosterior with a mock base that returns samples."""
+        from baybe.surrogates.generality import _GeneralityPosterior
+
+        if aggregation is None:
+            aggregation = MeanAggregation()
+
+        base_posterior = MagicMock()
+        base_posterior.rsample = MagicMock(return_value=samples)
+        base_posterior.device = torch.device("cpu")
+        base_posterior.dtype = torch.float32
+
+        return _GeneralityPosterior(
+            base_posterior=base_posterior,
+            q=q,
+            r=r,
+            m=m,
+            aggregation=aggregation,
+            target_transform=_NoOpTransform(),
+        )
+
+    def test_mean_aggregation_numerical(self):
+        """Mean aggregation produces correct values with known input."""
+        # q=1, r=3, m=1 → base returns shape (n_samples, q*r, m) = (1, 3, 1)
+        # Values per context: 2, 4, 6 → mean = 4
+        samples = torch.tensor([[[2.0], [4.0], [6.0]]])
+        post = self._make_posterior(samples, q=1, r=3, m=1)
+        result = post.rsample(torch.Size([1]))
+        assert result.shape == (1, 1, 1)  # (n_samples, q, m)
+        assert result.item() == pytest.approx(4.0)
+
+    def test_min_aggregation_numerical(self):
+        """Min aggregation picks worst context."""
+        samples = torch.tensor([[[2.0], [4.0], [6.0]]])
+        post = self._make_posterior(
+            samples, q=1, r=3, m=1, aggregation=MinAggregation()
+        )
+        result = post.rsample(torch.Size([1]))
+        assert result.item() == pytest.approx(2.0)
+
+    def test_multi_q(self):
+        """Aggregation works with multiple candidates (q>1)."""
+        # q=2, r=2, m=1 → base shape (1, 4, 1)
+        # Candidate 1: contexts [1, 3] → mean 2
+        # Candidate 2: contexts [5, 7] → mean 6
+        samples = torch.tensor([[[1.0], [3.0], [5.0], [7.0]]])
+        post = self._make_posterior(samples, q=2, r=2, m=1)
+        result = post.rsample(torch.Size([1]))
+        assert result.shape == (1, 2, 1)
+        assert result[0, 0, 0].item() == pytest.approx(2.0)
+        assert result[0, 1, 0].item() == pytest.approx(6.0)
+
+    def test_mean_property(self):
+        """The mean property aggregates correctly."""
+        from baybe.surrogates.generality import _GeneralityPosterior
+
+        base_posterior = MagicMock()
+        type(base_posterior).mean = PropertyMock(
+            return_value=torch.tensor([[[2.0], [4.0], [6.0]]])
+        )
+        base_posterior.device = torch.device("cpu")
+        base_posterior.dtype = torch.float32
+
+        post = _GeneralityPosterior(
+            base_posterior=base_posterior,
+            q=1,
+            r=3,
+            m=1,
+            aggregation=MeanAggregation(),
+            target_transform=_NoOpTransform(),
+        )
+        assert post.mean.item() == pytest.approx(4.0)
+
+
+# ─── recommend_generality wiring ──────────────────────────────────────────────
+
+
+class TestRecommendGeneralityWiring:
+    """Tests for recommend_generality with mocked surrogate and optimizer."""
+
+    @pytest.fixture(name="setup")
+    def fixture_setup(self):
+        """Set up a mocked recommender and search space for generality."""
+        from baybe.objectives import SingleTargetObjective
+        from baybe.targets import NumericalTarget
+
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0, 3.0])
+        w = GeneralityParameter(
+            name="solvent",
+            context=CategoricalParameter("solvent", values=["A", "B", "C"]),
+        )
+        ss = SearchSpace.from_product(parameters=[x, w])
+        objective = SingleTargetObjective(target=NumericalTarget("yield"))
+
+        measurements = pd.DataFrame(
+            {"x": [1.0, 2.0], "solvent": ["A", "B"], "yield": [0.5, 0.8]}
+        )
+
+        return ss, objective, measurements
+
+    def _make_recommender_mock(self, ss, objective):
+        """Build a mocked recommender for recommend_generality."""
+        from baybe.acquisition.acqfs import ExpectedImprovement
+
+        design_ss, _, _, _ = ss._split_by_generality()
+
+        mock_base_model = MagicMock()
+        mock_base_model.num_outputs = 1
+        mock_base_model.posterior = MagicMock(
+            return_value=MagicMock(
+                mean=torch.zeros(1, 1),
+                variance=torch.ones(1, 1),
+            )
+        )
+
+        recommender = MagicMock()
+        recommender._objective = objective
+        recommender._surrogate_model.to_botorch.return_value = mock_base_model
+        recommender._get_acquisition_function = MagicMock(
+            return_value=ExpectedImprovement()
+        )
+        return recommender, design_ss
+
+    def _make_smart_optimizer(self, ss):
+        """Return a fake optimizer that returns valid comp-rep for any subspace."""
+        design_ss, _, _, _ = ss._split_by_generality()
+
+        def fake_optimizer(batch_size, acqf, space):
+            # Return the first row of comp-rep for whatever space is passed
+            import numpy as np
+
+            if not space.discrete.is_empty and len(space.discrete.comp_rep) > 0:
+                row = np.array(space.discrete.comp_rep.iloc[0].values, dtype=float)
+            else:
+                n_cols = len(space.comp_rep_columns)
+                row = np.zeros(n_cols)
+            pts = torch.from_numpy(row).float().unsqueeze(0).expand(batch_size, -1)
+            return pts, torch.zeros(batch_size)
+
+        return fake_optimizer
+
+    def test_optimizer_called_with_x_subspace(self, setup):
+        """The optimizer is invoked on the x-only design subspace."""
+        from baybe.recommenders.pure.bayesian.generality import recommend_generality
+
+        ss, objective, measurements = setup
+        recommender, _ = self._make_recommender_mock(ss, objective)
+        recommender.optimizer = self._make_smart_optimizer(ss)
+
+        result = recommend_generality(
+            recommender, ss, batch_size=1, measurements=measurements
+        )
+
+        assert len(result) == 1
+        assert "x" in result.columns
+        assert "solvent" in result.columns
+
+    def test_batch_produces_correct_count(self, setup):
+        """recommend_generality returns exactly batch_size rows."""
+        from baybe.recommenders.pure.bayesian.generality import recommend_generality
+
+        ss, objective, measurements = setup
+        recommender, _ = self._make_recommender_mock(ss, objective)
+        recommender.optimizer = self._make_smart_optimizer(ss)
+
+        result = recommend_generality(
+            recommender, ss, batch_size=2, measurements=measurements
+        )
+
+        assert len(result) == 2
+
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+
+
+class TestValidation:
+    """Validation tests for generality in search spaces."""
+
+    def test_multiple_generality_params_raises(self):
+        """Cannot have more than one GeneralityParameter."""
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0])
+        w1 = GeneralityParameter(
+            name="w1", context=CategoricalParameter("w1", values=["A", "B"])
+        )
+        w2 = GeneralityParameter(
+            name="w2", context=CategoricalParameter("w2", values=["X", "Y"])
+        )
+        with pytest.raises(NotImplementedError, match="at most one"):
+            SearchSpace.from_product(parameters=[x, w1, w2])
+
+    def test_generality_with_task_param_raises(self):
+        """Cannot combine GeneralityParameter with TaskParameter."""
+        from baybe.parameters.categorical import TaskParameter
+
+        x = NumericalDiscreteParameter("x", values=[1.0, 2.0])
+        w = GeneralityParameter(
+            name="solvent", context=CategoricalParameter("solvent", values=["A", "B"])
+        )
+        t = TaskParameter("task", values=["t1", "t2"])
+        with pytest.raises(Exception, match="[Tt]ask|[Gg]enerality"):
+            SearchSpace.from_product(parameters=[x, w, t])


### PR DESCRIPTION
# Generality-BO integration into BayBE

This PR creates a first draft for generality-oriented BO (done in this paper https://arxiv.org/abs/2502.18966) within BayBE.

Main features/changes:

- Introduce `GeneralityParameter`, which triggers generality-oriented BO (inspired by `TaskParameter`)
- Add `recommend_generality` on the Recommender level
- Introduce `GeneralityModel` and `GeneralityPosterior`, which are models that perform the Aggregation described in the paper, over which the optimizer can then run