### PR TITLE
Add Per-Parameter Convenience Kernel Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   number of required models instead of the number of transform outputs
 
 ### Added
+- Parameter-specific kernel overrides for conveniently composing Gaussian process
+  kernels on individual parameter dimensions
 - `coefficients` attribute for `DiscreteSumConstraint`, enabling weighted sums. Follows
   the same pattern as `ContinuousLinearConstraint.coefficients`
 - `simplex_coefficients` keyword argument to `SubspaceDiscrete.from_simplex` for

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -15,12 +15,12 @@ from typing_extensions import override
 
 from baybe.exceptions import UnmatchedAttributeError
 from baybe.priors.base import Prior
-from baybe.searchspace.core import SearchSpace
 from baybe.serialization.mixin import SerialMixin
 from baybe.settings import active_settings
 from baybe.utils.basic import classproperty, get_baseclasses, match_attributes, to_tuple
 
 if TYPE_CHECKING:
+    from baybe.searchspace.core import SearchSpace
     from baybe.surrogates.gaussian_process.components.kernel import PlainKernelFactory
 
 
@@ -119,6 +119,22 @@ class Kernel(ABC, SerialMixin):
         """
         raise TypeError(
             f"Cannot remove a parameter from kernel '{self.__class__.__name__}'. "
+        )
+
+    def _with_parameter(self, name: str, /) -> Kernel:
+        """Return a copy of the kernel scoped to a single parameter.
+
+        Args:
+            name: The name of the parameter to scope the kernel to.
+
+        Raises:
+            TypeError: If the kernel structure cannot be scoped unambiguously.
+
+        Returns:
+            The scoped kernel.
+        """
+        raise TypeError(
+            f"Cannot scope kernel '{self.__class__.__name__}' to a parameter."
         )
 
     @abstractmethod
@@ -272,6 +288,10 @@ class BasicKernel(Kernel, ABC):
         else:
             return self
         return evolve(self, parameter_names=remaining) if remaining else None
+
+    @override
+    def _with_parameter(self, name: str, /) -> Kernel:
+        return evolve(self, parameter_names=(name,))
 
 
 @define(frozen=True)

--- a/baybe/kernels/base.py
+++ b/baybe/kernels/base.py
@@ -122,7 +122,7 @@ class Kernel(ABC, SerialMixin):
         )
 
     def _with_parameter(self, name: str, /) -> Kernel:
-        """Return a copy of the kernel scoped to a single parameter.
+        """Return a copy of the kernel that acts only on the given parameter.
 
         Args:
             name: The name of the parameter to scope the kernel to.

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -1,8 +1,11 @@
 """Composite kernels (that is, kernels composed of other kernels)."""
 
+from __future__ import annotations
+
 import gc
 from functools import reduce
 from operator import add, mul
+from typing import TYPE_CHECKING
 
 from attrs import define, evolve, field
 from attrs.converters import optional as optional_c
@@ -12,10 +15,12 @@ from typing_extensions import override
 
 from baybe.kernels.base import CompositeKernel, Kernel
 from baybe.priors.base import Prior
-from baybe.searchspace.core import SearchSpace
 from baybe.settings import active_settings
 from baybe.utils.basic import to_tuple
 from baybe.utils.validation import finite_float
+
+if TYPE_CHECKING:
+    from baybe.searchspace.core import SearchSpace
 
 
 @define(frozen=True)
@@ -51,6 +56,10 @@ class ScaleKernel(CompositeKernel):
         return None if stripped is None else evolve(self, base_kernel=stripped)
 
     @override
+    def _with_parameter(self, name: str, /) -> Kernel:
+        return evolve(self, base_kernel=self.base_kernel._with_parameter(name))
+
+    @override
     def to_gpytorch(self, *args, **kwargs):
         import torch
 
@@ -77,6 +86,13 @@ class AdditiveKernel(CompositeKernel):
     """The individual kernels to be summed."""
 
     @override
+    def _with_parameter(self, name: str, /) -> Kernel:
+        return evolve(
+            self,
+            base_kernels=tuple(k._with_parameter(name) for k in self.base_kernels),
+        )
+
+    @override
     def to_gpytorch(self, *args, **kwargs):
         return reduce(add, (k.to_gpytorch(*args, **kwargs) for k in self.base_kernels))
 
@@ -92,6 +108,13 @@ class ProductKernel(CompositeKernel):
         ),
     )
     """The individual kernels to be multiplied."""
+
+    @override
+    def _with_parameter(self, name: str, /) -> Kernel:
+        return evolve(
+            self,
+            base_kernels=tuple(k._with_parameter(name) for k in self.base_kernels),
+        )
 
     @override
     def to_gpytorch(self, *args, **kwargs):

--- a/baybe/kernels/composite.py
+++ b/baybe/kernels/composite.py
@@ -110,6 +110,21 @@ class ProductKernel(CompositeKernel):
     """The individual kernels to be multiplied."""
 
     @override
+    def _without_parameter(
+        self, name: str, searchspace: SearchSpace, /
+    ) -> Kernel | None:
+        remaining = tuple(
+            reduced
+            for kernel in self.base_kernels
+            if (reduced := kernel._without_parameter(name, searchspace)) is not None
+        )
+        if not remaining:
+            return None
+        if len(remaining) == 1:
+            return remaining[0]
+        return evolve(self, base_kernels=remaining)
+
+    @override
     def _with_parameter(self, name: str, /) -> Kernel:
         return evolve(
             self,

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import gc
+import sys
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 import attrs
 import pandas as pd
-from attrs import define, field
+from attrs import Converter, define, field
 from attrs.converters import optional as optional_c
 from attrs.validators import instance_of, min_len
 from typing_extensions import override
 
+from baybe.kernels.base import Kernel
 from baybe.parameters.enum import ParameterEncoding
 from baybe.serialization import (
     SerialMixin,
@@ -22,13 +24,91 @@ from baybe.utils.basic import to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
     from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
     from baybe.searchspace.core import SearchSpace
     from baybe.searchspace.discrete import SubspaceDiscrete
 
+    KernelOverride: TypeAlias = Kernel | GPyTorchKernel
+else:
+    KernelOverride: TypeAlias = Kernel
+
 # TODO: Reactive slots in all classes once cached_property is supported:
 #   https://github.com/python-attrs/attrs/issues/164
+
+
+def _iter_basic_kernels(kernel: Kernel):
+    """Iterate over the basic kernel leaves of a BayBE kernel."""
+    from baybe.kernels.base import BasicKernel
+    from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
+
+    if isinstance(kernel, BasicKernel):
+        yield kernel
+    elif isinstance(kernel, ScaleKernel):
+        yield from _iter_basic_kernels(kernel.base_kernel)
+    elif isinstance(kernel, (AdditiveKernel, ProductKernel)):
+        for sub in kernel.base_kernels:
+            yield from _iter_basic_kernels(sub)
+
+
+def _to_kernel_override(
+    value: KernelOverride | None, instance: Parameter
+) -> KernelOverride | None:
+    """Validate a kernel override and scope BayBE kernels to their parameter.
+
+    Args:
+        value: The provided kernel override.
+        instance: The parameter the override belongs to.
+
+    Raises:
+        ValueError: If a BayBE kernel targets a different parameter or a GPyTorch
+            kernel specifies explicit active dimensions.
+        TypeError: If the object is neither a BayBE nor a GPyTorch kernel.
+
+    Returns:
+        The validated override, with BayBE kernels scoped to the parameter.
+    """
+    if value is None:
+        return None
+
+    # BayBE kernels: every basic leaf must be unscoped or scoped to the owner. The
+    # kernel is then rebound to the owning parameter (dropping unspecified names).
+    if isinstance(value, Kernel):
+        if any(
+            leaf.parameter_names not in (None, (instance.name,))
+            for leaf in _iter_basic_kernels(value)
+        ):
+            raise ValueError(
+                f"The kernel provided for the kernel override of "
+                f"'{instance.__class__.__name__}' may only act on the parameter "
+                f"itself. Its basic kernels must specify 'parameter_names' as "
+                f"``None`` or ({instance.name!r},)."
+            )
+        return value._with_parameter(instance.name)
+
+    # GPyTorch kernels: no explicit active dimensions allowed anywhere in the tree.
+    if sys.modules.get("gpytorch") is not None:
+        from gpytorch.kernels import Kernel as GPyTorchKernel
+
+        if isinstance(value, GPyTorchKernel):
+            if any(
+                k.active_dims is not None
+                for k in value.modules()
+                if isinstance(k, GPyTorchKernel)
+            ):
+                raise ValueError(
+                    "The GPyTorch kernel provided for the kernel override must not "
+                    "specify 'active_dims'."
+                )
+            return value
+
+    raise TypeError(
+        f"The object provided for the kernel override of "
+        f"'{instance.__class__.__name__}' must be a BayBE or GPyTorch kernel. "
+        f"Got: {type(value)}"
+    )
 
 
 @define(frozen=True, slots=False)
@@ -46,6 +126,13 @@ class Parameter(ABC, SerialMixin):
     # object variables
     name: str = field(validator=(instance_of(str), min_len(1)))
     """The name of the parameter"""
+
+    kernel_override: KernelOverride | None = field(
+        default=None,
+        converter=Converter(_to_kernel_override, takes_self=True),  # type: ignore[misc, call-overload]
+        kw_only=True,
+    )
+    """An optional kernel replacing the overall kernel for this parameter."""
 
     metadata: MeasurableMetadata = field(
         factory=MeasurableMetadata,
@@ -111,7 +198,14 @@ class Parameter(ABC, SerialMixin):
         """
         if type(self) is not type(other):
             return False
-        return attrs.evolve(self, name=other.name) == other
+        # The override is owner-scoped, so rebind it to the other parameter's name.
+        kernel_override = self.kernel_override
+        if isinstance(kernel_override, Kernel):
+            kernel_override = kernel_override._with_parameter(other.name)
+        return (
+            attrs.evolve(self, name=other.name, kernel_override=kernel_override)
+            == other
+        )
 
     @abstractmethod
     def summary(self) -> dict:

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -89,6 +89,8 @@ def _to_kernel_override(
         return value._with_parameter(instance.name)
 
     # GPyTorch kernels: no explicit active dimensions allowed anywhere in the tree.
+    # An existing GPyTorch instance implies the module is already imported. Avoid
+    # importing it (and Torch) solely to validate other parameter inputs.
     if sys.modules.get("gpytorch") is not None:
         from gpytorch.kernels import Kernel as GPyTorchKernel
 

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -50,6 +50,9 @@ def _iter_basic_kernels(kernel: Kernel) -> Iterator[BasicKernel]:
 
     Yields:
         The basic kernel leaves.
+
+    Raises:
+        TypeError: If the kernel structure is unsupported.
     """
     from baybe.kernels.base import BasicKernel
     from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
@@ -61,6 +64,9 @@ def _iter_basic_kernels(kernel: Kernel) -> Iterator[BasicKernel]:
     elif isinstance(kernel, (AdditiveKernel, ProductKernel)):
         for sub in kernel.base_kernels:
             yield from _iter_basic_kernels(sub)
+
+    else:
+        raise TypeError(f"Cannot traverse kernel '{type(kernel).__name__}'.")
 
 
 def _to_kernel_override(

--- a/baybe/parameters/base.py
+++ b/baybe/parameters/base.py
@@ -24,8 +24,11 @@ from baybe.utils.basic import to_tuple
 from baybe.utils.metadata import MeasurableMetadata, to_metadata
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from gpytorch.kernels import Kernel as GPyTorchKernel
 
+    from baybe.kernels.base import BasicKernel
     from baybe.parameters.enum import _ParameterKind
     from baybe.searchspace.continuous import SubspaceContinuous
     from baybe.searchspace.core import SearchSpace
@@ -39,8 +42,15 @@ else:
 #   https://github.com/python-attrs/attrs/issues/164
 
 
-def _iter_basic_kernels(kernel: Kernel):
-    """Iterate over the basic kernel leaves of a BayBE kernel."""
+def _iter_basic_kernels(kernel: Kernel) -> Iterator[BasicKernel]:
+    """Iterate over the basic kernel leaves of a BayBE kernel.
+
+    Args:
+        kernel: The kernel to traverse.
+
+    Yields:
+        The basic kernel leaves.
+    """
     from baybe.kernels.base import BasicKernel
     from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 

--- a/baybe/parameters/categorical.py
+++ b/baybe/parameters/categorical.py
@@ -88,6 +88,9 @@ class TaskParameter(CategoricalParameter):
     encoding: CategoricalEncoding = field(default=CategoricalEncoding.INT, init=False)
     # See base class.
 
+    kernel_override: None = field(init=False, default=None)
+    """Task parameters do not support parameter-specific kernel overrides."""
+
     override_transfer_learning_mode: TransferLearningMode | None = field(
         default=None,
         converter=optional_c(TransferLearningMode),

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import Enum, auto
@@ -13,7 +14,11 @@ from attrs import define, field
 from joblib.hashing import hash
 from typing_extensions import override
 
-from baybe.exceptions import IncompatibleSurrogateError, ModelNotTrainedError
+from baybe.exceptions import (
+    IncompatibleSurrogateError,
+    ModelNotTrainedError,
+    UnusedObjectWarning,
+)
 from baybe.objectives.base import Objective
 from baybe.parameters.base import Parameter
 from baybe.searchspace import SearchSpace
@@ -81,6 +86,9 @@ class SurrogateProtocol(Protocol):
 @define
 class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     """Abstract base class for all surrogate models."""
+
+    supports_kernel_overrides: ClassVar[bool] = False
+    """Whether parameter-specific kernel overrides are supported."""
 
     supports_transfer_learning: ClassVar[bool]
     """Class variable encoding whether or not the surrogate supports transfer
@@ -429,6 +437,15 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
                 f"The search space contains task parameters but the selected "
                 f"surrogate model type ({self.__class__.__name__}) does not "
                 f"support transfer learning."
+            )
+
+        if not self.supports_kernel_overrides and (
+            names := [p.name for p in searchspace.parameters if p.kernel_override]
+        ):
+            warnings.warn(
+                f"The selected surrogate model ({self.__class__.__name__}) does not "
+                f"use the kernel overrides specified for parameters {names}.",
+                UnusedObjectWarning,
             )
 
         # Block partial measurements

--- a/baybe/surrogates/gaussian_process/_override/__init__.py
+++ b/baybe/surrogates/gaussian_process/_override/__init__.py
@@ -1,0 +1,19 @@
+"""Kernel override resolution for Gaussian process surrogates."""
+
+from baybe.surrogates.gaussian_process._override.core import (
+    raise_incompatible_override,
+    reduce_kernel_spec,
+)
+from baybe.surrogates.gaussian_process._override.parameter import (
+    extract_parameter_overrides,
+)
+from baybe.surrogates.gaussian_process._override.tl import (
+    extract_transfer_learning_overrides,
+)
+
+__all__ = [
+    "extract_parameter_overrides",
+    "extract_transfer_learning_overrides",
+    "raise_incompatible_override",
+    "reduce_kernel_spec",
+]

--- a/baybe/surrogates/gaussian_process/_override/__init__.py
+++ b/baybe/surrogates/gaussian_process/_override/__init__.py
@@ -1,6 +1,7 @@
 """Kernel override resolution for Gaussian process surrogates."""
 
 from baybe.surrogates.gaussian_process._override.core import (
+    get_active_dimensions,
     raise_incompatible_override,
     reduce_kernel_spec,
 )
@@ -12,6 +13,7 @@ from baybe.surrogates.gaussian_process._override.tl import (
 )
 
 __all__ = [
+    "get_active_dimensions",
     "extract_parameter_overrides",
     "extract_transfer_learning_overrides",
     "raise_incompatible_override",

--- a/baybe/surrogates/gaussian_process/_override/core.py
+++ b/baybe/surrogates/gaussian_process/_override/core.py
@@ -1,0 +1,61 @@
+"""Shared helpers for kernel override resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+from baybe.exceptions import IncompatibleOverrideError
+from baybe.kernels.base import Kernel
+
+if TYPE_CHECKING:
+    from baybe.searchspace import SearchSpace
+
+
+def reduce_kernel_spec(
+    component: object,
+    excluded_names: set[str],
+    searchspace: SearchSpace,
+    factory: object,
+) -> Kernel | None:
+    """Remove the excluded parameters from a fixed BayBE kernel.
+
+    Args:
+        component: The kernel specification to reduce.
+        excluded_names: The names of the parameters to remove.
+        searchspace: The search space the kernel operates on.
+        factory: The originating factory (for error messages).
+
+    Returns:
+        The reduced kernel, or ``None`` if nothing remains.
+    """
+    if not isinstance(component, Kernel):
+        raise_incompatible_override(excluded_names, factory)
+    spec: Kernel | None = component
+    for name in excluded_names:
+        if spec is None:
+            break
+        try:
+            spec = spec._without_parameter(name, searchspace)
+        except TypeError as ex:
+            raise_incompatible_override(excluded_names, factory, ex)
+    return spec
+
+
+def raise_incompatible_override(
+    parameter_names: set[str], factory: object, cause: Exception | None = None
+) -> NoReturn:
+    """Raise an error for a surrogate kernel that cannot be reduced.
+
+    Args:
+        parameter_names: The overridden parameter names.
+        factory: The offending kernel factory.
+        cause: The underlying exception, if any.
+
+    Raises:
+        IncompatibleOverrideError: Always.
+    """
+    raise IncompatibleOverrideError(
+        f"Kernel overrides for {sorted(parameter_names)} require a surrogate "
+        f"kernel (factory) that can exclude these parameters. "
+        f"'{type(factory).__name__}' does not satisfy this requirement."
+    ) from cause

--- a/baybe/surrogates/gaussian_process/_override/core.py
+++ b/baybe/surrogates/gaussian_process/_override/core.py
@@ -8,14 +8,43 @@ from baybe.exceptions import IncompatibleOverrideError
 from baybe.kernels.base import Kernel
 
 if TYPE_CHECKING:
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
     from baybe.searchspace import SearchSpace
+    from baybe.surrogates.gaussian_process.components.kernel import (
+        KernelFactoryProtocol,
+    )
+
+
+def get_active_dimensions(kernel: GPyTorchKernel, searchspace: SearchSpace) -> set[int]:
+    """Get the input columns used by a kernel, including standard composites.
+
+    Args:
+        kernel: The resolved kernel to inspect.
+        searchspace: The search space defining the full model input.
+
+    Returns:
+        The active input column indices.
+    """
+    from gpytorch.kernels import AdditiveKernel, ProductKernel, ScaleKernel
+
+    if kernel.active_dims is not None:
+        # TODO[typing]: https://github.com/facebook/pyrefly/issues/3988
+        return set(kernel.active_dims.tolist())  # pyrefly: ignore[not-callable]
+    if isinstance(kernel, (AdditiveKernel, ProductKernel)):
+        return set().union(
+            *(get_active_dimensions(k, searchspace) for k in kernel.kernels)
+        )
+    if isinstance(kernel, ScaleKernel):
+        return get_active_dimensions(kernel.base_kernel, searchspace)
+    return set(range(len(searchspace.comp_rep_columns)))
 
 
 def reduce_kernel_spec(
-    component: object,
+    component: Kernel | GPyTorchKernel,
     excluded_names: set[str],
     searchspace: SearchSpace,
-    factory: object,
+    factory: KernelFactoryProtocol,
 ) -> Kernel | None:
     """Remove the excluded parameters from a fixed BayBE kernel.
 
@@ -38,11 +67,14 @@ def reduce_kernel_spec(
             spec = spec._without_parameter(name, searchspace)
         except TypeError as ex:
             raise_incompatible_override(excluded_names, factory, ex)
+
     return spec
 
 
 def raise_incompatible_override(
-    parameter_names: set[str], factory: object, cause: Exception | None = None
+    parameter_names: set[str],
+    factory: KernelFactoryProtocol,
+    cause: Exception | None = None,
 ) -> NoReturn:
     """Raise an error for a surrogate kernel that cannot be reduced.
 

--- a/baybe/surrogates/gaussian_process/_override/core.py
+++ b/baybe/surrogates/gaussian_process/_override/core.py
@@ -59,6 +59,7 @@ def reduce_kernel_spec(
     """
     if not isinstance(component, Kernel):
         raise_incompatible_override(excluded_names, factory)
+    # Reduction can exhaust the scope and return None despite a non-None input.
     spec: Kernel | None = component
     for name in excluded_names:
         if spec is None:

--- a/baybe/surrogates/gaussian_process/_override/parameter.py
+++ b/baybe/surrogates/gaussian_process/_override/parameter.py
@@ -1,0 +1,96 @@
+"""Resolution of parameter-specific kernel overrides."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+from baybe.exceptions import IncompatibleOverrideError
+from baybe.kernels.base import Kernel
+
+if TYPE_CHECKING:
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
+    from baybe.parameters.base import Parameter
+    from baybe.searchspace import SearchSpace
+    from baybe.surrogates.gaussian_process.core import _ModelContext
+
+
+def extract_parameter_overrides(
+    context: _ModelContext,
+) -> list[tuple[str, GPyTorchKernel]]:
+    """Extract the regular parameter-specific kernel overrides.
+
+    Args:
+        context: The model context providing the search space.
+
+    Returns:
+        A ``(parameter_name, kernel)`` pair for each parameter with an override.
+    """
+    return [
+        (p.name, make_parameter_override_kernel(p, context.searchspace))
+        for p in context.searchspace.parameters
+        if p.kernel_override is not None
+    ]
+
+
+def make_parameter_override_kernel(
+    parameter: Parameter, searchspace: SearchSpace
+) -> GPyTorchKernel:
+    """Create the kernel factor for a parameter's override.
+
+    Args:
+        parameter: The parameter carrying the override.
+        searchspace: The search space the kernel operates on.
+
+    Returns:
+        The GPyTorch kernel bound to the parameter's dimensions.
+    """
+    override = parameter.kernel_override
+    assert override is not None
+
+    # BayBE kernels resolve their own dimensions; raw kernels are bound manually.
+    if isinstance(override, Kernel):
+        return override.to_gpytorch(searchspace)
+    indices = searchspace.get_comp_rep_parameter_indices(parameter.name)
+    return bind_gpytorch_override(override, indices, parameter.name)
+
+
+def bind_gpytorch_override(
+    override: GPyTorchKernel, indices: tuple[int, ...], name: str
+) -> GPyTorchKernel:
+    """Copy a raw GPyTorch override and bind it to the given dimensions.
+
+    Args:
+        override: The provided GPyTorch kernel (must not specify active dimensions).
+        indices: The computational column indices of the owning parameter.
+        name: The owning parameter name (for error messages).
+
+    Raises:
+        IncompatibleOverrideError: If the kernel specifies active dimensions or an
+            incompatible number of ARD dimensions.
+
+    Returns:
+        A copy of the kernel bound to the given dimensions.
+    """
+    import torch
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
+    for kernel in override.modules():
+        if not isinstance(kernel, GPyTorchKernel):
+            continue
+        if kernel.active_dims is not None:
+            raise IncompatibleOverrideError(
+                f"The GPyTorch kernel override for parameter '{name}' must not "
+                f"specify 'active_dims'."
+            )
+        if kernel.ard_num_dims not in (None, len(indices)):
+            raise IncompatibleOverrideError(
+                f"The GPyTorch kernel override for parameter '{name}' specifies "
+                f"{kernel.ard_num_dims} ARD dimensions, but the parameter has "
+                f"{len(indices)} computational dimensions."
+            )
+
+    result = deepcopy(override)
+    result.active_dims = torch.tensor(indices)
+    return result

--- a/baybe/surrogates/gaussian_process/_override/parameter.py
+++ b/baybe/surrogates/gaussian_process/_override/parameter.py
@@ -40,7 +40,8 @@ def make_parameter_override_kernel(
     """Create the kernel factor for a parameter's override.
 
     Args:
-        parameter: The parameter carrying the override.
+        parameter: The parameter carrying a non-``None`` kernel override, as ensured
+            by :func:`extract_parameter_overrides`.
         searchspace: The search space the kernel operates on.
 
     Returns:

--- a/baybe/surrogates/gaussian_process/_override/tl.py
+++ b/baybe/surrogates/gaussian_process/_override/tl.py
@@ -1,0 +1,62 @@
+"""Resolution of the transfer-learning kernel override."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typing_extensions import assert_never
+
+from baybe.kernels.base import Kernel
+from baybe.parameters.enum import TransferLearningMode
+
+if TYPE_CHECKING:
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
+    from baybe.surrogates.gaussian_process.core import _ModelContext
+
+
+def extract_transfer_learning_overrides(
+    context: _ModelContext,
+) -> list[tuple[str, GPyTorchKernel]]:
+    """Extract the transfer-learning kernel override, if any.
+
+    Args:
+        context: The model context providing the task parameter and override mode.
+
+    Returns:
+        A single ``(task_name, kernel)`` pair if an override is set, else an empty
+        list.
+    """
+    task_param = context.searchspace._task_parameter
+    if task_param is None or context.tl_override is None:
+        return []
+    return [(task_param.name, make_transfer_learning_override_kernel(context))]
+
+
+def make_transfer_learning_override_kernel(
+    context: _ModelContext,
+) -> GPyTorchKernel:
+    """Create the task kernel factor requested by a transfer-learning override.
+
+    Args:
+        context: The model context providing the task parameter and override mode.
+
+    Returns:
+        The GPyTorch task kernel for the requested transfer-learning mode.
+    """
+    from baybe.kernels.basic import IndexKernel, PositiveIndexKernel
+
+    task_param = context.searchspace._task_parameter
+    override = context.tl_override
+    assert task_param is not None and override is not None
+    n_tasks, names = context.n_tasks, (task_param.name,)
+    match override:
+        case TransferLearningMode.POSITIVE_INDEX_KERNEL:
+            spec: Kernel = PositiveIndexKernel(
+                num_tasks=n_tasks, rank=n_tasks, parameter_names=names
+            )
+        case TransferLearningMode.INDEX_KERNEL:
+            spec = IndexKernel(num_tasks=n_tasks, rank=n_tasks, parameter_names=names)
+        case _:
+            assert_never(override)
+    return spec.to_gpytorch(context.searchspace)

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -9,30 +9,29 @@ import os
 import warnings
 from copy import deepcopy
 from functools import partial, reduce
-from typing import TYPE_CHECKING, ClassVar, NoReturn
+from typing import TYPE_CHECKING, ClassVar
 
 import pandas as pd
 from attrs import Converter, define, field
 from attrs.converters import optional as optional_c
 from attrs.converters import pipe
 from attrs.validators import instance_of, is_callable, optional
-from typing_extensions import Self, assert_never, override
+from typing_extensions import Self, override
 
 from baybe.exceptions import (
     DeprecationError,
-    IncompatibleOverrideError,
     IncompatibleSearchSpaceError,
     ModelNotTrainedError,
     _UnsupportedSearchSpaceAttributeError,
 )
 from baybe.kernels.base import Kernel
-from baybe.kernels.basic import IndexKernel, PositiveIndexKernel
 from baybe.objectives.base import Objective
 from baybe.parameters.base import Parameter
 from baybe.parameters.categorical import TaskParameter
 from baybe.parameters.enum import TransferLearningMode
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates.base import Surrogate
+from baybe.surrogates.gaussian_process import _override
 from baybe.surrogates.gaussian_process.components.fit_criterion import (
     FitCriterion,
     FitCriterionFactoryProtocol,
@@ -144,45 +143,6 @@ def _mark_custom_kernel(
         self._custom_kernel = True
 
     return value
-
-
-def _bind_gpytorch_override(
-    override: GPyTorchKernel, indices: tuple[int, ...], name: str
-) -> GPyTorchKernel:
-    """Copy a raw GPyTorch override and bind it to the given dimensions.
-
-    Args:
-        override: The provided GPyTorch kernel (must not specify active dimensions).
-        indices: The computational column indices of the owning parameter.
-        name: The owning parameter name (for error messages).
-
-    Raises:
-        IncompatibleOverrideError: If the kernel specifies active dimensions or an
-            incompatible number of ARD dimensions.
-
-    Returns:
-        A copy of the kernel bound to the given dimensions.
-    """
-    import torch
-    from gpytorch.kernels import Kernel as GPyTorchKernel
-
-    for kernel in override.modules():
-        if not isinstance(kernel, GPyTorchKernel):
-            continue
-        if kernel.active_dims is not None:
-            raise IncompatibleOverrideError(
-                f"The GPyTorch kernel override for parameter '{name}' must not "
-                f"specify 'active_dims'."
-            )
-        if kernel.ard_num_dims not in (None, len(indices)):
-            raise IncompatibleOverrideError(
-                f"The GPyTorch kernel override for parameter '{name}' specifies "
-                f"{kernel.ard_num_dims} ARD dimensions, but the parameter has "
-                f"{len(indices)} computational dimensions."
-            )
-    result = deepcopy(override)
-    result.active_dims = torch.tensor(indices)
-    return result
 
 
 @define
@@ -448,8 +408,8 @@ class GaussianProcessSurrogate(Surrogate):
         The effective kernel is the surrogate kernel restricted to the
         non-overridden dimensions, multiplied by one factor per override.
         """
-        overrides = self._extract_parameter_overrides(context)
-        overrides.extend(self._extract_transfer_learning_overrides(context))
+        overrides = _override.extract_parameter_overrides(context)
+        overrides.extend(_override.extract_transfer_learning_overrides(context))
 
         # No overrides: let the surrogate kernel (factory) handle everything.
         if not overrides:
@@ -457,68 +417,14 @@ class GaussianProcessSurrogate(Surrogate):
             kernel = factory(
                 context.searchspace, context.objective, context.measurements
             )
-            return self._as_gpytorch(kernel, context.searchspace)
+            if isinstance(kernel, Kernel):
+                return kernel.to_gpytorch(context.searchspace)
+            return kernel
 
         excluded_names = {name for name, _ in overrides}
         residual = self._resolve_residual_kernel(context, excluded_names)
         factors = ([] if residual is None else [residual]) + [k for _, k in overrides]
         return reduce(operator.mul, factors)
-
-    def _extract_parameter_overrides(
-        self, context: _ModelContext
-    ) -> list[tuple[str, GPyTorchKernel]]:
-        """Extract regular parameter-specific kernel overrides."""
-        return [
-            (p.name, self._make_parameter_override_kernel(p, context.searchspace))
-            for p in context.searchspace.parameters
-            if p.kernel_override is not None
-        ]
-
-    def _extract_transfer_learning_overrides(
-        self, context: _ModelContext
-    ) -> list[tuple[str, GPyTorchKernel]]:
-        """Extract the transfer-learning kernel override, if any."""
-        task_param = context.searchspace._task_parameter
-        if task_param is None or context.tl_override is None:
-            return []
-        kernel = self._make_transfer_learning_override_kernel(context)
-        return [(task_param.name, kernel)]
-
-    @staticmethod
-    def _make_parameter_override_kernel(
-        parameter: Parameter, searchspace: SearchSpace
-    ) -> GPyTorchKernel:
-        """Create the kernel factor for a parameter's override."""
-        override = parameter.kernel_override
-        assert override is not None
-        indices = searchspace.get_comp_rep_parameter_indices(parameter.name)
-
-        # BayBE kernels resolve their own dimensions; raw kernels are bound manually.
-        if isinstance(override, Kernel):
-            return override.to_gpytorch(searchspace)
-        return _bind_gpytorch_override(override, indices, parameter.name)
-
-    @staticmethod
-    def _make_transfer_learning_override_kernel(
-        context: _ModelContext,
-    ) -> GPyTorchKernel:
-        """Create the task kernel factor requested by a transfer-learning override."""
-        task_param = context.searchspace._task_parameter
-        override = context.tl_override
-        assert task_param is not None and override is not None
-        n_tasks, names = context.n_tasks, (task_param.name,)
-        match override:
-            case TransferLearningMode.POSITIVE_INDEX_KERNEL:
-                spec: Kernel = PositiveIndexKernel(
-                    num_tasks=n_tasks, rank=n_tasks, parameter_names=names
-                )
-            case TransferLearningMode.INDEX_KERNEL:
-                spec = IndexKernel(
-                    num_tasks=n_tasks, rank=n_tasks, parameter_names=names
-                )
-            case _:
-                assert_never(override)
-        return spec.to_gpytorch(context.searchspace)
 
     def _resolve_residual_kernel(
         self, context: _ModelContext, excluded_names: set[str]
@@ -531,18 +437,17 @@ class GaussianProcessSurrogate(Surrogate):
         """
         searchspace = context.searchspace
         factory = self.kernel_factory or BayBEKernelFactory()
-        remaining = [p for p in searchspace.parameters if p.name not in excluded_names]
-        if not remaining:
+        if all(p.name in excluded_names for p in searchspace.parameters):
             return None
 
-        # Default kernel: reuse the default machinery, but restrict it to the
-        # remaining (non-overridden) parameters via the factory's selector.
+        # Default kernel: build the (task-free) numerical base restricted to the
+        # remaining parameters and re-add the default task kernel unless overridden.
         if isinstance(factory, BayBEKernelFactory):
             return self._resolve_default_base(context, excluded_names)
 
         # A fixed kernel is reduced directly by removing the excluded parameters.
         if isinstance(factory, PlainGPComponentFactory):
-            spec = self._reduce_kernel_spec(
+            spec = _override.reduce_kernel_spec(
                 factory.component, excluded_names, searchspace, factory
             )
             return None if spec is None else spec.to_gpytorch(searchspace)
@@ -557,8 +462,10 @@ class GaussianProcessSurrogate(Surrogate):
             IncompatibleSearchSpaceError,
             _UnsupportedSearchSpaceAttributeError,
         ) as ex:
-            self._raise_incompatible_override(excluded_names, factory, ex)
-        spec = self._reduce_kernel_spec(returned, excluded_names, searchspace, factory)
+            _override.raise_incompatible_override(excluded_names, factory, ex)
+        spec = _override.reduce_kernel_spec(
+            returned, excluded_names, searchspace, factory
+        )
         return None if spec is None else spec.to_gpytorch(searchspace)
 
     def _resolve_default_base(
@@ -569,18 +476,13 @@ class GaussianProcessSurrogate(Surrogate):
         The numerical base always excludes the task; the default task kernel is
         re-added unless the task is itself overridden (i.e. already excluded).
         """
-        from baybe.surrogates.gaussian_process.components.kernel import (
-            _PureKernelFactory,
-        )
         from baybe.surrogates.gaussian_process.presets.baybe import (
             _BayBENumericalKernelFactory,
             _BayBETaskKernelFactory,
         )
 
         searchspace = context.searchspace
-        factory = self.kernel_factory or BayBEKernelFactory()
-        assert isinstance(factory, _PureKernelFactory)
-        selector = factory.parameter_selector
+        selector = getattr(self.kernel_factory, "parameter_selector", None)
         task_param = searchspace._task_parameter
 
         keep: ParameterSelectorProtocol = lambda parameter: (  # noqa: E731
@@ -593,56 +495,18 @@ class GaussianProcessSurrogate(Surrogate):
             base = _BayBENumericalKernelFactory(parameter_selector=keep)(
                 searchspace, context.objective, context.measurements
             )
-            factors.append(self._as_gpytorch(base, searchspace))
+            factors.append(
+                base.to_gpytorch(searchspace) if isinstance(base, Kernel) else base
+            )
         if task_param is not None and task_param.name not in excluded_names:
             task = _BayBETaskKernelFactory()(
                 searchspace, context.objective, context.measurements
             )
-            factors.append(self._as_gpytorch(task, searchspace))
+            factors.append(
+                task.to_gpytorch(searchspace) if isinstance(task, Kernel) else task
+            )
 
         return reduce(operator.mul, factors) if factors else None
-
-    @staticmethod
-    def _reduce_kernel_spec(
-        component: object,
-        excluded_names: set[str],
-        searchspace: SearchSpace,
-        factory: object,
-    ) -> Kernel | None:
-        """Remove the excluded parameters from a fixed BayBE kernel."""
-        if not isinstance(component, Kernel):
-            GaussianProcessSurrogate._raise_incompatible_override(
-                excluded_names, factory
-            )
-        spec: Kernel | None = component
-        for name in excluded_names:
-            if spec is None:
-                break
-            try:
-                spec = spec._without_parameter(name, searchspace)
-            except TypeError as ex:
-                GaussianProcessSurrogate._raise_incompatible_override(
-                    excluded_names, factory, ex
-                )
-        return spec
-
-    @staticmethod
-    def _as_gpytorch(
-        kernel: Kernel | GPyTorchKernel, searchspace: SearchSpace
-    ) -> GPyTorchKernel:
-        """Convert a BayBE kernel to GPyTorch, passing through raw kernels."""
-        return kernel.to_gpytorch(searchspace) if isinstance(kernel, Kernel) else kernel
-
-    @staticmethod
-    def _raise_incompatible_override(
-        parameter_names: set[str], factory: object, cause: Exception | None = None
-    ) -> NoReturn:
-        """Raise an error for a surrogate kernel that cannot be reduced."""
-        raise IncompatibleOverrideError(
-            f"Kernel overrides for {sorted(parameter_names)} require a surrogate "
-            f"kernel (factory) that can exclude these parameters. "
-            f"'{type(factory).__name__}' does not satisfy this requirement."
-        ) from cause
 
     def _resolve_components(
         self, context: _ModelContext
@@ -799,8 +663,6 @@ def _make_posterior_mean_module(
     Returns:
         A mean module ready for use in a new GP.
     """
-    from copy import deepcopy
-
     import gpytorch
 
     frozen_model = deepcopy(model)

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import gc
 import importlib
+import operator
 import os
 import warnings
-from functools import partial
-from typing import TYPE_CHECKING, ClassVar
+from copy import deepcopy
+from functools import partial, reduce
+from typing import TYPE_CHECKING, ClassVar, NoReturn
 
 import pandas as pd
-from attrs import Converter, define, field, fields
+from attrs import Converter, define, field
 from attrs.converters import optional as optional_c
 from attrs.converters import pipe
 from attrs.validators import instance_of, is_callable, optional
@@ -71,6 +73,8 @@ if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
     from gpytorch.means import Mean as GPyTorchMean
     from torch import Tensor
+
+    from baybe.parameters.selectors import ParameterSelectorProtocol
 
 
 @define
@@ -142,6 +146,45 @@ def _mark_custom_kernel(
     return value
 
 
+def _bind_gpytorch_override(
+    override: GPyTorchKernel, indices: tuple[int, ...], name: str
+) -> GPyTorchKernel:
+    """Copy a raw GPyTorch override and bind it to the given dimensions.
+
+    Args:
+        override: The provided GPyTorch kernel (must not specify active dimensions).
+        indices: The computational column indices of the owning parameter.
+        name: The owning parameter name (for error messages).
+
+    Raises:
+        IncompatibleOverrideError: If the kernel specifies active dimensions or an
+            incompatible number of ARD dimensions.
+
+    Returns:
+        A copy of the kernel bound to the given dimensions.
+    """
+    import torch
+    from gpytorch.kernels import Kernel as GPyTorchKernel
+
+    for kernel in override.modules():
+        if not isinstance(kernel, GPyTorchKernel):
+            continue
+        if kernel.active_dims is not None:
+            raise IncompatibleOverrideError(
+                f"The GPyTorch kernel override for parameter '{name}' must not "
+                f"specify 'active_dims'."
+            )
+        if kernel.ard_num_dims not in (None, len(indices)):
+            raise IncompatibleOverrideError(
+                f"The GPyTorch kernel override for parameter '{name}' specifies "
+                f"{kernel.ard_num_dims} ARD dimensions, but the parameter has "
+                f"{len(indices)} computational dimensions."
+            )
+    result = deepcopy(override)
+    result.active_dims = torch.tensor(indices)
+    return result
+
+
 @define
 class GaussianProcessSurrogate(Surrogate):
     """A Gaussian process surrogate model."""
@@ -160,6 +203,9 @@ class GaussianProcessSurrogate(Surrogate):
     # problem since the resulting `posterior` method of that object is exposed
     # to `optimize_acqf_*`, which is configured to be called on the original scale.
     # Moving the scaling operation into the botorch GP object avoids this conflict.
+
+    supports_kernel_overrides: ClassVar[bool] = True
+    # See base class.
 
     supports_transfer_learning: ClassVar[bool] = True
     # See base class.
@@ -397,129 +443,206 @@ class GaussianProcessSurrogate(Surrogate):
         return self._model.posterior(candidates_comp_scaled)
 
     def _resolve_kernel(self, context: _ModelContext) -> GPyTorchKernel:
-        """Resolve the GP kernel, dispatching on task parameter overrides.
+        """Resolve the GP kernel, applying parameter and transfer overrides.
 
-        Args:
-            context: The model context providing searchspace information.
+        The effective kernel is the surrogate kernel restricted to the
+        non-overridden dimensions, multiplied by one factor per override.
+        """
+        overrides = self._extract_parameter_overrides(context)
+        overrides.extend(self._extract_transfer_learning_overrides(context))
 
-        Raises:
-            IncompatibleOverrideError: If a transfer learning override is combined
-                with a kernel or kernel factory that cannot be reduced to a task-free
-                base kernel operating on parameter names.
+        # No overrides: let the surrogate kernel (factory) handle everything.
+        if not overrides:
+            factory = self.kernel_factory or BayBEKernelFactory()
+            kernel = factory(
+                context.searchspace, context.objective, context.measurements
+            )
+            return self._as_gpytorch(kernel, context.searchspace)
 
-        Returns:
-            The constructed gpytorch kernel.
+        excluded_names = {name for name, _ in overrides}
+        residual = self._resolve_residual_kernel(context, excluded_names)
+        factors = ([] if residual is None else [residual]) + [k for _, k in overrides]
+        return reduce(operator.mul, factors)
+
+    def _extract_parameter_overrides(
+        self, context: _ModelContext
+    ) -> list[tuple[str, GPyTorchKernel]]:
+        """Extract regular parameter-specific kernel overrides."""
+        return [
+            (p.name, self._make_parameter_override_kernel(p, context.searchspace))
+            for p in context.searchspace.parameters
+            if p.kernel_override is not None
+        ]
+
+    def _extract_transfer_learning_overrides(
+        self, context: _ModelContext
+    ) -> list[tuple[str, GPyTorchKernel]]:
+        """Extract the transfer-learning kernel override, if any."""
+        task_param = context.searchspace._task_parameter
+        if task_param is None or context.tl_override is None:
+            return []
+        kernel = self._make_transfer_learning_override_kernel(context)
+        return [(task_param.name, kernel)]
+
+    @staticmethod
+    def _make_parameter_override_kernel(
+        parameter: Parameter, searchspace: SearchSpace
+    ) -> GPyTorchKernel:
+        """Create the kernel factor for a parameter's override."""
+        override = parameter.kernel_override
+        assert override is not None
+        indices = searchspace.get_comp_rep_parameter_indices(parameter.name)
+
+        # BayBE kernels resolve their own dimensions; raw kernels are bound manually.
+        if isinstance(override, Kernel):
+            return override.to_gpytorch(searchspace)
+        return _bind_gpytorch_override(override, indices, parameter.name)
+
+    @staticmethod
+    def _make_transfer_learning_override_kernel(
+        context: _ModelContext,
+    ) -> GPyTorchKernel:
+        """Create the task kernel factor requested by a transfer-learning override."""
+        task_param = context.searchspace._task_parameter
+        override = context.tl_override
+        assert task_param is not None and override is not None
+        n_tasks, names = context.n_tasks, (task_param.name,)
+        match override:
+            case TransferLearningMode.POSITIVE_INDEX_KERNEL:
+                spec: Kernel = PositiveIndexKernel(
+                    num_tasks=n_tasks, rank=n_tasks, parameter_names=names
+                )
+            case TransferLearningMode.INDEX_KERNEL:
+                spec = IndexKernel(
+                    num_tasks=n_tasks, rank=n_tasks, parameter_names=names
+                )
+            case _:
+                assert_never(override)
+        return spec.to_gpytorch(context.searchspace)
+
+    def _resolve_residual_kernel(
+        self, context: _ModelContext, excluded_names: set[str]
+    ) -> GPyTorchKernel | None:
+        """Resolve the surrogate kernel restricted to the non-excluded dimensions.
+
+        This is intentionally task-agnostic: it only removes ``excluded_names``.
+        A task parameter is excluded here only if a transfer-learning override
+        already replaced it; otherwise it is preserved by the surrogate kernel.
         """
         searchspace = context.searchspace
-        task_param = searchspace._task_parameter
-        tl_override = context.tl_override
+        factory = self.kernel_factory or BayBEKernelFactory()
+        remaining = [p for p in searchspace.parameters if p.name not in excluded_names]
+        if not remaining:
+            return None
 
-        if tl_override is None:
-            # No override: let the factory handle everything (default path)
-            kernel_factory = self.kernel_factory or BayBEKernelFactory()
-            kernel = kernel_factory(
+        # Default kernel: reuse the default machinery, but restrict it to the
+        # remaining (non-overridden) parameters via the factory's selector.
+        if isinstance(factory, BayBEKernelFactory):
+            return self._resolve_default_base(context, excluded_names)
+
+        # A fixed kernel is reduced directly by removing the excluded parameters.
+        if isinstance(factory, PlainGPComponentFactory):
+            spec = self._reduce_kernel_spec(
+                factory.component, excluded_names, searchspace, factory
+            )
+            return None if spec is None else spec.to_gpytorch(searchspace)
+
+        # Any other callable factory: call it on the reduced space and reduce the
+        # returned BayBE kernel. Factories needing full-space information or
+        # returning a raw kernel are unsupported.
+        reduced_space = searchspace._drop_parameters(excluded_names)
+        try:
+            returned = factory(reduced_space, context.objective, context.measurements)
+        except (
+            IncompatibleSearchSpaceError,
+            _UnsupportedSearchSpaceAttributeError,
+        ) as ex:
+            self._raise_incompatible_override(excluded_names, factory, ex)
+        spec = self._reduce_kernel_spec(returned, excluded_names, searchspace, factory)
+        return None if spec is None else spec.to_gpytorch(searchspace)
+
+    def _resolve_default_base(
+        self, context: _ModelContext, excluded_names: set[str]
+    ) -> GPyTorchKernel | None:
+        """Resolve the default kernel base, excluding the given parameters.
+
+        The numerical base always excludes the task; the default task kernel is
+        re-added unless the task is itself overridden (i.e. already excluded).
+        """
+        from baybe.surrogates.gaussian_process.components.kernel import (
+            _PureKernelFactory,
+        )
+        from baybe.surrogates.gaussian_process.presets.baybe import (
+            _BayBENumericalKernelFactory,
+            _BayBETaskKernelFactory,
+        )
+
+        searchspace = context.searchspace
+        factory = self.kernel_factory or BayBEKernelFactory()
+        assert isinstance(factory, _PureKernelFactory)
+        selector = factory.parameter_selector
+        task_param = searchspace._task_parameter
+
+        keep: ParameterSelectorProtocol = lambda parameter: (  # noqa: E731
+            parameter.name not in excluded_names
+            and parameter is not task_param
+            and (selector is None or selector(parameter))
+        )
+        factors: list[GPyTorchKernel] = []
+        if any(keep(p) for p in searchspace.parameters):
+            base = _BayBENumericalKernelFactory(parameter_selector=keep)(
                 searchspace, context.objective, context.measurements
             )
-            if isinstance(kernel, Kernel):
-                kernel = kernel.to_gpytorch(searchspace=searchspace)
-            return kernel
+            factors.append(self._as_gpytorch(base, searchspace))
+        if task_param is not None and task_param.name not in excluded_names:
+            task = _BayBETaskKernelFactory()(
+                searchspace, context.objective, context.measurements
+            )
+            factors.append(self._as_gpytorch(task, searchspace))
 
-        assert task_param is not None  # a set override implies a task parameter
+        return reduce(operator.mul, factors) if factors else None
 
-        # Override is set: assemble the prescribed task kernel
-        n_tasks = searchspace.n_tasks
-        task_kernel_cls: type[IndexKernel]
-        match tl_override:
-            case TransferLearningMode.POSITIVE_INDEX_KERNEL:
-                task_kernel_cls = PositiveIndexKernel
-            case TransferLearningMode.INDEX_KERNEL:
-                task_kernel_cls = IndexKernel
-            case _:
-                assert_never(tl_override)
-        task_kernel_spec = task_kernel_cls(
-            num_tasks=n_tasks, rank=n_tasks, parameter_names=(task_param.name,)
-        )
-
-        # Default factory (None or a `BayBEKernelFactory` without a custom parameter
-        # selector): reuse the ICM machinery on the full searchspace, which builds the
-        # task-excluded base kernel and combines it with the prescribed task kernel.
-        # This avoids the reduced searchspace, on which the default factory's numerical
-        # kernel cannot resolve its active dimensions. A `BayBEKernelFactory` carrying a
-        # custom selector falls through to the general factory path below, so the
-        # selector is honored (or loudly rejected when it cannot be).
-        if self.kernel_factory is None or (
-            isinstance(self.kernel_factory, BayBEKernelFactory)
-            and self.kernel_factory.parameter_selector is None
-        ):
-            icm = ICMKernelFactory(task_kernel_or_factory=task_kernel_spec)
-            kernel = icm(searchspace, context.objective, context.measurements)
-            if isinstance(kernel, Kernel):
-                kernel = kernel.to_gpytorch(searchspace=searchspace)
-            return kernel
-
-        # Otherwise, build a task-free base kernel and attach the prescribed task
-        # kernel manually.
-        effective_factory = self.kernel_factory
-        incompatible_message = (
-            f"The '{TaskParameter.__name__}' '{task_param.name}' specifies "
-            f"'{fields(TaskParameter).override_transfer_learning_mode.name}="
-            f"{tl_override.name}', which requires a "
-            f"kernel (factory) that yields a task-free BayBE kernel operating on "
-            f"parameter names. The provided kernel factory "
-            f"'{type(effective_factory).__name__}' does not satisfy this (e.g., it "
-            f"returns a raw gpytorch kernel or already operates on the task "
-            f"parameter)."
-        )
-
-        if isinstance(self.kernel_factory, PlainGPComponentFactory):
-            # A fixed kernel was provided: strip the task parameter directly.
-            component = self.kernel_factory.component
-            if not isinstance(component, Kernel):
-                raise IncompatibleOverrideError(incompatible_message)
+    @staticmethod
+    def _reduce_kernel_spec(
+        component: object,
+        excluded_names: set[str],
+        searchspace: SearchSpace,
+        factory: object,
+    ) -> Kernel | None:
+        """Remove the excluded parameters from a fixed BayBE kernel."""
+        if not isinstance(component, Kernel):
+            GaussianProcessSurrogate._raise_incompatible_override(
+                excluded_names, factory
+            )
+        spec: Kernel | None = component
+        for name in excluded_names:
+            if spec is None:
+                break
             try:
-                base_spec = component._without_parameter(task_param.name, searchspace)
+                spec = spec._without_parameter(name, searchspace)
             except TypeError as ex:
-                raise IncompatibleOverrideError(incompatible_message) from ex
-        else:
-            # Call the factory on a reduced (task-free) searchspace so that it
-            # produces only the base kernel. Factories that need computational
-            # information unavailable on the reduced space, or that return a raw
-            # gpytorch kernel, are not supported.
-            reduced_searchspace = searchspace._drop_parameters({task_param.name})
-            try:
-                factory_kernel = effective_factory(
-                    reduced_searchspace, context.objective, context.measurements
+                GaussianProcessSurrogate._raise_incompatible_override(
+                    excluded_names, factory, ex
                 )
-            except (
-                IncompatibleSearchSpaceError,
-                _UnsupportedSearchSpaceAttributeError,
-            ) as ex:
-                raise IncompatibleOverrideError(incompatible_message) from ex
-            if not isinstance(factory_kernel, Kernel):
-                raise IncompatibleOverrideError(incompatible_message)
-            # Normalize to an explicitly task-free spec.
-            try:
-                base_spec = factory_kernel._without_parameter(
-                    task_param.name, searchspace
-                )
-            except TypeError as ex:
-                raise IncompatibleOverrideError(incompatible_message) from ex
+        return spec
 
-        # Stripping left no base kernel: return only the prescribed task kernel.
-        if base_spec is None:
-            return task_kernel_spec.to_gpytorch(searchspace=searchspace)
+    @staticmethod
+    def _as_gpytorch(
+        kernel: Kernel | GPyTorchKernel, searchspace: SearchSpace
+    ) -> GPyTorchKernel:
+        """Convert a BayBE kernel to GPyTorch, passing through raw kernels."""
+        return kernel.to_gpytorch(searchspace) if isinstance(kernel, Kernel) else kernel
 
-        # Combine base and task kernel via the ICM machinery (as in the default-factory
-        # branch above), which converts both on the full searchspace and validates the
-        # dimension partitioning between base and task kernel.
-        icm = ICMKernelFactory(
-            base_kernel_or_factory=base_spec,
-            task_kernel_or_factory=task_kernel_spec,
-        )
-        kernel = icm(searchspace, context.objective, context.measurements)
-        if isinstance(kernel, Kernel):
-            kernel = kernel.to_gpytorch(searchspace=searchspace)
-        return kernel
+    @staticmethod
+    def _raise_incompatible_override(
+        parameter_names: set[str], factory: object, cause: Exception | None = None
+    ) -> NoReturn:
+        """Raise an error for a surrogate kernel that cannot be reduced."""
+        raise IncompatibleOverrideError(
+            f"Kernel overrides for {sorted(parameter_names)} require a surrogate "
+            f"kernel (factory) that can exclude these parameters. "
+            f"'{type(factory).__name__}' does not satisfy this requirement."
+        ) from cause
 
     def _resolve_components(
         self, context: _ModelContext

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -7,7 +7,6 @@ import importlib
 import operator
 import os
 import warnings
-from copy import deepcopy
 from functools import partial, reduce
 from typing import TYPE_CHECKING, ClassVar
 
@@ -407,22 +406,43 @@ class GaussianProcessSurrogate(Surrogate):
 
         The effective kernel is the surrogate kernel restricted to the
         non-overridden dimensions, multiplied by one factor per override.
+
+        Args:
+            context: The model context providing the inputs and override settings.
+
+        Raises:
+            ValueError: If the resolved kernels violate the override partition.
+
+        Returns:
+            The resolved and partition-validated kernel.
         """
         overrides = _override.extract_parameter_overrides(context)
-        overrides.extend(_override.extract_transfer_learning_overrides(context))
-
-        # No overrides: let the surrogate kernel (factory) handle everything.
-        if not overrides:
-            factory = self.kernel_factory or BayBEKernelFactory()
-            kernel = factory(
-                context.searchspace, context.objective, context.measurements
-            )
-            if isinstance(kernel, Kernel):
-                return kernel.to_gpytorch(context.searchspace)
-            return kernel
+        overrides += _override.extract_transfer_learning_overrides(context)
 
         excluded_names = {name for name, _ in overrides}
         residual = self._resolve_residual_kernel(context, excluded_names)
+        searchspace = context.searchspace
+        excluded_dimensions: set[int] = set()
+        for name, kernel in overrides:
+            expected = set(searchspace.get_comp_rep_parameter_indices(name))
+            actual = _override.get_active_dimensions(kernel, searchspace)
+            if actual != expected:
+                raise ValueError(
+                    f"The kernel override for '{name}' has 'active_dims' {actual}, "
+                    f"but must use exactly the parameter indices {expected}."
+                )
+            excluded_dimensions.update(expected)
+
+        if residual is not None and excluded_names:
+            allowed = (
+                set(range(len(searchspace.comp_rep_columns))) - excluded_dimensions
+            )
+            actual = _override.get_active_dimensions(residual, searchspace)
+            if not actual <= allowed:
+                raise ValueError(
+                    f"The residual kernel's 'active_dims' {actual} must be a subset "
+                    f"of the non-overridden indices {allowed}."
+                )
         factors = ([] if residual is None else [residual]) + [k for _, k in overrides]
         return reduce(operator.mul, factors)
 
@@ -437,6 +457,14 @@ class GaussianProcessSurrogate(Surrogate):
         """
         searchspace = context.searchspace
         factory = self.kernel_factory or BayBEKernelFactory()
+        if not excluded_names:
+            kernel = factory(searchspace, context.objective, context.measurements)
+            return (
+                kernel.to_gpytorch(searchspace)
+                if isinstance(kernel, Kernel)
+                else kernel
+            )
+
         if all(p.name in excluded_names for p in searchspace.parameters):
             return None
 
@@ -663,6 +691,8 @@ def _make_posterior_mean_module(
     Returns:
         A mean module ready for use in a new GP.
     """
+    from copy import deepcopy
+
     import gpytorch
 
     frozen_model = deepcopy(model)

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -170,7 +170,12 @@ class GaussianProcessSurrogate(Surrogate):
     # See base class.
 
     _custom_kernel: bool = field(init=False, default=False, repr=False, eq=False)
-    # For deprecation only!
+    """Legacy flag for custom surrogate kernels affected by task-attachment changes.
+
+    Parameter overrides do not set this flag: default residual construction still
+    attaches the default task kernel unless an explicit TL override replaces it.
+    This flag does not classify the final composed covariance.
+    """
 
     kernel_factory: KernelFactoryProtocol | None = field(
         alias="kernel_or_factory",

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -195,9 +195,16 @@ class GaussianProcessSurrogate(Surrogate):
         * :obj:`.components.kernel.KernelFactoryProtocol`
         * :class:`gpytorch.kernels.Kernel`
 
-    If a :class:`.TaskParameter` sets ``override_transfer_learning_mode``, this must
-    reduce to a task-free BayBE kernel or an :class:`.IncompatibleOverrideError` is
-    raised.
+    A :attr:`~baybe.parameters.base.Parameter.kernel_override` removes its parameter
+    from this kernel and contributes a separate multiplicative factor. A
+    :attr:`~baybe.parameters.categorical.TaskParameter.override_transfer_learning_mode`
+    replaces the task factor in the same way. When a residual kernel is needed,
+    the configured kernel or factory must support excluding the overridden parameters;
+    otherwise, :class:`~baybe.exceptions.IncompatibleOverrideError` is raised.
+    If all parameters are overridden, this kernel or factory is not used. Without
+    overrides, it is used unchanged.
+
+    See :ref:`parameter_kernel_overrides` for details and limitations.
     """
 
     mean_factory: MeanFactoryProtocol | None = field(

--- a/docs/components/parameters.md
+++ b/docs/components/parameters.md
@@ -285,3 +285,61 @@ enlarged data corpus.
 ```{seealso}
 For details, refer to [transfer learning](../concepts/transfer_learning.md).
 ```
+
+(parameter_kernel_overrides)=
+## Parameter-Specific Kernel Overrides
+
+Regular parameters can replace the surrogate kernel on their computational dimensions
+using ``kernel_override``:
+
+```python
+from baybe.kernels import RBFKernel
+from baybe.parameters import NumericalContinuousParameter
+
+x3 = NumericalContinuousParameter(
+    name="x3",
+    bounds=(0.0, 1.0),
+    kernel_override=RBFKernel(),
+)
+```
+
+The surrogate kernel is the kernel supplied to the surrogate, or BayBE's default kernel
+if none is supplied. Overrides remove their parameter dimensions from that kernel and
+replace them with multiplicative parameter-specific factors:
+
+```{math}
+k_{\mathrm{effective}}
+= k_{\mathrm{surrogate}}(X_{\mathrm{remaining}})
+\prod_{p \in P_{\mathrm{override}}} k_p(X_p).
+```
+
+For parameters ``x1``, ``x2``, and ``x3`` in the example above, this produces
+``surrogate kernel(x1, x2) * RBF(x3)``. The override does not replace a dimension inside
+the surrogate kernel itself. It partitions the dimensions and creates a separate kernel
+factor. Multiple overrides produce multiple factors. For a parameter with several
+computational dimensions, the override acts jointly on the complete computational
+representation.
+
+An override can be a configured BayBE or GPyTorch kernel instance. For a BayBE kernel,
+``parameter_names`` must be ``None`` or contain exactly the owning parameter. Here,
+``None`` is rebound to the owning parameter instead of acting on all dimensions.
+
+```{admonition} Limitations
+:class: warning
+Parameter-local kernel factories are not supported. The surrogate kernel or factory of
+the {class}`~baybe.surrogates.gaussian_process.core.GaussianProcessSurrogate` must allow
+the overridden dimensions to be excluded. Otherwise, BayBE raises
+{class}`~baybe.exceptions.IncompatibleOverrideError`.
+
+Raw GPyTorch overrides must not specify ``active_dims``, and their ``ard_num_dims`` must
+be ``None`` or match the number of computational dimensions of the parameter. ``None``
+is preserved and does not automatically enable ARD. Like raw GPyTorch kernels used
+elsewhere, they cannot be serialized.
+```
+
+The feature applies only to Gaussian process surrogates. Other surrogates ignore kernel
+overrides and emit an {class}`~baybe.exceptions.UnusedObjectWarning`. Task parameters do
+not expose {attr}`~baybe.parameters.base.Parameter.kernel_override`; use
+{attr}`~baybe.parameters.categorical.TaskParameter.override_transfer_learning_mode`
+instead. Both override mechanisms can be used in the same searchspace, in which case
+their kernel factors are multiplied.

--- a/docs/components/surrogates.md
+++ b/docs/components/surrogates.md
@@ -161,6 +161,9 @@ kernel = ScaleKernel(
 kernel = MaternKernel(parameter_names=["Param_A", "Param_B"])
 ```
 
+For a convenience interface that assigns a kernel directly to one parameter, see
+{ref}`parameter_kernel_overrides`.
+
 #### Presets
 
 Providing customized GP configurations on the component level is powerful for expert

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ nitpick_ignore_regex = [
     (r"py:class", r"^(dtype=np\.int64|if metric == 'precomputed')$"),
     ##### Type aliases in TYPE_CHECKING blocks #####
     # These exist only at type-checking time and cannot be resolved by Sphinx.
-    (r"py:class", r"^(GPComponent|TensorCallable|ConvertibleToFloat)$"),
+    (r"py:class", r"^(GPComponent|KernelOverride|TensorCallable|ConvertibleToFloat)$"),
     (r"py:class", r"^(GPyTorchKernel|GPyTorchLikelihood|GPyTorchMean|GPyTorchModel)$"),
     (r"py:class", r"^(pd\.DataFrame|pl\.Expr)$"),
     (r"py:class", r"^(TypeAliasForwardRef|P)$"),

--- a/tests/hypothesis_strategies/parameters.py
+++ b/tests/hypothesis_strategies/parameters.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 import hypothesis.strategies as st
 import numpy as np
+from attrs import evolve
 from hypothesis.extra.pandas import columns, data_frames
 
 from baybe.parameters.categorical import (
@@ -36,6 +37,39 @@ categories = st.lists(
     st.one_of(st.text(min_size=1), st.booleans()), min_size=2, unique=True
 )
 """A strategy that generates parameter categories."""
+
+
+def _remove_kernel_parameter_names(kernel):
+    """Remove explicit parameter names from all basic kernel leaves."""
+    from baybe.kernels.base import BasicKernel
+    from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
+
+    if isinstance(kernel, BasicKernel):
+        return evolve(kernel, parameter_names=None)
+    if isinstance(kernel, ScaleKernel):
+        return evolve(
+            kernel,
+            base_kernel=_remove_kernel_parameter_names(kernel.base_kernel),
+        )
+    if isinstance(kernel, (AdditiveKernel, ProductKernel)):
+        return evolve(
+            kernel,
+            base_kernels=tuple(
+                _remove_kernel_parameter_names(k) for k in kernel.base_kernels
+            ),
+        )
+    raise TypeError(f"Unsupported kernel type: {type(kernel)}")
+
+
+@st.composite
+def kernel_overrides(draw: st.DrawFn, parameter_name: str):
+    """Generate valid kernel overrides for a parameter."""
+    from tests.hypothesis_strategies.kernels import kernels
+
+    kernel = draw(st.one_of(st.none(), kernels(parameter_names=(parameter_name,))))
+    if kernel is not None and draw(st.booleans()):
+        kernel = _remove_kernel_parameter_names(kernel)
+    return kernel
 
 
 @st.composite
@@ -121,8 +155,13 @@ def numerical_discrete_parameters(
             )
         )
     param_metadata = draw(measurable_metadata())
+    kernel_override = draw(kernel_overrides(name))
     return NumericalDiscreteParameter(
-        name=name, values=values, tolerance=tolerance, metadata=param_metadata
+        name=name,
+        values=values,
+        tolerance=tolerance,
+        metadata=param_metadata,
+        kernel_override=kernel_override,
     )
 
 
@@ -132,8 +171,12 @@ def numerical_continuous_parameters(draw: st.DrawFn):
     name = draw(parameter_names)
     bounds = draw(intervals(exclude_half_bounded=True, exclude_fully_unbounded=True))
     param_metadata = draw(measurable_metadata())
+    kernel_override = draw(kernel_overrides(name))
     return NumericalContinuousParameter(
-        name=name, bounds=bounds, metadata=param_metadata
+        name=name,
+        bounds=bounds,
+        metadata=param_metadata,
+        kernel_override=kernel_override,
     )
 
 
@@ -145,12 +188,14 @@ def categorical_parameters(draw: st.DrawFn):
     encoding = draw(st.sampled_from(CategoricalEncoding))
     active_values = draw(_active_values(values))
     param_metadata = draw(measurable_metadata())
+    kernel_override = draw(kernel_overrides(name))
     return CategoricalParameter(
         name=name,
         values=values,
         encoding=encoding,
         active_values=active_values,
         metadata=param_metadata,
+        kernel_override=kernel_override,
     )
 
 
@@ -188,6 +233,7 @@ def substance_parameters(draw: st.DrawFn):
     encoding = draw(st.sampled_from(encodings))
 
     param_metadata = draw(measurable_metadata())
+    kernel_override = draw(kernel_overrides(name))
 
     return SubstanceParameter(
         name=name,
@@ -196,6 +242,7 @@ def substance_parameters(draw: st.DrawFn):
         encoding=encoding,
         active_values=active_values,
         metadata=param_metadata,
+        kernel_override=kernel_override,
     )
 
 
@@ -207,12 +254,14 @@ def custom_parameters(draw: st.DrawFn):
     decorrelate = draw(decorrelations)
     active_values = draw(_active_values(list(data.index)))
     param_metadata = draw(measurable_metadata())
+    kernel_override = draw(kernel_overrides(name))
     return CustomDiscreteParameter(
         name=name,
         data=data,
         decorrelate=decorrelate,
         active_values=active_values,
         metadata=param_metadata,
+        kernel_override=kernel_override,
     )
 
 

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -27,6 +27,7 @@ from baybe.kernels.basic import (
 )
 from baybe.kernels.composite import ScaleKernel
 from baybe.objectives.pareto import ParetoObjective
+from baybe.parameters import NumericalContinuousParameter
 from baybe.priors import (
     GammaPrior,
     HalfCauchyPrior,
@@ -368,6 +369,25 @@ def test_non_batching_acqfs(ongoing_campaign, n_iterations, batch_size):
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_kernels(ongoing_campaign, n_iterations, batch_size):
+    run_iterations(ongoing_campaign, n_iterations, batch_size)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        [
+            NumericalContinuousParameter("x1", (0, 1)),
+            NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+        ]
+    ],
+    ids=["parameter_kernel_override"],
+)
+@pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
+def test_parameter_kernel_override_iteration(
+    ongoing_campaign, n_iterations, batch_size
+):
+    """A complete optimization iteration supports a parameter kernel override."""
     run_iterations(ongoing_campaign, n_iterations, batch_size)
 
 

--- a/tests/test_iterations.py
+++ b/tests/test_iterations.py
@@ -27,7 +27,11 @@ from baybe.kernels.basic import (
 )
 from baybe.kernels.composite import ScaleKernel
 from baybe.objectives.pareto import ParetoObjective
-from baybe.parameters import NumericalContinuousParameter
+from baybe.parameters import (
+    NumericalContinuousParameter,
+    TaskParameter,
+    TransferLearningMode,
+)
 from baybe.priors import (
     GammaPrior,
     HalfCauchyPrior,
@@ -379,9 +383,19 @@ def test_kernels(ongoing_campaign, n_iterations, batch_size):
         [
             NumericalContinuousParameter("x1", (0, 1)),
             NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+            *(
+                []
+                if mode is None
+                else [
+                    TaskParameter(
+                        "task", ["a", "b"], override_transfer_learning_mode=mode
+                    )
+                ]
+            ),
         ]
+        for mode in [None, *TransferLearningMode]
     ],
-    ids=["parameter_kernel_override"],
+    ids=["parameter_kernel_override", *(mode.name for mode in TransferLearningMode)],
 )
 @pytest.mark.parametrize("n_iterations", [3], ids=["i3"])
 def test_parameter_kernel_override_iteration(

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -147,6 +147,14 @@ def _make_dispatch_context(override_mode):
     ("override_mode", "kernel_or_factory", "expected_task_kernel_cls", "has_base"),
     [
         param(
+            TransferLearningMode.POSITIVE_INDEX_KERNEL,
+            MaternKernel(parameter_names=("x",))
+            * IndexKernel(num_tasks=3, rank=3, parameter_names=("Task",)),
+            GPyTorchPositiveIndexKernel,
+            True,
+            id="override+product_kernel",
+        ),
+        param(
             None,
             None,
             GPyTorchPositiveIndexKernel,
@@ -307,12 +315,6 @@ def test_resolve_kernel_dispatch_success(
         ),
         param(
             TransferLearningMode.POSITIVE_INDEX_KERNEL,
-            MaternKernel(parameter_names=("x",))
-            * IndexKernel(num_tasks=3, rank=3, parameter_names=("Task",)),
-            id="override+product_kernel",
-        ),
-        param(
-            TransferLearningMode.POSITIVE_INDEX_KERNEL,
             ICMKernelFactory(
                 task_kernel_or_factory=IndexKernel(
                     num_tasks=3, rank=3, parameter_names=("Task",)
@@ -330,7 +332,7 @@ def test_resolve_kernel_dispatch_success(
 def test_resolve_kernel_dispatch_raises(monkeypatch, override_mode, kernel_or_factory):
     """`_resolve_kernel` raises for inputs incompatible with an override.
 
-    This covers raw gpytorch kernels, composite kernels, and task-aware factories.
+    This covers raw gpytorch kernels and task-aware factories.
     """
     monkeypatch.setenv("BAYBE_DISABLE_CUSTOM_KERNEL_WARNING", "True")
 

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -12,7 +12,7 @@ from gpytorch.kernels import IndexKernel as GPyTorchIndexKernel
 from pytest import param
 
 from baybe.exceptions import IncompatibleOverrideError, IncompatibleSearchSpaceError
-from baybe.kernels.basic import IndexKernel, MaternKernel, RBFKernel
+from baybe.kernels.basic import IndexKernel, MaternKernel
 from baybe.kernels.composite import ScaleKernel
 from baybe.parameters.categorical import (
     CategoricalParameter,
@@ -23,7 +23,7 @@ from baybe.parameters.numerical import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
 )
-from baybe.parameters.selectors import NameSelector, TypeSelector
+from baybe.parameters.selectors import TypeSelector
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates import GaussianProcessSurrogate
 from baybe.surrogates.gaussian_process.components.kernel import ICMKernelFactory
@@ -342,69 +342,3 @@ def test_resolve_kernel_dispatch_raises(monkeypatch, override_mode, kernel_or_fa
 
     with pytest.raises(IncompatibleOverrideError):
         surrogate._resolve_kernel(context)
-
-
-@pytest.mark.parametrize(
-    ("override_mode", "expected_task_kernel_cls"),
-    [
-        param(
-            TransferLearningMode.POSITIVE_INDEX_KERNEL,
-            GPyTorchPositiveIndexKernel,
-            id="positive-index",
-        ),
-        param(TransferLearningMode.INDEX_KERNEL, GPyTorchIndexKernel, id="index"),
-    ],
-)
-@pytest.mark.parametrize(
-    "has_regular_override", [False, True], ids=["tl-only", "tl-and-regular"]
-)
-def test_default_factory_selector_override_precedence(
-    override_mode: TransferLearningMode,
-    expected_task_kernel_cls: type[gpytorch.kernels.Kernel],
-    has_regular_override: bool,
-) -> None:
-    """Selectors restrict the base kernel but cannot exclude parameter overrides."""
-    from baybe.surrogates.gaussian_process.core import _ModelContext
-
-    searchspace = SearchSpace.from_product(
-        [
-            NumericalContinuousParameter("x1", (0, 1)),
-            NumericalContinuousParameter(
-                "x2",
-                (0, 1),
-                kernel_override=RBFKernel() if has_regular_override else None,
-            ),
-            NumericalContinuousParameter("omitted", (0, 1)),
-            TaskParameter(
-                "Task", ["A", "B"], override_transfer_learning_mode=override_mode
-            ),
-        ]
-    )
-    selector = NameSelector(("x1",), regex=False)
-    assert [p.name for p in searchspace.parameters if selector(p)] == ["x1"]
-    surrogate = GaussianProcessSurrogate(
-        kernel_or_factory=BayBEKernelFactory(parameter_selector=selector)
-    )
-    context = _ModelContext(
-        searchspace, NumericalTarget("y").to_objective(), pd.DataFrame()
-    )
-
-    kernel = surrogate._resolve_kernel(context)
-
-    expected_names = ["x1"] + (["x2"] if has_regular_override else []) + ["Task"]
-    expected_types = (
-        [gpytorch.kernels.MaternKernel]
-        + ([gpytorch.kernels.RBFKernel] if has_regular_override else [])
-        + [expected_task_kernel_cls]
-    )
-    expected_dimensions = [
-        searchspace.get_comp_rep_parameter_indices(name) for name in expected_names
-    ]
-    assert isinstance(kernel, gpytorch.kernels.ProductKernel)
-    assert [type(k) for k in kernel.kernels] == expected_types
-    assert [
-        tuple(k.active_dims.tolist()) for k in kernel.kernels
-    ] == expected_dimensions
-    assert [k.ard_num_dims for k in kernel.kernels] == [
-        len(d) for d in expected_dimensions
-    ]

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -12,7 +12,7 @@ from gpytorch.kernels import IndexKernel as GPyTorchIndexKernel
 from pytest import param
 
 from baybe.exceptions import IncompatibleOverrideError, IncompatibleSearchSpaceError
-from baybe.kernels.basic import IndexKernel, MaternKernel
+from baybe.kernels.basic import IndexKernel, MaternKernel, RBFKernel
 from baybe.kernels.composite import ScaleKernel
 from baybe.parameters.categorical import (
     CategoricalParameter,
@@ -23,7 +23,7 @@ from baybe.parameters.numerical import (
     NumericalContinuousParameter,
     NumericalDiscreteParameter,
 )
-from baybe.parameters.selectors import TypeSelector
+from baybe.parameters.selectors import NameSelector, TypeSelector
 from baybe.searchspace.core import SearchSpace
 from baybe.surrogates import GaussianProcessSurrogate
 from baybe.surrogates.gaussian_process.components.kernel import ICMKernelFactory
@@ -248,6 +248,24 @@ def _make_dispatch_context(override_mode):
             True,
             id="index_override+default_factory",
         ),
+        param(
+            TransferLearningMode.POSITIVE_INDEX_KERNEL,
+            BayBEKernelFactory(
+                parameter_selector=TypeSelector((TaskParameter,), exclude=True)
+            ),
+            GPyTorchPositiveIndexKernel,
+            True,
+            id="positive_index_override+default_factory_with_selector",
+        ),
+        param(
+            TransferLearningMode.INDEX_KERNEL,
+            BayBEKernelFactory(
+                parameter_selector=TypeSelector((TaskParameter,), exclude=True)
+            ),
+            GPyTorchIndexKernel,
+            True,
+            id="index_override+default_factory_with_selector",
+        ),
     ],
 )
 def test_resolve_kernel_dispatch_success(
@@ -307,15 +325,6 @@ def test_resolve_kernel_dispatch_success(
             _gpytorch_returning_factory,
             id="override+factory_returning_gpytorch",
         ),
-        param(
-            TransferLearningMode.INDEX_KERNEL,
-            BayBEKernelFactory(
-                parameter_selector=TypeSelector((TaskParameter,), exclude=True)
-            ),
-            # On a searchspace without a substance parameter, the default factory
-            # yields a gpytorch kernel and cannot be combined with an override.
-            id="override+default_factory_with_selector_unsupported",
-        ),
     ],
 )
 def test_resolve_kernel_dispatch_raises(monkeypatch, override_mode, kernel_or_factory):
@@ -333,3 +342,69 @@ def test_resolve_kernel_dispatch_raises(monkeypatch, override_mode, kernel_or_fa
 
     with pytest.raises(IncompatibleOverrideError):
         surrogate._resolve_kernel(context)
+
+
+@pytest.mark.parametrize(
+    ("override_mode", "expected_task_kernel_cls"),
+    [
+        param(
+            TransferLearningMode.POSITIVE_INDEX_KERNEL,
+            GPyTorchPositiveIndexKernel,
+            id="positive-index",
+        ),
+        param(TransferLearningMode.INDEX_KERNEL, GPyTorchIndexKernel, id="index"),
+    ],
+)
+@pytest.mark.parametrize(
+    "has_regular_override", [False, True], ids=["tl-only", "tl-and-regular"]
+)
+def test_default_factory_selector_override_precedence(
+    override_mode: TransferLearningMode,
+    expected_task_kernel_cls: type[gpytorch.kernels.Kernel],
+    has_regular_override: bool,
+) -> None:
+    """Selectors restrict the base kernel but cannot exclude parameter overrides."""
+    from baybe.surrogates.gaussian_process.core import _ModelContext
+
+    searchspace = SearchSpace.from_product(
+        [
+            NumericalContinuousParameter("x1", (0, 1)),
+            NumericalContinuousParameter(
+                "x2",
+                (0, 1),
+                kernel_override=RBFKernel() if has_regular_override else None,
+            ),
+            NumericalContinuousParameter("omitted", (0, 1)),
+            TaskParameter(
+                "Task", ["A", "B"], override_transfer_learning_mode=override_mode
+            ),
+        ]
+    )
+    selector = NameSelector(("x1",), regex=False)
+    assert [p.name for p in searchspace.parameters if selector(p)] == ["x1"]
+    surrogate = GaussianProcessSurrogate(
+        kernel_or_factory=BayBEKernelFactory(parameter_selector=selector)
+    )
+    context = _ModelContext(
+        searchspace, NumericalTarget("y").to_objective(), pd.DataFrame()
+    )
+
+    kernel = surrogate._resolve_kernel(context)
+
+    expected_names = ["x1"] + (["x2"] if has_regular_override else []) + ["Task"]
+    expected_types = (
+        [gpytorch.kernels.MaternKernel]
+        + ([gpytorch.kernels.RBFKernel] if has_regular_override else [])
+        + [expected_task_kernel_cls]
+    )
+    expected_dimensions = [
+        searchspace.get_comp_rep_parameter_indices(name) for name in expected_names
+    ]
+    assert isinstance(kernel, gpytorch.kernels.ProductKernel)
+    assert [type(k) for k in kernel.kernels] == expected_types
+    assert [
+        tuple(k.active_dims.tolist()) for k in kernel.kernels
+    ] == expected_dimensions
+    assert [k.ard_num_dims for k in kernel.kernels] == [
+        len(d) for d in expected_dimensions
+    ]

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -273,18 +273,56 @@ def fixture_task_searchspace() -> SearchSpace:
             None,
             id="scale_kernel_over_sole_parameter_collapses_to_none",
         ),
+        param(
+            MaternKernel() * RBFKernel(),
+            MaternKernel(parameter_names=("x",)) * RBFKernel(parameter_names=("x",)),
+            id="product_reduces_each_factor",
+        ),
+        param(
+            MaternKernel() * RBFKernel(parameter_names=("Task",)),
+            MaternKernel(parameter_names=("x",)),
+            id="product_collapses_to_single_factor",
+        ),
+        param(
+            MaternKernel(parameter_names=("Task",))
+            * RBFKernel(parameter_names=("Task",)),
+            None,
+            id="product_collapses_to_none",
+        ),
+        param(
+            ScaleKernel(
+                ProductKernel(
+                    [
+                        MaternKernel(),
+                        ProductKernel(
+                            [
+                                RBFKernel(parameter_names=("Task",)),
+                                RBFKernel(parameter_names=("x",)),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            ScaleKernel(
+                MaternKernel(parameter_names=("x",)) * RBFKernel(parameter_names=("x",))
+            ),
+            id="nested_product_under_scale",
+        ),
     ],
 )
 def test_without_parameter(kernel, expected, task_searchspace):
-    """Removing a parameter reduces basic and scaled kernels as expected."""
+    """Removing a parameter reduces basic, scaled, and product kernels as expected."""
     assert kernel._without_parameter("Task", task_searchspace) == expected
 
 
 @pytest.mark.parametrize(
     "kernel",
     [
-        param(MaternKernel() * RBFKernel(), id="product_kernel"),
         param(MaternKernel() + RBFKernel(), id="additive_kernel"),
+        param(
+            MaternKernel() * (MaternKernel() + RBFKernel()),
+            id="product_with_unsupported_factor",
+        ),
     ],
 )
 def test_without_parameter_unsupported(kernel, task_searchspace):

--- a/tests/test_parameter_kernel_overrides.py
+++ b/tests/test_parameter_kernel_overrides.py
@@ -1,0 +1,296 @@
+"""Functional tests for parameter-specific kernel overrides.
+
+These tests resolve or fit kernels to check binding and composition behavior.
+Construction-time input validation lives in ``tests/validation``.
+"""
+
+from copy import deepcopy
+
+import pandas as pd
+import pytest
+import torch
+from botorch.models.kernels.positive_index import PositiveIndexKernel
+from gpytorch import kernels as gk
+from pytest import param
+
+from baybe.exceptions import IncompatibleOverrideError
+from baybe.kernels import MaternKernel, RBFKernel
+from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
+from baybe.parameters import (
+    CategoricalParameter,
+    NumericalContinuousParameter,
+    NumericalDiscreteParameter,
+    TaskParameter,
+)
+from baybe.parameters.enum import TransferLearningMode
+from baybe.parameters.selectors import NameSelector
+from baybe.searchspace import SearchSpace
+from baybe.surrogates import GaussianProcessSurrogate
+from baybe.surrogates.gaussian_process.core import _ModelContext
+from baybe.surrogates.gaussian_process.presets import BayBEKernelFactory
+from baybe.targets import NumericalTarget
+
+
+def _resolve(parameters, kernel_or_factory=None):
+    """Resolve the default GP kernel for the given parameters."""
+    searchspace = SearchSpace.from_product(parameters)
+    context = _ModelContext(
+        searchspace, NumericalTarget("y").to_objective(), pd.DataFrame()
+    )
+    surrogate = GaussianProcessSurrogate(kernel_or_factory=kernel_or_factory)
+    return surrogate._resolve_kernel(context), searchspace
+
+
+def _leaf_kernels(kernel):
+    """Return the leaf kernels of a GPyTorch kernel tree."""
+    children = tuple(kernel.sub_kernels())
+    return (
+        (kernel,)
+        if not children
+        else tuple(k for c in children for k in _leaf_kernels(c))
+    )
+
+
+def _fit(parameters):
+    """Fit a GP and return its installed covariance module and searchspace."""
+    searchspace = SearchSpace.from_product(parameters)
+    measurements = pd.DataFrame(
+        [
+            {**{p.name: p.values[0] for p in parameters}, "y": 0.0},
+            {**{p.name: p.values[-1] for p in parameters}, "y": 1.0},
+        ]
+    )
+    surrogate = GaussianProcessSurrogate()
+    surrogate.fit(searchspace, NumericalTarget("y").to_objective(), measurements)
+    assert surrogate._model is not None
+    return surrogate._model.covar_module, searchspace
+
+
+def test_default_factory_selector_is_preserved():
+    """Partitioning preserves an explicit default-factory parameter selector."""
+    kernel, _ = _resolve(
+        [
+            NumericalContinuousParameter("x1", (0, 1)),
+            NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+            NumericalContinuousParameter("x3", (0, 1)),
+        ],
+        BayBEKernelFactory(parameter_selector=NameSelector(("x1",), regex=False)),
+    )
+
+    assert {tuple(k.active_dims.tolist()) for k in _leaf_kernels(kernel)} == {
+        (0,),
+        (1,),
+    }
+
+
+@pytest.mark.parametrize(
+    ("parameters", "expected_types", "expected_names"),
+    [
+        param(
+            [
+                CategoricalParameter("base", ["a", "b"]),
+                NumericalDiscreteParameter(
+                    "override", [0, 1, 2], kernel_override=RBFKernel()
+                ),
+            ],
+            [gk.MaternKernel, gk.RBFKernel],
+            ["base", "override"],
+            id="single-dim",
+        ),
+        param(
+            [
+                CategoricalParameter("base", ["a", "b"]),
+                CategoricalParameter(
+                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
+                ),
+            ],
+            [gk.MaternKernel, gk.RBFKernel],
+            ["base", "override"],
+            id="multi-dim",
+        ),
+        param(
+            [
+                CategoricalParameter("first", ["a", "b"], kernel_override=RBFKernel()),
+                CategoricalParameter(
+                    "second", ["a", "b"], kernel_override=MaternKernel()
+                ),
+            ],
+            [gk.RBFKernel, gk.MaternKernel],
+            ["first", "second"],
+            id="all-overridden",
+        ),
+        param(
+            [
+                CategoricalParameter("base", ["a", "b"]),
+                CategoricalParameter(
+                    "override", ["a", "b"], kernel_override=RBFKernel()
+                ),
+                TaskParameter("task", ["a", "b"]),
+            ],
+            [
+                gk.MaternKernel,
+                PositiveIndexKernel,
+                gk.RBFKernel,
+            ],
+            ["base", "task", "override"],
+            id="task-without-tl-override",
+        ),
+        param(
+            [
+                CategoricalParameter("base", ["a", "b"]),
+                CategoricalParameter(
+                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
+                ),
+                TaskParameter(
+                    "task",
+                    ["a", "b"],
+                    override_transfer_learning_mode=TransferLearningMode.INDEX_KERNEL,
+                ),
+            ],
+            [
+                gk.MaternKernel,
+                gk.RBFKernel,
+                gk.IndexKernel,
+            ],
+            ["base", "override", "task"],
+            id="override-and-tl-index",
+        ),
+        param(
+            [
+                CategoricalParameter("base", ["a", "b"]),
+                CategoricalParameter(
+                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
+                ),
+                TaskParameter(
+                    "task",
+                    ["a", "b"],
+                    override_transfer_learning_mode=(
+                        TransferLearningMode.POSITIVE_INDEX_KERNEL
+                    ),
+                ),
+            ],
+            [
+                gk.MaternKernel,
+                gk.RBFKernel,
+                PositiveIndexKernel,
+            ],
+            ["base", "override", "task"],
+            id="override-and-tl-pos-index",
+        ),
+    ],
+)
+def test_fitted_model_uses_parameter_kernel_overrides(
+    parameters, expected_types, expected_names
+):
+    """The fitted model uses each configured kernel on the intended dimensions."""
+    kernel, searchspace = _fit(parameters)
+    leaves = _leaf_kernels(kernel)
+    expected_dimensions = [
+        searchspace.get_comp_rep_parameter_indices(name) for name in expected_names
+    ]
+
+    assert isinstance(kernel, gk.ProductKernel)
+    assert [type(k) for k in leaves] == expected_types
+    assert [tuple(k.active_dims.tolist()) for k in leaves] == expected_dimensions
+    assert [k.ard_num_dims for k in leaves] == [len(d) for d in expected_dimensions]
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        param(RBFKernel(), id="unscoped"),
+        param(RBFKernel(parameter_names=("override",)), id="owner-scoped"),
+        param(ScaleKernel(RBFKernel()), id="scale"),
+        param(AdditiveKernel([RBFKernel(), MaternKernel()]), id="additive"),
+        param(ProductKernel([RBFKernel(), MaternKernel()]), id="product"),
+    ],
+)
+def test_valid_baybe_kernel_override(override):
+    """Valid BayBE overrides bind all their leaves to the owning parameter."""
+    parameters = [
+        CategoricalParameter("base", ["a", "b"]),
+        CategoricalParameter("override", ["a", "b", "c"], kernel_override=override),
+    ]
+    kernel, searchspace = _resolve(parameters)
+    expected = set(searchspace.get_comp_rep_parameter_indices("override"))
+
+    override_leaves = [
+        k
+        for k in _leaf_kernels(kernel)
+        if set(k.active_dims.tolist())
+        != set(searchspace.get_comp_rep_parameter_indices("base"))
+    ]
+    assert override_leaves
+    assert all(set(k.active_dims.tolist()) == expected for k in override_leaves)
+
+
+@pytest.mark.parametrize(
+    ("categories", "override"),
+    [
+        param(["a", "b"], gk.RBFKernel(), id="no-ard"),
+        param(["a", "b"], gk.RBFKernel(ard_num_dims=2), id="ard"),
+        param(["a", "b", "c"], gk.RBFKernel(ard_num_dims=3), id="multi-column-ard"),
+        param(["a", "b"], gk.ScaleKernel(gk.RBFKernel()), id="nested"),
+    ],
+)
+def test_valid_gpytorch_kernel_override(categories, override):
+    """Valid GPyTorch overrides are bound to the owner without mutating the input."""
+    snapshot = deepcopy(override.state_dict())
+    base = NumericalContinuousParameter("base", (0, 1))
+    kernel, searchspace = _resolve(
+        [base, CategoricalParameter("override", categories, kernel_override=override)]
+    )
+    expected = set(searchspace.get_comp_rep_parameter_indices("override"))
+
+    # The override factor is the product factor acting on the override dimensions.
+    factor = next(k for k in kernel.kernels if set(k.active_dims.tolist()) == expected)
+    assert type(factor) is type(override)
+
+    # The provided kernel is copied, not mutated.
+    assert override.active_dims is None
+    assert all(torch.equal(snapshot[k], override.state_dict()[k]) for k in snapshot)
+
+
+def test_gpytorch_ard_mismatch_rejected():
+    """A GPyTorch override with mismatched ARD size is rejected during resolution."""
+    override = gk.RBFKernel(ard_num_dims=2)
+    parameter = CategoricalParameter("p", ["a", "b", "c"], kernel_override=override)
+    with pytest.raises(IncompatibleOverrideError, match="has 3 computational"):
+        _resolve([parameter])
+
+
+def test_parameter_equivalence_ignores_override_parameter_name():
+    """Equivalent parameters may scope the same override to their own names."""
+    left = NumericalContinuousParameter(
+        "left", (0, 1), kernel_override=RBFKernel(parameter_names=("left",))
+    )
+    right = NumericalContinuousParameter(
+        "right", (0, 1), kernel_override=RBFKernel(parameter_names=("right",))
+    )
+
+    assert left.is_equivalent(right)
+
+
+@pytest.mark.parametrize(
+    "kernel_or_factory",
+    [
+        param(
+            AdditiveKernel([MaternKernel(), MaternKernel()]),
+            id="non-reducible-baybe-kernel",
+        ),
+        param(gk.MaternKernel(), id="raw-gpytorch-kernel"),
+        param(
+            lambda s, o, m: gk.MaternKernel(),
+            id="factory-returning-raw-kernel",
+        ),
+    ],
+)
+def test_incompatible_surrogate_kernel_is_rejected(kernel_or_factory):
+    """Surrogate kernels that cannot exclude overridden dimensions are rejected."""
+    parameters = [
+        NumericalContinuousParameter("x1", (0, 1)),
+        NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+    ]
+
+    with pytest.raises(IncompatibleOverrideError):
+        _resolve(parameters, kernel_or_factory)

--- a/tests/test_parameter_kernel_overrides.py
+++ b/tests/test_parameter_kernel_overrides.py
@@ -15,6 +15,7 @@ from pytest import param
 
 from baybe.exceptions import IncompatibleOverrideError
 from baybe.kernels import MaternKernel, RBFKernel
+from baybe.kernels.basic import IndexKernel
 from baybe.kernels.composite import AdditiveKernel, ProductKernel, ScaleKernel
 from baybe.parameters import (
     CategoricalParameter,
@@ -26,6 +27,7 @@ from baybe.parameters.enum import TransferLearningMode
 from baybe.parameters.selectors import NameSelector
 from baybe.searchspace import SearchSpace
 from baybe.surrogates import GaussianProcessSurrogate
+from baybe.surrogates.gaussian_process.components.kernel import ICMKernelFactory
 from baybe.surrogates.gaussian_process.core import _ModelContext
 from baybe.surrogates.gaussian_process.presets import BayBEKernelFactory
 from baybe.targets import NumericalTarget
@@ -294,3 +296,123 @@ def test_incompatible_surrogate_kernel_is_rejected(kernel_or_factory):
 
     with pytest.raises(IncompatibleOverrideError):
         _resolve(parameters, kernel_or_factory)
+
+
+@pytest.mark.parametrize("resolver", ["icm", "unified"], ids=["icm", "unified"])
+@pytest.mark.parametrize(
+    ("factor", "active_dims"),
+    [
+        param("residual", None, id="unrestricted-residual"),
+        param("residual", (0, 1), id="overlapping-residual"),
+        param("task", None, id="unrestricted-task"),
+        param("task", (0, 1), id="overlapping-task"),
+        param("task", (), id="empty-task"),
+    ],
+)
+def test_tl_partition_validation(monkeypatch, resolver, factor, active_dims):
+    """The unified resolver retains ICM's rejection of misbound kernel outputs."""
+    parameters = [
+        NumericalContinuousParameter("x", (0, 1)),
+        TaskParameter(
+            "task",
+            ["a", "b"],
+            override_transfer_learning_mode=TransferLearningMode.INDEX_KERNEL,
+        ),
+    ]
+    searchspace = SearchSpace.from_product(parameters)
+    objective = NumericalTarget("y").to_objective()
+    measurements = pd.DataFrame()
+    kernel_cls = MaternKernel if factor == "residual" else IndexKernel
+
+    def misbound_kernel(self, searchspace):
+        return gk.RBFKernel(active_dims=active_dims)
+
+    monkeypatch.setattr(kernel_cls, "to_gpytorch", misbound_kernel)
+    with pytest.raises(ValueError, match="active_dims"):
+        if resolver == "icm":
+            ICMKernelFactory(
+                base_kernel_or_factory=MaternKernel(parameter_names=("x",)),
+                task_kernel_or_factory=IndexKernel(
+                    num_tasks=2, rank=2, parameter_names=("task",)
+                ),
+            )(searchspace, objective, measurements)
+        else:
+            GaussianProcessSurrogate(kernel_or_factory=MaternKernel())._resolve_kernel(
+                _ModelContext(searchspace, objective, measurements)
+            )
+
+
+@pytest.mark.parametrize(
+    "factor", ["residual", "override"], ids=["residual", "override"]
+)
+def test_regular_partition_validation(monkeypatch, factor):
+    """Partition validation also rejects overlap for regular parameter overrides."""
+
+    def misbound_kernel(self, searchspace):
+        return gk.RBFKernel()
+
+    monkeypatch.setattr(
+        MaternKernel if factor == "residual" else RBFKernel,
+        "to_gpytorch",
+        misbound_kernel,
+    )
+    with pytest.raises(ValueError, match="active_dims"):
+        _resolve(
+            [
+                NumericalContinuousParameter("x", (0, 1)),
+                NumericalContinuousParameter("y", (0, 1), kernel_override=RBFKernel()),
+            ],
+            MaternKernel(),
+        )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        param(ScaleKernel(RBFKernel()), id="scale"),
+        param(AdditiveKernel([RBFKernel(), MaternKernel()]), id="additive"),
+        param(ProductKernel([RBFKernel(), MaternKernel()]), id="product"),
+        param(gk.ScaleKernel(gk.RBFKernel()), id="raw-scale"),
+    ],
+)
+def test_composite_partition_omits_unselected_columns(override):
+    """Composite factors may share their owner while unused columns stay irrelevant."""
+    kernel, searchspace = _resolve(
+        [
+            NumericalContinuousParameter("x", (0, 1)),
+            NumericalContinuousParameter("y", (0, 1), kernel_override=override),
+            NumericalContinuousParameter("omitted", (0, 1)),
+            TaskParameter("task", ["a", "b"]),
+        ],
+        BayBEKernelFactory(parameter_selector=NameSelector(("x",), regex=False)),
+    )
+    inputs = torch.zeros(2, len(searchspace.comp_rep_columns))
+    baseline = kernel(inputs).to_dense()
+    omitted = searchspace.get_comp_rep_parameter_indices("omitted")
+    inputs[1, list(omitted)] = 1.0
+    torch.testing.assert_close(kernel(inputs).to_dense(), baseline)
+    overridden = searchspace.get_comp_rep_parameter_indices("y")
+    inputs[1, list(overridden)] = 1.0
+    assert not torch.allclose(kernel(inputs).to_dense(), baseline)
+
+
+@pytest.mark.parametrize("as_factory", [False, True], ids=["fixed", "callable"])
+def test_raw_surrogate_kernel_without_overrides(as_factory):
+    """Without overrides, raw surrogate kernels are passed through unchanged."""
+    raw = gk.RBFKernel(active_dims=(0,))
+    specification = (lambda s, o, m: raw) if as_factory else raw
+    kernel, _ = _resolve([NumericalContinuousParameter("x", (0, 1))], specification)
+    assert kernel is raw
+
+
+def test_all_overridden_bypasses_surrogate_factory():
+    """A fully overridden space does not construct an unused residual kernel."""
+
+    def unused_factory(searchspace, objective, measurements):
+        pytest.fail("The residual factory must not be called.")
+
+    kernel, _ = _resolve(
+        [NumericalContinuousParameter("x", (0, 1), kernel_override=RBFKernel())],
+        unused_factory,
+    )
+    assert isinstance(kernel, gk.RBFKernel)

--- a/tests/test_parameter_kernel_overrides.py
+++ b/tests/test_parameter_kernel_overrides.py
@@ -83,7 +83,16 @@ def test_default_factory_selector_is_preserved(mode):
 
 @pytest.mark.parametrize(
     ("kernel_or_factory", "expected_residual_dims"),
-    [param(MaternKernel(), (0, 2), id="unnamed")],
+    [
+        param(MaternKernel(), (0, 2), id="unnamed"),
+        param(MaternKernel(parameter_names=("x1", "x2")), (0,), id="named"),
+        param(ScaleKernel(MaternKernel()), (0, 2), id="scaled"),
+        param(
+            lambda s, o, m: MaternKernel(parameter_names=s.parameter_names),
+            (0, 2),
+            id="callable",
+        ),
+    ],
 )
 def test_nondefault_residual_indices(kernel_or_factory, expected_residual_dims):
     """Removing a middle parameter preserves the original computational indices."""

--- a/tests/test_parameter_kernel_overrides.py
+++ b/tests/test_parameter_kernel_overrides.py
@@ -82,6 +82,26 @@ def test_default_factory_selector_is_preserved(mode):
 
 
 @pytest.mark.parametrize(
+    ("kernel_or_factory", "expected_residual_dims"),
+    [param(MaternKernel(), (0, 2), id="unnamed")],
+)
+def test_nondefault_residual_indices(kernel_or_factory, expected_residual_dims):
+    """Removing a middle parameter preserves the original computational indices."""
+    kernel, _ = _resolve(
+        [
+            NumericalContinuousParameter("x1", (0, 1)),
+            NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+            NumericalContinuousParameter("x3", (0, 1)),
+        ],
+        kernel_or_factory,
+    )
+    residual, override = kernel.kernels
+    assert tuple(residual.active_dims.tolist()) == expected_residual_dims
+    assert tuple(override.active_dims.tolist()) == (1,)
+    assert isinstance(override, gk.RBFKernel)
+
+
+@pytest.mark.parametrize(
     ("override_parameter", "base_override", "task_parameter"),
     [
         (NumericalDiscreteParameter("override", [0, 1, 2]), None, None),

--- a/tests/test_parameter_kernel_overrides.py
+++ b/tests/test_parameter_kernel_overrides.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 import pandas as pd
 import pytest
 import torch
+from attrs import evolve
 from botorch.models.kernels.positive_index import PositiveIndexKernel
 from gpytorch import kernels as gk
 from pytest import param
@@ -53,148 +54,98 @@ def _leaf_kernels(kernel):
     )
 
 
-def _fit(parameters):
-    """Fit a GP and return its installed covariance module and searchspace."""
+@pytest.mark.parametrize(
+    "mode",
+    [None, *TransferLearningMode],
+    ids=lambda mode: mode.name if mode else "no-task",
+)
+def test_default_factory_selector_is_preserved(mode):
+    """Selectors omit unselected dimensions but cannot exclude parameter overrides."""
+    parameters = [
+        NumericalContinuousParameter("x1", (0, 1)),
+        NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
+        NumericalContinuousParameter("omitted", (0, 1)),
+    ]
+    expected_names = ["x1", "x2"]
+    if mode is not None:
+        parameters.append(
+            TaskParameter("task", ["a", "b"], override_transfer_learning_mode=mode)
+        )
+        expected_names.append("task")
+    kernel, searchspace = _resolve(
+        parameters,
+        BayBEKernelFactory(parameter_selector=NameSelector(("x1",), regex=False)),
+    )
+    assert {tuple(k.active_dims.tolist()) for k in _leaf_kernels(kernel)} == {
+        searchspace.get_comp_rep_parameter_indices(name) for name in expected_names
+    }
+
+
+@pytest.mark.parametrize(
+    ("override_parameter", "base_override", "task_parameter"),
+    [
+        (NumericalDiscreteParameter("override", [0, 1, 2]), None, None),
+        (CategoricalParameter("override", ["a", "b", "c"]), None, None),
+        (CategoricalParameter("override", ["a", "b"]), MaternKernel(), None),
+        (
+            CategoricalParameter("override", ["a", "b"]),
+            None,
+            TaskParameter("task", ["a", "b"]),
+        ),
+        *[
+            (
+                CategoricalParameter("override", ["a", "b", "c"]),
+                None,
+                TaskParameter("task", ["a", "b"], override_transfer_learning_mode=mode),
+            )
+            for mode in TransferLearningMode
+        ],
+    ],
+    ids=[
+        "single-dim",
+        "multi-dim",
+        "all-overridden",
+        "task-without-tl-override",
+        *(mode.name for mode in TransferLearningMode),
+    ],
+)
+def test_fitted_model_uses_parameter_kernel_overrides(
+    override_parameter, base_override, task_parameter
+):
+    """The fitted model uses each configured kernel on the intended dimensions."""
+    parameters = [
+        CategoricalParameter("base", ["a", "b"], kernel_override=base_override),
+        evolve(override_parameter, kernel_override=RBFKernel()),
+    ]
+    expected = {"base": gk.MaternKernel, "override": gk.RBFKernel}
+    if task_parameter is not None:
+        parameters.append(task_parameter)
+        expected["task"] = (
+            gk.IndexKernel
+            if task_parameter.override_transfer_learning_mode
+            == TransferLearningMode.INDEX_KERNEL
+            else PositiveIndexKernel
+        )
     searchspace = SearchSpace.from_product(parameters)
     measurements = pd.DataFrame(
         [
-            {**{p.name: p.values[0] for p in parameters}, "y": 0.0},
-            {**{p.name: p.values[-1] for p in parameters}, "y": 1.0},
+            {**{p.name: p.values[i] for p in parameters}, "y": y}
+            for i, y in [(0, 0.0), (-1, 1.0)]
         ]
     )
     surrogate = GaussianProcessSurrogate()
     surrogate.fit(searchspace, NumericalTarget("y").to_objective(), measurements)
     assert surrogate._model is not None
-    return surrogate._model.covar_module, searchspace
-
-
-def test_default_factory_selector_is_preserved():
-    """Partitioning preserves an explicit default-factory parameter selector."""
-    kernel, _ = _resolve(
-        [
-            NumericalContinuousParameter("x1", (0, 1)),
-            NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
-            NumericalContinuousParameter("x3", (0, 1)),
-        ],
-        BayBEKernelFactory(parameter_selector=NameSelector(("x1",), regex=False)),
-    )
-
-    assert {tuple(k.active_dims.tolist()) for k in _leaf_kernels(kernel)} == {
-        (0,),
-        (1,),
-    }
-
-
-@pytest.mark.parametrize(
-    ("parameters", "expected_types", "expected_names"),
-    [
-        param(
-            [
-                CategoricalParameter("base", ["a", "b"]),
-                NumericalDiscreteParameter(
-                    "override", [0, 1, 2], kernel_override=RBFKernel()
-                ),
-            ],
-            [gk.MaternKernel, gk.RBFKernel],
-            ["base", "override"],
-            id="single-dim",
-        ),
-        param(
-            [
-                CategoricalParameter("base", ["a", "b"]),
-                CategoricalParameter(
-                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
-                ),
-            ],
-            [gk.MaternKernel, gk.RBFKernel],
-            ["base", "override"],
-            id="multi-dim",
-        ),
-        param(
-            [
-                CategoricalParameter("first", ["a", "b"], kernel_override=RBFKernel()),
-                CategoricalParameter(
-                    "second", ["a", "b"], kernel_override=MaternKernel()
-                ),
-            ],
-            [gk.RBFKernel, gk.MaternKernel],
-            ["first", "second"],
-            id="all-overridden",
-        ),
-        param(
-            [
-                CategoricalParameter("base", ["a", "b"]),
-                CategoricalParameter(
-                    "override", ["a", "b"], kernel_override=RBFKernel()
-                ),
-                TaskParameter("task", ["a", "b"]),
-            ],
-            [
-                gk.MaternKernel,
-                PositiveIndexKernel,
-                gk.RBFKernel,
-            ],
-            ["base", "task", "override"],
-            id="task-without-tl-override",
-        ),
-        param(
-            [
-                CategoricalParameter("base", ["a", "b"]),
-                CategoricalParameter(
-                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
-                ),
-                TaskParameter(
-                    "task",
-                    ["a", "b"],
-                    override_transfer_learning_mode=TransferLearningMode.INDEX_KERNEL,
-                ),
-            ],
-            [
-                gk.MaternKernel,
-                gk.RBFKernel,
-                gk.IndexKernel,
-            ],
-            ["base", "override", "task"],
-            id="override-and-tl-index",
-        ),
-        param(
-            [
-                CategoricalParameter("base", ["a", "b"]),
-                CategoricalParameter(
-                    "override", ["a", "b", "c"], kernel_override=RBFKernel()
-                ),
-                TaskParameter(
-                    "task",
-                    ["a", "b"],
-                    override_transfer_learning_mode=(
-                        TransferLearningMode.POSITIVE_INDEX_KERNEL
-                    ),
-                ),
-            ],
-            [
-                gk.MaternKernel,
-                gk.RBFKernel,
-                PositiveIndexKernel,
-            ],
-            ["base", "override", "task"],
-            id="override-and-tl-pos-index",
-        ),
-    ],
-)
-def test_fitted_model_uses_parameter_kernel_overrides(
-    parameters, expected_types, expected_names
-):
-    """The fitted model uses each configured kernel on the intended dimensions."""
-    kernel, searchspace = _fit(parameters)
+    kernel = surrogate._model.covar_module
     leaves = _leaf_kernels(kernel)
-    expected_dimensions = [
-        searchspace.get_comp_rep_parameter_indices(name) for name in expected_names
-    ]
 
     assert isinstance(kernel, gk.ProductKernel)
-    assert [type(k) for k in leaves] == expected_types
-    assert [tuple(k.active_dims.tolist()) for k in leaves] == expected_dimensions
-    assert [k.ard_num_dims for k in leaves] == [len(d) for d in expected_dimensions]
+    assert len(leaves) == len(expected)
+    assert {tuple(k.active_dims.tolist()): type(k) for k in leaves} == {
+        searchspace.get_comp_rep_parameter_indices(name): cls
+        for name, cls in expected.items()
+    }
+    assert all(k.ard_num_dims == len(k.active_dims) for k in leaves)
 
 
 @pytest.mark.parametrize(
@@ -215,12 +166,10 @@ def test_valid_baybe_kernel_override(override):
     ]
     kernel, searchspace = _resolve(parameters)
     expected = set(searchspace.get_comp_rep_parameter_indices("override"))
+    base_dims = set(searchspace.get_comp_rep_parameter_indices("base"))
 
     override_leaves = [
-        k
-        for k in _leaf_kernels(kernel)
-        if set(k.active_dims.tolist())
-        != set(searchspace.get_comp_rep_parameter_indices("base"))
+        k for k in _leaf_kernels(kernel) if set(k.active_dims.tolist()) != base_dims
     ]
     assert override_leaves
     assert all(set(k.active_dims.tolist()) == expected for k in override_leaves)
@@ -261,18 +210,6 @@ def test_gpytorch_ard_mismatch_rejected():
         _resolve([parameter])
 
 
-def test_parameter_equivalence_ignores_override_parameter_name():
-    """Equivalent parameters may scope the same override to their own names."""
-    left = NumericalContinuousParameter(
-        "left", (0, 1), kernel_override=RBFKernel(parameter_names=("left",))
-    )
-    right = NumericalContinuousParameter(
-        "right", (0, 1), kernel_override=RBFKernel(parameter_names=("right",))
-    )
-
-    assert left.is_equivalent(right)
-
-
 @pytest.mark.parametrize(
     "kernel_or_factory",
     [
@@ -281,10 +218,7 @@ def test_parameter_equivalence_ignores_override_parameter_name():
             id="non-reducible-baybe-kernel",
         ),
         param(gk.MaternKernel(), id="raw-gpytorch-kernel"),
-        param(
-            lambda s, o, m: gk.MaternKernel(),
-            id="factory-returning-raw-kernel",
-        ),
+        param(lambda s, o, m: gk.MaternKernel(), id="factory-returning-raw-kernel"),
     ],
 )
 def test_incompatible_surrogate_kernel_is_rejected(kernel_or_factory):
@@ -294,125 +228,72 @@ def test_incompatible_surrogate_kernel_is_rejected(kernel_or_factory):
         NumericalContinuousParameter("x2", (0, 1), kernel_override=RBFKernel()),
     ]
 
-    with pytest.raises(IncompatibleOverrideError):
+    with pytest.raises(IncompatibleOverrideError, match="can exclude these parameters"):
         _resolve(parameters, kernel_or_factory)
 
 
-@pytest.mark.parametrize("resolver", ["icm", "unified"], ids=["icm", "unified"])
 @pytest.mark.parametrize(
-    ("factor", "active_dims"),
+    ("override_kind", "kernel_cls", "active_dims"),
     [
-        param("residual", None, id="unrestricted-residual"),
-        param("residual", (0, 1), id="overlapping-residual"),
-        param("task", None, id="unrestricted-task"),
-        param("task", (0, 1), id="overlapping-task"),
-        param("task", (), id="empty-task"),
+        param("tl", MaternKernel, None, id="tl-unrestricted-residual"),
+        param("tl", MaternKernel, (0, 1), id="tl-overlapping-residual"),
+        param("tl", IndexKernel, None, id="unrestricted-task"),
+        param("tl", IndexKernel, (0, 1), id="overlapping-task"),
+        param("tl", IndexKernel, (), id="empty-task"),
+        param("regular", MaternKernel, None, id="regular-unrestricted-residual"),
+        param("regular", RBFKernel, None, id="unrestricted-override"),
     ],
 )
-def test_tl_partition_validation(monkeypatch, resolver, factor, active_dims):
-    """The unified resolver retains ICM's rejection of misbound kernel outputs."""
+def test_partition_validation(monkeypatch, override_kind, kernel_cls, active_dims):
+    """Reject misbound regular and TL factors, matching ICM for TL partitions."""
     parameters = [
         NumericalContinuousParameter("x", (0, 1)),
         TaskParameter(
             "task",
             ["a", "b"],
             override_transfer_learning_mode=TransferLearningMode.INDEX_KERNEL,
+        )
+        if override_kind == "tl"
+        else NumericalContinuousParameter(
+            "override", (0, 1), kernel_override=RBFKernel()
         ),
     ]
     searchspace = SearchSpace.from_product(parameters)
     objective = NumericalTarget("y").to_objective()
     measurements = pd.DataFrame()
-    kernel_cls = MaternKernel if factor == "residual" else IndexKernel
 
     def misbound_kernel(self, searchspace):
         return gk.RBFKernel(active_dims=active_dims)
 
     monkeypatch.setattr(kernel_cls, "to_gpytorch", misbound_kernel)
     with pytest.raises(ValueError, match="active_dims"):
-        if resolver == "icm":
+        GaussianProcessSurrogate(kernel_or_factory=MaternKernel())._resolve_kernel(
+            _ModelContext(searchspace, objective, measurements)
+        )
+    if override_kind == "tl":
+        with pytest.raises(ValueError, match="active_dims"):
             ICMKernelFactory(
                 base_kernel_or_factory=MaternKernel(parameter_names=("x",)),
                 task_kernel_or_factory=IndexKernel(
                     num_tasks=2, rank=2, parameter_names=("task",)
                 ),
             )(searchspace, objective, measurements)
-        else:
-            GaussianProcessSurrogate(kernel_or_factory=MaternKernel())._resolve_kernel(
-                _ModelContext(searchspace, objective, measurements)
-            )
-
-
-@pytest.mark.parametrize(
-    "factor", ["residual", "override"], ids=["residual", "override"]
-)
-def test_regular_partition_validation(monkeypatch, factor):
-    """Partition validation also rejects overlap for regular parameter overrides."""
-
-    def misbound_kernel(self, searchspace):
-        return gk.RBFKernel()
-
-    monkeypatch.setattr(
-        MaternKernel if factor == "residual" else RBFKernel,
-        "to_gpytorch",
-        misbound_kernel,
-    )
-    with pytest.raises(ValueError, match="active_dims"):
-        _resolve(
-            [
-                NumericalContinuousParameter("x", (0, 1)),
-                NumericalContinuousParameter("y", (0, 1), kernel_override=RBFKernel()),
-            ],
-            MaternKernel(),
-        )
-
-
-@pytest.mark.parametrize(
-    "override",
-    [
-        param(ScaleKernel(RBFKernel()), id="scale"),
-        param(AdditiveKernel([RBFKernel(), MaternKernel()]), id="additive"),
-        param(ProductKernel([RBFKernel(), MaternKernel()]), id="product"),
-        param(gk.ScaleKernel(gk.RBFKernel()), id="raw-scale"),
-    ],
-)
-def test_composite_partition_omits_unselected_columns(override):
-    """Composite factors may share their owner while unused columns stay irrelevant."""
-    kernel, searchspace = _resolve(
-        [
-            NumericalContinuousParameter("x", (0, 1)),
-            NumericalContinuousParameter("y", (0, 1), kernel_override=override),
-            NumericalContinuousParameter("omitted", (0, 1)),
-            TaskParameter("task", ["a", "b"]),
-        ],
-        BayBEKernelFactory(parameter_selector=NameSelector(("x",), regex=False)),
-    )
-    inputs = torch.zeros(2, len(searchspace.comp_rep_columns))
-    baseline = kernel(inputs).to_dense()
-    omitted = searchspace.get_comp_rep_parameter_indices("omitted")
-    inputs[1, list(omitted)] = 1.0
-    torch.testing.assert_close(kernel(inputs).to_dense(), baseline)
-    overridden = searchspace.get_comp_rep_parameter_indices("y")
-    inputs[1, list(overridden)] = 1.0
-    assert not torch.allclose(kernel(inputs).to_dense(), baseline)
 
 
 @pytest.mark.parametrize("as_factory", [False, True], ids=["fixed", "callable"])
 def test_raw_surrogate_kernel_without_overrides(as_factory):
-    """Without overrides, raw surrogate kernels are passed through unchanged."""
+    """Preserve raw kernels and the factory's original searchspace without overrides."""
     raw = gk.RBFKernel(active_dims=(0,))
-    specification = (lambda s, o, m: raw) if as_factory else raw
-    kernel, _ = _resolve([NumericalContinuousParameter("x", (0, 1))], specification)
-    assert kernel is raw
+    searchspace = SearchSpace.from_product([NumericalContinuousParameter("x", (0, 1))])
 
+    def factory(received_searchspace, objective, measurements):
+        assert received_searchspace is searchspace
+        return raw
 
-def test_all_overridden_bypasses_surrogate_factory():
-    """A fully overridden space does not construct an unused residual kernel."""
-
-    def unused_factory(searchspace, objective, measurements):
-        pytest.fail("The residual factory must not be called.")
-
-    kernel, _ = _resolve(
-        [NumericalContinuousParameter("x", (0, 1), kernel_override=RBFKernel())],
-        unused_factory,
+    surrogate = GaussianProcessSurrogate(
+        kernel_or_factory=factory if as_factory else raw
     )
-    assert isinstance(kernel, gk.RBFKernel)
+    context = _ModelContext(
+        searchspace, NumericalTarget("y").to_objective(), pd.DataFrame()
+    )
+    assert surrogate._resolve_kernel(context) is raw

--- a/tests/test_surrogate.py
+++ b/tests/test_surrogate.py
@@ -8,7 +8,8 @@ import pandas as pd
 import pytest
 from pytest import param
 
-from baybe.exceptions import IncompatibleSurrogateError
+from baybe.exceptions import IncompatibleSurrogateError, UnusedObjectWarning
+from baybe.kernels import RBFKernel
 from baybe.objectives.base import Objective
 from baybe.objectives.desirability import DesirabilityObjective
 from baybe.objectives.pareto import ParetoObjective
@@ -46,6 +47,19 @@ def test_caching(patched, searchspace, objective, fake_measurements):
     # Second call
     surrogate.fit(searchspace, objective, fake_measurements)
     patched.assert_not_called()
+
+
+def test_ignored_kernel_override_warning():
+    """Non-GP surrogates warn when ignoring a parameter kernel override."""
+    parameter = NumericalDiscreteParameter("x", [0, 1], kernel_override=RBFKernel())
+    measurements = pd.DataFrame({"x": [0, 1], "y": [0.0, 1.0]})
+
+    with pytest.warns(UnusedObjectWarning, match=r"kernel overrides.*\['x'\]"):
+        MeanPredictionSurrogate().fit(
+            parameter.to_searchspace(),
+            NumericalTarget("y").to_objective(),
+            measurements,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/validation/test_parameter_validation.py
+++ b/tests/validation/test_parameter_validation.py
@@ -1,5 +1,6 @@
 """Validation tests for parameters."""
 
+from functools import partial
 from unittest.mock import Mock
 
 import numpy as np
@@ -7,9 +8,12 @@ import pandas as pd
 import pytest
 from cattrs.errors import IterableValidationError
 from exceptiongroup import ExceptionGroup
+from gpytorch import kernels as gk
 from pytest import param
 
 from baybe._optional.info import CHEM_INSTALLED
+from baybe.kernels import RBFKernel
+from baybe.kernels.composite import ScaleKernel
 from baybe.parameters.categorical import (
     CategoricalParameter,
     TaskParameter,
@@ -35,6 +39,59 @@ def test_invalid_parameter_name(name, error):
     """Providing an invalid parameter name raises an exception."""
     with pytest.raises(error):
         NumericalDiscreteParameter(name=name, values=[1, 2, 3])
+
+
+@pytest.mark.parametrize(
+    ("constructor", "override", "error", "match"),
+    [
+        param(
+            partial(TaskParameter, "task", ["a", "b"]),
+            RBFKernel(),
+            TypeError,
+            "kernel_override",
+            id="task_parameter",
+        ),
+        param(
+            partial(NumericalContinuousParameter, "x", (0, 1)),
+            RBFKernel(parameter_names=("other",)),
+            ValueError,
+            "may only act on the parameter itself",
+            id="baybe_different_name",
+        ),
+        param(
+            partial(NumericalContinuousParameter, "x", (0, 1)),
+            RBFKernel(parameter_names=("x", "other")),
+            ValueError,
+            "may only act on the parameter itself",
+            id="baybe_multiple_names",
+        ),
+        param(
+            partial(NumericalContinuousParameter, "x", (0, 1)),
+            ScaleKernel(RBFKernel(parameter_names=("other",))),
+            ValueError,
+            "may only act on the parameter itself",
+            id="baybe_composite_leaf",
+        ),
+        param(
+            partial(NumericalContinuousParameter, "x", (0, 1)),
+            gk.RBFKernel(active_dims=[0]),
+            ValueError,
+            "must not specify 'active_dims'",
+            id="gpytorch_active_dims",
+        ),
+        param(
+            partial(NumericalContinuousParameter, "x", (0, 1)),
+            gk.ScaleKernel(gk.RBFKernel(active_dims=[0])),
+            ValueError,
+            "must not specify 'active_dims'",
+            id="gpytorch_nested_active_dims",
+        ),
+    ],
+)
+def test_invalid_kernel_override(constructor, override, error, match):
+    """Invalid parameter kernel overrides raise the expected exceptions."""
+    with pytest.raises(error, match=match):
+        constructor(kernel_override=override)
 
 
 @pytest.mark.parametrize(

--- a/tests/validation/test_parameter_validation.py
+++ b/tests/validation/test_parameter_validation.py
@@ -13,6 +13,7 @@ from pytest import param
 
 from baybe._optional.info import CHEM_INSTALLED
 from baybe.kernels import RBFKernel
+from baybe.kernels.base import Kernel
 from baybe.kernels.composite import ScaleKernel
 from baybe.parameters.categorical import (
     CategoricalParameter,
@@ -92,6 +93,16 @@ def test_invalid_kernel_override(constructor, override, error, match):
     """Invalid parameter kernel overrides raise the expected exceptions."""
     with pytest.raises(error, match=match):
         constructor(kernel_override=override)
+
+
+@pytest.mark.parametrize("scaled", [False, True], ids=["direct", "nested"])
+def test_unsupported_kernel_override_structure(scaled):
+    """Unknown kernel structures cannot silently bypass owner-scope validation."""
+    kernel = Mock(spec=Kernel)
+    with pytest.raises(TypeError, match="Cannot traverse kernel"):
+        NumericalContinuousParameter(
+            "x", (0, 1), kernel_override=ScaleKernel(kernel) if scaled else kernel
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Builds on #868, now merged into `main`

- Adds optional, keyword-only `kernel_override` to regular parameters, accepting BayBE or raw GPyTorch kernel instances. Overrides cover the parameter’s full computational block.
- Unifies GP kernel resolution: collect parameter and TL overrides, resolve the residual kernel excluding overridden parameters, validate dimension partitioning, then multiply the factors. Without overrides, the configured kernel/factory is used unchanged.
- Preserves factory selectors and supports reduction of basic, scaled, and product BayBE kernels. Overrides can coexist with `TaskParameter.override_transfer_learning_mode`.
- Keeps override-specific logic in the private `_override` package, providing a foundation for future override mechanisms.

**Limitations**
- GP surrogates only; other surrogates emit `UnusedObjectWarning`.
- Composition is multiplicative. `kernel_override` accepts kernel instances only, not factories.
- `TaskParameter` does not expose `kernel_override`; use `override_transfer_learning_mode` instead.
- BayBE override leaves must have `parameter_names=None` or exactly the owning parameter’s name.
- Raw GPyTorch overrides cannot set `active_dims`; `ard_num_dims` must be `None` or match the parameter’s computational width. `None` is preserved. Raw overrides are not serializable.
- When a residual is needed, the surrogate kernel/factory must support parameter exclusion; incompatible inputs raise `IncompatibleOverrideError`. Additive-kernel reduction remains unsupported.

**Long Term Control Flow Vision**
<img width="939" height="825" alt="image" src="https://github.com/user-attachments/assets/a580cff6-7fb3-48d8-858d-c09c23e23478" />
