### PR TITLE
Forbid Excluded Permutation Dependencies

### DIFF
--- a/baybe/constraints/discrete.py
+++ b/baybe/constraints/discrete.py
@@ -440,6 +440,21 @@ class DiscretePermutationInvarianceConstraint(DiscreteFilteringConstraint):
     dependencies: DiscreteDependenciesConstraint | None = field(default=None)
     """Dependencies connected with the invariant parameters."""
 
+    @dependencies.validator
+    def _validate_dependencies(  # noqa: DOC101, DOC103
+        self, _: Any, value: DiscreteDependenciesConstraint | None
+    ) -> None:
+        """Validate the dependencies constraint.
+
+        Raises:
+            ValueError: If the dependencies constraint uses ``exclude=True``.
+        """
+        if value is not None and value.exclude:
+            raise ValueError(
+                "Dependencies of a permutation invariance constraint cannot use "
+                "'exclude=True'."
+            )
+
     @property
     @override
     def _required_parameters(self) -> set[str]:

--- a/tests/hypothesis_strategies/constraints.py
+++ b/tests/hypothesis_strategies/constraints.py
@@ -70,6 +70,7 @@ def discrete_dependencies_constraints(
     draw: st.DrawFn,
     parameters: list[DiscreteParameter] | None = None,
     affected_parameter_names: list[list[str]] | None = None,
+    exclude: bool | None = None,
 ):
     if parameters is None:
         # Draw random unique parameter names
@@ -132,7 +133,8 @@ def discrete_dependencies_constraints(
             p not in affected_parameter_names[k] for k, p in enumerate(parameter_names)
         ), "Affected parameters cannot overlap with the parameters they depend on"
 
-    exclude = draw(st.booleans())
+    if exclude is None:
+        exclude = draw(st.booleans())
     return DiscreteDependenciesConstraint(
         parameter_names, conditions, affected_parameter_names, exclude=exclude
     )
@@ -158,6 +160,7 @@ def discrete_permutation_invariance_constraints(
                     discrete_dependencies_constraints(
                         parameters=None,
                         affected_parameter_names=[[p] for p in parameter_names],
+                        exclude=False,
                     ),
                 ]
             )

--- a/tests/validation/test_constraint_validation.py
+++ b/tests/validation/test_constraint_validation.py
@@ -3,12 +3,16 @@
 import pytest
 from pytest import param
 
-from baybe.constraints.conditions import ThresholdCondition
+from baybe.constraints.conditions import SubSelectionCondition, ThresholdCondition
 from baybe.constraints.continuous import (
     ContinuousCardinalityConstraint,
     ContinuousLinearConstraint,
 )
-from baybe.constraints.discrete import DiscreteSumConstraint
+from baybe.constraints.discrete import (
+    DiscreteDependenciesConstraint,
+    DiscretePermutationInvarianceConstraint,
+    DiscreteSumConstraint,
+)
 
 
 @pytest.mark.parametrize(
@@ -48,4 +52,22 @@ def test_invalid_coefficients(coefficients, match):
             parameters=["A", "B", "C"],
             operator="<=",
             coefficients=coefficients,
+        )
+
+
+def test_excluded_permutation_dependencies():
+    """Excluded permutation dependencies raise a ValueError."""
+    dependencies = DiscreteDependenciesConstraint(
+        parameters=["Gate"],
+        conditions=[SubSelectionCondition(selection=["on"])],
+        affected_parameters=[["P1", "P2"]],
+        exclude=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Dependencies of a permutation invariance constraint cannot use",
+    ):
+        DiscretePermutationInvarianceConstraint(
+            parameters=["P1", "P2"], dependencies=dependencies
         )


### PR DESCRIPTION
there is a small bug reported by @AVHopp 
```python
"""DiscretePermutationInvarianceConstraint inverts deduplication when dependencies.exclude=True.

Root cause: DiscreteFilteringConstraint.get_invalid (base class) returns the
*matching* rows when exclude=True and df.index.drop(matching) otherwise.
DiscretePermutationInvarianceConstraint._get_matching_rows calls
    self.dependencies.get_invalid(df.loc[inds_valid])
and drops the result from inds_valid, expecting dependency-duplicates back.
With exclude=True, get_invalid instead returns the canonical (non-duplicate)
rows, so the drop removes the keepers and retains the duplicates.
"""

import pandas as pd

from baybe.constraints.conditions import SubSelectionCondition
from baybe.constraints.discrete import (
    DiscreteDependenciesConstraint,
    DiscretePermutationInvarianceConstraint,
)

# Row 0: (X, Y) — canonical representative of the {X, Y} permutation class
# Row 1: (Y, X) — permutation duplicate; should be the only invalid row
df = pd.DataFrame(
    {
        "P1": ["X", "Y"],
        "P2": ["Y", "X"],
        "Gate": ["on", "on"],
    }
)

deps = DiscreteDependenciesConstraint(
    parameters=["Gate"],
    conditions=[SubSelectionCondition(selection=["on"])],
    affected_parameters=[["P1", "P2"]],
    exclude=True,  # triggers the inversion bug
)
perm = DiscretePermutationInvarianceConstraint(
    parameters=["P1", "P2"],
    dependencies=deps,
)

invalid = perm.get_invalid(df)
print("Expected invalid: [1]")
print("Actual invalid:  ", invalid.tolist())  # Bug: returns [0, 1]
```

- This PR forbids `exclude=True` for dependencies inside permutation constraints
- This is intended as a small hotfix that simply avoids this bad configuration, there is much work planned anyway for the two involved constraints #664 and #670 - in particular they should be decoupled at class level), so tis really not worth spending more time on this for the moment