### PR TITLE
Fix Python 3.10 type checking

### DIFF
--- a/baybe/constraints/validation.py
+++ b/baybe/constraints/validation.py
@@ -3,6 +3,8 @@
 from collections.abc import Collection
 from itertools import combinations
 
+from exceptiongroup import ExceptionGroup
+
 from baybe.constraints.base import Constraint
 from baybe.constraints.continuous import ContinuousCardinalityConstraint
 from baybe.constraints.discrete import (
@@ -11,11 +13,6 @@ from baybe.constraints.discrete import (
 )
 from baybe.parameters import NumericalContinuousParameter
 from baybe.parameters.base import Parameter
-
-try:  # For python < 3.11, use the exceptiongroup backport
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import ExceptionGroup
 
 
 def validate_constraints(  # noqa: DOC101, DOC103

--- a/baybe/parameters/substance.py
+++ b/baybe/parameters/substance.py
@@ -7,6 +7,7 @@ from typing import Any
 import pandas as pd
 from attrs import define, field
 from attrs.validators import deep_mapping, instance_of, min_len
+from exceptiongroup import ExceptionGroup
 from typing_extensions import override
 
 from baybe.parameters.base import _DiscreteLabelLikeParameter
@@ -18,11 +19,6 @@ from baybe.utils.dataframe import (
     df_drop_single_value_columns,
     df_uncorrelated_features,
 )
-
-try:  # For python < 3.11, use the exceptiongroup backport
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import ExceptionGroup
 
 Smiles = str
 """Type alias for SMILES strings."""

--- a/baybe/searchspace/validation.py
+++ b/baybe/searchspace/validation.py
@@ -5,16 +5,12 @@ from collections.abc import Collection, Sequence
 from typing import TypeVar
 
 import pandas as pd
+from exceptiongroup import ExceptionGroup
 
 from baybe.exceptions import EmptySearchSpaceError, IncompatibilityError
 from baybe.parameters import TaskParameter
 from baybe.parameters.base import Parameter, _DiscreteLabelLikeParameter
 from baybe.utils.dataframe import get_transform_objects
-
-try:  # For python < 3.11, use the exceptiongroup backport
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import ExceptionGroup
 
 _T = TypeVar("_T", bound=Parameter)
 

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+from importlib import import_module
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar
 
@@ -58,7 +59,6 @@ class BotorchKernelFactory(_PureKernelFactory):
         from botorch.models.utils.gpytorch_modules import (
             get_covar_module_with_dim_scaled_prior,
         )
-        from botorch.models.utils.priors import BetaPrior
 
         parameter_names = self.get_parameter_names(searchspace)
 
@@ -82,7 +82,9 @@ class BotorchKernelFactory(_PureKernelFactory):
         if (task_idx := searchspace.task_idx) is None:
             return base_kernel
 
-        task_prior = BetaPrior(concentration1=2.5, concentration0=1.5)
+        # BoTorch versions lacking this module are rejected at the start of this method.
+        beta_prior = import_module("botorch.models.utils.priors").BetaPrior
+        task_prior = beta_prior(concentration1=2.5, concentration0=1.5)
         index_kernel = PositiveIndexKernel(
             num_tasks=searchspace.n_tasks,
             rank=searchspace.n_tasks,

--- a/tests/test_searchspace.py
+++ b/tests/test_searchspace.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from exceptiongroup import ExceptionGroup
 from pandas.testing import assert_frame_equal
 
 from baybe._optional.info import POLARS_INSTALLED
@@ -34,11 +35,6 @@ from baybe.searchspace.utils import (
     parameter_cartesian_prod_polars,
 )
 from baybe.utils.basic import is_all_instance
-
-try:
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import ExceptionGroup
 
 
 def test_empty_parameters():

--- a/tests/validation/test_parameter_validation.py
+++ b/tests/validation/test_parameter_validation.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from cattrs.errors import IterableValidationError
+from exceptiongroup import ExceptionGroup
 from pytest import param
 
 from baybe._optional.info import CHEM_INSTALLED
@@ -21,11 +22,6 @@ from baybe.parameters.numerical import (
 from baybe.parameters.substance import SubstanceParameter
 from baybe.parameters.validation import validate_decorrelation
 from baybe.utils.interval import InfiniteIntervalError
-
-try:  # For python < 3.11, use the exceptiongroup backport
-    ExceptionGroup
-except NameError:
-    from exceptiongroup import ExceptionGroup
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes the Regular Action, specifically the [typecheck in Python 3.10](https://github.com/emdgroup/baybe/actions/runs/33483570142/job/99778572153)

- Two independent problems that only surface in Python 3.10. For pre-commit reasons they had to be committed as one atomic commit
- `ExceptionGroup` import
  - Previously we made a `try`-`except` shenanigans for the `ExceptionGroup` import to account for it not being avaialble in Python 3.10
  - On 3.10 pyrefly does not realize the access to the unavailable `ExceptionGroup` in the try block is intentional to trigger the exception
  - But since `exceptiongroup` is a default dependency of the package anyway we can just always import it normally, it automatically refers to either the back port or the actual object
- Import of beta prior from botorch
  - This is only relevant in 3.10 because the highest available botorch verison does not have this prior avaialble there
  - There is an already existing preset that avoids the import happening in that case, but pyrefly is not able to see this as imports are assessed statically
  - This is usually a situation for an `ignore` comment. But this would be flagged as `unused ignore` in higher Python version 
  - Hence, I went for the slightly more creative solution with impor_module