### PR TITLE
Lazify `get_candidates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anywhere. In particular, recommendation dataframes no longer reflect discrete subspace
   locations via their index. Similarly, `_recommend_discrete` and kin now return a
   dataframe-based subselection instead of a `pd.Index`.
+- `Objective.handle_missing_values` is now private (`_handle_missing_values`)
 - All optional arguments of `SubspaceDiscrete.from_simplex` after `simplex_parameters` 
   are now keyword-only
 - `Campaign.measurements` no longer contains `FitNr` or `BatchNr` metadata columns

--- a/baybe/acquisition/_builder.py
+++ b/baybe/acquisition/_builder.py
@@ -4,9 +4,9 @@ from collections.abc import Callable, Iterable
 from functools import cached_property
 from inspect import signature
 from types import MappingProxyType
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 import torch
 from attrs import Attribute, asdict, define, field, fields
 from attrs.validators import instance_of, optional
@@ -42,7 +42,12 @@ from baybe.targets.binary import BinaryTarget
 from baybe.targets.numerical import NumericalTarget
 from baybe.transformations import IdentityTransformation
 from baybe.utils.basic import match_attributes
-from baybe.utils.dataframe import handle_missing_values, to_tensor
+from baybe.utils.dataframe import _df_with_backend, handle_missing_values, to_tensor
+
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrameT
+else:
+    IntoDataFrameT = TypeVar("IntoDataFrameT")
 
 _OPT_FIELD: None = object()  # type: ignore[assignment]
 """Sentinel value indicating optional acquisition function attributes."""
@@ -96,7 +101,7 @@ flds = fields(BotorchAcquisitionArgs)
 
 
 @define
-class BotorchAcquisitionFunctionBuilder:
+class BotorchAcquisitionFunctionBuilder(Generic[IntoDataFrameT]):
     """A class for building BoTorch acquisition functions from BayBE objects."""
 
     # The BayBE acquisition function to be translated
@@ -106,8 +111,8 @@ class BotorchAcquisitionFunctionBuilder:
     surrogate: SurrogateProtocol = field()
     searchspace: SearchSpace = field()
     objective: Objective = field()
-    measurements: pd.DataFrame = field()
-    pending_experiments: pd.DataFrame | None = field(default=None)
+    measurements: IntoDataFrameT = field()
+    pending_experiments: IntoDataFrameT | None = field(default=None)
 
     # Context shared across building methods
     _args: BotorchAcquisitionArgs = field(init=False)
@@ -134,7 +139,7 @@ class BotorchAcquisitionFunctionBuilder:
         return self.surrogate.to_botorch()
 
     @cached_property
-    def _train_x(self) -> pd.DataFrame:
+    def _train_x(self) -> IntoDataFrameT:
         """The training parameter values."""
         return self.searchspace.transform(self.measurements, allow_extra=True)
 
@@ -161,7 +166,7 @@ class BotorchAcquisitionFunctionBuilder:
         return mean.squeeze(-2)
 
     @cached_property
-    def _target_configurations(self) -> pd.DataFrame:
+    def _target_configurations(self) -> IntoDataFrameT:
         """The target configurations used for reference point calculation.
 
         Only completely measured points are considered.
@@ -172,9 +177,11 @@ class BotorchAcquisitionFunctionBuilder:
         Raises:
             ValueError: If no complete measurement exists.
         """
+        target_names = [t.name for t in self.objective.targets]
+        measurements_nw = nw.from_native(self.measurements, eager_only=True)
         configurations = handle_missing_values(
-            self.measurements[[t.name for t in self.objective.targets]],
-            [t.name for t in self.objective.targets],
+            measurements_nw.select(target_names).to_pandas(),
+            target_names,
             drop=True,
         )
 
@@ -190,7 +197,10 @@ class BotorchAcquisitionFunctionBuilder:
                 f"argument of '{self.acqf.__class__.__name__}' explicitly."
             )
 
-        return configurations
+        return _df_with_backend(
+            nw.from_native(configurations, eager_only=True),
+            measurements_nw.implementation,
+        ).to_native()
 
     def build(self) -> BoAcquisitionFunction:
         """Build the BoTorch acquisition function object."""

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import gc
 import math
 from abc import ABC
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
+import narwhals.stable.v2 as nw
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -16,9 +17,14 @@ from attrs import AttrsInstance, define, field, fields
 from attrs.validators import gt, instance_of, le
 from typing_extensions import override
 
+if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
+
 from baybe.acquisition.base import AcquisitionFunction
 from baybe.searchspace import SearchSpace
+from baybe.settings import active_settings
 from baybe.utils.basic import classproperty, convert_to_float
+from baybe.utils.dataframe import _df_with_backend
 from baybe.utils.sampling_algorithms import DiscreteSamplingMethod, sample_numerical_df
 from baybe.utils.validation import finite_float
 
@@ -81,7 +87,7 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
             flds.sampling_fraction.name,
         )
 
-    def get_integration_points(self, searchspace: SearchSpace) -> pd.DataFrame:
+    def get_integration_points(self, searchspace: SearchSpace) -> IntoDataFrame:
         """Sample points from a search space for integration purposes.
 
         Sampling of the discrete part can be controlled via 'sampling_method', but
@@ -137,7 +143,10 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
         # Combine different search space parts
         result = pd.concat(sampled_parts, axis=1)
 
-        return result
+        return _df_with_backend(
+            nw.from_native(result, eager_only=True),
+            active_settings.default_dataframe_backend,
+        ).to_native()
 
 
 ########################################################################################

--- a/baybe/acquisition/acqfs.py
+++ b/baybe/acquisition/acqfs.py
@@ -111,7 +111,7 @@ class qNegIntegratedPosteriorVariance(AcquisitionFunction):
         # Discrete part
         if not searchspace.discrete.is_empty:
             candidates_discrete = searchspace.discrete.transform(
-                searchspace.discrete.get_candidates()
+                searchspace.discrete._get_candidates().collect().to_pandas()
             )
             n_candidates = self.sampling_n_points or math.ceil(
                 self.sampling_fraction * len(candidates_discrete)  # type: ignore[operator]

--- a/baybe/acquisition/base.py
+++ b/baybe/acquisition/base.py
@@ -6,7 +6,7 @@ import gc
 from abc import ABC
 from typing import TYPE_CHECKING, ClassVar, Literal, overload
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 from attrs import define
 
 from baybe.exceptions import (
@@ -19,10 +19,11 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.surrogates.base import SurrogateProtocol
 from baybe.utils.basic import classproperty
 from baybe.utils.boolean import is_abstract
-from baybe.utils.dataframe import to_tensor
+from baybe.utils.dataframe import _copy_index, to_tensor
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BotorchAcquisitionFunction
+    from narwhals.stable.v2.typing import IntoDataFrameT, IntoSeries
 
 
 @define(frozen=True)
@@ -63,8 +64,8 @@ class AcquisitionFunction(ABC, SerialMixin):
         surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> BotorchAcquisitionFunction:
         """Create the botorch-ready representation of the function.
 
@@ -86,12 +87,12 @@ class AcquisitionFunction(ABC, SerialMixin):
     @overload
     def evaluate(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
         *,
         jointly: Literal[True],
     ) -> float: ...
@@ -99,27 +100,27 @@ class AcquisitionFunction(ABC, SerialMixin):
     @overload
     def evaluate(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
         *,
         jointly: Literal[False] = False,
-    ) -> pd.Series: ...
+    ) -> IntoSeries: ...
 
     def evaluate(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         surrogate: SurrogateProtocol,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
         *,
         jointly: bool = False,
-    ) -> pd.Series | float:
+    ) -> IntoSeries | float:
         """Get the acquisition values for the given candidates.
 
         Args:
@@ -144,6 +145,8 @@ class AcquisitionFunction(ABC, SerialMixin):
         """
         import torch
 
+        candidates_nw = nw.from_native(candidates, eager_only=True)
+
         # Assemble the Botorch acquisition function and its input
         botorch_acqf = self.to_botorch(
             surrogate, searchspace, objective, measurements, pending_experiments
@@ -156,7 +159,11 @@ class AcquisitionFunction(ABC, SerialMixin):
             out = botorch_acqf(in_)
         if jointly:
             return out.item()
-        return pd.Series(out.numpy(), index=candidates.index)
+
+        backend = nw.get_native_namespace(candidates_nw)
+        return _copy_index(
+            nw.new_series("", out.numpy(), backend=backend), candidates_nw
+        ).to_native()
 
 
 def _get_botorch_acqf_class(

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -431,7 +431,7 @@ class Campaign(SerialMixin):
         #  * Additional shortcuts might be possible.
         self.clear_cache()
 
-        df = self.searchspace.discrete.get_candidates()
+        df = self.searchspace.discrete._get_candidates().collect().to_pandas()
 
         if isinstance(constraints, pd.DataFrame):
             # Determine the candidate subset to be toggled
@@ -532,7 +532,9 @@ class Campaign(SerialMixin):
         if self.searchspace.type is SearchSpaceType.DISCRETE:
             # TODO: This implementation should at some point be hidden behind an
             #   appropriate public interface, like `SubspaceDiscrete.filter()`
-            candidates = self.searchspace.discrete.get_candidates()
+            candidates = (
+                self.searchspace.discrete._get_candidates().collect().to_pandas()
+            )
             mask_todrop = pd.Series(False, index=candidates.index)
             if not self._excluded_experiments.empty:
                 mask_todrop |= (
@@ -1082,7 +1084,9 @@ def _structure_campaign(d: dict, cl: type) -> Campaign:
     # >>>>>>>>>> Deprecation
     # Post-structure reconstruction from legacy metadata indices
     if legacy_recommended_idxs is not None or legacy_excluded_idxs is not None:
-        candidates = campaign.searchspace.discrete.get_candidates()
+        candidates = (
+            campaign.searchspace.discrete._get_candidates().collect().to_pandas()
+        )
         if legacy_recommended_idxs is not None:
             campaign._recommended_experiments = candidates.loc[
                 legacy_recommended_idxs

--- a/baybe/campaign.py
+++ b/baybe/campaign.py
@@ -56,6 +56,7 @@ from baybe.utils.validation import (
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
     from botorch.posteriors import Posterior
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
 
     from baybe.acquisition.base import AcquisitionFunction
 
@@ -799,7 +800,7 @@ class Campaign(SerialMixin):
     def _get_non_meta_recommender(
         self,
         batch_size: int | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> RecommenderProtocol:
         """Get the current recommender.
 
@@ -825,7 +826,7 @@ class Campaign(SerialMixin):
     def _get_bayesian_recommender(
         self,
         batch_size: int | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> BayesianRecommender:
         """Get the current Bayesian recommender (if available).
 
@@ -845,7 +846,7 @@ class Campaign(SerialMixin):
     def get_acquisition_function(
         self,
         batch_size: int | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        pending_experiments: IntoDataFrame | None = None,
     ) -> BoAcquisitionFunction:
         """Get the current BoTorch acquisition function.
 
@@ -876,12 +877,12 @@ class Campaign(SerialMixin):
 
     def acquisition_values(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         acquisition_function: AcquisitionFunction | None = None,
         *,
         batch_size: int | None = None,
-        pending_experiments: pd.DataFrame | None = None,
-    ) -> pd.Series:
+        pending_experiments: IntoDataFrameT | None = None,
+    ) -> IntoSeries:
         """Compute the acquisition values for the given candidates.
 
         Args:
@@ -910,11 +911,11 @@ class Campaign(SerialMixin):
 
     def joint_acquisition_value(  # noqa: DOC101, DOC103
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         acquisition_function: AcquisitionFunction | None = None,
         *,
         batch_size: int | None = None,
-        pending_experiments: pd.DataFrame | None = None,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> float:
         """Compute the joint acquisition values for the given candidate batch.
 

--- a/baybe/objectives/base.py
+++ b/baybe/objectives/base.py
@@ -15,7 +15,12 @@ from baybe.serialization.mixin import SerialMixin
 from baybe.targets.base import Target
 from baybe.targets.numerical import NumericalTarget
 from baybe.utils.basic import is_all_instance
-from baybe.utils.dataframe import _copy_index, get_transform_objects, to_tensor
+from baybe.utils.dataframe import (
+    _copy_index,
+    _df_with_backend,
+    get_transform_objects,
+    to_tensor,
+)
 from baybe.utils.dataframe import (
     handle_missing_values as df_handle_missing_values,
 )
@@ -111,9 +116,9 @@ class Objective(ABC, SerialMixin):
         """The end-to-end transformation applied, from targets to objective values."""
         return self.to_botorch()
 
-    def handle_missing_values(
-        self, measurements: pd.DataFrame
-    ) -> dict[str, pd.DataFrame]:
+    def _handle_missing_values(
+        self, measurements: IntoDataFrameT
+    ) -> dict[str, IntoDataFrameT]:
         """Handle missing values in the given measurements for each modeled quantity.
 
         Args:
@@ -122,10 +127,16 @@ class Objective(ABC, SerialMixin):
         Returns:
             A dictionary with one dataframe for each modeled quantity.
         """
-        cleaned: dict[str, pd.DataFrame] = {}
+        # TODO: The logic should be reworked. Currently, the returned dataframes contain
+        #    all original columns, even those not related to the modeled quantities.
+        measurements_nw = nw.from_native(measurements, eager_only=True)
+        measurements_pd = measurements_nw.to_pandas()
+        cleaned: dict[str, IntoDataFrameT] = {}
         for quantity, target_names in self._model_quantities_to_target_names.items():
-            data = df_handle_missing_values(measurements, target_names, drop=True)
-            cleaned[quantity] = data
+            data_pd = df_handle_missing_values(measurements_pd, target_names, drop=True)
+            cleaned[quantity] = _df_with_backend(
+                nw.from_native(data_pd, eager_only=True), measurements_nw.implementation
+            ).to_native()
 
         return cleaned
 

--- a/baybe/recommenders/naive.py
+++ b/baybe/recommenders/naive.py
@@ -100,23 +100,11 @@ class NaiveHybridSpaceRecommender(PureRecommender):
         cont_part = searchspace.continuous.sample_uniform(1)
         cont_part_tensor = to_tensor(cont_part).unsqueeze(-2)
 
-        # Convert to pandas for BoTorch internals (acqf setup requires pd.DataFrame)
-        measurements_pd = (
-            nw.from_native(measurements, eager_only=True).to_pandas()
-            if measurements is not None
-            else None
-        )
-        pending_experiments_pd = (
-            nw.from_native(pending_experiments, eager_only=True).to_pandas()
-            if pending_experiments is not None
-            else None
-        )
-
         # We now check whether the discrete recommender is bayesian.
         if isinstance(self.disc_recommender, BayesianRecommender):
             # Get access to the recommenders acquisition function
             self.disc_recommender._setup_botorch_acqf(
-                searchspace, objective, measurements_pd, pending_experiments_pd
+                searchspace, objective, measurements, pending_experiments
             )
 
             # Construct the partial acquisition function that attaches cont_part
@@ -143,7 +131,7 @@ class NaiveHybridSpaceRecommender(PureRecommender):
 
             # Setup a fresh acquisition function for the continuous recommender
             self.cont_recommender._setup_botorch_acqf(
-                searchspace, objective, measurements_pd, pending_experiments_pd
+                searchspace, objective, measurements, pending_experiments
             )
 
             # Construct the continuous space as a standalone space

--- a/baybe/recommenders/pure/base.py
+++ b/baybe/recommenders/pure/base.py
@@ -304,7 +304,8 @@ class PureRecommender(ABC, RecommenderProtocol):
         # Check if enough candidates are left
         # TODO [15917]: This check is not perfectly correct.
         if (not is_hybrid_space) and (
-            len(searchspace.discrete.get_candidates()) < batch_size
+            searchspace.discrete._get_candidates().select(nw.len()).collect().item()
+            < batch_size
         ):
             raise NotEnoughPointsLeftError(
                 f"Using the current settings, there are fewer than {batch_size} "

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -24,6 +24,7 @@ from baybe.settings import Settings
 from baybe.surrogates import GaussianProcessSurrogate
 from baybe.surrogates.base import Surrogate, SurrogateProtocol
 from baybe.symmetries.base import Symmetry
+from baybe.utils.dataframe import _df_with_backend
 from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
@@ -108,8 +109,13 @@ class BayesianRecommender(PureRecommender, ABC):
             )
 
         # Perform data augmentation
+        backend = nw.get_native_namespace(measurements)
         for s in self.symmetries:
-            measurements = s.augment_measurements(measurements, searchspace)
+            measurements_pd = nw.from_native(measurements, eager_only=True).to_pandas()
+            augmented = nw.from_native(
+                s.augment_measurements(measurements_pd, searchspace), eager_only=True
+            )
+            measurements = _df_with_backend(augmented, backend).to_native()
 
         surrogate = self.get_surrogate(searchspace, objective, measurements)
         self._botorch_acqf = acqf.to_botorch(

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -7,7 +7,6 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 import narwhals.stable.v2 as nw
-import pandas as pd
 from attrs import define, field
 from attrs.converters import optional
 from attrs.validators import deep_iterable, instance_of
@@ -29,6 +28,7 @@ from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
 
 
 def _autoreplicate(surrogate: SurrogateProtocol, /) -> SurrogateProtocol:
@@ -84,7 +84,7 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
+        measurements: IntoDataFrame,
     ) -> SurrogateProtocol:
         """Get the trained surrogate model."""
         # This fit applies internal caching and does not necessarily involve computation
@@ -95,8 +95,8 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> None:
         """Create the acquisition function for the current training data."""  # noqa: E501
         self._objective = objective
@@ -125,8 +125,8 @@ class BayesianRecommender(PureRecommender, ABC):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
     ) -> BoAcquisitionFunction:
         """Get the BoTorch acquisition function for the given recommendation context.
 
@@ -168,7 +168,6 @@ class BayesianRecommender(PureRecommender, ABC):
             objective,
             numerical_measurements_must_be_within_tolerance=False,
         )
-        measurements_pd = nw.from_native(measurements, eager_only=True).to_pandas()
 
         if pending_experiments is not None:
             pending_experiments = preprocess_dataframe(
@@ -176,14 +175,9 @@ class BayesianRecommender(PureRecommender, ABC):
                 searchspace,
                 numerical_measurements_must_be_within_tolerance=False,
             )
-        pending_experiments_pd = (
-            nw.from_native(pending_experiments, eager_only=True).to_pandas()
-            if pending_experiments is not None
-            else None
-        )
 
         self._setup_botorch_acqf(
-            searchspace, objective, measurements_pd, pending_experiments_pd
+            searchspace, objective, measurements, pending_experiments
         )
 
         try:
@@ -217,13 +211,13 @@ class BayesianRecommender(PureRecommender, ABC):
 
     def acquisition_values(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
         acquisition_function: AcquisitionFunction | None = None,
-    ) -> pd.Series:
+    ) -> IntoSeries:
         """Compute the acquisition values for the given candidates.
 
         Args:
@@ -257,11 +251,11 @@ class BayesianRecommender(PureRecommender, ABC):
 
     def joint_acquisition_value(  # noqa: DOC101, DOC103
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
-        pending_experiments: pd.DataFrame | None = None,
+        measurements: IntoDataFrameT,
+        pending_experiments: IntoDataFrameT | None = None,
         acquisition_function: AcquisitionFunction | None = None,
     ) -> float:
         """Compute the joint acquisition value for the given candidate batch.

--- a/baybe/recommenders/pure/bayesian/base.py
+++ b/baybe/recommenders/pure/bayesian/base.py
@@ -10,7 +10,7 @@ import narwhals.stable.v2 as nw
 from attrs import define, field
 from attrs.converters import optional
 from attrs.validators import deep_iterable, instance_of
-from narwhals.stable.v2.typing import IntoDataFrameT
+from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
 from typing_extensions import override
 
 from baybe.acquisition import qLogEI, qLogNEHVI
@@ -28,7 +28,6 @@ from baybe.utils.validation import preprocess_dataframe, validate_object_names
 
 if TYPE_CHECKING:
     from botorch.acquisition import AcquisitionFunction as BoAcquisitionFunction
-    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoSeries
 
 
 def _autoreplicate(surrogate: SurrogateProtocol, /) -> SurrogateProtocol:

--- a/baybe/recommenders/pure/bayesian/botorch/discrete.py
+++ b/baybe/recommenders/pure/bayesian/botorch/discrete.py
@@ -46,7 +46,7 @@ def recommend_discrete_with_subsets(
     """
     import torch
 
-    candidates = subspace_discrete.get_candidates()
+    candidates = subspace_discrete._get_candidates().collect()
     masks: Iterable[npt.NDArray[np.bool_]]
     if subspace_discrete.n_subsets <= recommender.max_n_subsets:
         masks = subspace_discrete.subset_masks(min_candidates=batch_size)
@@ -65,9 +65,7 @@ def recommend_discrete_with_subsets(
                 subspace_discrete,
                 candidates=TableCandidates(
                     subspace_discrete.parameters,
-                    nw.from_native(candidates, eager_only=True)
-                    .filter(mask.tolist())
-                    .to_native(),
+                    candidates.filter(mask.tolist()).to_native(),
                 ),
             )
 
@@ -128,7 +126,7 @@ def recommend_discrete_without_subsets(
 
     from botorch.optim import optimize_acqf_discrete
 
-    candidates = subspace_discrete.get_candidates()
+    candidates = subspace_discrete._get_candidates().collect()
     candidates_comp = subspace_discrete.transform(candidates)
     choices = to_tensor(candidates_comp)
 
@@ -143,7 +141,7 @@ def recommend_discrete_without_subsets(
 
     return nw.maybe_reset_index(
         _df_with_backend(
-            nw.from_native(candidates, eager_only=True)[row_idxs],
+            candidates[row_idxs],
             active_settings.default_dataframe_backend,
         )
     ).to_native()

--- a/baybe/recommenders/pure/bayesian/botorch/hybrid.py
+++ b/baybe/recommenders/pure/bayesian/botorch/hybrid.py
@@ -89,7 +89,7 @@ def recommend_hybrid_without_subsets(
     from botorch.optim import optimize_acqf_mixed
 
     # Transform discrete candidates
-    candidates = searchspace.discrete.get_candidates()
+    candidates = searchspace.discrete._get_candidates().collect().to_pandas()
     candidates_comp = searchspace.discrete.transform(candidates)
 
     # Calculate the number of samples from the given percentage
@@ -197,7 +197,7 @@ def recommend_hybrid_with_subsets(
     # NOTE: No min_discrete_candidates filtering in hybrid spaces because
     # optimize_acqf_mixed can produce multiple recommendations from a single
     # discrete candidate by varying continuous parameters.
-    candidates = nw.from_native(searchspace.discrete.get_candidates(), eager_only=True)
+    candidates = searchspace.discrete._get_candidates().collect()
     combined_masks: Iterable[tuple[np.ndarray, frozenset[str]]]
     if searchspace.n_subsets <= recommender.max_n_subsets:
         combined_masks = searchspace.subsets()

--- a/baybe/recommenders/pure/nonpredictive/clustering.py
+++ b/baybe/recommenders/pure/nonpredictive/clustering.py
@@ -111,7 +111,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         from sklearn.preprocessing import StandardScaler
 
         # TODO [Scaling]: scaling should be handled by search space object
-        candidates = subspace_discrete.get_candidates()
+        candidates = subspace_discrete._get_candidates().collect()
         candidates_comp = subspace_discrete.transform(candidates)
         scaler = StandardScaler()
         scaler.fit(candidates_comp)
@@ -135,7 +135,7 @@ class SKLearnClusteringRecommender(NonPredictiveRecommender, ABC):
         # Select rows by positional indices and return the corresponding subset
         return nw.maybe_reset_index(
             _df_with_backend(
-                nw.from_native(candidates, eager_only=True)[selection],
+                candidates[selection],
                 active_settings.default_dataframe_backend,
             )
         ).to_native()

--- a/baybe/recommenders/pure/nonpredictive/sampling.py
+++ b/baybe/recommenders/pure/nonpredictive/sampling.py
@@ -54,9 +54,7 @@ class RandomRecommender(NonPredictiveRecommender):
             if searchspace.type is SearchSpaceType.CONTINUOUS:
                 return cont_random.to_native()
 
-        candidates_exp = nw.from_native(
-            searchspace.discrete.get_candidates(), eager_only=True
-        )
+        candidates_exp = searchspace.discrete._get_candidates().collect()
 
         # Restrict to a random subset if subset-generating constraints are present
         if searchspace.discrete.n_subsets > 0:
@@ -162,7 +160,7 @@ class FPSRecommender(NonPredictiveRecommender):
         from sklearn.preprocessing import StandardScaler
 
         # TODO [Scaling]: scaling should be handled by search space object
-        candidates = subspace_discrete.get_candidates()
+        candidates = subspace_discrete._get_candidates().collect()
         candidates_comp = subspace_discrete.transform(candidates)
         scaler = StandardScaler()
         scaler.fit(candidates_comp)
@@ -186,7 +184,7 @@ class FPSRecommender(NonPredictiveRecommender):
             )
         return nw.maybe_reset_index(
             _df_with_backend(
-                nw.from_native(candidates, eager_only=True)[idcs],
+                candidates[idcs],
                 active_settings.default_dataframe_backend,
             )
         ).to_native()

--- a/baybe/searchspace/candidates.py
+++ b/baybe/searchspace/candidates.py
@@ -37,7 +37,7 @@ class CandidatesProtocol(Protocol):
     def is_finite(self) -> bool:
         """Indicates whether the candidate set is finite or infinite."""
 
-    def to_lazy(self) -> nw.LazyFrame:
+    def _to_lazy(self) -> nw.LazyFrame:
         """Generate all candidates."""
 
 
@@ -56,7 +56,7 @@ class EmptyCandidates(CandidatesProtocol):
         return True
 
     @override
-    def to_lazy(self) -> nw.LazyFrame:
+    def _to_lazy(self) -> nw.LazyFrame:
         backend = active_settings.default_dataframe_backend
         return nw.from_dict({}, backend=backend).lazy()
 
@@ -98,7 +98,7 @@ class ProductCandidates(CandidatesProtocol):
         return all(p.is_finite for p in self.parameters)
 
     @override
-    def to_lazy(self) -> nw.LazyFrame:
+    def _to_lazy(self) -> nw.LazyFrame:
         if not self.is_finite:
             raise InfiniteSpaceError(
                 "Cannot generate all candidates from an infinite space."
@@ -125,13 +125,13 @@ class TableCandidates(CandidatesProtocol):
     )
     """See :attr:`CandidatesProtocol.parameters`."""
 
-    dataframe: nw.DataFrame = field(
+    _dataframe: nw.DataFrame = field(
         converter=lambda x: nw.from_native(x, eager_only=True),
         eq=cmp_using(eq=_df_equals),
     )
     """The dataframe containing the candidates."""
 
-    @dataframe.validator
+    @_dataframe.validator
     def _validate_dataframe(self, _: Attribute, value: nw.DataFrame) -> None:  # noqa: DOC101, DOC103
         validate_parameter_input(
             value.to_pandas(),
@@ -146,8 +146,8 @@ class TableCandidates(CandidatesProtocol):
         return True
 
     @override
-    def to_lazy(self) -> nw.LazyFrame:
-        return self.dataframe.lazy()
+    def _to_lazy(self) -> nw.LazyFrame:
+        return self._dataframe.lazy()
 
 
 # Collect leftover original slotted classes processed by `attrs.define`

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -50,7 +50,7 @@ from baybe.utils.dataframe import (
 from baybe.utils.memory import bytes_to_human_readable
 
 if TYPE_CHECKING:
-    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT, IntoLazyFrame
 
     from baybe.searchspace.core import SearchSpace
 
@@ -621,7 +621,7 @@ class SubspaceDiscrete(SerialMixin):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.get_candidates()
+        return self._get_candidates().collect().to_pandas()
 
     @property
     def comp_rep(self) -> pd.DataFrame:
@@ -635,7 +635,7 @@ class SubspaceDiscrete(SerialMixin):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.transform(self.get_candidates())
+        return self.transform(self._get_candidates().collect().to_pandas())
 
     # <<<<<<<<<< Deprecation
 
@@ -770,10 +770,18 @@ class SubspaceDiscrete(SerialMixin):
 
         per_constraint: list[list[npt.NDArray[np.bool_]]]
         if not self.batch_constraints:
-            per_constraint = [[np.ones(len(self.get_candidates()), dtype=bool)]]
+            per_constraint = [
+                [
+                    np.ones(
+                        self._get_candidates().select(nw.len()).collect().item(),
+                        dtype=bool,
+                    )
+                ]
+            ]
         else:
             per_constraint = [
-                c.subset_masks(self.get_candidates()) for c in self.batch_constraints
+                c.subset_masks(self._get_candidates().collect().to_pandas())
+                for c in self.batch_constraints
             ]
 
         total = prod(len(masks) for masks in per_constraint)
@@ -825,9 +833,13 @@ class SubspaceDiscrete(SerialMixin):
             )
         )
 
-    def get_candidates(self) -> pd.DataFrame:
+    def _get_candidates(self) -> nw.LazyFrame:
+        """Return all candidate parameter configurations as a narwhals LazyFrame."""
+        return self.candidates.to_lazy()
+
+    def get_candidates(self) -> IntoLazyFrame:
         """Return all candidate parameter configurations."""
-        return self.candidates.to_lazy().collect().to_pandas()
+        return self._get_candidates().to_native()
 
     def transform(
         self,

--- a/baybe/searchspace/discrete.py
+++ b/baybe/searchspace/discrete.py
@@ -835,7 +835,7 @@ class SubspaceDiscrete(SerialMixin):
 
     def _get_candidates(self) -> nw.LazyFrame:
         """Return all candidate parameter configurations as a narwhals LazyFrame."""
-        return self.candidates.to_lazy()
+        return self.candidates._to_lazy()
 
     def get_candidates(self) -> IntoLazyFrame:
         """Return all candidate parameter configurations."""

--- a/baybe/simulation/scenarios.py
+++ b/baybe/simulation/scenarios.py
@@ -282,14 +282,16 @@ def _simulate_groupby(
     #   all duplicates). While duplicate entries should be prevented by the search
     #   space constructor, the integer-based indexing provides a second safety net.
     #   Hence, the "reset_index" call.
+    candidates = (
+        campaign.searchspace.discrete._get_candidates()
+        .collect()
+        .to_pandas()
+        .reset_index()
+    )
     if groupby is None:
-        groups = ((None, campaign.searchspace.discrete.get_candidates().reset_index()),)
+        groups = ((None, candidates),)
     else:
-        groups = (
-            campaign.searchspace.discrete.get_candidates()
-            .reset_index()
-            .groupby(groupby)
-        )
+        groups = candidates.groupby(groupby)
 
     # Simulate all subgroups
     dfs = []

--- a/baybe/surrogates/base.py
+++ b/baybe/surrogates/base.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from enum import Enum, auto
 from typing import TYPE_CHECKING, ClassVar, Literal, Protocol, TypeAlias
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 from attrs import define, field
 from joblib.hashing import hash
 from typing_extensions import override
@@ -20,7 +20,7 @@ from baybe.searchspace import SearchSpace
 from baybe.serialization.mixin import SerialMixin
 from baybe.utils.basic import classproperty
 from baybe.utils.conversion import to_string
-from baybe.utils.dataframe import handle_missing_values, to_tensor
+from baybe.utils.dataframe import _copy_index, handle_missing_values, to_tensor
 from baybe.utils.scaling import ColumnTransformer
 
 if TYPE_CHECKING:
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from botorch.models.transforms.input import InputTransform
     from botorch.models.transforms.outcome import OutcomeTransform
     from botorch.posteriors import GPyTorchPosterior, Posterior
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
     from torch import Tensor
 
     from baybe.surrogates.composite import CompositeSurrogate
@@ -60,7 +61,7 @@ class SurrogateProtocol(Protocol):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
+        measurements: IntoDataFrame,
     ) -> None:
         """Fit the surrogate to training data in a given modelling context.
 
@@ -96,7 +97,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
     _objective: Objective | None = field(init=False, default=None, eq=False)
     """The objective for which the surrogate was trained. Available after fitting."""
 
-    _measurements: pd.DataFrame | None = field(init=False, default=None, eq=False)
+    _measurements: nw.DataFrame | None = field(init=False, default=None, eq=False)
     """The measurements used for training. Available after fitting."""
 
     _measurements_hash: str | None = field(init=False, default=None, eq=False)
@@ -191,7 +192,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         return scaler
 
     def _make_output_scaler(
-        self, objective: Objective, measurements: pd.DataFrame
+        self, objective: Objective, measurements: IntoDataFrame
     ) -> OutcomeTransform | _NoTransform:
         """Make and fit the output scaler for transforming computational dataframes."""
         if (factory := self._make_target_scaler_factory()) is None:
@@ -210,7 +211,7 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
         return scaler
 
-    def posterior(self, candidates: pd.DataFrame, *, joint: bool = True) -> Posterior:
+    def posterior(self, candidates: IntoDataFrame, *, joint: bool = True) -> Posterior:
         """Compute the posterior for candidates in experimental representation.
 
         Takes a dataframe of parameter configurations in **experimental representation**
@@ -307,9 +308,9 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
     def posterior_stats(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         stats: Sequence[PosteriorStatistic] = ("mean", "std"),
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrameT:
         """Return posterior statistics for each target.
 
         Args:
@@ -344,7 +345,9 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
         import torch
 
-        result = pd.DataFrame(index=candidates.index)
+        df = nw.from_native(candidates, eager_only=True)
+        stat_frames: list[nw.DataFrame] = []
+
         with torch.no_grad():
             for stat in stats:
                 try:
@@ -372,23 +375,31 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
 
                 # Enforce a consistent shape
                 # https://github.com/pytorch/botorch/issues/2958
-                vals = vals.reshape((len(candidates), 1))
+                vals = vals.reshape((len(df), 1))
 
-                result[
-                    [
-                        f"{name}_{stat_name}"
-                        for name in self._objective._modeled_quantity_names
-                    ]
-                ] = vals.cpu().numpy()
+                col_names = [
+                    f"{name}_{stat_name}"
+                    for name in self._objective._modeled_quantity_names
+                ]
+                stat_frames.append(
+                    nw.from_numpy(
+                        vals.numpy(),
+                        schema=col_names,
+                        backend=nw.get_native_namespace(df),
+                    )
+                )
 
-        return result
+        # TODO[typing]: https://github.com/narwhals-dev/narwhals/issues/3897
+        result: nw.DataFrame = nw.concat(stat_frames, how="horizontal")  # type: ignore[assignment]
+        result = _copy_index(result, df)
+        return result.to_native()
 
     @override
     def fit(
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
+        measurements: IntoDataFrame,
     ) -> None:
         """Train the surrogate model on the provided data.
 
@@ -405,6 +416,9 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
         """
         # TODO: consider adding a validation step for `measurements`
 
+        # Wrap in narwhals for backend-agnostic handling
+        measurements = nw.from_native(measurements, eager_only=True)
+
         # Validate multi-target compatibility
         if objective._is_multi_model and not self.supports_multi_output:
             raise IncompatibleSurrogateError(
@@ -416,10 +430,11 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             )
 
         # When the context is unchanged, no retraining is necessary
+        measurements_pd = measurements.to_pandas()
         if (
             searchspace == self._searchspace
             and objective == self._objective
-            and hash(measurements) == self._measurements_hash
+            and hash(measurements_pd) == self._measurements_hash
         ):
             return
 
@@ -432,13 +447,13 @@ class Surrogate(ABC, SurrogateProtocol, SerialMixin):
             )
 
         # Block partial measurements
-        handle_missing_values(measurements, [t.name for t in objective.targets])
+        handle_missing_values(measurements_pd, [t.name for t in objective.targets])
 
         # Remember the training context
         self._searchspace = searchspace
         self._objective = objective
         self._measurements = measurements
-        self._measurements_hash = hash(measurements)
+        self._measurements_hash = hash(measurements_pd)
 
         # Create context-specific transformations
         self._input_scaler = self._make_input_scaler(searchspace)

--- a/baybe/surrogates/composite.py
+++ b/baybe/surrogates/composite.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
-import pandas as pd
+import narwhals.stable.v2 as nw
 from attrs import define, field
 from typing_extensions import Self, override
 
@@ -24,6 +24,7 @@ from baybe.utils.basic import is_all_instance
 if TYPE_CHECKING:
     from botorch.models.model import ModelList
     from botorch.posteriors import PosteriorList
+    from narwhals.stable.v2.typing import IntoDataFrame, IntoDataFrameT
     from torch import Tensor
 
 _T = TypeVar("_T")
@@ -103,21 +104,26 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
         self,
         searchspace: SearchSpace,
         objective: Objective,
-        measurements: pd.DataFrame,
+        measurements: IntoDataFrame,
     ) -> None:
-        # See base class.
-
-        for name, data in objective.handle_missing_values(measurements).items():
-            pre_transformed = objective._pre_transform(
-                data[[t.name for t in objective.targets]]
+        for name, data in objective._handle_missing_values(measurements).items():
+            data_nw = nw.from_native(data, eager_only=True)
+            targets_pre_transformed = objective._pre_transform(
+                data_nw.select([t.name for t in objective.targets])
             )
-            pre_transformed = pd.concat(
-                [data[list(searchspace.parameter_names)], pre_transformed],
-                axis=1,
+            # TODO[typing]: https://github.com/narwhals-dev/narwhals/issues/3897
+            pre_transformed: nw.DataFrame = nw.concat(  # type: ignore[assignment]
+                [
+                    data_nw.select(searchspace.parameter_names),
+                    nw.from_native(targets_pre_transformed, eager_only=True),
+                ],
+                how="horizontal",
             )
             quantity = next(x for x in objective._modeled_quantities if x.name == name)
             self.surrogates[name].fit(
-                searchspace, quantity.to_objective(), pre_transformed
+                searchspace,
+                quantity.to_objective(),
+                pre_transformed.to_native(),
             )
 
         self._modeled_quantity_names = objective._modeled_quantity_names
@@ -133,7 +139,7 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
         else:
             return ModelList(*(s.to_botorch() for s in surrogates))
 
-    def posterior(self, candidates: pd.DataFrame, joint: bool = True) -> PosteriorList:
+    def posterior(self, candidates: IntoDataFrame, joint: bool = True) -> PosteriorList:
         """Compute the posterior for candidates in experimental representation.
 
         The (independent joint) posterior is represented as a collection of individual
@@ -180,9 +186,9 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
 
     def posterior_stats(
         self,
-        candidates: pd.DataFrame,
+        candidates: IntoDataFrameT,
         stats: Sequence[PosteriorStatistic] = ("mean", "std"),
-    ) -> pd.DataFrame:
+    ) -> IntoDataFrameT:
         """See :meth:`baybe.surrogates.base.Surrogate.posterior_stats`."""
         if not all(hasattr(s, "posterior_stats") for s in self._surrogates_flat):
             raise IncompatibleSurrogateError(
@@ -190,8 +196,12 @@ class CompositeSurrogate(SerialMixin, SurrogateProtocol):
                 "offer this computation."
             )
 
-        dfs = [s.posterior_stats(candidates, stats) for s in self._surrogates_flat]  # type: ignore[attr-defined]
-        return pd.concat(dfs, axis=1)
+        dfs = [
+            nw.from_native(s.posterior_stats(candidates, stats), eager_only=True)  # type: ignore[attr-defined]
+            for s in self._surrogates_flat
+        ]
+
+        return nw.concat(dfs, how="horizontal").to_native()
 
 
 def _get_surrogate_getter_type(type: str) -> type[_SurrogateGetter]:

--- a/baybe/surrogates/gaussian_process/components/fit_criterion.py
+++ b/baybe/surrogates/gaussian_process/components/fit_criterion.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -15,6 +14,7 @@ if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
     from gpytorch.mlls import MarginalLogLikelihood
     from gpytorch.models import GP as GPyTorchModel
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     from baybe.searchspace.core import SearchSpace
 
@@ -64,7 +64,10 @@ class _MLLForNonTLFitCriterionFactory(FitCriterionFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> FitCriterion:
         if searchspace.n_tasks == 1:
             return FitCriterion.MARGINAL_LOG_LIKELIHOOD

--- a/baybe/surrogates/gaussian_process/components/generic.py
+++ b/baybe/surrogates/gaussian_process/components/generic.py
@@ -7,7 +7,6 @@ import sys
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, TypeVar
 
-import pandas as pd
 from attrs import Attribute, define, field
 from typing_extensions import TypeIs, override
 
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
     from gpytorch.means import Mean as GPyTorchMean
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     GPyTorchGPComponent: TypeAlias = GPyTorchKernel | GPyTorchMean | GPyTorchLikelihood
     GPComponent: TypeAlias = BayBEGPComponent | GPyTorchGPComponent
@@ -115,7 +115,10 @@ class GPComponentFactoryProtocol(Protocol, Generic[_T_co]):
     """A protocol defining the interface for Gaussian process component factories."""
 
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> _T_co:
         """Create a Gaussian process component for the given recommendation context.
 
@@ -138,7 +141,10 @@ class PlainGPComponentFactory(GPComponentFactoryProtocol[_T_co], SerialMixin):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> _T_co:
         return self.component
 

--- a/baybe/surrogates/gaussian_process/components/kernel.py
+++ b/baybe/surrogates/gaussian_process/components/kernel.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar, cast
 
-import pandas as pd
 from attrs import define, field, fields
 from attrs.converters import optional
 from attrs.validators import is_callable
@@ -35,6 +34,7 @@ from baybe.surrogates.gaussian_process.components.generic import (
 
 if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     from baybe.parameters.base import Parameter
 
@@ -109,7 +109,10 @@ class _PureKernelFactory(KernelFactoryProtocol, SerialMixin, ABC):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         """Construct the kernel, validating parameter kinds before construction."""
         if self.parameter_selector is not None:
@@ -122,7 +125,10 @@ class _PureKernelFactory(KernelFactoryProtocol, SerialMixin, ABC):
 
     @abstractmethod
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         """Construct the kernel."""
 
@@ -188,7 +194,10 @@ def _enable_transfer_learning(
 
     @functools.wraps(original_call)
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ):
         # Temporarily narrow the supported parameter kinds to those of the original
         # class. If the decorator logic is correct, the original factory should never
@@ -230,7 +239,10 @@ class _MetaKernelFactory(KernelFactoryProtocol, ABC):
     @override
     @abstractmethod
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel: ...
 
 
@@ -297,7 +309,10 @@ class ICMKernelFactory(_MetaKernelFactory):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         if searchspace.n_tasks == 1:
             raise IncompatibleSearchSpaceError(

--- a/baybe/surrogates/gaussian_process/components/likelihood.py
+++ b/baybe/surrogates/gaussian_process/components/likelihood.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -17,6 +16,7 @@ from baybe.surrogates.gaussian_process.components.generic import (
 
 if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     LikelihoodFactoryProtocol = GPComponentFactoryProtocol[GPyTorchLikelihood]
     PlainLikelihoodFactory = PlainGPComponentFactory[GPyTorchLikelihood]
@@ -35,7 +35,10 @@ class LazyGaussianLikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
         from gpytorch.likelihoods import GaussianLikelihood
 

--- a/baybe/surrogates/gaussian_process/components/mean.py
+++ b/baybe/surrogates/gaussian_process/components/mean.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import gc
 from typing import TYPE_CHECKING, Any
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -18,6 +17,7 @@ from baybe.surrogates.gaussian_process.components.generic import (
 
 if TYPE_CHECKING:
     from gpytorch.means import Mean as GPyTorchMean
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     MeanFactoryProtocol = GPComponentFactoryProtocol[GPyTorchMean]
     PlainMeanFactory = PlainGPComponentFactory[GPyTorchMean]
@@ -36,7 +36,10 @@ class LazyConstantMeanFactory(MeanFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchMean:
         from gpytorch.means import ConstantMean
 

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -353,7 +353,9 @@ class GaussianProcessSurrogate(Surrogate):
             mean_factory = self.mean_factory or BayBEMeanFactory()
             return mean_factory(searchspace, objective, measurements)
 
-        context = _ModelContext(searchspace, objective, measurements)
+        context = _ModelContext(
+            searchspace, objective, nw.from_native(measurements, eager_only=True)
+        )
 
         train_y = to_tensor(objective._pre_transform(measurements, allow_extra=True))
         if train_y.ndim == 1:

--- a/baybe/surrogates/gaussian_process/core.py
+++ b/baybe/surrogates/gaussian_process/core.py
@@ -9,6 +9,7 @@ import warnings
 from functools import partial
 from typing import TYPE_CHECKING, ClassVar
 
+import narwhals.stable.v2 as nw
 import pandas as pd
 from attrs import Converter, define, field, fields
 from attrs.converters import optional as optional_c
@@ -83,7 +84,7 @@ class _ModelContext:
     objective: Objective = field(validator=instance_of(Objective))
     """The objective for which the model is trained."""
 
-    measurements: pd.DataFrame = field(validator=instance_of(pd.DataFrame))
+    measurements: nw.DataFrame = field(validator=instance_of(nw.DataFrame))
     """The training data in experimental representation."""
 
     @property

--- a/baybe/surrogates/gaussian_process/presets/baybe.py
+++ b/baybe/surrogates/gaussian_process/presets/baybe.py
@@ -7,7 +7,6 @@ import math
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar, TypeVar
 
-import pandas as pd
 from attrs import define, field
 from typing_extensions import override
 
@@ -46,6 +45,7 @@ if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
     from gpytorch.means import Mean as GPyTorchMean
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 _T = TypeVar("_T", bound=GPComponentFactoryProtocol)
 
@@ -73,7 +73,10 @@ class _CustomScaledNumericalKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         from gpytorch.constraints import GreaterThan
         from gpytorch.kernels import MaternKernel
@@ -124,7 +127,10 @@ class _CustomScaledLikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
         from botorch.models.utils.gpytorch_modules import MIN_INFERRED_NOISE_LEVEL
         from gpytorch.constraints import GreaterThan
@@ -181,7 +187,10 @@ class _BayBENumericalKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         from baybe.surrogates.gaussian_process.presets.chen import (
             _ChenNumericalKernelFactory,
@@ -221,7 +230,10 @@ class _BayBETaskKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel:
         return PositiveIndexKernel(
             num_tasks=searchspace.n_tasks,
@@ -236,7 +248,10 @@ class BayBEMeanFactory(MeanFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchMean:
         from baybe.surrogates.gaussian_process.presets.chen import ChenMeanFactory
 
@@ -254,7 +269,10 @@ class BayBELikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
         from baybe.surrogates.gaussian_process.presets.chen import ChenLikelihoodFactory
 
@@ -272,7 +290,10 @@ class BayBEFitCriterionFactory(FitCriterionFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> FitCriterion:
         return (
             FitCriterion.MARGINAL_LOG_LIKELIHOOD

--- a/baybe/surrogates/gaussian_process/presets/botorch.py
+++ b/baybe/surrogates/gaussian_process/presets/botorch.py
@@ -7,7 +7,6 @@ from importlib import import_module
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -32,6 +31,7 @@ from baybe.surrogates.gaussian_process.presets.hvarfner import (
 
 if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 # The minimum BoTorch version required for the preset
 _MIN_BOTORCH_VERSION = "0.18.0"
@@ -51,7 +51,10 @@ class BotorchKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         self._validate_botorch_version()
 

--- a/baybe/surrogates/gaussian_process/presets/chen.py
+++ b/baybe/surrogates/gaussian_process/presets/chen.py
@@ -6,7 +6,6 @@ import gc
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -27,6 +26,8 @@ from baybe.surrogates.gaussian_process.components.likelihood import (
 from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFactory
 
 if TYPE_CHECKING:
+    from narwhals.stable.v2.typing import IntoDataFrame
+
     from baybe.kernels.base import Kernel
     from baybe.searchspace.core import SearchSpace
 
@@ -40,7 +41,10 @@ class _ChenNumericalKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel:
         n_dimensions = self._get_effective_dimensionality(searchspace)
         lengthscale = 0.4 * math.sqrt(n_dimensions) + 4.0

--- a/baybe/surrogates/gaussian_process/presets/edbo.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo.py
@@ -6,7 +6,6 @@ import gc
 from collections.abc import Collection
 from typing import TYPE_CHECKING, ClassVar
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -31,6 +30,7 @@ from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFa
 
 if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     from baybe.kernels.base import Kernel
     from baybe.searchspace.core import SearchSpace
@@ -69,7 +69,10 @@ class EDBOKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel:
         effective_dims = self._get_effective_dimensionality(searchspace)
 
@@ -131,7 +134,10 @@ class EDBOLikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
         import torch
         from gpytorch.likelihoods import GaussianLikelihood

--- a/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
+++ b/baybe/surrogates/gaussian_process/presets/edbo_smoothed.py
@@ -6,7 +6,6 @@ import gc
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -29,6 +28,7 @@ from baybe.surrogates.gaussian_process.components.mean import LazyConstantMeanFa
 
 if TYPE_CHECKING:
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
+    from narwhals.stable.v2.typing import IntoDataFrame
 
     from baybe.kernels.base import Kernel
     from baybe.searchspace.core import SearchSpace
@@ -53,7 +53,10 @@ class SmoothedEDBOKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel:
         effective_dims = self._get_effective_dimensionality(searchspace)
 
@@ -98,7 +101,10 @@ class SmoothedEDBOLikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
         import torch
         from gpytorch.likelihoods import GaussianLikelihood

--- a/baybe/surrogates/gaussian_process/presets/hvarfner.py
+++ b/baybe/surrogates/gaussian_process/presets/hvarfner.py
@@ -6,7 +6,6 @@ import gc
 from itertools import chain
 from typing import TYPE_CHECKING, ClassVar
 
-import pandas as pd
 from attrs import define
 from typing_extensions import override
 
@@ -29,6 +28,7 @@ if TYPE_CHECKING:
     from gpytorch.kernels import Kernel as GPyTorchKernel
     from gpytorch.likelihoods import Likelihood as GPyTorchLikelihood
     from gpytorch.means import Mean as GPyTorchMean
+    from narwhals.stable.v2.typing import IntoDataFrame
 
 
 @define
@@ -45,7 +45,10 @@ class HvarfnerKernelFactory(_PureKernelFactory):
 
     @override
     def _make(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> Kernel | GPyTorchKernel:
         from botorch.models.kernels.positive_index import PositiveIndexKernel
         from botorch.models.utils.gpytorch_modules import (
@@ -89,7 +92,10 @@ class HvarfnerMeanFactory(MeanFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchMean:
         from gpytorch.means import ConstantMean
 
@@ -111,7 +117,10 @@ class HvarfnerLikelihoodFactory(LikelihoodFactoryProtocol):
 
     @override
     def __call__(
-        self, searchspace: SearchSpace, objective: Objective, measurements: pd.DataFrame
+        self,
+        searchspace: SearchSpace,
+        objective: Objective,
+        measurements: IntoDataFrame,
     ) -> GPyTorchLikelihood:
 
         if searchspace.n_tasks == 1:

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -35,7 +35,7 @@ edf = pd.DataFrame()
 def test_empty_candidates():
     """EmptyCandidates has no parameters, is finite, and yields an empty lazy frame."""
     candidates = EmptyCandidates()
-    candidates_ldf = candidates.to_lazy()
+    candidates_ldf = candidates._to_lazy()
     candidates_df = candidates_ldf.collect()
 
     assert candidates.parameters == ()
@@ -58,7 +58,7 @@ def test_table_candidates_generation(dataframe_factory):
     data = pd.DataFrame({"disc": [1, 2], "cat": ["a", "b"]})
     df = dataframe_factory(data)
     candidates = TableCandidates(parameters, df)
-    candidates_ldf = candidates.to_lazy()
+    candidates_ldf = candidates._to_lazy()
     candidates_df = candidates_ldf.collect()
 
     assert candidates.is_finite
@@ -73,7 +73,7 @@ def test_table_candidates_empty_rows():
     parameters = [p_disc, p_cat]
     empty_df = pd.DataFrame(columns=[p.name for p in parameters])
     candidates = TableCandidates(parameters, empty_df)
-    candidates_df = candidates.to_lazy().collect()
+    candidates_df = candidates._to_lazy().collect()
 
     assert candidates.is_finite
     assert set(candidates_df.columns) == {p.name for p in parameters}
@@ -152,7 +152,7 @@ def test_product_candidates_generation(constraints, expected):
     """ProductCandidates generates the expected lazy dataframe."""
     parameters = [p_disc, p_disc2]
     candidates = ProductCandidates(parameters, constraints)
-    candidates_ldf = candidates.to_lazy()
+    candidates_ldf = candidates._to_lazy()
     candidates_df = candidates_ldf.collect()
 
     assert candidates.is_finite

--- a/tests/test_kernel_factories.py
+++ b/tests/test_kernel_factories.py
@@ -3,6 +3,7 @@
 from contextlib import nullcontext
 
 import gpytorch
+import narwhals.stable.v2 as nw
 import pandas as pd
 import pytest
 from botorch.models.kernels.positive_index import (
@@ -139,7 +140,7 @@ def _make_dispatch_context(override_mode):
     num_param = NumericalDiscreteParameter("x", [1, 2, 3, 4, 5])
     searchspace = SearchSpace.from_product([num_param, task_param])
     objective = NumericalTarget("y").to_objective()
-    measurements = pd.DataFrame()
+    measurements = nw.from_native(pd.DataFrame())
     return _ModelContext(searchspace, objective, measurements)
 
 


### PR DESCRIPTION
Another step closer to lazification. Finally avoids candidate materialization by offering an appropriate lazy interface.

**Why the two-method interface?**

`get_candidates()` is part of the public API and must return a native type – returning a narwhals wrapper would leak an implementation detail to users. The natural return type for a potentially large candidate set is a lazy frame, so callers can defer materialization until they actually need the data.

The tension is: internal library callers need an *eager* narwhals `DataFrame` to perform operations like `.filter()`, positional indexing, and `.sample()`. If `get_candidates()` returned the native lazy frame, every such caller would need to re-wrap it in narwhals and normalize before collecting:

```python
# with a single public get_candidates() -> IntoLazyFrame
candidates = nw.from_native(subspace.get_candidates()).lazy().collect()

# with the two-method design
candidates = subspace._get_candidates().collect()
```

The `.lazy()` call in the first form is unavoidable: for a pandas-backed result, `nw.from_native(pd.DataFrame)` gives a `nw.DataFrame` (not a `nw.LazyFrame`), so `.collect()` does not exist on it without normalizing through `.lazy()` first. This boilerplate would appear at every internal call site.

The two-method design resolves this cleanly:

- **`get_candidates() -> IntoLazyFrame`**: public API, returns the native lazy frame. Callers own the decision of when to materialize.
- **`_get_candidates() -> nw.LazyFrame`**: private, stays in narwhals. Internal callers collect exactly when and how they need to (eager frame, specific native type, or a lazy aggregation like a row count), without any re-wrapping overhead.